### PR TITLE
fix(hydro_lang): fix codegen non-determinism that triggers rebuilds

### DIFF
--- a/hydro_deploy/core/src/rust_crate/mod.rs
+++ b/hydro_deploy/core/src/rust_crate/mod.rs
@@ -117,11 +117,15 @@ impl RustCrate {
     }
 
     pub fn features(mut self, features: impl IntoIterator<Item = impl Into<String>>) -> Self {
-        if self.features.is_some() {
-            panic!("{} already set", name_of!(features in Self));
+        if self.features.is_none() {
+            self.features = Some(vec![]);
         }
 
-        self.features = Some(features.into_iter().map(|s| s.into()).collect());
+        self.features
+            .as_mut()
+            .unwrap()
+            .extend(features.into_iter().map(|s| s.into()));
+
         self
     }
 

--- a/hydro_lang/src/builder/deploy.rs
+++ b/hydro_lang/src/builder/deploy.rs
@@ -183,7 +183,11 @@ impl<'a, D: Deploy<'a>> DeployFlow<'a, D> {
 
     fn extra_stmts(&self, env: &<D as Deploy<'a>>::CompileEnv) -> BTreeMap<usize, Vec<syn::Stmt>> {
         let mut extra_stmts: BTreeMap<usize, Vec<syn::Stmt>> = BTreeMap::new();
-        for &c_id in self.clusters.keys() {
+
+        let mut all_clusters_sorted = self.clusters.keys().collect::<Vec<_>>();
+        all_clusters_sorted.sort();
+
+        for &c_id in all_clusters_sorted {
             let self_id_ident = syn::Ident::new(
                 &format!("__hydro_lang_cluster_self_id_{}", c_id),
                 Span::call_site(),


### PR DESCRIPTION

Also makes the generated `Cargo.toml` fixed regardless of the "extra Hydro features" or "test mode", by shifting them into special features defined on the trybuild repo. Overall, this results in the only dynamic piece being the generated `src/bin` files, which means that deploying the same code multiple times does not result in any recompilation.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydro-project/hydro/pull/1779).
* #1780
* __->__ #1779