### PR TITLE
refactor(hydro_test): make logic for sending payloads to current leader reusable

### DIFF
--- a/hydro_test/examples/paxos.rs
+++ b/hydro_test/examples/paxos.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use hydro_deploy::gcp::GcpNetwork;
 use hydro_deploy::{Deployment, Host};
 use hydro_lang::deploy::TrybuildHost;
-use hydro_test::cluster::paxos::PaxosConfig;
+use hydro_test::cluster::paxos::{CorePaxos, PaxosConfig};
 use tokio::sync::RwLock;
 
 type HostCreator = Box<dyn Fn(&mut Deployment) -> Arc<dyn Host>>;
@@ -42,16 +42,25 @@ async fn main() {
     let i_am_leader_check_timeout = 10; // Sec
     let i_am_leader_check_timeout_delay_multiplier = 15;
 
-    let (proposers, acceptors, clients, replicas) = hydro_test::cluster::paxos_bench::paxos_bench(
+    let proposers = builder.cluster();
+    let acceptors = builder.cluster();
+
+    let (clients, replicas) = hydro_test::cluster::paxos_bench::paxos_bench(
         &builder,
         num_clients_per_node,
         median_latency_window_size,
         checkpoint_frequency,
-        PaxosConfig {
-            f,
-            i_am_leader_send_timeout,
-            i_am_leader_check_timeout,
-            i_am_leader_check_timeout_delay_multiplier,
+        f + 1,
+        |replica_checkpoint| CorePaxos {
+            proposers: proposers.clone(),
+            acceptors: acceptors.clone(),
+            replica_checkpoint: replica_checkpoint.broadcast_bincode(&acceptors),
+            paxos_config: PaxosConfig {
+                f,
+                i_am_leader_send_timeout,
+                i_am_leader_check_timeout,
+                i_am_leader_check_timeout_delay_multiplier,
+            },
         },
     );
 

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir.snap
@@ -1570,7 +1570,7 @@ expression: built.ir()
                                 acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos :: Proposer > , () > ({ use hydro_lang :: __staged :: stream :: * ; | count , _ | * count += 1 }),
                                 input: Tee {
                                     inner: <tee 15>: Map {
-                                        f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: cluster :: paxos :: Ballot , hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos :: Proposer > > ({ use crate :: __staged :: cluster :: paxos_with_client :: * ; | ballot : Ballot | ballot . proposer_id }),
+                                        f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: cluster :: paxos :: Ballot , hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos :: Proposer > > ({ use crate :: __staged :: cluster :: paxos :: * ; | ballot | ballot . proposer_id }),
                                         input: Reduce {
                                             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: cluster :: paxos :: Ballot , hydro_test :: cluster :: paxos :: Ballot , () > ({ use hydro_lang :: __staged :: stream :: * ; | curr , new | { if new > * curr { * curr = new ; } } }),
                                             input: Persist {


### PR DESCRIPTION

Extracts out the interface to invoking Paxos-like algorithms into a common trait.
