### PR TITLE
fix(stageleft): don't emit imports when staged code is in a doctest

### DIFF
--- a/stageleft/src/lib.rs
+++ b/stageleft/src/lib.rs
@@ -412,7 +412,11 @@ impl<
             .skip(1)
             .cloned()
             .collect::<Vec<_>>();
-        let module_path = if module_path_segments.is_empty() {
+        let module_path = if module_path_segments.is_empty()
+            || module_path_segments
+                .iter()
+                .any(|segment| segment.ident.to_string().starts_with("__doctest"))
+        {
             None
         } else {
             Some(syn::Path {


### PR DESCRIPTION

We have no way of generating the `__staged` variant of an `__doctest` module (in Rust 2024), so we skip adding that import. This means that any imports outside the quoted code will not function inside quoted code (existing behavior in Rust 2021).
