### PR TITLE
fix(hydro_deploy): improve error message when crates fail to build

### DIFF
--- a/hydro_deploy/core/src/hydroflow_crate/build.rs
+++ b/hydro_deploy/core/src/hydroflow_crate/build.rs
@@ -213,7 +213,7 @@ impl Display for BuildError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::FailedToBuildCrate(exit_status, diagnostics) => {
-                writeln!(f, "Failed to build crate (exit status {}):", exit_status)?;
+                writeln!(f, "Failed to build crate ({}):", exit_status)?;
                 for diagnostic in diagnostics {
                     write!(f, "{}", diagnostic)?;
                 }


### PR DESCRIPTION

`Display` for `ExitStatus` already includes "exit status: " prefix
