### PR TITLE
fix(hydro_deploy)!: fix perf setup, remove GCP `startup_script`, use `TracingOptions::setup_command` instead

### DIFF
--- a/hydro_deploy/core/src/deployment.rs
+++ b/hydro_deploy/core/src/deployment.rs
@@ -233,19 +233,9 @@ impl Deployment {
         region: String,
         network: Arc<RwLock<GcpNetwork>>,
         user: Option<String>,
-        startup_script: Option<String>,
     ) -> Arc<GcpComputeEngineHost> {
         self.add_host(|id| {
-            GcpComputeEngineHost::new(
-                id,
-                project,
-                machine_type,
-                image,
-                region,
-                network,
-                user,
-                startup_script,
-            )
+            GcpComputeEngineHost::new(id, project, machine_type, image, region, network, user)
         })
     }
 

--- a/hydro_deploy/core/src/gcp.rs
+++ b/hydro_deploy/core/src/gcp.rs
@@ -178,16 +178,11 @@ pub struct GcpComputeEngineHost {
     region: String,
     network: Arc<RwLock<GcpNetwork>>,
     user: Option<String>,
-    startup_script: Option<String>,
     pub launched: OnceLock<Arc<LaunchedComputeEngine>>, // TODO(mingwei): fix pub
     external_ports: Mutex<Vec<u16>>,
 }
 
 impl GcpComputeEngineHost {
-    #[expect(
-        clippy::too_many_arguments,
-        reason = "internal code called by builder elsewhere"
-    )]
     pub fn new(
         id: usize,
         project: impl Into<String>,
@@ -196,7 +191,6 @@ impl GcpComputeEngineHost {
         region: impl Into<String>,
         network: Arc<RwLock<GcpNetwork>>,
         user: Option<String>,
-        startup_script: Option<String>,
     ) -> Self {
         Self {
             id,
@@ -206,7 +200,6 @@ impl GcpComputeEngineHost {
             region: region.into(),
             network,
             user,
-            startup_script,
             launched: OnceLock::new(),
             external_ports: Mutex::new(Vec::new()),
         }
@@ -422,7 +415,6 @@ impl Host for GcpComputeEngineHost {
                         }
                     ],
                     "network_interface": external_interfaces,
-                    "metadata_startup_script": self.startup_script,
                 }),
             );
 

--- a/hydro_deploy/core/src/rust_crate/tracing_options.rs
+++ b/hydro_deploy/core/src/rust_crate/tracing_options.rs
@@ -12,6 +12,12 @@ use inferno::collapse::perf::Options as PerfOptions;
 
 type FlamegraphOptions = inferno::flamegraph::Options<'static>;
 
+/// `Cow<'static, str>`.
+///
+/// `buildstructor` doesn't support `Into<_>` for types with parameters (like `Cow<'static, str>`),
+/// so we trick it by defining a type alias.
+pub type CowStr = Cow<'static, str>;
+
 #[derive(Clone, buildstructor::Builder)]
 #[non_exhaustive] // Prevent direct construction.
 pub struct TracingOptions {
@@ -40,7 +46,7 @@ pub struct TracingOptions {
     /// NOTE: Currently is only run for remote/cloud ssh hosts, not local hosts.
     ///
     /// Example: see [`DEBIAN_PERF_SETUP_COMMAND`].
-    pub setup_command: Option<Cow<'static, str>>,
+    pub setup_command: Option<CowStr>,
 }
 
 pub const DEBIAN_PERF_SETUP_COMMAND: &str = "sudo sh -c 'apt update && apt install -y linux-perf binutils && echo -1 > /proc/sys/kernel/perf_event_paranoid && echo 0 > /proc/sys/kernel/kptr_restrict'";

--- a/hydro_deploy/core/src/rust_crate/tracing_options.rs
+++ b/hydro_deploy/core/src/rust_crate/tracing_options.rs
@@ -4,6 +4,7 @@
     reason = "https://github.com/BrynCooke/buildstructor/issues/192"
 )]
 
+use std::borrow::Cow;
 use std::path::PathBuf;
 
 use inferno::collapse::dtrace::Options as DtraceOptions;
