### PR TITLE
fix(dfir_rs): restore not running `two_pc_hf` test concurrently with others

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -6,7 +6,7 @@ filter = 'binary(deadlock_detector)'
 test-group = 'serial-integration'
 
 [[profile.default.overrides]]
-filter = 'binary(two_pc)'
+filter = 'binary(two_pc_hf)'
 test-group = 'serial-integration'
 
 [[profile.default.overrides]]


### PR DESCRIPTION

Nextest filter was broken accidentally by rename in #1601
