### PR TITLE
fix(stageleft)!: reduce where `#[cfg(stageleft_runtime)]` needs to be used

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,7 +217,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -270,7 +270,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -287,7 +287,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -304,7 +304,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -414,7 +414,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "str_inflector",
- "syn 2.0.75",
+ "syn 2.0.98",
  "try_match",
 ]
 
@@ -604,7 +604,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -849,7 +849,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn 2.0.75",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -899,7 +899,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -914,7 +914,7 @@ dependencies = [
  "rust-sitter",
  "rust-sitter-tool",
  "slotmap",
- "syn 2.0.75",
+ "syn 2.0.98",
  "tempfile",
 ]
 
@@ -933,7 +933,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slotmap",
- "syn 2.0.75",
+ "syn 2.0.98",
  "webbrowser",
 ]
 
@@ -948,7 +948,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.75",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1225,7 +1225,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1608,7 +1608,7 @@ dependencies = [
  "sha2",
  "stageleft",
  "stageleft_tool",
- "syn 2.0.75",
+ "syn 2.0.98",
  "tokio",
  "tokio-test",
  "toml",
@@ -1957,7 +1957,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2051,7 +2051,7 @@ checksum = "c33c1d4fa92364abfc42bcc58c201cfbb63ae80f5e471aac5c051db48dab6843"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2496,7 +2496,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2527,7 +2527,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2625,12 +2625,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.20"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
+checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
 dependencies = [
  "proc-macro2",
- "syn 2.0.75",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2645,9 +2645,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.88"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -2765,7 +2765,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2778,7 +2778,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2928,7 +2928,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2985,7 +2985,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3036,7 +3036,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d8e1c8d26b8d5fb23415a5123588669e776ad934abbfbe6d8677ed322694216"
 dependencies = [
  "quote",
- "syn 2.0.75",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3048,7 +3048,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-sitter-common",
- "syn 2.0.75",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3061,7 +3061,7 @@ dependencies = [
  "rust-sitter-common",
  "serde",
  "serde_json",
- "syn 2.0.75",
+ "syn 2.0.98",
  "syn-inline-mod",
  "tempfile",
  "tree-sitter",
@@ -3159,7 +3159,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3170,7 +3170,7 @@ checksum = "22f968c5ea23d555e670b449c1c5e7b2fc399fdaec1d304a17cd48e288abc107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3231,7 +3231,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3402,7 +3402,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "stageleft_macro",
- "syn 2.0.75",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3415,7 +3415,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha2",
- "syn 2.0.75",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3439,10 +3439,11 @@ dependencies = [
 name = "stageleft_tool"
 version = "0.5.0"
 dependencies = [
+ "prettyplease",
  "proc-macro2",
  "quote",
  "sha2",
- "syn 2.0.75",
+ "syn 2.0.98",
  "syn-inline-mod",
 ]
 
@@ -3493,9 +3494,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.75"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3509,7 +3510,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fa6dca1fdb7b2ed46dd534a326725419d4fb10f23d8c85a8b2860e5eb25d0f9"
 dependencies = [
  "proc-macro2",
- "syn 2.0.75",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3569,7 +3570,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3718,7 +3719,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3869,7 +3870,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3990,7 +3991,7 @@ checksum = "b9c81686f7ab4065ccac3df7a910c4249f8c0f3fb70421d6ddec19b9311f63f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4182,7 +4183,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.98",
  "variadics",
 ]
 
@@ -4274,7 +4275,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.98",
  "wasm-bindgen-shared",
 ]
 
@@ -4309,7 +4310,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.98",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4344,7 +4345,7 @@ checksum = "17d5042cc5fa009658f9a7333ef24291b1291a25b6382dd68862a7f3b969f69b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4399,7 +4400,7 @@ dependencies = [
  "quote",
  "serde",
  "serde-wasm-bindgen",
- "syn 2.0.75",
+ "syn 2.0.98",
  "tokio",
  "wasm-bindgen",
  "wasm-bindgen-test",
@@ -4715,7 +4716,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.98",
 ]
 
 [[package]]

--- a/hydro_lang/src/deploy/mod.rs
+++ b/hydro_lang/src/deploy/mod.rs
@@ -13,20 +13,23 @@ pub mod macro_runtime;
 pub use macro_runtime::*;
 
 #[cfg(feature = "deploy")]
+#[cfg(stageleft_runtime)]
 pub(crate) mod trybuild;
 
-// TODO(shadaj): has to be public due to stageleft limitations
 #[cfg(feature = "deploy")]
-#[doc(hidden)]
-pub mod trybuild_rewriters;
+#[cfg(stageleft_runtime)]
+mod trybuild_rewriters;
 
 #[cfg(feature = "deploy")]
+#[cfg(stageleft_runtime)]
 pub use trybuild::init_test;
 
 #[cfg(feature = "deploy")]
+#[cfg(stageleft_runtime)]
 pub mod deploy_graph;
 
 #[cfg(feature = "deploy")]
+#[cfg(stageleft_runtime)]
 pub use deploy_graph::*;
 
 pub mod in_memory_graph;

--- a/hydro_lang/src/lib.rs
+++ b/hydro_lang/src/lib.rs
@@ -46,7 +46,6 @@ mod staging_util;
 #[cfg(feature = "deploy")]
 pub mod test_util;
 
-#[stageleft::runtime]
 #[cfg(test)]
 mod test_init {
     #[ctor::ctor]

--- a/hydro_std/src/lib.rs
+++ b/hydro_std/src/lib.rs
@@ -4,7 +4,6 @@ pub mod compartmentalize;
 pub mod quorum;
 pub mod request_response;
 
-#[stageleft::runtime]
 #[cfg(test)]
 mod test_init {
     #[ctor::ctor]

--- a/hydro_test/src/lib.rs
+++ b/hydro_test/src/lib.rs
@@ -4,13 +4,11 @@ pub mod cluster;
 pub mod distributed;
 
 #[doc(hidden)]
-#[stageleft::runtime]
 #[cfg(doctest)]
 mod docs {
     dfir_macro::doctest_markdown_glob!("docs/docs/hydro/**/*.md*");
 }
 
-#[stageleft::runtime]
 #[cfg(test)]
 mod test_init {
     #[ctor::ctor]

--- a/hydro_test_local/Cargo.toml
+++ b/hydro_test_local/Cargo.toml
@@ -11,8 +11,10 @@ workspace = true
 stageleft_devel = []
 
 [dependencies]
-dfir_rs = { path = "../dfir_rs", version = "^0.11.0", default-features = false } # , features = ["debugging"] }
-hydro_lang = { path = "../hydro_lang", version = "^0.11.0", features = ["build"] }
+dfir_rs = { path = "../dfir_rs", version = "^0.11.0", default-features = false }
+hydro_lang = { path = "../hydro_lang", version = "^0.11.0", features = [
+    "build",
+] }
 stageleft = { path = "../stageleft", version = "^0.6.0" }
 rand = "0.8.0"
 
@@ -22,5 +24,8 @@ hydro_test_local_macro = { path = "../hydro_test_local_macro" }
 stageleft_tool = { path = "../stageleft_tool", version = "^0.5.0" }
 
 [dev-dependencies]
+dfir_rs = { path = "../dfir_rs", version = "^0.11.0", default-features = false, features = [
+    "meta",
+] }
 insta = "1.39"
 futures = "0.3.0"

--- a/hydro_test_local/src/local/chat_app.rs
+++ b/hydro_test_local/src/local/chat_app.rs
@@ -51,7 +51,7 @@ pub fn chat_app<'a>(
     flow.compile_no_network::<SingleProcessGraph>()
 }
 
-#[stageleft::runtime]
+#[cfg(stageleft_runtime)]
 #[cfg(test)]
 mod tests {
     use dfir_rs::assert_graphvis_snapshots;

--- a/hydro_test_local/src/local/count_elems.rs
+++ b/hydro_test_local/src/local/count_elems.rs
@@ -37,7 +37,7 @@ pub fn count_elems<'a>(
     count_elems_generic(flow, input_stream, output)
 }
 
-#[stageleft::runtime]
+#[cfg(stageleft_runtime)]
 #[cfg(test)]
 mod tests {
     use dfir_rs::assert_graphvis_snapshots;

--- a/hydro_test_local/src/local/first_ten.rs
+++ b/hydro_test_local/src/local/first_ten.rs
@@ -15,7 +15,7 @@ pub fn first_ten_runtime<'a>(flow: FlowBuilder<'a>) -> impl Quoted<'a, Dfir<'a>>
     flow.compile_no_network::<SingleProcessGraph>()
 }
 
-#[stageleft::runtime]
+#[cfg(stageleft_runtime)]
 #[cfg(test)]
 mod tests {
     #[test]

--- a/hydro_test_local/src/local/graph_reachability.rs
+++ b/hydro_test_local/src/local/graph_reachability.rs
@@ -41,7 +41,7 @@ pub fn graph_reachability<'a>(
     flow.compile_no_network::<SingleProcessGraph>()
 }
 
-#[stageleft::runtime]
+#[cfg(stageleft_runtime)]
 #[cfg(test)]
 mod tests {
     use dfir_rs::assert_graphvis_snapshots;

--- a/hydro_test_local/src/local/negation.rs
+++ b/hydro_test_local/src/local/negation.rs
@@ -73,7 +73,7 @@ pub fn test_anti_join<'a>(
     flow.compile_no_network::<SingleProcessGraph>()
 }
 
-#[stageleft::runtime]
+#[cfg(stageleft_runtime)]
 #[cfg(test)]
 mod tests {
     use dfir_rs::assert_graphvis_snapshots;

--- a/hydro_test_local/src/local/teed_join.rs
+++ b/hydro_test_local/src/local/teed_join.rs
@@ -49,7 +49,7 @@ pub fn teed_join<'a, S: Stream<Item = u32> + Unpin + 'a>(
         .with_dynamic_id(subgraph_id)
 }
 
-#[stageleft::runtime]
+#[cfg(stageleft_runtime)]
 #[cfg(test)]
 mod tests {
     use dfir_rs::assert_graphvis_snapshots;

--- a/stageleft/src/lib.rs
+++ b/stageleft/src/lib.rs
@@ -14,7 +14,7 @@ pub mod internal {
     pub type CaptureVec = Vec<(String, (Option<TokenStream>, Option<TokenStream>))>;
 }
 
-pub use stageleft_macro::{entry, q, quse_fn, runtime, top_level_mod};
+pub use stageleft_macro::{entry, q, quse_fn, top_level_mod};
 
 pub mod runtime_support;
 use runtime_support::FreeVariableWithContext;

--- a/stageleft_macro/src/lib.rs
+++ b/stageleft_macro/src/lib.rs
@@ -137,22 +137,6 @@ pub fn quse_fn(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     .into()
 }
 
-/// Marks a chunk of code as being runtime-only, which means that no staged code in its crate can depend on it.
-/// Code behind this attribute is allowed to use staged entrypoints defined in the same crate.
-#[proc_macro_attribute]
-pub fn runtime(
-    _attr: proc_macro::TokenStream,
-    input: proc_macro::TokenStream,
-) -> proc_macro::TokenStream {
-    // TODO(shadaj): when this is used for a struct, emit two versions:
-    // one that is runtime-only with public fields and one that is staged-only without
-    let input: TokenStream = input.into();
-    proc_macro::TokenStream::from(quote! {
-        #[cfg(not(stageleft_macro))]
-        #input
-    })
-}
-
 /// A utility for declaring top-level public modules in a Stageleft crate that exports macros.
 ///
 /// This gets around errors in compiling the macro crate when there
@@ -226,6 +210,9 @@ pub fn entry(
         syn::parse_macro_input!(attr with Punctuated<Type, Token![,]>::parse_terminated);
 
     let mut input = syn::parse_macro_input!(input as syn::ItemFn);
+    let input_visibility = input.vis.clone();
+    input.vis = syn::Visibility::Inherited; // normalize pub
+
     let input_name = &input.sig.ident;
 
     let input_generics = &input.sig.generics;
@@ -340,11 +327,11 @@ pub fn entry(
         .chars()
         .filter(|c| c.is_alphanumeric())
         .collect::<String>();
+
     let input_hash = "macro_".to_string() + &format!("{:X}", Sha256::digest(input_contents));
     let input_hash_ident = syn::Ident::new(&input_hash, Span::call_site());
     let input_hash_impl_ident = syn::Ident::new(&(input_hash + "_impl"), Span::call_site());
 
-    let input_visibility = input.vis.clone();
     input.vis = syn::parse_quote!(pub(crate));
 
     proc_macro::TokenStream::from(quote_spanned! {input.span()=>

--- a/stageleft_test/Cargo.toml
+++ b/stageleft_test/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 
 [features]
 stageleft_devel = []
+test_feature = []
 
 [dependencies]
 stageleft = { path = "../stageleft", version = "^0.6.0" }

--- a/stageleft_test/src/features.rs
+++ b/stageleft_test/src/features.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "test_feature")]
+pub struct Test {}

--- a/stageleft_test/src/lib.rs
+++ b/stageleft_test/src/lib.rs
@@ -2,6 +2,7 @@ stageleft::stageleft_crate!(stageleft_test_macro);
 
 use stageleft::{q, BorrowBounds, IntoQuotedOnce, Quoted, RuntimeData};
 
+pub(crate) mod features;
 pub(crate) mod submodule;
 
 #[stageleft::entry]
@@ -42,7 +43,7 @@ fn crate_paths<'a>(_ctx: BorrowBounds<'a>) -> impl Quoted<'a, bool> {
     q!(crate::my_top_level_function())
 }
 
-#[stageleft::runtime]
+#[cfg(stageleft_runtime)]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/stageleft_test_macro/Cargo.toml
+++ b/stageleft_test_macro/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2021"
 [lints]
 workspace = true
 
+[features]
+test_feature = []
+
 [lib]
 proc-macro = true
 path = "../stageleft_test/src/lib.rs"

--- a/stageleft_tool/Cargo.toml
+++ b/stageleft_tool/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/lib.rs"
 [dependencies]
 syn-inline-mod = "0.6.0"
 quote = "1.0.35"
-syn = { version = "2.0.46", features = [ "parsing", "extra-traits", "visit" ] }
+syn = { version = "2.0.46", features = ["parsing", "extra-traits", "visit"] }
 proc-macro2 = "1.0.74"
 sha2 = "0.10.0"
+prettyplease = "0.2.0"

--- a/template/hydro/src/lib.rs
+++ b/template/hydro/src/lib.rs
@@ -4,7 +4,6 @@ pub mod first_ten;
 pub mod first_ten_cluster;
 pub mod first_ten_distributed;
 
-#[stageleft::runtime]
 #[cfg(test)]
 mod test_init {
     #[ctor::ctor]

--- a/variadics_macro/Cargo.toml
+++ b/variadics_macro/Cargo.toml
@@ -15,9 +15,9 @@ proc-macro = true
 proc-macro2 = "1.0.63"
 proc-macro-crate = "1.1.0"
 quote = "1.0.0"
-syn = { version = "2.0.0", features = [ "full", "parsing", "visit-mut" ] }
+syn = { version = "2.0.0", features = ["full", "parsing", "visit-mut"] }
 variadics = { path = "../variadics", version = "^0.0.8" }
 
 [dev-dependencies]
 insta = "1.7.1"
-prettyplease = "0.2.20"
+prettyplease = "0.2.0"


### PR DESCRIPTION

Simplifies the logic for generating the public clone of the code, which eliminates the need to sprinkle `#[cfg(stageleft_runtime)]` (renamed from `#[stageleft::runtime]`) everywhere. Also adds logic to pass through `cfg` attrs when re-exporting public types.
