### PR TITLE
fixup!: ci(hydro_cli): fix matrix clobbering the same artifact path

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -123,7 +123,7 @@ jobs:
       - name: "Upload wheels"
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.target }}
+          name: wheels-${{ matrix.platform.target }}
           path: hydro_deploy/hydro_cli/dist
 
   windows:
@@ -160,7 +160,7 @@ jobs:
       - name: "Upload wheels"
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.target }}
+          name: wheels-${{ matrix.platform.target }}
           path: hydro_deploy/hydro_cli/dist
 
   release:


### PR DESCRIPTION

Some of the matrices nest `target` under `platform`.
