### PR TITLE
fix(hydro_test): add "--no-rosegment" to LLD flags when running perf on remote Linux

### DIFF
--- a/hydro_deploy/core/src/progress.rs
+++ b/hydro_deploy/core/src/progress.rs
@@ -375,6 +375,17 @@ impl ProgressTracker {
         });
     }
 
+    pub fn eprintln(msg: impl AsRef<str>) {
+        let progress_bar = PROGRESS_TRACKER
+            .get_or_init(|| Mutex::new(ProgressTracker::new()))
+            .lock()
+            .unwrap();
+
+        progress_bar.multi_progress.suspend(|| {
+            eprintln!("{}", msg.as_ref());
+        });
+    }
+
     pub fn with_group<'a, T, F: Future<Output = T>>(
         name: impl Into<String>,
         anticipated_total: Option<usize>,

--- a/hydro_deploy/core/src/ssh.rs
+++ b/hydro_deploy/core/src/ssh.rs
@@ -15,11 +15,13 @@ use hydroflow_deploy_integration::ServerBindConfig;
 use inferno::collapse::Collapse;
 use inferno::collapse::perf::Folder;
 use nanoid::nanoid;
-use tokio::io::BufReader as TokioBufReader;
+use tokio::fs::File;
+use tokio::io::{AsyncReadExt, BufReader as TokioBufReader};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::runtime::Handle;
 use tokio::sync::{mpsc, oneshot};
 use tokio_stream::StreamExt;
+use tokio_util::compat::FuturesAsyncReadCompatExt;
 use tokio_util::io::SyncIoBridge;
 
 use crate::hydroflow_crate::build::BuildOutput;
