### PR TITLE
docs: fix extraneous `\<` escaping introduced in #1558, fix #1614

### DIFF
--- a/dfir_lang/src/graph/ops/join.rs
+++ b/dfir_lang/src/graph/ops/join.rs
@@ -7,7 +7,7 @@ use super::{
 };
 use crate::diagnostic::{Diagnostic, Level};
 
-/// > 2 input streams of type <(K, V1)> and <(K, V2)>, 1 output stream of type <(K, (V1, V2))>
+/// > 2 input streams of type `<(K, V1)>` and `<(K, V2)>`, 1 output stream of type `<(K, (V1, V2))>`
 ///
 /// Forms the equijoin of the tuples in the input streams by their first (key) attribute. Note that the result nests the 2nd input field (values) into a tuple in the 2nd output field.
 ///

--- a/dfir_lang/src/graph/ops/join_fused.rs
+++ b/dfir_lang/src/graph/ops/join_fused.rs
@@ -9,7 +9,7 @@ use super::{
 };
 use crate::diagnostic::{Diagnostic, Level};
 
-/// > 2 input streams of type <(K, V1)> and <(K, V2)>, 1 output stream of type <(K, (V1, V2))>
+/// > 2 input streams of type `<(K, V1)>` and `<(K, V2)>`, 1 output stream of type `<(K, (V1, V2))>`
 ///
 /// `join_fused` takes two arguments, they are the configuration options for the left hand side and right hand side inputs respectively.
 /// There are three available configuration options, they are `Reduce`: if the input type is the same as the accumulator type,

--- a/dfir_lang/src/graph/ops/join_multiset.rs
+++ b/dfir_lang/src/graph/ops/join_multiset.rs
@@ -5,7 +5,7 @@ use super::{
     WriteContextArgs, RANGE_0, RANGE_1,
 };
 
-/// > 2 input streams of type <(K, V1)> and <(K, V2)>, 1 output stream of type <(K, (V1, V2))>
+/// > 2 input streams of type `<(K, V1)>` and `<(K, V2)>`, 1 output stream of type `<(K, (V1, V2))>`
 ///
 /// This operator is equivalent to `join` except that the LHS and RHS are collected into multisets rather than sets before joining.
 ///

--- a/dfir_macro/build.rs
+++ b/dfir_macro/build.rs
@@ -1,9 +1,9 @@
 //! Build script to generate operator book docs.
 
 use std::env::VarError;
-use std::fmt::Write as _FmtWrite;
+use std::fmt::Write as _;
 use std::fs::File;
-use std::io::{BufWriter, Read, Result, Write};
+use std::io::{BufWriter, Result, Write};
 use std::path::{Path, PathBuf};
 
 use dfir_lang::graph::ops::{PortListSpec, OPERATORS};
@@ -33,16 +33,8 @@ fn write_operator_docgen(op_name: &str, write: &mut impl Write) -> Result<()> {
         "../docs/docgen",
         &*format!("{}.md", op_name),
     ]);
-    let mut read_string = String::new();
-    File::open(doctest_path)?.read_to_string(&mut read_string)?;
-    write!(
-        write,
-        "{}",
-        read_string
-            .split("<!--")
-            .map(|t| t.replace("<", "\\<"))
-            .join("<!--")
-    )?;
+    let mut read = File::open(doctest_path)?;
+    std::io::copy(&mut read, write)?;
     Ok(())
 }
 


### PR DESCRIPTION
Previous code also inserted `\<` into code blocks. This fixes the original issue of unescaped `<`s by ensuring all op docs have them in `code blocks`, removes the escaping.