### PR TITLE
fix: update RunLLM assistant ID to match new account

### DIFF
--- a/docs/src/pages/askai.js
+++ b/docs/src/pages/askai.js
@@ -21,7 +21,7 @@ export default function AskAI() {
       script.setAttribute("runllm-keyboard-shortcut", "Mod+j");
       script.setAttribute("runllm-name", "Hydro");
       script.setAttribute("runllm-position", "TOP_RIGHT");
-      script.setAttribute("runllm-assistant-id", "136");
+      script.setAttribute("runllm-assistant-id", "600");
       script.setAttribute("runllm-preset", "docusaurus");
       script.setAttribute("runllm-brand-logo", "img/hydro-turtle.png");
 


### PR DESCRIPTION
The old AI assistant was set up by hand by RunLLM staff. We now have an assistant set up via their canonical self-service pipeline, under my berkeley credentials, which should be easier to manage/share.