### PR TITLE
ci(hydro_cli): bump upload-artifact action to v4

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           pip install hydro_deploy/hydro_cli/dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
       - name: "Upload wheels"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: hydro_deploy/hydro_cli/dist
@@ -92,7 +92,7 @@ jobs:
         run: |
           pip install hydro_deploy/hydro_cli/dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
       - name: "Upload wheels"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: hydro_deploy/hydro_cli/dist
@@ -121,7 +121,7 @@ jobs:
           manylinux: auto
           args: --release --out dist
       - name: "Upload wheels"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: hydro_deploy/hydro_cli/dist
@@ -158,7 +158,7 @@ jobs:
         run: |
           python -m pip install hydro_deploy/hydro_cli/dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
       - name: "Upload wheels"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: hydro_deploy/hydro_cli/dist


### PR DESCRIPTION

v3 now fails on GHA