@@ -33,4 +34,13 @@ pub struct TracingOptions {
     pub flamegraph_outfile: Option<PathBuf>,
     // This type is super annoying and isn't `clone` and has a lifetime... so wrap in fn pointer for now.
     pub flamegraph_options: Option<fn() -> FlamegraphOptions>,
+
+    /// Command to setup tracing before running the command, i.e. to install `perf` or set kernel flags.
+    ///
+    /// NOTE: Currently is only run for remote/cloud ssh hosts, not local hosts.
+    ///
+    /// Example: see [`DEBIAN_PERF_SETUP_COMMAND`].
+    pub setup_command: Option<Cow<'static, str>>,
 }
+
+pub const DEBIAN_PERF_SETUP_COMMAND: &str = "sudo sh -c 'apt update && apt install -y linux-perf binutils && echo -1 > /proc/sys/kernel/perf_event_paranoid && echo 0 > /proc/sys/kernel/kptr_restrict'";

--- a/hydro_deploy/core/src/ssh.rs
+++ b/hydro_deploy/core/src/ssh.rs
@@ -324,6 +324,17 @@ pub trait LaunchedSshHost: Send + Sync {
     }
 }
 
+async fn create_channel(session: &AsyncSession<TcpStream>) -> Result<AsyncChannel<TcpStream>> {
+    async_retry(
+        &|| async {
+            Ok(tokio::time::timeout(Duration::from_secs(60), session.channel_session()).await??)
+        },
+        10,
+        Duration::from_secs(1),
+    )
+    .await
+}
+
 #[async_trait]
 impl<T: LaunchedSshHost> LaunchedHost for T {
     fn server_config(&self, bind_type: &ServerStrategy) -> ServerBindConfig {
@@ -414,22 +425,9 @@ impl<T: LaunchedSshHost> LaunchedHost for T {
         let user = self.ssh_user();
         let binary_path = PathBuf::from(format!("/home/{user}/hydro-{unique_name}"));
 
-        let channel = ProgressTracker::leaf(
-            format!("launching binary {}", binary_path.display()),
+        let channel = ProgressTracker::leaf(format!("launching binary {}", binary_path.display()),
             async {
-                let mut channel =
-                    async_retry(
-                        &|| async {
-                            Ok(tokio::time::timeout(
-                                Duration::from_secs(60),
-                                session.channel_session(),
-                            )
-                            .await??)
-                        },
-                        10,
-                        Duration::from_secs(1),
-                    )
-                    .await?;
+                let mut channel = create_channel(&session).await?;
 
                 let mut command = binary_path.to_str().unwrap().to_owned();
                 for arg in args{
@@ -438,6 +436,26 @@ impl<T: LaunchedSshHost> LaunchedHost for T {
                 }
                 // Launch with perf if specified, also copy local binary to expected place for perf report to work
                 if let Some(TracingOptions { frequency, .. }) = tracing.clone() {
+
+                    // Install perf
+                    let mut perf_install_channel = create_channel(&session).await?;
+                    perf_install_channel
+                        .exec("sudo sh -c 'apt update && apt install -y linux-perf binutils && echo -1 > /proc/sys/kernel/perf_event_paranoid && echo 0 > /proc/sys/kernel/kptr_restrict'")
+                        .await?;
+
+                    // log outputs
+                    let mut perf_install_out = FuturesBufReader::new(perf_install_channel.stream(0)).lines();
+                    while let Some(line) = perf_install_out.next().await {
+                        ProgressTracker::eprintln(format!("[install perf] {}", line.unwrap()));
+                    }
+
+                    perf_install_channel.wait_eof().await?;
+                    let exit_code = perf_install_channel.exit_status()?;
+                    perf_install_channel.wait_close().await?;
+                    if exit_code != 0 {
+                        anyhow::bail!("Failed to install perf on remote host");
+                    }
+
                     // Attach perf to the command
                     command = format!(
                         "perf record -F {frequency} -e cycles:u --call-graph dwarf,65528 -o {PERF_OUTFILE} {command}",
@@ -445,7 +463,7 @@ impl<T: LaunchedSshHost> LaunchedHost for T {
                 }
                 channel.exec(&command).await?;
                 anyhow::Ok(channel)
-            },
+            }
         )
         .await?;
 

--- a/hydro_deploy/hydro_cli/src/lib.rs
+++ b/hydro_deploy/hydro_cli/src/lib.rs
@@ -187,7 +187,6 @@ impl Deployment {
         region: String,
         network: GcpNetwork,
         user: Option<String>,
-        startup_script: Option<String>,
     ) -> PyResult<Py<PyAny>> {
         let arc = self.underlying.blocking_write().add_host(|id| {
             core::GcpComputeEngineHost::new(
@@ -198,7 +197,6 @@ impl Deployment {
                 region,
                 network.underlying,
                 user,
-                startup_script,
             )
         });
 

--- a/hydro_test/examples/perf_compute_pi.rs
+++ b/hydro_test/examples/perf_compute_pi.rs
@@ -41,7 +41,6 @@ async fn main() {
 
     let create_host: HostCreator = if host_arg == "gcp" {
         Box::new(move |deployment| -> Arc<dyn Host> {
-            let startup_script = "sudo sh -c 'apt update && apt install -y linux-perf binutils && echo -1 > /proc/sys/kernel/perf_event_paranoid && echo 0 > /proc/sys/kernel/kptr_restrict'";
             deployment
                 .GcpComputeEngineHost()
                 .project(project.as_ref().unwrap())
@@ -49,7 +48,6 @@ async fn main() {
                 .image("debian-cloud/debian-11")
                 .region("us-west1-a")
                 .network(network.as_ref().unwrap().clone())
-                .startup_script(startup_script)
                 .add()
         })
     } else {

--- a/hydro_test/examples/perf_compute_pi.rs
+++ b/hydro_test/examples/perf_compute_pi.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use hydro_deploy::gcp::GcpNetwork;
-use hydro_deploy::rust_crate::tracing_options::TracingOptions;
+use hydro_deploy::rust_crate::tracing_options::{DEBIAN_PERF_SETUP_COMMAND, TracingOptions};
 use hydro_deploy::{Deployment, Host};
 use hydro_lang::deploy::{DeployCrateWrapper, TrybuildHost};
 use hydro_lang::ir::deep_clone;
@@ -84,6 +84,7 @@ async fn main() {
                         .fold_outfile("leader.data.folded")
                         .flamegraph_outfile("leader.svg")
                         .frequency(frequency)
+                        .setup_command(DEBIAN_PERF_SETUP_COMMAND)
                         .build(),
                 ),
         )
@@ -100,6 +101,7 @@ async fn main() {
                             .fold_outfile(format!("cluster{}.data.folded", idx))
                             .flamegraph_outfile(format!("cluster{}.svg", idx))
                             .frequency(frequency)
+                            .setup_command(DEBIAN_PERF_SETUP_COMMAND)
                             .build(),
                     )
             }),

--- a/hydro_test/examples/perf_paxos.rs
+++ b/hydro_test/examples/perf_paxos.rs
@@ -26,7 +26,6 @@ fn cluster_specs(
 ) -> Vec<TrybuildHost> {
     let create_host: HostCreator = if host_arg == "gcp" {
         Box::new(move |deployment| -> Arc<dyn Host> {
-            let startup_script = "sudo sh -c 'apt update && apt install -y linux-perf binutils && echo -1 > /proc/sys/kernel/perf_event_paranoid && echo 0 > /proc/sys/kernel/kptr_restrict'";
             deployment
                 .GcpComputeEngineHost()
                 .project(project.as_ref().unwrap())
@@ -34,7 +33,6 @@ fn cluster_specs(
                 .image("debian-cloud/debian-11")
                 .region("us-west1-a")
                 .network(network.as_ref().unwrap().clone())
-                .startup_script(startup_script)
                 .add()
         })
     } else {

--- a/hydro_test/examples/perf_paxos.rs
+++ b/hydro_test/examples/perf_paxos.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use hydro_deploy::gcp::GcpNetwork;
-use hydro_deploy::rust_crate::tracing_options::TracingOptions;
+use hydro_deploy::rust_crate::tracing_options::{DEBIAN_PERF_SETUP_COMMAND, TracingOptions};
 use hydro_deploy::{Deployment, Host};
 use hydro_lang::deploy::{DeployCrateWrapper, TrybuildHost};
 use hydro_lang::ir::deep_clone;
@@ -56,6 +56,7 @@ fn cluster_specs(
                         .perf_raw_outfile(format!("{}{}.perf.data", cluster_name, idx))
                         .fold_outfile(format!("{}{}.data.folded", cluster_name, idx))
                         .frequency(128)
+                        .setup_command(DEBIAN_PERF_SETUP_COMMAND)
                         .build(),
                 )
         })


### PR DESCRIPTION
BREAKING CHANGE: `startup_script` on GCP no longer exists, use `TracingOptions::setup_command` instead.