### PR TITLE
refactor(dfir_lang)!: require semicolons after loop braces, fix #1726

### DIFF
--- a/dfir_lang/src/parse.rs
+++ b/dfir_lang/src/parse.rs
@@ -227,6 +227,7 @@ pub struct LoopStatement {
     pub ident: Option<Ident>,
     pub brace_token: Brace,
     pub statements: Vec<DfirStatement>,
+    pub semi_token: Token![;],
 }
 impl Parse for LoopStatement {
     fn parse(input: ParseStream) -> syn::Result<Self> {
@@ -238,11 +239,13 @@ impl Parse for LoopStatement {
         while !content.is_empty() {
             statements.push(content.parse()?);
         }
+        let semi_token = input.parse()?;
         Ok(Self {
             loop_token,
             ident,
             brace_token,
             statements,
+            semi_token,
         })
     }
 }
@@ -255,6 +258,7 @@ impl ToTokens for LoopStatement {
                 statement.to_tokens(tokens);
             }
         });
+        self.semi_token.to_tokens(tokens);
     }
 }
 

--- a/dfir_rs/tests/compile-fail/surface_loop_cycle.rs
+++ b/dfir_rs/tests/compile-fail/surface_loop_cycle.rs
@@ -3,7 +3,7 @@ fn main() {
         loop {
             a = identity() -> identity() -> identity() -> identity();
             a -> a;
-        }
+        };
     };
     df.run_available();
 }

--- a/dfir_rs/tests/compile-fail/surface_loop_missing_semi.rs
+++ b/dfir_rs/tests/compile-fail/surface_loop_missing_semi.rs
@@ -2,9 +2,8 @@ fn main() {
     let mut df = dfir_rs::dfir_syntax! {
         a = source_iter(0..10);
         loop {
-            b = a -> batch();
-        };
-        b -> null();
+            a -> batch();
+        }
     };
     df.run_available();
 }

--- a/dfir_rs/tests/compile-fail/surface_loop_missing_semi.stderr
+++ b/dfir_rs/tests/compile-fail/surface_loop_missing_semi.stderr
@@ -1,0 +1,13 @@
+error: expected `;`
+ --> tests/compile-fail/surface_loop_missing_semi.rs:2:18
+  |
+2 |       let mut df = dfir_rs::dfir_syntax! {
+  |  __________________^
+3 | |         a = source_iter(0..10);
+4 | |         loop {
+5 | |             a -> batch();
+6 | |         }
+7 | |     };
+  | |_____^
+  |
+  = note: this error originates in the macro `dfir_rs::dfir_syntax` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/dfir_rs/tests/compile-fail/surface_loop_missing_windowing.rs
+++ b/dfir_rs/tests/compile-fail/surface_loop_missing_windowing.rs
@@ -3,7 +3,7 @@ fn main() {
         a = source_iter(0..10);
         loop {
             a -> null();
-        }
+        };
     };
     df.run_available();
 }

--- a/dfir_rs/tests/compile-fail/surface_loop_multiple_window.rs
+++ b/dfir_rs/tests/compile-fail/surface_loop_multiple_window.rs
@@ -4,8 +4,8 @@ fn main() {
         loop {
             loop {
                 a -> batch() -> null();
-            }
-        }
+            };
+        };
     };
     df.run_available();
 }

--- a/dfir_rs/tests/compile-fail/surface_loop_source.rs
+++ b/dfir_rs/tests/compile-fail/surface_loop_source.rs
@@ -2,7 +2,7 @@ fn main() {
     let mut df = dfir_rs::dfir_syntax! {
         loop {
             source_iter(0..10) -> null();
-        }
+        };
     };
     df.run_available();
 }

--- a/dfir_rs/tests/surface_loop.rs
+++ b/dfir_rs/tests/surface_loop.rs
@@ -15,7 +15,7 @@ pub fn test_flo_syntax() {
             cp = cross_join()
                 -> map(|item| (context.loop_iter_count(), item))
                 -> for_each(|x| result_send.send(x).unwrap());
-        }
+        };
     };
     assert_graphvis_snapshots!(df);
     df.run_available();
@@ -67,8 +67,8 @@ pub fn test_flo_nested() {
                     -> all_once()
                     -> map(|item| (context.current_tick().0, item))
                     -> for_each(|x| result_send.send(x).unwrap());
-            }
-        }
+            };
+        };
     };
     assert_graphvis_snapshots!(df);
     df.run_available();
@@ -119,8 +119,8 @@ pub fn test_flo_repeat_n() {
                 cp -> repeat_n(2)
                     -> inspect(|x| println!("{:?} {}", x, context.loop_iter_count()))
                     -> for_each(|x| result_send.send(x).unwrap());
-            }
-        }
+            };
+        };
     };
     assert_graphvis_snapshots!(df);
     df.run_available();
@@ -182,9 +182,9 @@ pub fn test_flo_repeat_n_nested() {
                     usrs3 -> repeat_n(3)
                         -> inspect(|x| println!("B {:?} {}", x, context.loop_iter_count()))
                         -> for_each(|x| result_send.send(x).unwrap());
-                }
-            }
-        }
+                };
+            };
+        };
     };
     assert_graphvis_snapshots!(df);
     df.run_available();
@@ -215,14 +215,14 @@ pub fn test_flo_repeat_n_multiple_nested() {
                     usrs3 -> repeat_n(3)
                     -> inspect(|x| println!("{} {:?} {}", line!(), x, context.loop_iter_count()))
                     -> for_each(|x| result1_send.send(x).unwrap());
-            }
-            loop {
-                usrs3 -> repeat_n(3)
-                    -> inspect(|x| println!("{} {:?} {}", line!(), x, context.loop_iter_count()))
-                    -> for_each(|x| result2_send.send(x).unwrap());
-                }
-            }
-        }
+                };
+                loop {
+                    usrs3 -> repeat_n(3)
+                        -> inspect(|x| println!("{} {:?} {}", line!(), x, context.loop_iter_count()))
+                        -> for_each(|x| result2_send.send(x).unwrap());
+                };
+            };
+        };
     };
     assert_graphvis_snapshots!(df);
     df.run_available();

--- a/dfir_rs/tests/surface_parser.rs
+++ b/dfir_rs/tests/surface_parser.rs
@@ -246,6 +246,6 @@ pub fn test_flo_syntax() {
             users -> batch() -> flatten() -> [0]cp;
             messages -> batch() -> flatten() -> [1]cp;
             cp = cross_join() -> for_each(|(user, message)| println!("notify {} of {}", user, message));
-        }
+        };
     }
 }


### PR DESCRIPTION
Is better for syntax highlighting.

BREAKING CHANGE: Need to add a semi colon `;` to after every `loop { ... };`.