### PR TITLE
fix(hydro_deploy): always write logs to stdout

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,6 +5,9 @@ rustflags = [
     '--cfg=HYDROFLOW_GENERATE_DOCS',
 ]
 
+[target.aarch64-apple-darwin]
+linker = "rust-lld"
+
 [target.x86_64-apple-darwin]
 linker = "rust-lld"
 

--- a/hydro_deploy/core/src/progress.rs
+++ b/hydro_deploy/core/src/progress.rs
@@ -370,11 +370,9 @@ impl ProgressTracker {
             .lock()
             .unwrap();
 
-        if progress_bar.current_count == 0
-            || progress_bar.multi_progress.println(msg.as_ref()).is_err()
-        {
+        progress_bar.multi_progress.suspend(|| {
             println!("{}", msg.as_ref());
-        }
+        });
     }
 
     pub fn with_group<'a, T, F: Future<Output = T>>(


### PR DESCRIPTION

Previously, some logs may have gone to stderr depending on the status of the `ProgressBar`. Also enables `rust-lld` linker on Apple Silicon to improve compilation times.
