### PR TITLE
fix(hydro_lang): use correct `__staged` path when rewriting `crate::` imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1636,6 +1636,7 @@ name = "hydro_test"
 version = "0.0.0"
 dependencies = [
  "async-ssh2-lite",
+ "ctor",
  "dfir_macro",
  "futures",
  "hydro_deploy",

--- a/hydro_lang/Cargo.toml
+++ b/hydro_lang/Cargo.toml
@@ -22,7 +22,6 @@ build = [ "dep:dfir_lang" ]
 
 [dependencies]
 bincode = "1.3.1"
-ctor = "0.2.8"
 hydro_deploy = { path = "../hydro_deploy/core", version = "^0.11.0", optional = true }
 dfir_rs = { path = "../dfir_rs", version = "^0.11.0", default-features = false, features = ["deploy_integration"] }
 dfir_lang = { path = "../dfir_lang", version = "^0.11.0", optional = true }
@@ -41,6 +40,7 @@ syn = { version = "2.0.46", features = [ "parsing", "extra-traits", "visit-mut" 
 tokio = { version = "1.29.0", features = [ "full" ] }
 toml = { version = "0.8.0", optional = true }
 trybuild-internals-api = { version = "1.0.99", optional = true }
+ctor = "0.2"
 
 [build-dependencies]
 stageleft_tool = { path = "../stageleft_tool", version = "^0.5.0" }

--- a/hydro_lang/src/deploy/trybuild_rewriters.rs
+++ b/hydro_lang/src/deploy/trybuild_rewriters.rs
@@ -2,6 +2,7 @@ use syn::visit_mut::VisitMut;
 
 pub struct ReplaceCrateNameWithStaged {
     pub crate_name: String,
+    pub is_test: bool,
 }
 
 impl VisitMut for ReplaceCrateNameWithStaged {
@@ -9,27 +10,22 @@ impl VisitMut for ReplaceCrateNameWithStaged {
         if let Some(first) = i.path.segments.first() {
             if first.ident == self.crate_name {
                 let tail = i.path.segments.iter().skip(1).collect::<Vec<_>>();
-                *i = syn::parse_quote!(crate::__staged #(::#tail)*);
+
+                if self.is_test {
+                    *i = syn::parse_quote!(crate::__staged #(::#tail)*);
+                } else {
+                    let crate_ident = syn::Ident::new(&self.crate_name, first.ident.span());
+                    *i = syn::parse_quote!(#crate_ident::__staged #(::#tail)*);
+                }
             }
         }
 
         syn::visit_mut::visit_type_path_mut(self, i);
     }
-}
 
-pub struct ReplaceCrateWithOrig {
-    pub crate_name: String,
-}
-
-impl VisitMut for ReplaceCrateWithOrig {
-    fn visit_item_use_mut(&mut self, i: &mut syn::ItemUse) {
-        if let syn::UseTree::Path(p) = &mut i.tree {
-            if p.ident == "crate" {
-                p.ident = syn::Ident::new(&self.crate_name, p.ident.span());
-                i.leading_colon = Some(Default::default());
-            }
+    fn visit_use_path_mut(&mut self, i: &mut syn::UsePath) {
+        if i.ident == "crate" && !self.is_test {
+            i.ident = syn::Ident::new(&self.crate_name, i.ident.span());
         }
-
-        syn::visit_mut::visit_item_use_mut(self, i);
     }
 }

--- a/hydro_lang/src/lib.rs
+++ b/hydro_lang/src/lib.rs
@@ -54,7 +54,7 @@ fn add_private_reexports() {
 
 #[stageleft::runtime]
 #[cfg(test)]
-mod tests {
+mod test_init {
     #[ctor::ctor]
     fn init() {
         crate::deploy::init_test();

--- a/hydro_std/Cargo.toml
+++ b/hydro_std/Cargo.toml
@@ -26,4 +26,4 @@ hydro_lang = { path = "../hydro_lang", version = "^0.11.0" }
 insta = "1.39"
 hydro_deploy = { path = "../hydro_deploy/core", version = "^0.11.0" }
 async-ssh2-lite = { version = "0.5.0", features = ["vendored-openssl"] }
-ctor = "0.2.8"
+ctor = "0.2"

--- a/hydro_std/src/lib.rs
+++ b/hydro_std/src/lib.rs
@@ -5,7 +5,7 @@ pub mod request_response;
 
 #[stageleft::runtime]
 #[cfg(test)]
-mod tests {
+mod test_init {
     #[ctor::ctor]
     fn init() {
         hydro_lang::deploy::init_test();

--- a/hydro_test/Cargo.toml
+++ b/hydro_test/Cargo.toml
@@ -23,6 +23,7 @@ serde = { version = "1.0.197", features = [ "derive" ] }
 stageleft_tool = { path = "../stageleft_tool", version = "^0.5.0" }
 
 [dev-dependencies]
+ctor = "0.2"
 insta = "1.39"
 hydro_deploy = { path = "../hydro_deploy/core", version = "^0.11.0" }
 hydro_lang = { path = "../hydro_lang", version = "^0.11.0", features = [ "deploy" ] }

--- a/hydro_test/src/lib.rs
+++ b/hydro_test/src/lib.rs
@@ -9,3 +9,12 @@ pub mod distributed;
 mod docs {
     dfir_macro::doctest_markdown_glob!("docs/docs/hydro/**/*.md*");
 }
+
+#[stageleft::runtime]
+#[cfg(test)]
+mod test_init {
+    #[ctor::ctor]
+    fn init() {
+        hydro_lang::deploy::init_test();
+    }
+}

--- a/stageleft_tool/src/lib.rs
+++ b/stageleft_tool/src/lib.rs
@@ -157,6 +157,22 @@ impl VisitMut for GenFinalPubVistor {
         syn::visit_mut::visit_use_path_mut(self, i);
     }
 
+    fn visit_vis_restricted_mut(&mut self, _i: &mut syn::VisRestricted) {
+        // don't treat the restriction as a path, we don't want to rewrite that to `__staged`
+    }
+
+    fn visit_path_mut(&mut self, i: &mut syn::Path) {
+        if !i.segments.is_empty() && i.segments[0].ident == "crate" {
+            i.segments.insert(
+                1,
+                syn::PathSegment {
+                    ident: parse_quote!(__staged),
+                    arguments: Default::default(),
+                },
+            );
+        }
+    }
+
     fn visit_item_mod_mut(&mut self, i: &mut syn::ItemMod) {
         let is_runtime_or_test = i.attrs.iter().any(|a| {
             a.path().to_token_stream().to_string() == "stageleft :: runtime"

--- a/template/hydro/Cargo.toml
+++ b/template/hydro/Cargo.toml
@@ -19,6 +19,7 @@ stageleft_tool = { git = "{{ hydro_git | default: 'https://github.com/hydro-proj
 
 [dev-dependencies]
 async-ssh2-lite = { version = "0.5.0", features = ["vendored-openssl"] }
+ctor = "0.2"
 hydro_deploy = { git = "{{ hydro_git | default: 'https://github.com/hydro-project/hydro.git' }}", branch = "{{ hydro_branch | default: 'main' }}" }
 hydro_lang = { git = "{{ hydro_git | default: 'https://github.com/hydro-project/hydro.git' }}", branch = "{{ hydro_branch | default: 'main' }}", features = [
     "deploy",

--- a/template/hydro/src/lib.rs
+++ b/template/hydro/src/lib.rs
@@ -3,3 +3,12 @@ stageleft::stageleft_no_entry_crate!();
 pub mod first_ten;
 pub mod first_ten_cluster;
 pub mod first_ten_distributed;
+
+#[stageleft::runtime]
+#[cfg(test)]
+mod test_init {
+    #[ctor::ctor]
+    fn init() {
+        hydro_lang::deploy::init_test();
+    }
+}


### PR DESCRIPTION

Previously, a rewrite would first turn `crate` into `crate::__staged`, and another would rewrite `crate::__staged` into `hydro_test::__staged`. The latter global rewrite is unnecessary because the stageleft logic already will use the full crate name when handling public types, so we drop it.