@@ -127,7 +129,41 @@ impl LaunchedBinary for LaunchedSshBinary {
 
         // Run perf post-processing and download perf output.
         if let Some(tracing) = self.tracing.as_ref() {
-            let mut script_channel = self.session.as_ref().unwrap().channel_session().await?;
+            let session = self.session.as_ref().unwrap();
+            if let Some(local_raw_perf) = tracing.perf_raw_outfile.as_ref() {
+                ProgressTracker::progress_leaf("downloading perf data", |progress, _| async move {
+                    let sftp = async_retry(
+                        &|| async { Ok(session.sftp().await?) },
+                        10,
+                        Duration::from_secs(1),
+                    )
+                    .await?;
+
+                    let mut remote_raw_perf = sftp.open(&PathBuf::from(PERF_OUTFILE)).await?;
+                    let mut local_raw_perf = File::create(local_raw_perf).await?;
+
+                    let total_size = remote_raw_perf.stat().await?.size.unwrap();
+                    let mut remote_tokio = remote_raw_perf.compat();
+
+                    use tokio::io::AsyncWriteExt;
+                    let mut index = 0;
+                    loop {
+                        let mut buffer = [0; 16 * 1024];
+                        let n = remote_tokio.read(&mut buffer).await?;
+                        if n == 0 {
+                            break;
+                        }
+                        local_raw_perf.write_all(&buffer[..n]).await?;
+                        index += n;
+                        progress(((index as f64 / total_size as f64) * 100.0) as u64);
+                    }
+
+                    Ok::<(), anyhow::Error>(())
+                })
+                .await?;
+            }
+
+            let mut script_channel = session.channel_session().await?;
             let mut fold_er = Folder::from(tracing.fold_perf_options.clone().unwrap_or_default());
 
             let fold_data = ProgressTracker::leaf("perf script & folding", async move {
@@ -139,7 +175,7 @@ impl LaunchedBinary for LaunchedSshBinary {
                     async move {
                         // Log stderr.
                         while let Some(Ok(s)) = stderr_lines.next().await {
-                            ProgressTracker::println(format!("[perf stderr] {s}"));
+                            ProgressTracker::eprintln(format!("[perf stderr] {s}"));
                         }
                         Result::<_>::Ok(())
                     },

--- a/hydro_deploy/core/src/terraform.rs
+++ b/hydro_deploy/core/src/terraform.rs
@@ -222,7 +222,7 @@ fn filter_terraform_logs(child: &mut Child) {
                     && split.next().is_some()
                     && split.next().is_none()
                 {
-                    println!("[terraform] {}", line);
+                    eprintln!("[terraform] {}", line);
                 }
             }
         } else {

--- a/hydro_test/examples/perf_compute_pi.rs
+++ b/hydro_test/examples/perf_compute_pi.rs
@@ -21,25 +21,40 @@ async fn main() {
     let mut deployment = Deployment::new();
     let host_arg = std::env::args().nth(1).unwrap_or_default();
 
-    let rustflags = "-C opt-level=3 -C codegen-units=1 -C strip=none -C debuginfo=2 -C lto=off";
-    let create_host: HostCreator = if host_arg == *"gcp" {
-        let project = std::env::args().nth(2).unwrap();
-        let network = Arc::new(RwLock::new(GcpNetwork::new(&project, None)));
+    let project = if host_arg == "gcp" {
+        std::env::args().nth(2)
+    } else {
+        None
+    };
+
+    let network = if let Some(project) = project.as_ref() {
+        Some(Arc::new(RwLock::new(GcpNetwork::new(project, None))))
+    } else {
+        None
+    };
+
+    let create_host: HostCreator = if host_arg == "gcp" {
         Box::new(move |deployment| -> Arc<dyn Host> {
             let startup_script = "sudo sh -c 'apt update && apt install -y linux-perf binutils && echo -1 > /proc/sys/kernel/perf_event_paranoid && echo 0 > /proc/sys/kernel/kptr_restrict'";
             deployment
                 .GcpComputeEngineHost()
-                .project(&project)
+                .project(project.as_ref().unwrap())
                 .machine_type("e2-micro")
                 .image("debian-cloud/debian-11")
                 .region("us-west1-a")
-                .network(network.clone())
+                .network(network.as_ref().unwrap().clone())
                 .startup_script(startup_script)
                 .add()
         })
     } else {
         let localhost = deployment.Localhost();
         Box::new(move |_| -> Arc<dyn Host> { localhost.clone() })
+    };
+
+    let rustflags = if host_arg == "gcp" {
+        "-C opt-level=3 -C codegen-units=1 -C strip=none -C debuginfo=2 -C lto=off -C link-args=--no-rosegment"
+    } else {
+        "-C opt-level=3 -C codegen-units=1 -C strip=none -C debuginfo=2 -C lto=off"
     };
 
     let builder = hydro_lang::FlowBuilder::new();

--- a/hydro_test/examples/perf_paxos.rs
+++ b/hydro_test/examples/perf_paxos.rs
@@ -18,23 +18,22 @@ type HostCreator = Box<dyn Fn(&mut Deployment) -> Arc<dyn Host>>;
 
 fn cluster_specs(
     host_arg: &str,
+    project: Option<String>,
+    network: Option<Arc<RwLock<GcpNetwork>>>,
     deployment: &mut Deployment,
     cluster_name: &str,
     num_nodes: usize,
 ) -> Vec<TrybuildHost> {
     let create_host: HostCreator = if host_arg == "gcp" {
-        let project = std::env::args().nth(2).unwrap();
-        let network = Arc::new(RwLock::new(GcpNetwork::new(&project, None)));
-
         Box::new(move |deployment| -> Arc<dyn Host> {
             let startup_script = "sudo sh -c 'apt update && apt install -y linux-perf binutils && echo -1 > /proc/sys/kernel/perf_event_paranoid && echo 0 > /proc/sys/kernel/kptr_restrict'";
             deployment
                 .GcpComputeEngineHost()
-                .project(&project)
+                .project(project.as_ref().unwrap())
                 .machine_type("n2-highcpu-2")
                 .image("debian-cloud/debian-11")
                 .region("us-west1-a")
-                .network(network.clone())
+                .network(network.as_ref().unwrap().clone())
                 .startup_script(startup_script)
                 .add()
         })
@@ -43,7 +42,11 @@ fn cluster_specs(
         Box::new(move |_| -> Arc<dyn Host> { localhost.clone() })
     };
 
-    let rustflags = "-C opt-level=3 -C codegen-units=1 -C strip=none -C debuginfo=2 -C lto=off";
+    let rustflags = if host_arg == "gcp" {
+        "-C opt-level=3 -C codegen-units=1 -C strip=none -C debuginfo=2 -C lto=off -C link-args=--no-rosegment"
+    } else {
+        "-C opt-level=3 -C codegen-units=1 -C strip=none -C debuginfo=2 -C lto=off"
+    };
 
     (0..num_nodes)
         .map(|idx| {
@@ -107,22 +110,63 @@ async fn main() {
             insert_counter::insert_counter(leaf, counter_output_duration);
         });
     let mut ir = deep_clone(optimized.ir());
+
+    let project = if host_arg == "gcp" {
+        std::env::args().nth(2)
+    } else {
+        None
+    };
+
+    let network = if let Some(project) = project.as_ref() {
+        Some(Arc::new(RwLock::new(GcpNetwork::new(project, None))))
+    } else {
+        None
+    };
+
     let nodes = optimized
         .with_cluster(
             &proposers,
-            cluster_specs(&host_arg, &mut deployment, "proposer", f + 1),
+            cluster_specs(
+                &host_arg,
+                project.clone(),
+                network.clone(),
+                &mut deployment,
+                "proposer",
+                f + 1,
+            ),
         )
         .with_cluster(
             &acceptors,
-            cluster_specs(&host_arg, &mut deployment, "acceptor", 2 * f + 1),
+            cluster_specs(
+                &host_arg,
+                project.clone(),
+                network.clone(),
+                &mut deployment,
+                "acceptor",
+                2 * f + 1,
+            ),
         )
         .with_cluster(
             &clients,
-            cluster_specs(&host_arg, &mut deployment, "client", num_clients),
+            cluster_specs(
+                &host_arg,
+                project.clone(),
+                network.clone(),
+                &mut deployment,
+                "client",
+                num_clients,
+            ),
         )
         .with_cluster(
             &replicas,
-            cluster_specs(&host_arg, &mut deployment, "replica", f + 1),
+            cluster_specs(
+                &host_arg,
+                project.clone(),
+                network.clone(),
+                &mut deployment,
+                "replica",
+                f + 1,
+            ),
         )
         .deploy(&mut deployment);
 


### PR DESCRIPTION

On older Linux, `--no-rosegment` is required to get meaningful call graphs from `perf`. See https://github.com/llvm/llvm-project/issues/53156.
