### PR TITLE
chore: template `.gitignore`s, ignore `target/`, track `Cargo.lock`

### DIFF
--- a/template/dfir/.gitignore
+++ b/template/dfir/.gitignore
@@ -1,1 +1,1 @@
-/Cargo.lock
+/target/

--- a/template/hydro/.gitignore
+++ b/template/hydro/.gitignore
@@ -1,1 +1,1 @@
-/Cargo.lock
+/target/


### PR DESCRIPTION
Ignoring `Cargo.lock` was a remnant from the separate template repo, but `Cargo.lock` has always been recommended to be tracked in consuming bin crates