### PR TITLE
feat(hydro_deploy, hydro_lang): make profiling runnable on macOS

### DIFF
--- a/hydro_deploy/core/src/localhost/mod.rs
+++ b/hydro_deploy/core/src/localhost/mod.rs
@@ -162,8 +162,9 @@ impl LaunchedHost for LaunchedLocalhost {
                 );
                 let dtrace_outfile = tempfile::NamedTempFile::new()?;
 
-                let mut command = Command::new("dtrace");
+                let mut command = Command::new("sudo");
                 command
+                    .arg("dtrace")
                     .arg("-o")
                     .arg(dtrace_outfile.as_ref())
                     .arg("-n")

--- a/hydro_lang/src/runtime_support/resource_measurement.rs
+++ b/hydro_lang/src/runtime_support/resource_measurement.rs
@@ -53,5 +53,13 @@ pub async fn run(flow: Dfir<'_>) {
         );
     }
 
+    #[cfg(not(target_os = "linux"))]
+    {
+        println!(
+            "{} Total {:.4}%, User {:.4}%, System {:.4}%",
+            CPU_USAGE_PREFIX, 100.0, 100.0, 0.0
+        );
+    }
+
     res.unwrap();
 }


### PR DESCRIPTION

As long as the user runs `sudo dtrace` shortly before launching a Hydro deployment with profiling (so that sudo inherits the recent permission grant), things work end-to-end. We don't currently support measuring user vs system time on non-Linux so stub out that logic with dummy values.
