### PR TITLE
feat(hydro_lang): only serialize once in broadcast

### DIFF
--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__many_to_many__tests__many_to_many.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__many_to_many__tests__many_to_many.snap
@@ -11,28 +11,39 @@ expression: built.ir()
                 0,
             ),
             to_key: None,
-            serialize_fn: Some(
-                :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , i32) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
-            ),
+            serialize_fn: None,
             instantiate_fn: <network instantiate>,
             deserialize_fn: Some(
                 | res | { let (id , b) = res . unwrap () ; (hydro_lang :: ClusterId :: < () > :: from_raw (id) , hydro_lang :: runtime_support :: bincode :: deserialize :: < i32 > (& b) . unwrap ()) },
             ),
             input: FlatMap {
-                f: stageleft :: runtime_support :: fn1_type_hint :: < i32 , std :: iter :: Map < std :: slice :: Iter < hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < () > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < () >] > (__hydro_lang_cluster_ids_0) } ; | b | ids__free . iter () . map (move | id | (:: std :: clone :: Clone :: clone (id) , :: std :: clone :: Clone :: clone (& b))) }),
-                input: Source {
-                    source: Iter(
-                        { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: many_to_many :: * ; 0 .. 2 },
-                    ),
-                    location_kind: Cluster(
-                        0,
-                    ),
+                f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: bytes :: Bytes , std :: iter :: Map < std :: slice :: Iter < hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < () > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < () >] > (__hydro_lang_cluster_ids_0) } ; | v | { ids__free . iter () . map (move | id | (id . raw_id , v . clone ())) } }),
+                input: Map {
+                    f: stageleft :: runtime_support :: fn1_type_hint :: < i32 , hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: bytes :: Bytes > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | v | bincode :: serialize (& v) . unwrap () . into () }),
+                    input: Source {
+                        source: Iter(
+                            { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: many_to_many :: * ; 0 .. 2 },
+                        ),
+                        location_kind: Cluster(
+                            0,
+                        ),
+                        metadata: HydroIrMetadata {
+                            location_kind: Cluster(
+                                0,
+                            ),
+                            output_type: Some(
+                                i32,
+                            ),
+                            cardinality: None,
+                            cpu_usage: None,
+                        },
+                    },
                     metadata: HydroIrMetadata {
                         location_kind: Cluster(
                             0,
                         ),
                         output_type: Some(
-                            i32,
+                            hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: bytes :: Bytes,
                         ),
                         cardinality: None,
                         cpu_usage: None,
@@ -43,7 +54,7 @@ expression: built.ir()
                         0,
                     ),
                     output_type: Some(
-                        (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < () > , i32),
+                        (u32 , hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: bytes :: Bytes),
                     ),
                     cardinality: None,
                     cpu_usage: None,

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir.snap
@@ -371,32 +371,43 @@ expression: built.ir()
                         0,
                     ),
                     to_key: None,
-                    serialize_fn: Some(
-                        :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , hydro_test :: cluster :: paxos :: Ballot) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
-                    ),
+                    serialize_fn: None,
                     instantiate_fn: <network instantiate>,
                     deserialize_fn: Some(
                         | res | { let (id , b) = res . unwrap () ; (hydro_lang :: ClusterId :: < hydro_test :: cluster :: paxos :: Proposer > :: from_raw (id) , hydro_lang :: runtime_support :: bincode :: deserialize :: < hydro_test :: cluster :: paxos :: Ballot > (& b) . unwrap ()) },
                     ),
                     input: FlatMap {
-                        f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: cluster :: paxos :: Ballot , std :: iter :: Map < std :: slice :: Iter < hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos :: Proposer > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: cluster :: paxos :: Proposer >] > (__hydro_lang_cluster_ids_0) } ; | b | ids__free . iter () . map (move | id | (:: std :: clone :: Clone :: clone (id) , :: std :: clone :: Clone :: clone (& b))) }),
+                        f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: bytes :: Bytes , std :: iter :: Map < std :: slice :: Iter < hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos :: Proposer > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: cluster :: paxos :: Proposer >] > (__hydro_lang_cluster_ids_0) } ; | v | { ids__free . iter () . map (move | id | (id . raw_id , v . clone ())) } }),
                         input: Map {
-                            f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: cluster :: paxos :: Ballot , ()) , hydro_test :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: optional :: * ; | (d , _signal) | d }),
-                            input: CrossSingleton {
-                                left: Map {
-                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: cluster :: paxos :: Ballot , ()) , hydro_test :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: singleton :: * ; | (d , _signal) | d }),
-                                    input: CrossSingleton {
-                                        left: Tee {
-                                            inner: <tee 3>: Map {
-                                                f: stageleft :: runtime_support :: fn1_type_hint :: < u32 , hydro_test :: cluster :: paxos :: Ballot > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: ClusterId :: < hydro_test :: cluster :: paxos :: Proposer > :: from_raw (__hydro_lang_cluster_self_id_0) ; move | num | Ballot { num , proposer_id : CLUSTER_SELF_ID__free } }),
-                                                input: Tee {
-                                                    inner: <tee 1>,
+                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: cluster :: paxos :: Ballot , hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: bytes :: Bytes > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | v | bincode :: serialize (& v) . unwrap () . into () }),
+                            input: Map {
+                                f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: cluster :: paxos :: Ballot , ()) , hydro_test :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: optional :: * ; | (d , _signal) | d }),
+                                input: CrossSingleton {
+                                    left: Map {
+                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: cluster :: paxos :: Ballot , ()) , hydro_test :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: singleton :: * ; | (d , _signal) | d }),
+                                        input: CrossSingleton {
+                                            left: Tee {
+                                                inner: <tee 3>: Map {
+                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < u32 , hydro_test :: cluster :: paxos :: Ballot > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: ClusterId :: < hydro_test :: cluster :: paxos :: Proposer > :: from_raw (__hydro_lang_cluster_self_id_0) ; move | num | Ballot { num , proposer_id : CLUSTER_SELF_ID__free } }),
+                                                    input: Tee {
+                                                        inner: <tee 1>,
+                                                        metadata: HydroIrMetadata {
+                                                            location_kind: Cluster(
+                                                                0,
+                                                            ),
+                                                            output_type: Some(
+                                                                u32,
+                                                            ),
+                                                            cardinality: None,
+                                                            cpu_usage: None,
+                                                        },
+                                                    },
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Cluster(
                                                             0,
                                                         ),
                                                         output_type: Some(
-                                                            u32,
+                                                            hydro_test :: cluster :: paxos :: Ballot,
                                                         ),
                                                         cardinality: None,
                                                         cpu_usage: None,
@@ -413,30 +424,30 @@ expression: built.ir()
                                                     cpu_usage: None,
                                                 },
                                             },
-                                            metadata: HydroIrMetadata {
-                                                location_kind: Cluster(
-                                                    0,
-                                                ),
-                                                output_type: Some(
-                                                    hydro_test :: cluster :: paxos :: Ballot,
-                                                ),
-                                                cardinality: None,
-                                                cpu_usage: None,
-                                            },
-                                        },
-                                        right: Map {
-                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: singleton :: * ; | _u | () }),
-                                            input: Tee {
-                                                inner: <tee 4>: CycleSource {
-                                                    ident: Ident {
-                                                        sym: cycle_3,
-                                                    },
-                                                    location_kind: Tick(
-                                                        1,
-                                                        Cluster(
-                                                            0,
+                                            right: Map {
+                                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: singleton :: * ; | _u | () }),
+                                                input: Tee {
+                                                    inner: <tee 4>: CycleSource {
+                                                        ident: Ident {
+                                                            sym: cycle_3,
+                                                        },
+                                                        location_kind: Tick(
+                                                            1,
+                                                            Cluster(
+                                                                0,
+                                                            ),
                                                         ),
-                                                    ),
+                                                        metadata: HydroIrMetadata {
+                                                            location_kind: Cluster(
+                                                                0,
+                                                            ),
+                                                            output_type: Some(
+                                                                (),
+                                                            ),
+                                                            cardinality: None,
+                                                            cpu_usage: None,
+                                                        },
+                                                    },
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Cluster(
                                                             0,
@@ -464,7 +475,7 @@ expression: built.ir()
                                                     0,
                                                 ),
                                                 output_type: Some(
-                                                    (),
+                                                    (hydro_test :: cluster :: paxos :: Ballot , ()),
                                                 ),
                                                 cardinality: None,
                                                 cpu_usage: None,
@@ -475,38 +486,38 @@ expression: built.ir()
                                                 0,
                                             ),
                                             output_type: Some(
-                                                (hydro_test :: cluster :: paxos :: Ballot , ()),
+                                                hydro_test :: cluster :: paxos :: Ballot,
                                             ),
                                             cardinality: None,
                                             cpu_usage: None,
                                         },
                                     },
-                                    metadata: HydroIrMetadata {
-                                        location_kind: Cluster(
-                                            0,
-                                        ),
-                                        output_type: Some(
-                                            hydro_test :: cluster :: paxos :: Ballot,
-                                        ),
-                                        cardinality: None,
-                                        cpu_usage: None,
-                                    },
-                                },
-                                right: Map {
-                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: optional :: * ; | _u | () }),
-                                    input: Source {
-                                        source: Stream(
-                                            { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let interval__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let i_am_leader_send_timeout__free = 1u64 ; Duration :: from_secs (i_am_leader_send_timeout__free) } ; tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval (interval__free)) },
-                                        ),
-                                        location_kind: Cluster(
-                                            0,
-                                        ),
+                                    right: Map {
+                                        f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: optional :: * ; | _u | () }),
+                                        input: Source {
+                                            source: Stream(
+                                                { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let interval__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let i_am_leader_send_timeout__free = 1u64 ; Duration :: from_secs (i_am_leader_send_timeout__free) } ; tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval (interval__free)) },
+                                            ),
+                                            location_kind: Cluster(
+                                                0,
+                                            ),
+                                            metadata: HydroIrMetadata {
+                                                location_kind: Cluster(
+                                                    0,
+                                                ),
+                                                output_type: Some(
+                                                    hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: tokio :: time :: Instant,
+                                                ),
+                                                cardinality: None,
+                                                cpu_usage: None,
+                                            },
+                                        },
                                         metadata: HydroIrMetadata {
                                             location_kind: Cluster(
                                                 0,
                                             ),
                                             output_type: Some(
-                                                hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: tokio :: time :: Instant,
+                                                (),
                                             ),
                                             cardinality: None,
                                             cpu_usage: None,
@@ -517,7 +528,7 @@ expression: built.ir()
                                             0,
                                         ),
                                         output_type: Some(
-                                            (),
+                                            (hydro_test :: cluster :: paxos :: Ballot , ()),
                                         ),
                                         cardinality: None,
                                         cpu_usage: None,
@@ -528,7 +539,7 @@ expression: built.ir()
                                         0,
                                     ),
                                     output_type: Some(
-                                        (hydro_test :: cluster :: paxos :: Ballot , ()),
+                                        hydro_test :: cluster :: paxos :: Ballot,
                                     ),
                                     cardinality: None,
                                     cpu_usage: None,
@@ -539,7 +550,7 @@ expression: built.ir()
                                     0,
                                 ),
                                 output_type: Some(
-                                    hydro_test :: cluster :: paxos :: Ballot,
+                                    hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: bytes :: Bytes,
                                 ),
                                 cardinality: None,
                                 cpu_usage: None,
@@ -550,7 +561,7 @@ expression: built.ir()
                                 0,
                             ),
                             output_type: Some(
-                                (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos :: Proposer > , hydro_test :: cluster :: paxos :: Ballot),
+                                (u32 , hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: bytes :: Bytes),
                             ),
                             cardinality: None,
                             cpu_usage: None,
@@ -672,49 +683,60 @@ expression: built.ir()
                                                                                 1,
                                                                             ),
                                                                             to_key: None,
-                                                                            serialize_fn: Some(
-                                                                                :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , hydro_test :: cluster :: paxos :: Ballot) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
-                                                                            ),
+                                                                            serialize_fn: None,
                                                                             instantiate_fn: <network instantiate>,
                                                                             deserialize_fn: Some(
                                                                                 | res | { let (id , b) = res . unwrap () ; (hydro_lang :: ClusterId :: < hydro_test :: cluster :: paxos :: Proposer > :: from_raw (id) , hydro_lang :: runtime_support :: bincode :: deserialize :: < hydro_test :: cluster :: paxos :: Ballot > (& b) . unwrap ()) },
                                                                             ),
                                                                             input: FlatMap {
-                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: cluster :: paxos :: Ballot , std :: iter :: Map < std :: slice :: Iter < hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos :: Acceptor > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: cluster :: paxos :: Acceptor >] > (__hydro_lang_cluster_ids_1) } ; | b | ids__free . iter () . map (move | id | (:: std :: clone :: Clone :: clone (id) , :: std :: clone :: Clone :: clone (& b))) }),
-                                                                                input: Inspect {
-                                                                                    f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < hydro_test :: cluster :: paxos :: Ballot , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | _ | println ! ("Proposer leader expired, sending P1a") }),
-                                                                                    input: Map {
-                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: cluster :: paxos :: Ballot , ()) , hydro_test :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: singleton :: * ; | (d , _signal) | d }),
-                                                                                        input: CrossSingleton {
-                                                                                            left: Tee {
-                                                                                                inner: <tee 3>,
-                                                                                                metadata: HydroIrMetadata {
-                                                                                                    location_kind: Cluster(
-                                                                                                        0,
-                                                                                                    ),
-                                                                                                    output_type: Some(
-                                                                                                        hydro_test :: cluster :: paxos :: Ballot,
-                                                                                                    ),
-                                                                                                    cardinality: None,
-                                                                                                    cpu_usage: None,
+                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: bytes :: Bytes , std :: iter :: Map < std :: slice :: Iter < hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos :: Acceptor > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: cluster :: paxos :: Acceptor >] > (__hydro_lang_cluster_ids_1) } ; | v | { ids__free . iter () . map (move | id | (id . raw_id , v . clone ())) } }),
+                                                                                input: Map {
+                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: cluster :: paxos :: Ballot , hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: bytes :: Bytes > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | v | bincode :: serialize (& v) . unwrap () . into () }),
+                                                                                    input: Inspect {
+                                                                                        f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < hydro_test :: cluster :: paxos :: Ballot , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | _ | println ! ("Proposer leader expired, sending P1a") }),
+                                                                                        input: Map {
+                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: cluster :: paxos :: Ballot , ()) , hydro_test :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: singleton :: * ; | (d , _signal) | d }),
+                                                                                            input: CrossSingleton {
+                                                                                                left: Tee {
+                                                                                                    inner: <tee 3>,
+                                                                                                    metadata: HydroIrMetadata {
+                                                                                                        location_kind: Cluster(
+                                                                                                            0,
+                                                                                                        ),
+                                                                                                        output_type: Some(
+                                                                                                            hydro_test :: cluster :: paxos :: Ballot,
+                                                                                                        ),
+                                                                                                        cardinality: None,
+                                                                                                        cpu_usage: None,
+                                                                                                    },
                                                                                                 },
-                                                                                            },
-                                                                                            right: Map {
-                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: singleton :: * ; | _u | () }),
-                                                                                                input: Map {
-                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (() , ()) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: optional :: * ; | (d , _signal) | d }),
-                                                                                                    input: CrossSingleton {
-                                                                                                        left: Map {
-                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (() , ()) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: optional :: * ; | (d , _signal) | d }),
-                                                                                                            input: CrossSingleton {
-                                                                                                                left: FilterMap {
-                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: tokio :: time :: Instant > , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let duration__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let i_am_leader_check_timeout__free = 1u64 ; Duration :: from_secs (i_am_leader_check_timeout__free) } ; move | latest_received | { if let Some (latest_received) = latest_received { if Instant :: now () . duration_since (latest_received) > duration__free { Some (()) } else { None } } else { Some (()) } } }),
-                                                                                                                    input: Fold {
-                                                                                                                        init: stageleft :: runtime_support :: fn0_type_hint :: < core :: option :: Option < hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: tokio :: time :: Instant > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | | None }),
-                                                                                                                        acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < core :: option :: Option < hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: tokio :: time :: Instant > , hydro_test :: cluster :: paxos :: Ballot , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | latest , _ | { * latest = Some (Instant :: now ()) ; } }),
-                                                                                                                        input: Persist {
-                                                                                                                            inner: Tee {
-                                                                                                                                inner: <tee 2>,
+                                                                                                right: Map {
+                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: singleton :: * ; | _u | () }),
+                                                                                                    input: Map {
+                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (() , ()) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: optional :: * ; | (d , _signal) | d }),
+                                                                                                        input: CrossSingleton {
+                                                                                                            left: Map {
+                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (() , ()) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: optional :: * ; | (d , _signal) | d }),
+                                                                                                                input: CrossSingleton {
+                                                                                                                    left: FilterMap {
+                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: tokio :: time :: Instant > , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let duration__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let i_am_leader_check_timeout__free = 1u64 ; Duration :: from_secs (i_am_leader_check_timeout__free) } ; move | latest_received | { if let Some (latest_received) = latest_received { if Instant :: now () . duration_since (latest_received) > duration__free { Some (()) } else { None } } else { Some (()) } } }),
+                                                                                                                        input: Fold {
+                                                                                                                            init: stageleft :: runtime_support :: fn0_type_hint :: < core :: option :: Option < hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: tokio :: time :: Instant > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | | None }),
+                                                                                                                            acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < core :: option :: Option < hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: tokio :: time :: Instant > , hydro_test :: cluster :: paxos :: Ballot , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | latest , _ | { * latest = Some (Instant :: now ()) ; } }),
+                                                                                                                            input: Persist {
+                                                                                                                                inner: Tee {
+                                                                                                                                    inner: <tee 2>,
+                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                        location_kind: Cluster(
+                                                                                                                                            0,
+                                                                                                                                        ),
+                                                                                                                                        output_type: Some(
+                                                                                                                                            hydro_test :: cluster :: paxos :: Ballot,
+                                                                                                                                        ),
+                                                                                                                                        cardinality: None,
+                                                                                                                                        cpu_usage: None,
+                                                                                                                                    },
+                                                                                                                                },
                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                     location_kind: Cluster(
                                                                                                                                         0,
@@ -731,7 +753,7 @@ expression: built.ir()
                                                                                                                                     0,
                                                                                                                                 ),
                                                                                                                                 output_type: Some(
-                                                                                                                                    hydro_test :: cluster :: paxos :: Ballot,
+                                                                                                                                    core :: option :: Option < hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: tokio :: time :: Instant >,
                                                                                                                                 ),
                                                                                                                                 cardinality: None,
                                                                                                                                 cpu_usage: None,
@@ -742,38 +764,38 @@ expression: built.ir()
                                                                                                                                 0,
                                                                                                                             ),
                                                                                                                             output_type: Some(
-                                                                                                                                core :: option :: Option < hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: tokio :: time :: Instant >,
+                                                                                                                                (),
                                                                                                                             ),
                                                                                                                             cardinality: None,
                                                                                                                             cpu_usage: None,
                                                                                                                         },
                                                                                                                     },
-                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                        location_kind: Cluster(
-                                                                                                                            0,
-                                                                                                                        ),
-                                                                                                                        output_type: Some(
-                                                                                                                            (),
-                                                                                                                        ),
-                                                                                                                        cardinality: None,
-                                                                                                                        cpu_usage: None,
-                                                                                                                    },
-                                                                                                                },
-                                                                                                                right: Map {
-                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: optional :: * ; | _u | () }),
-                                                                                                                    input: Filter {
-                                                                                                                        f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < usize , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: optional :: * ; | c | * c == 0 }),
-                                                                                                                        input: Fold {
-                                                                                                                            init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | | 0usize }),
-                                                                                                                            acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | count , _ | * count += 1 }),
-                                                                                                                            input: Tee {
-                                                                                                                                inner: <tee 4>,
+                                                                                                                    right: Map {
+                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: optional :: * ; | _u | () }),
+                                                                                                                        input: Filter {
+                                                                                                                            f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < usize , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: optional :: * ; | c | * c == 0 }),
+                                                                                                                            input: Fold {
+                                                                                                                                init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | | 0usize }),
+                                                                                                                                acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | count , _ | * count += 1 }),
+                                                                                                                                input: Tee {
+                                                                                                                                    inner: <tee 4>,
+                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                        location_kind: Cluster(
+                                                                                                                                            0,
+                                                                                                                                        ),
+                                                                                                                                        output_type: Some(
+                                                                                                                                            (),
+                                                                                                                                        ),
+                                                                                                                                        cardinality: None,
+                                                                                                                                        cpu_usage: None,
+                                                                                                                                    },
+                                                                                                                                },
                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                     location_kind: Cluster(
                                                                                                                                         0,
                                                                                                                                     ),
                                                                                                                                     output_type: Some(
-                                                                                                                                        (),
+                                                                                                                                        usize,
                                                                                                                                     ),
                                                                                                                                     cardinality: None,
                                                                                                                                     cpu_usage: None,
@@ -795,7 +817,7 @@ expression: built.ir()
                                                                                                                                 0,
                                                                                                                             ),
                                                                                                                             output_type: Some(
-                                                                                                                                usize,
+                                                                                                                                (),
                                                                                                                             ),
                                                                                                                             cardinality: None,
                                                                                                                             cpu_usage: None,
@@ -806,7 +828,7 @@ expression: built.ir()
                                                                                                                             0,
                                                                                                                         ),
                                                                                                                         output_type: Some(
-                                                                                                                            (),
+                                                                                                                            (() , ()),
                                                                                                                         ),
                                                                                                                         cardinality: None,
                                                                                                                         cpu_usage: None,
@@ -817,38 +839,38 @@ expression: built.ir()
                                                                                                                         0,
                                                                                                                     ),
                                                                                                                     output_type: Some(
-                                                                                                                        (() , ()),
+                                                                                                                        (),
                                                                                                                     ),
                                                                                                                     cardinality: None,
                                                                                                                     cpu_usage: None,
                                                                                                                 },
                                                                                                             },
-                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                location_kind: Cluster(
-                                                                                                                    0,
-                                                                                                                ),
-                                                                                                                output_type: Some(
-                                                                                                                    (),
-                                                                                                                ),
-                                                                                                                cardinality: None,
-                                                                                                                cpu_usage: None,
-                                                                                                            },
-                                                                                                        },
-                                                                                                        right: Map {
-                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: optional :: * ; | _u | () }),
-                                                                                                            input: Source {
-                                                                                                                source: Stream(
-                                                                                                                    { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let delay__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: ClusterId :: < hydro_test :: cluster :: paxos :: Proposer > :: from_raw (__hydro_lang_cluster_self_id_0) ; let i_am_leader_check_timeout_delay_multiplier__free = 1usize ; Duration :: from_secs ((CLUSTER_SELF_ID__free . raw_id * i_am_leader_check_timeout_delay_multiplier__free as u32) . into ()) } ; let interval__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let i_am_leader_check_timeout__free = 1u64 ; Duration :: from_secs (i_am_leader_check_timeout__free) } ; tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval_at (tokio :: time :: Instant :: now () + delay__free , interval__free)) },
-                                                                                                                ),
-                                                                                                                location_kind: Cluster(
-                                                                                                                    0,
-                                                                                                                ),
+                                                                                                            right: Map {
+                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: optional :: * ; | _u | () }),
+                                                                                                                input: Source {
+                                                                                                                    source: Stream(
+                                                                                                                        { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let delay__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: ClusterId :: < hydro_test :: cluster :: paxos :: Proposer > :: from_raw (__hydro_lang_cluster_self_id_0) ; let i_am_leader_check_timeout_delay_multiplier__free = 1usize ; Duration :: from_secs ((CLUSTER_SELF_ID__free . raw_id * i_am_leader_check_timeout_delay_multiplier__free as u32) . into ()) } ; let interval__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let i_am_leader_check_timeout__free = 1u64 ; Duration :: from_secs (i_am_leader_check_timeout__free) } ; tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval_at (tokio :: time :: Instant :: now () + delay__free , interval__free)) },
+                                                                                                                    ),
+                                                                                                                    location_kind: Cluster(
+                                                                                                                        0,
+                                                                                                                    ),
+                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                        location_kind: Cluster(
+                                                                                                                            0,
+                                                                                                                        ),
+                                                                                                                        output_type: Some(
+                                                                                                                            hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: tokio :: time :: Instant,
+                                                                                                                        ),
+                                                                                                                        cardinality: None,
+                                                                                                                        cpu_usage: None,
+                                                                                                                    },
+                                                                                                                },
                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                     location_kind: Cluster(
                                                                                                                         0,
                                                                                                                     ),
                                                                                                                     output_type: Some(
-                                                                                                                        hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: tokio :: time :: Instant,
+                                                                                                                        (),
                                                                                                                     ),
                                                                                                                     cardinality: None,
                                                                                                                     cpu_usage: None,
@@ -859,7 +881,7 @@ expression: built.ir()
                                                                                                                     0,
                                                                                                                 ),
                                                                                                                 output_type: Some(
-                                                                                                                    (),
+                                                                                                                    (() , ()),
                                                                                                                 ),
                                                                                                                 cardinality: None,
                                                                                                                 cpu_usage: None,
@@ -870,7 +892,7 @@ expression: built.ir()
                                                                                                                 0,
                                                                                                             ),
                                                                                                             output_type: Some(
-                                                                                                                (() , ()),
+                                                                                                                (),
                                                                                                             ),
                                                                                                             cardinality: None,
                                                                                                             cpu_usage: None,
@@ -892,7 +914,7 @@ expression: built.ir()
                                                                                                         0,
                                                                                                     ),
                                                                                                     output_type: Some(
-                                                                                                        (),
+                                                                                                        (hydro_test :: cluster :: paxos :: Ballot , ()),
                                                                                                     ),
                                                                                                     cardinality: None,
                                                                                                     cpu_usage: None,
@@ -903,7 +925,7 @@ expression: built.ir()
                                                                                                     0,
                                                                                                 ),
                                                                                                 output_type: Some(
-                                                                                                    (hydro_test :: cluster :: paxos :: Ballot , ()),
+                                                                                                    hydro_test :: cluster :: paxos :: Ballot,
                                                                                                 ),
                                                                                                 cardinality: None,
                                                                                                 cpu_usage: None,
@@ -925,7 +947,7 @@ expression: built.ir()
                                                                                             0,
                                                                                         ),
                                                                                         output_type: Some(
-                                                                                            hydro_test :: cluster :: paxos :: Ballot,
+                                                                                            hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: bytes :: Bytes,
                                                                                         ),
                                                                                         cardinality: None,
                                                                                         cpu_usage: None,
@@ -936,7 +958,7 @@ expression: built.ir()
                                                                                         0,
                                                                                     ),
                                                                                     output_type: Some(
-                                                                                        (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos :: Acceptor > , hydro_test :: cluster :: paxos :: Ballot),
+                                                                                        (u32 , hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: bytes :: Bytes),
                                                                                     ),
                                                                                     cardinality: None,
                                                                                     cpu_usage: None,
@@ -1903,60 +1925,71 @@ expression: built.ir()
                                                                 2,
                                                             ),
                                                             to_key: None,
-                                                            serialize_fn: Some(
-                                                                :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , hydro_test :: cluster :: paxos :: Ballot) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
-                                                            ),
+                                                            serialize_fn: None,
                                                             instantiate_fn: <network instantiate>,
                                                             deserialize_fn: Some(
                                                                 | res | { let (id , b) = res . unwrap () ; (hydro_lang :: ClusterId :: < hydro_test :: cluster :: paxos :: Proposer > :: from_raw (id) , hydro_lang :: runtime_support :: bincode :: deserialize :: < hydro_test :: cluster :: paxos :: Ballot > (& b) . unwrap ()) },
                                                             ),
                                                             input: FlatMap {
-                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: cluster :: paxos :: Ballot , std :: iter :: Map < std :: slice :: Iter < hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client >] > (__hydro_lang_cluster_ids_2) } ; | b | ids__free . iter () . map (move | id | (:: std :: clone :: Clone :: clone (id) , :: std :: clone :: Clone :: clone (& b))) }),
+                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: bytes :: Bytes , std :: iter :: Map < std :: slice :: Iter < hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client >] > (__hydro_lang_cluster_ids_2) } ; | v | { ids__free . iter () . map (move | id | (id . raw_id , v . clone ())) } }),
                                                                 input: Map {
-                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: cluster :: paxos :: Ballot , ()) , hydro_test :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: singleton :: * ; | (d , _signal) | d }),
-                                                                    input: CrossSingleton {
-                                                                        left: Tee {
-                                                                            inner: <tee 3>,
-                                                                            metadata: HydroIrMetadata {
-                                                                                location_kind: Cluster(
-                                                                                    0,
-                                                                                ),
-                                                                                output_type: Some(
-                                                                                    hydro_test :: cluster :: paxos :: Ballot,
-                                                                                ),
-                                                                                cardinality: None,
-                                                                                cpu_usage: None,
+                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: cluster :: paxos :: Ballot , hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: bytes :: Bytes > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | v | bincode :: serialize (& v) . unwrap () . into () }),
+                                                                    input: Map {
+                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: cluster :: paxos :: Ballot , ()) , hydro_test :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: singleton :: * ; | (d , _signal) | d }),
+                                                                        input: CrossSingleton {
+                                                                            left: Tee {
+                                                                                inner: <tee 3>,
+                                                                                metadata: HydroIrMetadata {
+                                                                                    location_kind: Cluster(
+                                                                                        0,
+                                                                                    ),
+                                                                                    output_type: Some(
+                                                                                        hydro_test :: cluster :: paxos :: Ballot,
+                                                                                    ),
+                                                                                    cardinality: None,
+                                                                                    cpu_usage: None,
+                                                                                },
                                                                             },
-                                                                        },
-                                                                        right: Map {
-                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: singleton :: * ; | _u | () }),
-                                                                            input: Tee {
-                                                                                inner: <tee 16>: Map {
-                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (() , ()) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: optional :: * ; | (d , _signal) | d }),
-                                                                                    input: CrossSingleton {
-                                                                                        left: Tee {
-                                                                                            inner: <tee 11>,
-                                                                                            metadata: HydroIrMetadata {
-                                                                                                location_kind: Cluster(
-                                                                                                    0,
-                                                                                                ),
-                                                                                                output_type: Some(
-                                                                                                    (),
-                                                                                                ),
-                                                                                                cardinality: None,
-                                                                                                cpu_usage: None,
+                                                                            right: Map {
+                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: singleton :: * ; | _u | () }),
+                                                                                input: Tee {
+                                                                                    inner: <tee 16>: Map {
+                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (() , ()) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: optional :: * ; | (d , _signal) | d }),
+                                                                                        input: CrossSingleton {
+                                                                                            left: Tee {
+                                                                                                inner: <tee 11>,
+                                                                                                metadata: HydroIrMetadata {
+                                                                                                    location_kind: Cluster(
+                                                                                                        0,
+                                                                                                    ),
+                                                                                                    output_type: Some(
+                                                                                                        (),
+                                                                                                    ),
+                                                                                                    cardinality: None,
+                                                                                                    cpu_usage: None,
+                                                                                                },
                                                                                             },
-                                                                                        },
-                                                                                        right: Map {
-                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: optional :: * ; | _u | () }),
-                                                                                            input: Filter {
-                                                                                                f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < usize , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: optional :: * ; | c | * c == 0 }),
-                                                                                                input: Fold {
-                                                                                                    init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | | 0usize }),
-                                                                                                    acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | count , _ | * count += 1 }),
-                                                                                                    input: DeferTick {
-                                                                                                        input: Tee {
-                                                                                                            inner: <tee 11>,
+                                                                                            right: Map {
+                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: optional :: * ; | _u | () }),
+                                                                                                input: Filter {
+                                                                                                    f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < usize , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: optional :: * ; | c | * c == 0 }),
+                                                                                                    input: Fold {
+                                                                                                        init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | | 0usize }),
+                                                                                                        acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | count , _ | * count += 1 }),
+                                                                                                        input: DeferTick {
+                                                                                                            input: Tee {
+                                                                                                                inner: <tee 11>,
+                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                    location_kind: Cluster(
+                                                                                                                        0,
+                                                                                                                    ),
+                                                                                                                    output_type: Some(
+                                                                                                                        (),
+                                                                                                                    ),
+                                                                                                                    cardinality: None,
+                                                                                                                    cpu_usage: None,
+                                                                                                                },
+                                                                                                            },
                                                                                                             metadata: HydroIrMetadata {
                                                                                                                 location_kind: Cluster(
                                                                                                                     0,
@@ -1973,7 +2006,7 @@ expression: built.ir()
                                                                                                                 0,
                                                                                                             ),
                                                                                                             output_type: Some(
-                                                                                                                (),
+                                                                                                                usize,
                                                                                                             ),
                                                                                                             cardinality: None,
                                                                                                             cpu_usage: None,
@@ -1995,7 +2028,7 @@ expression: built.ir()
                                                                                                         0,
                                                                                                     ),
                                                                                                     output_type: Some(
-                                                                                                        usize,
+                                                                                                        (),
                                                                                                     ),
                                                                                                     cardinality: None,
                                                                                                     cpu_usage: None,
@@ -2006,7 +2039,7 @@ expression: built.ir()
                                                                                                     0,
                                                                                                 ),
                                                                                                 output_type: Some(
-                                                                                                    (),
+                                                                                                    (() , ()),
                                                                                                 ),
                                                                                                 cardinality: None,
                                                                                                 cpu_usage: None,
@@ -2017,7 +2050,7 @@ expression: built.ir()
                                                                                                 0,
                                                                                             ),
                                                                                             output_type: Some(
-                                                                                                (() , ()),
+                                                                                                (),
                                                                                             ),
                                                                                             cardinality: None,
                                                                                             cpu_usage: None,
@@ -2050,7 +2083,7 @@ expression: built.ir()
                                                                                     0,
                                                                                 ),
                                                                                 output_type: Some(
-                                                                                    (),
+                                                                                    (hydro_test :: cluster :: paxos :: Ballot , ()),
                                                                                 ),
                                                                                 cardinality: None,
                                                                                 cpu_usage: None,
@@ -2061,7 +2094,7 @@ expression: built.ir()
                                                                                 0,
                                                                             ),
                                                                             output_type: Some(
-                                                                                (hydro_test :: cluster :: paxos :: Ballot , ()),
+                                                                                hydro_test :: cluster :: paxos :: Ballot,
                                                                             ),
                                                                             cardinality: None,
                                                                             cpu_usage: None,
@@ -2072,7 +2105,7 @@ expression: built.ir()
                                                                             0,
                                                                         ),
                                                                         output_type: Some(
-                                                                            hydro_test :: cluster :: paxos :: Ballot,
+                                                                            hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: bytes :: Bytes,
                                                                         ),
                                                                         cardinality: None,
                                                                         cpu_usage: None,
@@ -2083,7 +2116,7 @@ expression: built.ir()
                                                                         0,
                                                                     ),
                                                                     output_type: Some(
-                                                                        (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , hydro_test :: cluster :: paxos :: Ballot),
+                                                                        (u32 , hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: bytes :: Bytes),
                                                                     ),
                                                                     cardinality: None,
                                                                     cpu_usage: None,
@@ -2840,46 +2873,57 @@ expression: built.ir()
                                                                             1,
                                                                         ),
                                                                         to_key: None,
-                                                                        serialize_fn: Some(
-                                                                            :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , hydro_test :: cluster :: paxos :: P2a < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: cluster :: paxos :: Proposer >) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
-                                                                        ),
+                                                                        serialize_fn: None,
                                                                         instantiate_fn: <network instantiate>,
                                                                         deserialize_fn: Some(
                                                                             | res | { let (id , b) = res . unwrap () ; (hydro_lang :: ClusterId :: < hydro_test :: cluster :: paxos :: Proposer > :: from_raw (id) , hydro_lang :: runtime_support :: bincode :: deserialize :: < hydro_test :: cluster :: paxos :: P2a < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: cluster :: paxos :: Proposer > > (& b) . unwrap ()) },
                                                                         ),
                                                                         input: FlatMap {
-                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: cluster :: paxos :: P2a < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: cluster :: paxos :: Proposer > , std :: iter :: Map < std :: slice :: Iter < hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos :: Acceptor > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: cluster :: paxos :: Acceptor >] > (__hydro_lang_cluster_ids_1) } ; | b | ids__free . iter () . map (move | id | (:: std :: clone :: Clone :: clone (id) , :: std :: clone :: Clone :: clone (& b))) }),
+                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: bytes :: Bytes , std :: iter :: Map < std :: slice :: Iter < hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos :: Acceptor > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: cluster :: paxos :: Acceptor >] > (__hydro_lang_cluster_ids_1) } ; | v | { ids__free . iter () . map (move | id | (id . raw_id , v . clone ())) } }),
                                                                             input: Map {
-                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >) , hydro_test :: cluster :: paxos :: P2a < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: cluster :: paxos :: Proposer > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: ClusterId :: < hydro_test :: cluster :: paxos :: Proposer > :: from_raw (__hydro_lang_cluster_self_id_0) ; move | ((slot , ballot) , value) | P2a { sender : CLUSTER_SELF_ID__free , ballot , slot , value } }),
-                                                                                input: Tee {
-                                                                                    inner: <tee 28>: Map {
-                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (((usize , hydro_test :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >) , ()) , ((usize , hydro_test :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (d , _signal) | d }),
-                                                                                        input: CrossSingleton {
-                                                                                            left: Chain {
-                                                                                                first: Map {
-                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) >) , hydro_test :: cluster :: paxos :: Ballot) , ((usize , hydro_test :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | ((slot , payload) , ballot) | ((slot , ballot) , Some (payload)) }),
-                                                                                                    input: CrossSingleton {
-                                                                                                        left: Tee {
-                                                                                                            inner: <tee 18>,
-                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                location_kind: Cluster(
-                                                                                                                    0,
-                                                                                                                ),
-                                                                                                                output_type: Some(
-                                                                                                                    (usize , hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) >),
-                                                                                                                ),
-                                                                                                                cardinality: None,
-                                                                                                                cpu_usage: None,
+                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: cluster :: paxos :: P2a < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: cluster :: paxos :: Proposer > , hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: bytes :: Bytes > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | v | bincode :: serialize (& v) . unwrap () . into () }),
+                                                                                input: Map {
+                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >) , hydro_test :: cluster :: paxos :: P2a < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: cluster :: paxos :: Proposer > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: ClusterId :: < hydro_test :: cluster :: paxos :: Proposer > :: from_raw (__hydro_lang_cluster_self_id_0) ; move | ((slot , ballot) , value) | P2a { sender : CLUSTER_SELF_ID__free , ballot , slot , value } }),
+                                                                                    input: Tee {
+                                                                                        inner: <tee 28>: Map {
+                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (((usize , hydro_test :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >) , ()) , ((usize , hydro_test :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (d , _signal) | d }),
+                                                                                            input: CrossSingleton {
+                                                                                                left: Chain {
+                                                                                                    first: Map {
+                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) >) , hydro_test :: cluster :: paxos :: Ballot) , ((usize , hydro_test :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | ((slot , payload) , ballot) | ((slot , ballot) , Some (payload)) }),
+                                                                                                        input: CrossSingleton {
+                                                                                                            left: Tee {
+                                                                                                                inner: <tee 18>,
+                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                    location_kind: Cluster(
+                                                                                                                        0,
+                                                                                                                    ),
+                                                                                                                    output_type: Some(
+                                                                                                                        (usize , hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) >),
+                                                                                                                    ),
+                                                                                                                    cardinality: None,
+                                                                                                                    cpu_usage: None,
+                                                                                                                },
                                                                                                             },
-                                                                                                        },
-                                                                                                        right: Tee {
-                                                                                                            inner: <tee 3>,
+                                                                                                            right: Tee {
+                                                                                                                inner: <tee 3>,
+                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                    location_kind: Cluster(
+                                                                                                                        0,
+                                                                                                                    ),
+                                                                                                                    output_type: Some(
+                                                                                                                        hydro_test :: cluster :: paxos :: Ballot,
+                                                                                                                    ),
+                                                                                                                    cardinality: None,
+                                                                                                                    cpu_usage: None,
+                                                                                                                },
+                                                                                                            },
                                                                                                             metadata: HydroIrMetadata {
                                                                                                                 location_kind: Cluster(
                                                                                                                     0,
                                                                                                                 ),
                                                                                                                 output_type: Some(
-                                                                                                                    hydro_test :: cluster :: paxos :: Ballot,
+                                                                                                                    ((usize , hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) >) , hydro_test :: cluster :: paxos :: Ballot),
                                                                                                                 ),
                                                                                                                 cardinality: None,
                                                                                                                 cpu_usage: None,
@@ -2890,81 +2934,81 @@ expression: built.ir()
                                                                                                                 0,
                                                                                                             ),
                                                                                                             output_type: Some(
-                                                                                                                ((usize , hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) >) , hydro_test :: cluster :: paxos :: Ballot),
+                                                                                                                ((usize , hydro_test :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >),
                                                                                                             ),
                                                                                                             cardinality: None,
                                                                                                             cpu_usage: None,
                                                                                                         },
                                                                                                     },
-                                                                                                    metadata: HydroIrMetadata {
-                                                                                                        location_kind: Cluster(
-                                                                                                            0,
-                                                                                                        ),
-                                                                                                        output_type: Some(
-                                                                                                            ((usize , hydro_test :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >),
-                                                                                                        ),
-                                                                                                        cardinality: None,
-                                                                                                        cpu_usage: None,
-                                                                                                    },
-                                                                                                },
-                                                                                                second: Chain {
-                                                                                                    first: FilterMap {
-                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (((usize , (usize , hydro_test :: cluster :: paxos :: LogValue < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >)) , hydro_test :: cluster :: paxos :: Ballot) , core :: option :: Option < usize >) , core :: option :: Option < ((usize , hydro_test :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let f__free = 1usize ; move | (((slot , (count , entry)) , ballot) , checkpoint) | { if count > f__free { return None ; } else if let Some (checkpoint) = checkpoint { if slot <= checkpoint { return None ; } } Some (((slot , ballot) , entry . value)) } }),
-                                                                                                        input: CrossSingleton {
-                                                                                                            left: CrossSingleton {
-                                                                                                                left: Tee {
-                                                                                                                    inner: <tee 21>,
+                                                                                                    second: Chain {
+                                                                                                        first: FilterMap {
+                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (((usize , (usize , hydro_test :: cluster :: paxos :: LogValue < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >)) , hydro_test :: cluster :: paxos :: Ballot) , core :: option :: Option < usize >) , core :: option :: Option < ((usize , hydro_test :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let f__free = 1usize ; move | (((slot , (count , entry)) , ballot) , checkpoint) | { if count > f__free { return None ; } else if let Some (checkpoint) = checkpoint { if slot <= checkpoint { return None ; } } Some (((slot , ballot) , entry . value)) } }),
+                                                                                                            input: CrossSingleton {
+                                                                                                                left: CrossSingleton {
+                                                                                                                    left: Tee {
+                                                                                                                        inner: <tee 21>,
+                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                            location_kind: Cluster(
+                                                                                                                                0,
+                                                                                                                            ),
+                                                                                                                            output_type: Some(
+                                                                                                                                (usize , (usize , hydro_test :: cluster :: paxos :: LogValue < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >)),
+                                                                                                                            ),
+                                                                                                                            cardinality: None,
+                                                                                                                            cpu_usage: None,
+                                                                                                                        },
+                                                                                                                    },
+                                                                                                                    right: Tee {
+                                                                                                                        inner: <tee 3>,
+                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                            location_kind: Cluster(
+                                                                                                                                0,
+                                                                                                                            ),
+                                                                                                                            output_type: Some(
+                                                                                                                                hydro_test :: cluster :: paxos :: Ballot,
+                                                                                                                            ),
+                                                                                                                            cardinality: None,
+                                                                                                                            cpu_usage: None,
+                                                                                                                        },
+                                                                                                                    },
                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                         location_kind: Cluster(
                                                                                                                             0,
                                                                                                                         ),
                                                                                                                         output_type: Some(
-                                                                                                                            (usize , (usize , hydro_test :: cluster :: paxos :: LogValue < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >)),
+                                                                                                                            ((usize , (usize , hydro_test :: cluster :: paxos :: LogValue < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >)) , hydro_test :: cluster :: paxos :: Ballot),
                                                                                                                         ),
                                                                                                                         cardinality: None,
                                                                                                                         cpu_usage: None,
                                                                                                                     },
                                                                                                                 },
                                                                                                                 right: Tee {
-                                                                                                                    inner: <tee 3>,
-                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                        location_kind: Cluster(
-                                                                                                                            0,
-                                                                                                                        ),
-                                                                                                                        output_type: Some(
-                                                                                                                            hydro_test :: cluster :: paxos :: Ballot,
-                                                                                                                        ),
-                                                                                                                        cardinality: None,
-                                                                                                                        cpu_usage: None,
-                                                                                                                    },
-                                                                                                                },
-                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                    location_kind: Cluster(
-                                                                                                                        0,
-                                                                                                                    ),
-                                                                                                                    output_type: Some(
-                                                                                                                        ((usize , (usize , hydro_test :: cluster :: paxos :: LogValue < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >)) , hydro_test :: cluster :: paxos :: Ballot),
-                                                                                                                    ),
-                                                                                                                    cardinality: None,
-                                                                                                                    cpu_usage: None,
-                                                                                                                },
-                                                                                                            },
-                                                                                                            right: Tee {
-                                                                                                                inner: <tee 29>: Chain {
-                                                                                                                    first: Map {
-                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < usize , core :: option :: Option < usize > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: optional :: * ; | v | Some (v) }),
-                                                                                                                        input: Reduce {
-                                                                                                                            f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | curr , new | { if new > * curr { * curr = new ; } } }),
-                                                                                                                            input: FilterMap {
-                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: cluster :: paxos :: LogValue < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > > >) , core :: option :: Option < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (checkpoint , _log) | checkpoint }),
-                                                                                                                                input: Tee {
-                                                                                                                                    inner: <tee 22>,
+                                                                                                                    inner: <tee 29>: Chain {
+                                                                                                                        first: Map {
+                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < usize , core :: option :: Option < usize > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: optional :: * ; | v | Some (v) }),
+                                                                                                                            input: Reduce {
+                                                                                                                                f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | curr , new | { if new > * curr { * curr = new ; } } }),
+                                                                                                                                input: FilterMap {
+                                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: cluster :: paxos :: LogValue < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > > >) , core :: option :: Option < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (checkpoint , _log) | checkpoint }),
+                                                                                                                                    input: Tee {
+                                                                                                                                        inner: <tee 22>,
+                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                            location_kind: Cluster(
+                                                                                                                                                0,
+                                                                                                                                            ),
+                                                                                                                                            output_type: Some(
+                                                                                                                                                (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: cluster :: paxos :: LogValue < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > > >),
+                                                                                                                                            ),
+                                                                                                                                            cardinality: None,
+                                                                                                                                            cpu_usage: None,
+                                                                                                                                        },
+                                                                                                                                    },
                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                         location_kind: Cluster(
                                                                                                                                             0,
                                                                                                                                         ),
                                                                                                                                         output_type: Some(
-                                                                                                                                            (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: cluster :: paxos :: LogValue < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > > >),
+                                                                                                                                            usize,
                                                                                                                                         ),
                                                                                                                                         cardinality: None,
                                                                                                                                         cpu_usage: None,
@@ -2986,31 +3030,31 @@ expression: built.ir()
                                                                                                                                     0,
                                                                                                                                 ),
                                                                                                                                 output_type: Some(
-                                                                                                                                    usize,
+                                                                                                                                    core :: option :: Option < usize >,
                                                                                                                                 ),
                                                                                                                                 cardinality: None,
                                                                                                                                 cpu_usage: None,
                                                                                                                             },
                                                                                                                         },
-                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                            location_kind: Cluster(
-                                                                                                                                0,
-                                                                                                                            ),
-                                                                                                                            output_type: Some(
-                                                                                                                                core :: option :: Option < usize >,
-                                                                                                                            ),
-                                                                                                                            cardinality: None,
-                                                                                                                            cpu_usage: None,
-                                                                                                                        },
-                                                                                                                    },
-                                                                                                                    second: Persist {
-                                                                                                                        inner: Source {
-                                                                                                                            source: Iter(
-                                                                                                                                [:: std :: option :: Option :: None],
-                                                                                                                            ),
-                                                                                                                            location_kind: Cluster(
-                                                                                                                                0,
-                                                                                                                            ),
+                                                                                                                        second: Persist {
+                                                                                                                            inner: Source {
+                                                                                                                                source: Iter(
+                                                                                                                                    [:: std :: option :: Option :: None],
+                                                                                                                                ),
+                                                                                                                                location_kind: Cluster(
+                                                                                                                                    0,
+                                                                                                                                ),
+                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                    location_kind: Cluster(
+                                                                                                                                        0,
+                                                                                                                                    ),
+                                                                                                                                    output_type: Some(
+                                                                                                                                        core :: option :: Option < usize >,
+                                                                                                                                    ),
+                                                                                                                                    cardinality: None,
+                                                                                                                                    cpu_usage: None,
+                                                                                                                                },
+                                                                                                                            },
                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                 location_kind: Cluster(
                                                                                                                                     0,
@@ -3049,7 +3093,7 @@ expression: built.ir()
                                                                                                                         0,
                                                                                                                     ),
                                                                                                                     output_type: Some(
-                                                                                                                        core :: option :: Option < usize >,
+                                                                                                                        (((usize , (usize , hydro_test :: cluster :: paxos :: LogValue < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >)) , hydro_test :: cluster :: paxos :: Ballot) , core :: option :: Option < usize >),
                                                                                                                     ),
                                                                                                                     cardinality: None,
                                                                                                                     cpu_usage: None,
@@ -3060,51 +3104,51 @@ expression: built.ir()
                                                                                                                     0,
                                                                                                                 ),
                                                                                                                 output_type: Some(
-                                                                                                                    (((usize , (usize , hydro_test :: cluster :: paxos :: LogValue < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >)) , hydro_test :: cluster :: paxos :: Ballot) , core :: option :: Option < usize >),
+                                                                                                                    ((usize , hydro_test :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >),
                                                                                                                 ),
                                                                                                                 cardinality: None,
                                                                                                                 cpu_usage: None,
                                                                                                             },
                                                                                                         },
-                                                                                                        metadata: HydroIrMetadata {
-                                                                                                            location_kind: Cluster(
-                                                                                                                0,
-                                                                                                            ),
-                                                                                                            output_type: Some(
-                                                                                                                ((usize , hydro_test :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >),
-                                                                                                            ),
-                                                                                                            cardinality: None,
-                                                                                                            cpu_usage: None,
-                                                                                                        },
-                                                                                                    },
-                                                                                                    second: Map {
-                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , hydro_test :: cluster :: paxos :: Ballot) , ((usize , hydro_test :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; move | (slot , ballot) | ((slot , ballot) , None) }),
-                                                                                                        input: CrossSingleton {
-                                                                                                            left: Difference {
-                                                                                                                pos: FlatMap {
-                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , core :: option :: Option < usize >) , std :: ops :: Range < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (max_slot , checkpoint) | { if let Some (checkpoint) = checkpoint { (checkpoint + 1) .. max_slot } else { 0 .. max_slot } } }),
-                                                                                                                    input: CrossSingleton {
-                                                                                                                        left: Tee {
-                                                                                                                            inner: <tee 20>,
-                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                location_kind: Cluster(
-                                                                                                                                    0,
-                                                                                                                                ),
-                                                                                                                                output_type: Some(
-                                                                                                                                    usize,
-                                                                                                                                ),
-                                                                                                                                cardinality: None,
-                                                                                                                                cpu_usage: None,
+                                                                                                        second: Map {
+                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , hydro_test :: cluster :: paxos :: Ballot) , ((usize , hydro_test :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; move | (slot , ballot) | ((slot , ballot) , None) }),
+                                                                                                            input: CrossSingleton {
+                                                                                                                left: Difference {
+                                                                                                                    pos: FlatMap {
+                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , core :: option :: Option < usize >) , std :: ops :: Range < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (max_slot , checkpoint) | { if let Some (checkpoint) = checkpoint { (checkpoint + 1) .. max_slot } else { 0 .. max_slot } } }),
+                                                                                                                        input: CrossSingleton {
+                                                                                                                            left: Tee {
+                                                                                                                                inner: <tee 20>,
+                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                    location_kind: Cluster(
+                                                                                                                                        0,
+                                                                                                                                    ),
+                                                                                                                                    output_type: Some(
+                                                                                                                                        usize,
+                                                                                                                                    ),
+                                                                                                                                    cardinality: None,
+                                                                                                                                    cpu_usage: None,
+                                                                                                                                },
                                                                                                                             },
-                                                                                                                        },
-                                                                                                                        right: Tee {
-                                                                                                                            inner: <tee 29>,
+                                                                                                                            right: Tee {
+                                                                                                                                inner: <tee 29>,
+                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                    location_kind: Cluster(
+                                                                                                                                        0,
+                                                                                                                                    ),
+                                                                                                                                    output_type: Some(
+                                                                                                                                        core :: option :: Option < usize >,
+                                                                                                                                    ),
+                                                                                                                                    cardinality: None,
+                                                                                                                                    cpu_usage: None,
+                                                                                                                                },
+                                                                                                                            },
                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                 location_kind: Cluster(
                                                                                                                                     0,
                                                                                                                                 ),
                                                                                                                                 output_type: Some(
-                                                                                                                                    core :: option :: Option < usize >,
+                                                                                                                                    (usize , core :: option :: Option < usize >),
                                                                                                                                 ),
                                                                                                                                 cardinality: None,
                                                                                                                                 cpu_usage: None,
@@ -3115,7 +3159,33 @@ expression: built.ir()
                                                                                                                                 0,
                                                                                                                             ),
                                                                                                                             output_type: Some(
-                                                                                                                                (usize , core :: option :: Option < usize >),
+                                                                                                                                usize,
+                                                                                                                            ),
+                                                                                                                            cardinality: None,
+                                                                                                                            cpu_usage: None,
+                                                                                                                        },
+                                                                                                                    },
+                                                                                                                    neg: Map {
+                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , (usize , hydro_test :: cluster :: paxos :: LogValue < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >)) , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (slot , _) | slot }),
+                                                                                                                        input: Tee {
+                                                                                                                            inner: <tee 21>,
+                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                location_kind: Cluster(
+                                                                                                                                    0,
+                                                                                                                                ),
+                                                                                                                                output_type: Some(
+                                                                                                                                    (usize , (usize , hydro_test :: cluster :: paxos :: LogValue < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >)),
+                                                                                                                                ),
+                                                                                                                                cardinality: None,
+                                                                                                                                cpu_usage: None,
+                                                                                                                            },
+                                                                                                                        },
+                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                            location_kind: Cluster(
+                                                                                                                                0,
+                                                                                                                            ),
+                                                                                                                            output_type: Some(
+                                                                                                                                usize,
                                                                                                                             ),
                                                                                                                             cardinality: None,
                                                                                                                             cpu_usage: None,
@@ -3132,27 +3202,14 @@ expression: built.ir()
                                                                                                                         cpu_usage: None,
                                                                                                                     },
                                                                                                                 },
-                                                                                                                neg: Map {
-                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , (usize , hydro_test :: cluster :: paxos :: LogValue < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >)) , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (slot , _) | slot }),
-                                                                                                                    input: Tee {
-                                                                                                                        inner: <tee 21>,
-                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                            location_kind: Cluster(
-                                                                                                                                0,
-                                                                                                                            ),
-                                                                                                                            output_type: Some(
-                                                                                                                                (usize , (usize , hydro_test :: cluster :: paxos :: LogValue < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >)),
-                                                                                                                            ),
-                                                                                                                            cardinality: None,
-                                                                                                                            cpu_usage: None,
-                                                                                                                        },
-                                                                                                                    },
+                                                                                                                right: Tee {
+                                                                                                                    inner: <tee 3>,
                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                         location_kind: Cluster(
                                                                                                                             0,
                                                                                                                         ),
                                                                                                                         output_type: Some(
-                                                                                                                            usize,
+                                                                                                                            hydro_test :: cluster :: paxos :: Ballot,
                                                                                                                         ),
                                                                                                                         cardinality: None,
                                                                                                                         cpu_usage: None,
@@ -3163,20 +3220,7 @@ expression: built.ir()
                                                                                                                         0,
                                                                                                                     ),
                                                                                                                     output_type: Some(
-                                                                                                                        usize,
-                                                                                                                    ),
-                                                                                                                    cardinality: None,
-                                                                                                                    cpu_usage: None,
-                                                                                                                },
-                                                                                                            },
-                                                                                                            right: Tee {
-                                                                                                                inner: <tee 3>,
-                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                    location_kind: Cluster(
-                                                                                                                        0,
-                                                                                                                    ),
-                                                                                                                    output_type: Some(
-                                                                                                                        hydro_test :: cluster :: paxos :: Ballot,
+                                                                                                                        (usize , hydro_test :: cluster :: paxos :: Ballot),
                                                                                                                     ),
                                                                                                                     cardinality: None,
                                                                                                                     cpu_usage: None,
@@ -3187,7 +3231,7 @@ expression: built.ir()
                                                                                                                     0,
                                                                                                                 ),
                                                                                                                 output_type: Some(
-                                                                                                                    (usize , hydro_test :: cluster :: paxos :: Ballot),
+                                                                                                                    ((usize , hydro_test :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >),
                                                                                                                 ),
                                                                                                                 cardinality: None,
                                                                                                                 cpu_usage: None,
@@ -3215,21 +3259,21 @@ expression: built.ir()
                                                                                                         cpu_usage: None,
                                                                                                     },
                                                                                                 },
-                                                                                                metadata: HydroIrMetadata {
-                                                                                                    location_kind: Cluster(
-                                                                                                        0,
-                                                                                                    ),
-                                                                                                    output_type: Some(
-                                                                                                        ((usize , hydro_test :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >),
-                                                                                                    ),
-                                                                                                    cardinality: None,
-                                                                                                    cpu_usage: None,
-                                                                                                },
-                                                                                            },
-                                                                                            right: Map {
-                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | _u | () }),
-                                                                                                input: Tee {
-                                                                                                    inner: <tee 11>,
+                                                                                                right: Map {
+                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | _u | () }),
+                                                                                                    input: Tee {
+                                                                                                        inner: <tee 11>,
+                                                                                                        metadata: HydroIrMetadata {
+                                                                                                            location_kind: Cluster(
+                                                                                                                0,
+                                                                                                            ),
+                                                                                                            output_type: Some(
+                                                                                                                (),
+                                                                                                            ),
+                                                                                                            cardinality: None,
+                                                                                                            cpu_usage: None,
+                                                                                                        },
+                                                                                                    },
                                                                                                     metadata: HydroIrMetadata {
                                                                                                         location_kind: Cluster(
                                                                                                             0,
@@ -3246,7 +3290,7 @@ expression: built.ir()
                                                                                                         0,
                                                                                                     ),
                                                                                                     output_type: Some(
-                                                                                                        (),
+                                                                                                        (((usize , hydro_test :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >) , ()),
                                                                                                     ),
                                                                                                     cardinality: None,
                                                                                                     cpu_usage: None,
@@ -3257,15 +3301,18 @@ expression: built.ir()
                                                                                                     0,
                                                                                                 ),
                                                                                                 output_type: Some(
-                                                                                                    (((usize , hydro_test :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >) , ()),
+                                                                                                    ((usize , hydro_test :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >),
                                                                                                 ),
                                                                                                 cardinality: None,
                                                                                                 cpu_usage: None,
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_kind: Cluster(
-                                                                                                0,
+                                                                                            location_kind: Tick(
+                                                                                                1,
+                                                                                                Cluster(
+                                                                                                    0,
+                                                                                                ),
                                                                                             ),
                                                                                             output_type: Some(
                                                                                                 ((usize , hydro_test :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >),
@@ -3282,7 +3329,7 @@ expression: built.ir()
                                                                                             ),
                                                                                         ),
                                                                                         output_type: Some(
-                                                                                            ((usize , hydro_test :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >),
+                                                                                            hydro_test :: cluster :: paxos :: P2a < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: cluster :: paxos :: Proposer >,
                                                                                         ),
                                                                                         cardinality: None,
                                                                                         cpu_usage: None,
@@ -3296,7 +3343,7 @@ expression: built.ir()
                                                                                         ),
                                                                                     ),
                                                                                     output_type: Some(
-                                                                                        hydro_test :: cluster :: paxos :: P2a < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: cluster :: paxos :: Proposer >,
+                                                                                        hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: bytes :: Bytes,
                                                                                     ),
                                                                                     cardinality: None,
                                                                                     cpu_usage: None,
@@ -3310,7 +3357,7 @@ expression: built.ir()
                                                                                     ),
                                                                                 ),
                                                                                 output_type: Some(
-                                                                                    (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos :: Acceptor > , hydro_test :: cluster :: paxos :: P2a < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: cluster :: paxos :: Proposer >),
+                                                                                    (u32 , hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: bytes :: Bytes),
                                                                                 ),
                                                                                 cardinality: None,
                                                                                 cpu_usage: None,
@@ -4072,41 +4119,52 @@ expression: built.ir()
                                                     3,
                                                 ),
                                                 to_key: None,
-                                                serialize_fn: Some(
-                                                    :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (usize , core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
-                                                ),
+                                                serialize_fn: None,
                                                 instantiate_fn: <network instantiate>,
                                                 deserialize_fn: Some(
                                                     | res | { let (id , b) = res . unwrap () ; (hydro_lang :: ClusterId :: < hydro_test :: cluster :: paxos :: Proposer > :: from_raw (id) , hydro_lang :: runtime_support :: bincode :: deserialize :: < (usize , core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >) > (& b) . unwrap ()) },
                                                 ),
                                                 input: FlatMap {
-                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >) , std :: iter :: Map < std :: slice :: Iter < hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: kv_replica :: Replica > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: cluster :: kv_replica :: Replica >] > (__hydro_lang_cluster_ids_3) } ; | b | ids__free . iter () . map (move | id | (:: std :: clone :: Clone :: clone (id) , :: std :: clone :: Clone :: clone (& b))) }),
+                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: bytes :: Bytes , std :: iter :: Map < std :: slice :: Iter < hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: kv_replica :: Replica > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: cluster :: kv_replica :: Replica >] > (__hydro_lang_cluster_ids_3) } ; | v | { ids__free . iter () . map (move | id | (id . raw_id , v . clone ())) } }),
                                                     input: Map {
-                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: cluster :: paxos :: Ballot) , (core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > > , ())) , (usize , core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | ((slot , _ballot) , (value , _)) | (slot , value) }),
+                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >) , hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: bytes :: Bytes > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | v | bincode :: serialize (& v) . unwrap () . into () }),
                                                         input: Map {
-                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: cluster :: paxos :: Ballot) , (core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > > , ())) , ((usize , hydro_test :: cluster :: paxos :: Ballot) , (core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > > , ())) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: request_response :: * ; | (key , (meta , resp)) | (key , (meta , resp)) }),
-                                                            input: Join {
-                                                                left: Tee {
-                                                                    inner: <tee 31>,
-                                                                    metadata: HydroIrMetadata {
-                                                                        location_kind: Cluster(
-                                                                            0,
-                                                                        ),
-                                                                        output_type: Some(
-                                                                            ((usize , hydro_test :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >),
-                                                                        ),
-                                                                        cardinality: None,
-                                                                        cpu_usage: None,
+                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: cluster :: paxos :: Ballot) , (core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > > , ())) , (usize , core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | ((slot , _ballot) , (value , _)) | (slot , value) }),
+                                                            input: Map {
+                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: cluster :: paxos :: Ballot) , (core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > > , ())) , ((usize , hydro_test :: cluster :: paxos :: Ballot) , (core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > > , ())) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: request_response :: * ; | (key , (meta , resp)) | (key , (meta , resp)) }),
+                                                                input: Join {
+                                                                    left: Tee {
+                                                                        inner: <tee 31>,
+                                                                        metadata: HydroIrMetadata {
+                                                                            location_kind: Cluster(
+                                                                                0,
+                                                                            ),
+                                                                            output_type: Some(
+                                                                                ((usize , hydro_test :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >),
+                                                                            ),
+                                                                            cardinality: None,
+                                                                            cpu_usage: None,
+                                                                        },
                                                                     },
-                                                                },
-                                                                right: Tee {
-                                                                    inner: <tee 32>,
+                                                                    right: Tee {
+                                                                        inner: <tee 32>,
+                                                                        metadata: HydroIrMetadata {
+                                                                            location_kind: Cluster(
+                                                                                0,
+                                                                            ),
+                                                                            output_type: Some(
+                                                                                ((usize , hydro_test :: cluster :: paxos :: Ballot) , ()),
+                                                                            ),
+                                                                            cardinality: None,
+                                                                            cpu_usage: None,
+                                                                        },
+                                                                    },
                                                                     metadata: HydroIrMetadata {
                                                                         location_kind: Cluster(
                                                                             0,
                                                                         ),
                                                                         output_type: Some(
-                                                                            ((usize , hydro_test :: cluster :: paxos :: Ballot) , ()),
+                                                                            ((usize , hydro_test :: cluster :: paxos :: Ballot) , (core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > > , ())),
                                                                         ),
                                                                         cardinality: None,
                                                                         cpu_usage: None,
@@ -4124,25 +4182,25 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_kind: Cluster(
-                                                                    0,
+                                                                location_kind: Tick(
+                                                                    1,
+                                                                    Cluster(
+                                                                        0,
+                                                                    ),
                                                                 ),
                                                                 output_type: Some(
-                                                                    ((usize , hydro_test :: cluster :: paxos :: Ballot) , (core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > > , ())),
+                                                                    (usize , core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >),
                                                                 ),
                                                                 cardinality: None,
                                                                 cpu_usage: None,
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_kind: Tick(
-                                                                1,
-                                                                Cluster(
-                                                                    0,
-                                                                ),
+                                                            location_kind: Cluster(
+                                                                0,
                                                             ),
                                                             output_type: Some(
-                                                                (usize , core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >),
+                                                                hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: bytes :: Bytes,
                                                             ),
                                                             cardinality: None,
                                                             cpu_usage: None,
@@ -4153,7 +4211,7 @@ expression: built.ir()
                                                             0,
                                                         ),
                                                         output_type: Some(
-                                                            (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: kv_replica :: Replica > , (usize , core :: option :: Option < hydro_test :: cluster :: kv_replica :: KvPayload < u32 , (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos_bench :: Client > , u32) > >)),
+                                                            (u32 , hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: bytes :: Bytes),
                                                         ),
                                                         cardinality: None,
                                                         cpu_usage: None,
@@ -4783,23 +4841,34 @@ expression: built.ir()
                                             1,
                                         ),
                                         to_key: None,
-                                        serialize_fn: Some(
-                                            :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , usize) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
-                                        ),
+                                        serialize_fn: None,
                                         instantiate_fn: <network instantiate>,
                                         deserialize_fn: Some(
                                             | res | { let (id , b) = res . unwrap () ; (hydro_lang :: ClusterId :: < hydro_test :: cluster :: kv_replica :: Replica > :: from_raw (id) , hydro_lang :: runtime_support :: bincode :: deserialize :: < usize > (& b) . unwrap ()) },
                                         ),
                                         input: FlatMap {
-                                            f: stageleft :: runtime_support :: fn1_type_hint :: < usize , std :: iter :: Map < std :: slice :: Iter < hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos :: Acceptor > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: cluster :: paxos :: Acceptor >] > (__hydro_lang_cluster_ids_1) } ; | b | ids__free . iter () . map (move | id | (:: std :: clone :: Clone :: clone (id) , :: std :: clone :: Clone :: clone (& b))) }),
-                                            input: Tee {
-                                                inner: <tee 37>,
+                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: bytes :: Bytes , std :: iter :: Map < std :: slice :: Iter < hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos :: Acceptor > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: cluster :: paxos :: Acceptor >] > (__hydro_lang_cluster_ids_1) } ; | v | { ids__free . iter () . map (move | id | (id . raw_id , v . clone ())) } }),
+                                            input: Map {
+                                                f: stageleft :: runtime_support :: fn1_type_hint :: < usize , hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: bytes :: Bytes > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | v | bincode :: serialize (& v) . unwrap () . into () }),
+                                                input: Tee {
+                                                    inner: <tee 37>,
+                                                    metadata: HydroIrMetadata {
+                                                        location_kind: Cluster(
+                                                            3,
+                                                        ),
+                                                        output_type: Some(
+                                                            usize,
+                                                        ),
+                                                        cardinality: None,
+                                                        cpu_usage: None,
+                                                    },
+                                                },
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Cluster(
                                                         3,
                                                     ),
                                                     output_type: Some(
-                                                        usize,
+                                                        hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: bytes :: Bytes,
                                                     ),
                                                     cardinality: None,
                                                     cpu_usage: None,
@@ -4810,7 +4879,7 @@ expression: built.ir()
                                                     3,
                                                 ),
                                                 output_type: Some(
-                                                    (hydro_std :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: cluster :: paxos :: Acceptor > , usize),
+                                                    (u32 , hydro_std :: __staged :: __deps :: hydro_lang :: __staged :: __deps :: bytes :: Bytes),
                                                 ),
                                                 cardinality: None,
                                                 cpu_usage: None,

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir@proposer_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir@proposer_mermaid.snap
@@ -34,8 +34,8 @@ linkStyle default stroke:#aaa
 24v1["<div style=text-align:center>(24v1)</div> <code><br>map({<br>    |_u| ()<br>})</code>"]:::otherClass
 25v1["<div style=text-align:center>(25v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
 26v1["<div style=text-align:center>(26v1)</div> <code><br>map({<br>    |(d, _signal)| d<br>})</code>"]:::otherClass
-27v1["<div style=text-align:center>(27v1)</div> <code><br>flat_map({<br>    let ids__free = unsafe {<br>        ::std::mem::transmute::&lt;<br>            _,<br>            &amp;[hydro_lang::ClusterId&lt;hydro_test::cluster::paxos::Proposer&gt;],<br>        &gt;(__hydro_lang_cluster_ids_0)<br>    };<br>    |b| {<br>        ids__free<br>            .iter()<br>            .map(move |id| (<br>                ::std::clone::Clone::clone(id),<br>                ::std::clone::Clone::clone(&amp;b),<br>            ))<br>    }<br>})</code>"]:::otherClass
-28v1["<div style=text-align:center>(28v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.raw_id,<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+27v1["<div style=text-align:center>(27v1)</div> <code><br>map({<br>    |v| bincode::serialize(&amp;v).unwrap().into()<br>})</code>"]:::otherClass
+28v1["<div style=text-align:center>(28v1)</div> <code><br>flat_map({<br>    let ids__free = unsafe {<br>        ::std::mem::transmute::&lt;<br>            _,<br>            &amp;[hydro_lang::ClusterId&lt;hydro_test::cluster::paxos::Proposer&gt;],<br>        &gt;(__hydro_lang_cluster_ids_0)<br>    };<br>    |v| { ids__free.iter().map(move |id| (id.raw_id, v.clone())) }<br>})</code>"]:::otherClass
 29v1["<div style=text-align:center>(29v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
 30v1["<div style=text-align:center>(30v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
 31v1["<div style=text-align:center>(31v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::ClusterId::&lt;hydro_test::cluster::paxos::Proposer&gt;::from_raw(id),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            hydro_test::cluster::paxos::Ballot,<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
@@ -56,8 +56,8 @@ linkStyle default stroke:#aaa
 46v1["<div style=text-align:center>(46v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
 47v1["<div style=text-align:center>(47v1)</div> <code><br>map({<br>    |(d, _signal)| d<br>})</code>"]:::otherClass
 48v1["<div style=text-align:center>(48v1)</div> <code><br>inspect({<br>    |_| println!(&quot;Proposer leader expired, sending P1a&quot;)<br>})</code>"]:::otherClass
-49v1["<div style=text-align:center>(49v1)</div> <code><br>flat_map({<br>    let ids__free = unsafe {<br>        ::std::mem::transmute::&lt;<br>            _,<br>            &amp;[hydro_lang::ClusterId&lt;hydro_test::cluster::paxos::Acceptor&gt;],<br>        &gt;(__hydro_lang_cluster_ids_1)<br>    };<br>    |b| {<br>        ids__free<br>            .iter()<br>            .map(move |id| (<br>                ::std::clone::Clone::clone(id),<br>                ::std::clone::Clone::clone(&amp;b),<br>            ))<br>    }<br>})</code>"]:::otherClass
-50v1["<div style=text-align:center>(50v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.raw_id,<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+49v1["<div style=text-align:center>(49v1)</div> <code><br>map({<br>    |v| bincode::serialize(&amp;v).unwrap().into()<br>})</code>"]:::otherClass
+50v1["<div style=text-align:center>(50v1)</div> <code><br>flat_map({<br>    let ids__free = unsafe {<br>        ::std::mem::transmute::&lt;<br>            _,<br>            &amp;[hydro_lang::ClusterId&lt;hydro_test::cluster::paxos::Acceptor&gt;],<br>        &gt;(__hydro_lang_cluster_ids_1)<br>    };<br>    |v| { ids__free.iter().map(move |id| (id.raw_id, v.clone())) }<br>})</code>"]:::otherClass
 51v1["<div style=text-align:center>(51v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
 52v1["<div style=text-align:center>(52v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
 53v1["<div style=text-align:center>(53v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::ClusterId::&lt;hydro_test::cluster::paxos::Acceptor&gt;::from_raw(id),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            (<br>                hydro_test::cluster::paxos::Ballot,<br>                core::result::Result&lt;<br>                    (<br>                        core::option::Option&lt;usize&gt;,<br>                        std::collections::hash_map::HashMap&lt;<br>                            usize,<br>                            hydro_test::cluster::paxos::LogValue&lt;<br>                                hydro_test::cluster::kv_replica::KvPayload&lt;<br>                                    u32,<br>                                    (<br>                                        hydro_std::__staged::__deps::hydro_lang::location::cluster::cluster_id::ClusterId&lt;<br>                                            hydro_test::cluster::paxos_bench::Client,<br>                                        &gt;,<br>                                        u32,<br>                                    ),<br>                                &gt;,<br>                            &gt;,<br>                        &gt;,<br>                    ),<br>                    hydro_test::cluster::paxos::Ballot,<br>                &gt;,<br>            ),<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
@@ -103,8 +103,8 @@ linkStyle default stroke:#aaa
 95v1["<div style=text-align:center>(95v1)</div> <code><br>map({<br>    |_u| ()<br>})</code>"]:::otherClass
 96v1["<div style=text-align:center>(96v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
 97v1["<div style=text-align:center>(97v1)</div> <code><br>map({<br>    |(d, _signal)| d<br>})</code>"]:::otherClass
-98v1["<div style=text-align:center>(98v1)</div> <code><br>flat_map({<br>    let ids__free = unsafe {<br>        ::std::mem::transmute::&lt;<br>            _,<br>            &amp;[hydro_lang::ClusterId&lt;hydro_test::cluster::paxos_bench::Client&gt;],<br>        &gt;(__hydro_lang_cluster_ids_2)<br>    };<br>    |b| {<br>        ids__free<br>            .iter()<br>            .map(move |id| (<br>                ::std::clone::Clone::clone(id),<br>                ::std::clone::Clone::clone(&amp;b),<br>            ))<br>    }<br>})</code>"]:::otherClass
-99v1["<div style=text-align:center>(99v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.raw_id,<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+98v1["<div style=text-align:center>(98v1)</div> <code><br>map({<br>    |v| bincode::serialize(&amp;v).unwrap().into()<br>})</code>"]:::otherClass
+99v1["<div style=text-align:center>(99v1)</div> <code><br>flat_map({<br>    let ids__free = unsafe {<br>        ::std::mem::transmute::&lt;<br>            _,<br>            &amp;[hydro_lang::ClusterId&lt;hydro_test::cluster::paxos_bench::Client&gt;],<br>        &gt;(__hydro_lang_cluster_ids_2)<br>    };<br>    |v| { ids__free.iter().map(move |id| (id.raw_id, v.clone())) }<br>})</code>"]:::otherClass
 100v1["<div style=text-align:center>(100v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
 101v1["<div style=text-align:center>(101v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
 102v1["<div style=text-align:center>(102v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::ClusterId::&lt;<br>            hydro_test::cluster::paxos_bench::Client,<br>        &gt;::from_raw(id),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            hydro_test::cluster::kv_replica::KvPayload&lt;<br>                u32,<br>                (<br>                    hydro_std::__staged::__deps::hydro_lang::location::cluster::cluster_id::ClusterId&lt;<br>                        hydro_test::cluster::paxos_bench::Client,<br>                    &gt;,<br>                    u32,<br>                ),<br>            &gt;,<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
@@ -161,8 +161,8 @@ linkStyle default stroke:#aaa
 154v1["<div style=text-align:center>(154v1)</div> <code><br>map({<br>    |(d, _signal)| d<br>})</code>"]:::otherClass
 155v1["<div style=text-align:center>(155v1)</div> <code><br>tee()</code>"]:::otherClass
 156v1["<div style=text-align:center>(156v1)</div> <code><br>map({<br>    let CLUSTER_SELF_ID__free = hydro_lang::ClusterId::&lt;<br>        hydro_test::cluster::paxos::Proposer,<br>    &gt;::from_raw(__hydro_lang_cluster_self_id_0);<br>    move |((slot, ballot), value)| P2a {<br>        sender: CLUSTER_SELF_ID__free,<br>        ballot,<br>        slot,<br>        value,<br>    }<br>})</code>"]:::otherClass
-157v1["<div style=text-align:center>(157v1)</div> <code><br>flat_map({<br>    let ids__free = unsafe {<br>        ::std::mem::transmute::&lt;<br>            _,<br>            &amp;[hydro_lang::ClusterId&lt;hydro_test::cluster::paxos::Acceptor&gt;],<br>        &gt;(__hydro_lang_cluster_ids_1)<br>    };<br>    |b| {<br>        ids__free<br>            .iter()<br>            .map(move |id| (<br>                ::std::clone::Clone::clone(id),<br>                ::std::clone::Clone::clone(&amp;b),<br>            ))<br>    }<br>})</code>"]:::otherClass
-158v1["<div style=text-align:center>(158v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.raw_id,<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+157v1["<div style=text-align:center>(157v1)</div> <code><br>map({<br>    |v| bincode::serialize(&amp;v).unwrap().into()<br>})</code>"]:::otherClass
+158v1["<div style=text-align:center>(158v1)</div> <code><br>flat_map({<br>    let ids__free = unsafe {<br>        ::std::mem::transmute::&lt;<br>            _,<br>            &amp;[hydro_lang::ClusterId&lt;hydro_test::cluster::paxos::Acceptor&gt;],<br>        &gt;(__hydro_lang_cluster_ids_1)<br>    };<br>    |v| { ids__free.iter().map(move |id| (id.raw_id, v.clone())) }<br>})</code>"]:::otherClass
 159v1["<div style=text-align:center>(159v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
 160v1["<div style=text-align:center>(160v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
 161v1["<div style=text-align:center>(161v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::ClusterId::&lt;hydro_test::cluster::paxos::Acceptor&gt;::from_raw(id),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            (<br>                (usize, hydro_test::cluster::paxos::Ballot),<br>                core::result::Result&lt;(), hydro_test::cluster::paxos::Ballot&gt;,<br>            ),<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
@@ -193,8 +193,8 @@ linkStyle default stroke:#aaa
 186v1["<div style=text-align:center>(186v1)</div> <code><br>join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
 187v1["<div style=text-align:center>(187v1)</div> <code><br>map({<br>    |(key, (meta, resp))| (key, (meta, resp))<br>})</code>"]:::otherClass
 188v1["<div style=text-align:center>(188v1)</div> <code><br>map({<br>    |((slot, _ballot), (value, _))| (slot, value)<br>})</code>"]:::otherClass
-189v1["<div style=text-align:center>(189v1)</div> <code><br>flat_map({<br>    let ids__free = unsafe {<br>        ::std::mem::transmute::&lt;<br>            _,<br>            &amp;[hydro_lang::ClusterId&lt;hydro_test::cluster::kv_replica::Replica&gt;],<br>        &gt;(__hydro_lang_cluster_ids_3)<br>    };<br>    |b| {<br>        ids__free<br>            .iter()<br>            .map(move |id| (<br>                ::std::clone::Clone::clone(id),<br>                ::std::clone::Clone::clone(&amp;b),<br>            ))<br>    }<br>})</code>"]:::otherClass
-190v1["<div style=text-align:center>(190v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.raw_id,<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+189v1["<div style=text-align:center>(189v1)</div> <code><br>map({<br>    |v| bincode::serialize(&amp;v).unwrap().into()<br>})</code>"]:::otherClass
+190v1["<div style=text-align:center>(190v1)</div> <code><br>flat_map({<br>    let ids__free = unsafe {<br>        ::std::mem::transmute::&lt;<br>            _,<br>            &amp;[hydro_lang::ClusterId&lt;hydro_test::cluster::kv_replica::Replica&gt;],<br>        &gt;(__hydro_lang_cluster_ids_3)<br>    };<br>    |v| { ids__free.iter().map(move |id| (id.raw_id, v.clone())) }<br>})</code>"]:::otherClass
 191v1["<div style=text-align:center>(191v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
 279v1["<div style=text-align:center>(279v1)</div> <code><br>identity()</code>"]:::otherClass
 281v1["<div style=text-align:center>(281v1)</div> <code><br>identity()</code>"]:::otherClass
@@ -234,8 +234,8 @@ linkStyle default stroke:#aaa
 24v1--x|single|25v1; linkStyle 27 stroke:red
 25v1-->26v1
 26v1-->27v1
-28v1-->29v1
 27v1-->28v1
+28v1-->29v1
 30v1-->31v1
 31v1-->32v1
 32v1-->33v1
@@ -257,8 +257,8 @@ linkStyle default stroke:#aaa
 46v1-->47v1
 47v1-->48v1
 48v1-->49v1
-50v1-->51v1
 49v1-->50v1
+50v1-->51v1
 52v1-->53v1
 53v1-->54v1
 54v1-->55v1
@@ -313,8 +313,8 @@ linkStyle default stroke:#aaa
 95v1--x|single|96v1; linkStyle 106 stroke:red
 96v1-->97v1
 97v1-->98v1
-99v1-->100v1
 98v1-->99v1
+99v1-->100v1
 101v1-->102v1
 102v1-->103v1
 85v1-->104v1
@@ -383,8 +383,8 @@ linkStyle default stroke:#aaa
 154v1-->155v1
 155v1-->156v1
 156v1-->157v1
-158v1-->159v1
 157v1-->158v1
+158v1-->159v1
 160v1-->161v1
 161v1-->162v1
 162v1-->163v1
@@ -421,8 +421,8 @@ linkStyle default stroke:#aaa
 186v1-->187v1
 187v1-->188v1
 188v1-->189v1
-190v1-->191v1
 189v1-->190v1
+190v1-->191v1
 279v1--o16v1; linkStyle 219 stroke:red
 281v1--o65v1; linkStyle 220 stroke:red
 283v1--o67v1; linkStyle 221 stroke:red
@@ -441,31 +441,31 @@ style var_stream_10 fill:transparent
 end
 subgraph var_stream_100 ["var <tt>stream_100</tt>"]
 style var_stream_100 fill:transparent
-    74v1
-end
-subgraph var_stream_101 ["var <tt>stream_101</tt>"]
-style var_stream_101 fill:transparent
-    75v1
+    73v1
 end
 subgraph var_stream_102 ["var <tt>stream_102</tt>"]
 style var_stream_102 fill:transparent
-    76v1
+    74v1
 end
 subgraph var_stream_103 ["var <tt>stream_103</tt>"]
 style var_stream_103 fill:transparent
+    75v1
+end
+subgraph var_stream_104 ["var <tt>stream_104</tt>"]
+style var_stream_104 fill:transparent
+    76v1
+end
+subgraph var_stream_105 ["var <tt>stream_105</tt>"]
+style var_stream_105 fill:transparent
     77v1
-end
-subgraph var_stream_106 ["var <tt>stream_106</tt>"]
-style var_stream_106 fill:transparent
-    78v1
-end
-subgraph var_stream_107 ["var <tt>stream_107</tt>"]
-style var_stream_107 fill:transparent
-    79v1
 end
 subgraph var_stream_108 ["var <tt>stream_108</tt>"]
 style var_stream_108 fill:transparent
-    80v1
+    78v1
+end
+subgraph var_stream_109 ["var <tt>stream_109</tt>"]
+style var_stream_109 fill:transparent
+    79v1
 end
 subgraph var_stream_11 ["var <tt>stream_11</tt>"]
 style var_stream_11 fill:transparent
@@ -473,51 +473,47 @@ style var_stream_11 fill:transparent
 end
 subgraph var_stream_110 ["var <tt>stream_110</tt>"]
 style var_stream_110 fill:transparent
-    82v1
-end
-subgraph var_stream_111 ["var <tt>stream_111</tt>"]
-style var_stream_111 fill:transparent
-    83v1
+    80v1
 end
 subgraph var_stream_112 ["var <tt>stream_112</tt>"]
 style var_stream_112 fill:transparent
-    84v1
+    82v1
 end
 subgraph var_stream_113 ["var <tt>stream_113</tt>"]
 style var_stream_113 fill:transparent
-    85v1
+    83v1
+end
+subgraph var_stream_114 ["var <tt>stream_114</tt>"]
+style var_stream_114 fill:transparent
+    84v1
 end
 subgraph var_stream_115 ["var <tt>stream_115</tt>"]
 style var_stream_115 fill:transparent
+    85v1
+end
+subgraph var_stream_117 ["var <tt>stream_117</tt>"]
+style var_stream_117 fill:transparent
     86v1
 end
-subgraph var_stream_116 ["var <tt>stream_116</tt>"]
-style var_stream_116 fill:transparent
+subgraph var_stream_118 ["var <tt>stream_118</tt>"]
+style var_stream_118 fill:transparent
     87v1
 end
 subgraph var_stream_12 ["var <tt>stream_12</tt>"]
 style var_stream_12 fill:transparent
     8v1
 end
-subgraph var_stream_125 ["var <tt>stream_125</tt>"]
-style var_stream_125 fill:transparent
-    88v1
-end
-subgraph var_stream_126 ["var <tt>stream_126</tt>"]
-style var_stream_126 fill:transparent
-    89v1
-end
 subgraph var_stream_127 ["var <tt>stream_127</tt>"]
 style var_stream_127 fill:transparent
-    90v1
+    88v1
 end
 subgraph var_stream_128 ["var <tt>stream_128</tt>"]
 style var_stream_128 fill:transparent
-    91v1
+    89v1
 end
 subgraph var_stream_129 ["var <tt>stream_129</tt>"]
 style var_stream_129 fill:transparent
-    92v1
+    90v1
 end
 subgraph var_stream_13 ["var <tt>stream_13</tt>"]
 style var_stream_13 fill:transparent
@@ -525,52 +521,56 @@ style var_stream_13 fill:transparent
 end
 subgraph var_stream_130 ["var <tt>stream_130</tt>"]
 style var_stream_130 fill:transparent
-    93v1
+    91v1
+end
+subgraph var_stream_131 ["var <tt>stream_131</tt>"]
+style var_stream_131 fill:transparent
+    92v1
 end
 subgraph var_stream_132 ["var <tt>stream_132</tt>"]
 style var_stream_132 fill:transparent
-    95v1
-end
-subgraph var_stream_133 ["var <tt>stream_133</tt>"]
-style var_stream_133 fill:transparent
-    96v1
+    93v1
 end
 subgraph var_stream_134 ["var <tt>stream_134</tt>"]
 style var_stream_134 fill:transparent
-    97v1
+    95v1
 end
 subgraph var_stream_135 ["var <tt>stream_135</tt>"]
 style var_stream_135 fill:transparent
+    96v1
+end
+subgraph var_stream_136 ["var <tt>stream_136</tt>"]
+style var_stream_136 fill:transparent
+    97v1
+end
+subgraph var_stream_137 ["var <tt>stream_137</tt>"]
+style var_stream_137 fill:transparent
     98v1
+end
+subgraph var_stream_138 ["var <tt>stream_138</tt>"]
+style var_stream_138 fill:transparent
+    99v1
 end
 subgraph var_stream_15 ["var <tt>stream_15</tt>"]
 style var_stream_15 fill:transparent
     10v1
 end
-subgraph var_stream_152 ["var <tt>stream_152</tt>"]
-style var_stream_152 fill:transparent
+subgraph var_stream_155 ["var <tt>stream_155</tt>"]
+style var_stream_155 fill:transparent
     101v1
     102v1
 end
-subgraph var_stream_153 ["var <tt>stream_153</tt>"]
-style var_stream_153 fill:transparent
-    103v1
-end
-subgraph var_stream_155 ["var <tt>stream_155</tt>"]
-style var_stream_155 fill:transparent
-    104v1
-end
 subgraph var_stream_156 ["var <tt>stream_156</tt>"]
 style var_stream_156 fill:transparent
-    105v1
-end
-subgraph var_stream_157 ["var <tt>stream_157</tt>"]
-style var_stream_157 fill:transparent
-    106v1
+    103v1
 end
 subgraph var_stream_158 ["var <tt>stream_158</tt>"]
 style var_stream_158 fill:transparent
-    107v1
+    104v1
+end
+subgraph var_stream_159 ["var <tt>stream_159</tt>"]
+style var_stream_159 fill:transparent
+    105v1
 end
 subgraph var_stream_16 ["var <tt>stream_16</tt>"]
 style var_stream_16 fill:transparent
@@ -578,43 +578,39 @@ style var_stream_16 fill:transparent
 end
 subgraph var_stream_160 ["var <tt>stream_160</tt>"]
 style var_stream_160 fill:transparent
-    108v1
+    106v1
 end
 subgraph var_stream_161 ["var <tt>stream_161</tt>"]
 style var_stream_161 fill:transparent
-    109v1
-end
-subgraph var_stream_162 ["var <tt>stream_162</tt>"]
-style var_stream_162 fill:transparent
-    110v1
+    107v1
 end
 subgraph var_stream_163 ["var <tt>stream_163</tt>"]
 style var_stream_163 fill:transparent
-    111v1
+    108v1
 end
 subgraph var_stream_164 ["var <tt>stream_164</tt>"]
 style var_stream_164 fill:transparent
-    112v1
+    109v1
 end
 subgraph var_stream_165 ["var <tt>stream_165</tt>"]
 style var_stream_165 fill:transparent
-    113v1
+    110v1
 end
 subgraph var_stream_166 ["var <tt>stream_166</tt>"]
 style var_stream_166 fill:transparent
-    114v1
+    111v1
 end
 subgraph var_stream_167 ["var <tt>stream_167</tt>"]
 style var_stream_167 fill:transparent
-    115v1
+    112v1
 end
 subgraph var_stream_168 ["var <tt>stream_168</tt>"]
 style var_stream_168 fill:transparent
-    116v1
+    113v1
 end
 subgraph var_stream_169 ["var <tt>stream_169</tt>"]
 style var_stream_169 fill:transparent
-    117v1
+    114v1
 end
 subgraph var_stream_17 ["var <tt>stream_17</tt>"]
 style var_stream_17 fill:transparent
@@ -622,39 +618,39 @@ style var_stream_17 fill:transparent
 end
 subgraph var_stream_170 ["var <tt>stream_170</tt>"]
 style var_stream_170 fill:transparent
-    118v1
+    115v1
+end
+subgraph var_stream_171 ["var <tt>stream_171</tt>"]
+style var_stream_171 fill:transparent
+    116v1
 end
 subgraph var_stream_172 ["var <tt>stream_172</tt>"]
 style var_stream_172 fill:transparent
-    119v1
+    117v1
 end
 subgraph var_stream_173 ["var <tt>stream_173</tt>"]
 style var_stream_173 fill:transparent
-    120v1
-end
-subgraph var_stream_174 ["var <tt>stream_174</tt>"]
-style var_stream_174 fill:transparent
-    121v1
+    118v1
 end
 subgraph var_stream_175 ["var <tt>stream_175</tt>"]
 style var_stream_175 fill:transparent
-    122v1
+    119v1
 end
 subgraph var_stream_176 ["var <tt>stream_176</tt>"]
 style var_stream_176 fill:transparent
-    123v1
+    120v1
 end
 subgraph var_stream_177 ["var <tt>stream_177</tt>"]
 style var_stream_177 fill:transparent
-    124v1
+    121v1
 end
 subgraph var_stream_178 ["var <tt>stream_178</tt>"]
 style var_stream_178 fill:transparent
-    125v1
+    122v1
 end
 subgraph var_stream_179 ["var <tt>stream_179</tt>"]
 style var_stream_179 fill:transparent
-    126v1
+    123v1
 end
 subgraph var_stream_18 ["var <tt>stream_18</tt>"]
 style var_stream_18 fill:transparent
@@ -662,55 +658,55 @@ style var_stream_18 fill:transparent
 end
 subgraph var_stream_180 ["var <tt>stream_180</tt>"]
 style var_stream_180 fill:transparent
-    127v1
+    124v1
+end
+subgraph var_stream_181 ["var <tt>stream_181</tt>"]
+style var_stream_181 fill:transparent
+    125v1
+end
+subgraph var_stream_182 ["var <tt>stream_182</tt>"]
+style var_stream_182 fill:transparent
+    126v1
 end
 subgraph var_stream_183 ["var <tt>stream_183</tt>"]
 style var_stream_183 fill:transparent
+    127v1
+end
+subgraph var_stream_186 ["var <tt>stream_186</tt>"]
+style var_stream_186 fill:transparent
     129v1
 end
-subgraph var_stream_184 ["var <tt>stream_184</tt>"]
-style var_stream_184 fill:transparent
+subgraph var_stream_187 ["var <tt>stream_187</tt>"]
+style var_stream_187 fill:transparent
     130v1
 end
-subgraph var_stream_185 ["var <tt>stream_185</tt>"]
-style var_stream_185 fill:transparent
+subgraph var_stream_188 ["var <tt>stream_188</tt>"]
+style var_stream_188 fill:transparent
     131v1
-end
-subgraph var_stream_189 ["var <tt>stream_189</tt>"]
-style var_stream_189 fill:transparent
-    132v1
 end
 subgraph var_stream_19 ["var <tt>stream_19</tt>"]
 style var_stream_19 fill:transparent
     14v1
 end
-subgraph var_stream_190 ["var <tt>stream_190</tt>"]
-style var_stream_190 fill:transparent
-    133v1
+subgraph var_stream_192 ["var <tt>stream_192</tt>"]
+style var_stream_192 fill:transparent
+    132v1
 end
 subgraph var_stream_193 ["var <tt>stream_193</tt>"]
 style var_stream_193 fill:transparent
-    134v1
-end
-subgraph var_stream_195 ["var <tt>stream_195</tt>"]
-style var_stream_195 fill:transparent
-    135v1
+    133v1
 end
 subgraph var_stream_196 ["var <tt>stream_196</tt>"]
 style var_stream_196 fill:transparent
-    136v1
-end
-subgraph var_stream_197 ["var <tt>stream_197</tt>"]
-style var_stream_197 fill:transparent
-    137v1
+    134v1
 end
 subgraph var_stream_198 ["var <tt>stream_198</tt>"]
 style var_stream_198 fill:transparent
-    138v1
+    135v1
 end
 subgraph var_stream_199 ["var <tt>stream_199</tt>"]
 style var_stream_199 fill:transparent
-    139v1
+    136v1
 end
 subgraph var_stream_20 ["var <tt>stream_20</tt>"]
 style var_stream_20 fill:transparent
@@ -718,31 +714,35 @@ style var_stream_20 fill:transparent
 end
 subgraph var_stream_200 ["var <tt>stream_200</tt>"]
 style var_stream_200 fill:transparent
-    140v1
+    137v1
 end
 subgraph var_stream_201 ["var <tt>stream_201</tt>"]
 style var_stream_201 fill:transparent
-    141v1
+    138v1
 end
 subgraph var_stream_202 ["var <tt>stream_202</tt>"]
 style var_stream_202 fill:transparent
-    142v1
+    139v1
 end
 subgraph var_stream_203 ["var <tt>stream_203</tt>"]
 style var_stream_203 fill:transparent
-    143v1
+    140v1
+end
+subgraph var_stream_204 ["var <tt>stream_204</tt>"]
+style var_stream_204 fill:transparent
+    141v1
+end
+subgraph var_stream_205 ["var <tt>stream_205</tt>"]
+style var_stream_205 fill:transparent
+    142v1
 end
 subgraph var_stream_206 ["var <tt>stream_206</tt>"]
 style var_stream_206 fill:transparent
-    144v1
-end
-subgraph var_stream_207 ["var <tt>stream_207</tt>"]
-style var_stream_207 fill:transparent
-    145v1
+    143v1
 end
 subgraph var_stream_209 ["var <tt>stream_209</tt>"]
 style var_stream_209 fill:transparent
-    146v1
+    144v1
 end
 subgraph var_stream_21 ["var <tt>stream_21</tt>"]
 style var_stream_21 fill:transparent
@@ -750,92 +750,92 @@ style var_stream_21 fill:transparent
 end
 subgraph var_stream_210 ["var <tt>stream_210</tt>"]
 style var_stream_210 fill:transparent
-    147v1
+    145v1
 end
 subgraph var_stream_212 ["var <tt>stream_212</tt>"]
 style var_stream_212 fill:transparent
-    148v1
+    146v1
 end
 subgraph var_stream_213 ["var <tt>stream_213</tt>"]
 style var_stream_213 fill:transparent
-    149v1
-end
-subgraph var_stream_214 ["var <tt>stream_214</tt>"]
-style var_stream_214 fill:transparent
-    150v1
+    147v1
 end
 subgraph var_stream_215 ["var <tt>stream_215</tt>"]
 style var_stream_215 fill:transparent
-    151v1
+    148v1
+end
+subgraph var_stream_216 ["var <tt>stream_216</tt>"]
+style var_stream_216 fill:transparent
+    149v1
 end
 subgraph var_stream_217 ["var <tt>stream_217</tt>"]
 style var_stream_217 fill:transparent
-    152v1
+    150v1
 end
 subgraph var_stream_218 ["var <tt>stream_218</tt>"]
 style var_stream_218 fill:transparent
-    153v1
-end
-subgraph var_stream_219 ["var <tt>stream_219</tt>"]
-style var_stream_219 fill:transparent
-    154v1
+    151v1
 end
 subgraph var_stream_220 ["var <tt>stream_220</tt>"]
 style var_stream_220 fill:transparent
-    155v1
+    152v1
 end
 subgraph var_stream_221 ["var <tt>stream_221</tt>"]
 style var_stream_221 fill:transparent
-    156v1
+    153v1
 end
 subgraph var_stream_222 ["var <tt>stream_222</tt>"]
 style var_stream_222 fill:transparent
+    154v1
+end
+subgraph var_stream_223 ["var <tt>stream_223</tt>"]
+style var_stream_223 fill:transparent
+    155v1
+end
+subgraph var_stream_224 ["var <tt>stream_224</tt>"]
+style var_stream_224 fill:transparent
+    156v1
+end
+subgraph var_stream_225 ["var <tt>stream_225</tt>"]
+style var_stream_225 fill:transparent
     157v1
 end
-subgraph var_stream_229 ["var <tt>stream_229</tt>"]
-style var_stream_229 fill:transparent
-    160v1
-    161v1
+subgraph var_stream_226 ["var <tt>stream_226</tt>"]
+style var_stream_226 fill:transparent
+    158v1
 end
 subgraph var_stream_23 ["var <tt>stream_23</tt>"]
 style var_stream_23 fill:transparent
     17v1
 end
-subgraph var_stream_230 ["var <tt>stream_230</tt>"]
-style var_stream_230 fill:transparent
-    162v1
-end
-subgraph var_stream_231 ["var <tt>stream_231</tt>"]
-style var_stream_231 fill:transparent
-    163v1
-end
-subgraph var_stream_232 ["var <tt>stream_232</tt>"]
-style var_stream_232 fill:transparent
-    164v1
-end
 subgraph var_stream_233 ["var <tt>stream_233</tt>"]
 style var_stream_233 fill:transparent
-    165v1
+    160v1
+    161v1
 end
 subgraph var_stream_234 ["var <tt>stream_234</tt>"]
 style var_stream_234 fill:transparent
-    166v1
+    162v1
 end
 subgraph var_stream_235 ["var <tt>stream_235</tt>"]
 style var_stream_235 fill:transparent
-    167v1
+    163v1
 end
 subgraph var_stream_236 ["var <tt>stream_236</tt>"]
 style var_stream_236 fill:transparent
-    168v1
+    164v1
 end
 subgraph var_stream_237 ["var <tt>stream_237</tt>"]
 style var_stream_237 fill:transparent
-    169v1
+    165v1
+end
+subgraph var_stream_238 ["var <tt>stream_238</tt>"]
+style var_stream_238 fill:transparent
+    166v1
 end
 subgraph var_stream_239 ["var <tt>stream_239</tt>"]
 style var_stream_239 fill:transparent
-    170v1
+    167v1
 end
 subgraph var_stream_24 ["var <tt>stream_24</tt>"]
 style var_stream_24 fill:transparent
@@ -843,91 +843,107 @@ style var_stream_24 fill:transparent
 end
 subgraph var_stream_240 ["var <tt>stream_240</tt>"]
 style var_stream_240 fill:transparent
-    171v1
+    168v1
 end
 subgraph var_stream_241 ["var <tt>stream_241</tt>"]
 style var_stream_241 fill:transparent
-    172v1
+    169v1
 end
-subgraph var_stream_242 ["var <tt>stream_242</tt>"]
-style var_stream_242 fill:transparent
-    173v1
+subgraph var_stream_243 ["var <tt>stream_243</tt>"]
+style var_stream_243 fill:transparent
+    170v1
+end
+subgraph var_stream_244 ["var <tt>stream_244</tt>"]
+style var_stream_244 fill:transparent
+    171v1
 end
 subgraph var_stream_245 ["var <tt>stream_245</tt>"]
 style var_stream_245 fill:transparent
-    174v1
+    172v1
 end
 subgraph var_stream_246 ["var <tt>stream_246</tt>"]
 style var_stream_246 fill:transparent
-    175v1
+    173v1
 end
 subgraph var_stream_249 ["var <tt>stream_249</tt>"]
 style var_stream_249 fill:transparent
-    176v1
+    174v1
 end
 subgraph var_stream_250 ["var <tt>stream_250</tt>"]
 style var_stream_250 fill:transparent
-    177v1
+    175v1
 end
 subgraph var_stream_253 ["var <tt>stream_253</tt>"]
 style var_stream_253 fill:transparent
-    178v1
+    176v1
 end
 subgraph var_stream_254 ["var <tt>stream_254</tt>"]
 style var_stream_254 fill:transparent
-    179v1
-end
-subgraph var_stream_255 ["var <tt>stream_255</tt>"]
-style var_stream_255 fill:transparent
-    180v1
-end
-subgraph var_stream_256 ["var <tt>stream_256</tt>"]
-style var_stream_256 fill:transparent
-    181v1
+    177v1
 end
 subgraph var_stream_257 ["var <tt>stream_257</tt>"]
 style var_stream_257 fill:transparent
-    182v1
+    178v1
 end
 subgraph var_stream_258 ["var <tt>stream_258</tt>"]
 style var_stream_258 fill:transparent
-    183v1
+    179v1
+end
+subgraph var_stream_259 ["var <tt>stream_259</tt>"]
+style var_stream_259 fill:transparent
+    180v1
 end
 subgraph var_stream_26 ["var <tt>stream_26</tt>"]
 style var_stream_26 fill:transparent
     19v1
 end
-subgraph var_stream_269 ["var <tt>stream_269</tt>"]
-style var_stream_269 fill:transparent
-    184v1
+subgraph var_stream_260 ["var <tt>stream_260</tt>"]
+style var_stream_260 fill:transparent
+    181v1
+end
+subgraph var_stream_261 ["var <tt>stream_261</tt>"]
+style var_stream_261 fill:transparent
+    182v1
+end
+subgraph var_stream_262 ["var <tt>stream_262</tt>"]
+style var_stream_262 fill:transparent
+    183v1
 end
 subgraph var_stream_27 ["var <tt>stream_27</tt>"]
 style var_stream_27 fill:transparent
     20v1
 end
-subgraph var_stream_270 ["var <tt>stream_270</tt>"]
-style var_stream_270 fill:transparent
-    185v1
-end
 subgraph var_stream_273 ["var <tt>stream_273</tt>"]
 style var_stream_273 fill:transparent
-    186v1
+    184v1
 end
 subgraph var_stream_274 ["var <tt>stream_274</tt>"]
 style var_stream_274 fill:transparent
+    185v1
+end
+subgraph var_stream_277 ["var <tt>stream_277</tt>"]
+style var_stream_277 fill:transparent
+    186v1
+end
+subgraph var_stream_278 ["var <tt>stream_278</tt>"]
+style var_stream_278 fill:transparent
     187v1
 end
-subgraph var_stream_275 ["var <tt>stream_275</tt>"]
-style var_stream_275 fill:transparent
+subgraph var_stream_279 ["var <tt>stream_279</tt>"]
+style var_stream_279 fill:transparent
     188v1
-end
-subgraph var_stream_276 ["var <tt>stream_276</tt>"]
-style var_stream_276 fill:transparent
-    189v1
 end
 subgraph var_stream_28 ["var <tt>stream_28</tt>"]
 style var_stream_28 fill:transparent
     21v1
+end
+subgraph var_stream_280 ["var <tt>stream_280</tt>"]
+style var_stream_280 fill:transparent
+    189v1
+end
+subgraph var_stream_281 ["var <tt>stream_281</tt>"]
+style var_stream_281 fill:transparent
+    190v1
 end
 subgraph var_stream_29 ["var <tt>stream_29</tt>"]
 style var_stream_29 fill:transparent
@@ -955,117 +971,117 @@ style var_stream_34 fill:transparent
 end
 subgraph var_stream_35 ["var <tt>stream_35</tt>"]
 style var_stream_35 fill:transparent
-    30v1
-    31v1
+    28v1
 end
 subgraph var_stream_36 ["var <tt>stream_36</tt>"]
 style var_stream_36 fill:transparent
-    32v1
+    30v1
+    31v1
 end
 subgraph var_stream_37 ["var <tt>stream_37</tt>"]
 style var_stream_37 fill:transparent
-    33v1
+    32v1
 end
-subgraph var_stream_41 ["var <tt>stream_41</tt>"]
-style var_stream_41 fill:transparent
-    34v1
+subgraph var_stream_38 ["var <tt>stream_38</tt>"]
+style var_stream_38 fill:transparent
+    33v1
 end
 subgraph var_stream_42 ["var <tt>stream_42</tt>"]
 style var_stream_42 fill:transparent
-    35v1
+    34v1
 end
-subgraph var_stream_44 ["var <tt>stream_44</tt>"]
-style var_stream_44 fill:transparent
-    36v1
+subgraph var_stream_43 ["var <tt>stream_43</tt>"]
+style var_stream_43 fill:transparent
+    35v1
 end
 subgraph var_stream_45 ["var <tt>stream_45</tt>"]
 style var_stream_45 fill:transparent
-    37v1
+    36v1
 end
 subgraph var_stream_46 ["var <tt>stream_46</tt>"]
 style var_stream_46 fill:transparent
-    38v1
+    37v1
 end
 subgraph var_stream_47 ["var <tt>stream_47</tt>"]
 style var_stream_47 fill:transparent
-    39v1
+    38v1
 end
 subgraph var_stream_48 ["var <tt>stream_48</tt>"]
 style var_stream_48 fill:transparent
-    40v1
+    39v1
 end
 subgraph var_stream_49 ["var <tt>stream_49</tt>"]
 style var_stream_49 fill:transparent
-    41v1
+    40v1
 end
 subgraph var_stream_50 ["var <tt>stream_50</tt>"]
 style var_stream_50 fill:transparent
-    42v1
+    41v1
 end
 subgraph var_stream_51 ["var <tt>stream_51</tt>"]
 style var_stream_51 fill:transparent
-    43v1
+    42v1
 end
 subgraph var_stream_52 ["var <tt>stream_52</tt>"]
 style var_stream_52 fill:transparent
-    44v1
+    43v1
 end
 subgraph var_stream_53 ["var <tt>stream_53</tt>"]
 style var_stream_53 fill:transparent
-    45v1
+    44v1
 end
 subgraph var_stream_54 ["var <tt>stream_54</tt>"]
 style var_stream_54 fill:transparent
-    46v1
+    45v1
 end
 subgraph var_stream_55 ["var <tt>stream_55</tt>"]
 style var_stream_55 fill:transparent
-    47v1
+    46v1
 end
 subgraph var_stream_56 ["var <tt>stream_56</tt>"]
 style var_stream_56 fill:transparent
-    48v1
+    47v1
 end
 subgraph var_stream_57 ["var <tt>stream_57</tt>"]
 style var_stream_57 fill:transparent
+    48v1
+end
+subgraph var_stream_58 ["var <tt>stream_58</tt>"]
+style var_stream_58 fill:transparent
     49v1
+end
+subgraph var_stream_59 ["var <tt>stream_59</tt>"]
+style var_stream_59 fill:transparent
+    50v1
 end
 subgraph var_stream_6 ["var <tt>stream_6</tt>"]
 style var_stream_6 fill:transparent
     3v1
 end
-subgraph var_stream_72 ["var <tt>stream_72</tt>"]
-style var_stream_72 fill:transparent
+subgraph var_stream_74 ["var <tt>stream_74</tt>"]
+style var_stream_74 fill:transparent
     52v1
     53v1
 end
-subgraph var_stream_73 ["var <tt>stream_73</tt>"]
-style var_stream_73 fill:transparent
-    54v1
-end
-subgraph var_stream_74 ["var <tt>stream_74</tt>"]
-style var_stream_74 fill:transparent
-    55v1
-end
 subgraph var_stream_75 ["var <tt>stream_75</tt>"]
 style var_stream_75 fill:transparent
-    56v1
+    54v1
 end
 subgraph var_stream_76 ["var <tt>stream_76</tt>"]
 style var_stream_76 fill:transparent
-    57v1
+    55v1
 end
 subgraph var_stream_77 ["var <tt>stream_77</tt>"]
 style var_stream_77 fill:transparent
-    58v1
+    56v1
 end
 subgraph var_stream_78 ["var <tt>stream_78</tt>"]
 style var_stream_78 fill:transparent
-    59v1
+    57v1
 end
 subgraph var_stream_79 ["var <tt>stream_79</tt>"]
 style var_stream_79 fill:transparent
-    60v1
+    58v1
 end
 subgraph var_stream_8 ["var <tt>stream_8</tt>"]
 style var_stream_8 fill:transparent
@@ -1073,57 +1089,61 @@ style var_stream_8 fill:transparent
 end
 subgraph var_stream_80 ["var <tt>stream_80</tt>"]
 style var_stream_80 fill:transparent
-    61v1
+    59v1
+end
+subgraph var_stream_81 ["var <tt>stream_81</tt>"]
+style var_stream_81 fill:transparent
+    60v1
 end
 subgraph var_stream_82 ["var <tt>stream_82</tt>"]
 style var_stream_82 fill:transparent
-    62v1
-end
-subgraph var_stream_83 ["var <tt>stream_83</tt>"]
-style var_stream_83 fill:transparent
-    63v1
+    61v1
 end
 subgraph var_stream_84 ["var <tt>stream_84</tt>"]
 style var_stream_84 fill:transparent
-    64v1
+    62v1
 end
 subgraph var_stream_85 ["var <tt>stream_85</tt>"]
 style var_stream_85 fill:transparent
+    63v1
+end
+subgraph var_stream_86 ["var <tt>stream_86</tt>"]
+style var_stream_86 fill:transparent
+    64v1
+end
+subgraph var_stream_87 ["var <tt>stream_87</tt>"]
+style var_stream_87 fill:transparent
     65v1
-end
-subgraph var_stream_88 ["var <tt>stream_88</tt>"]
-style var_stream_88 fill:transparent
-    66v1
-end
-subgraph var_stream_89 ["var <tt>stream_89</tt>"]
-style var_stream_89 fill:transparent
-    67v1
 end
 subgraph var_stream_9 ["var <tt>stream_9</tt>"]
 style var_stream_9 fill:transparent
     5v1
 end
-subgraph var_stream_92 ["var <tt>stream_92</tt>"]
-style var_stream_92 fill:transparent
-    68v1
+subgraph var_stream_90 ["var <tt>stream_90</tt>"]
+style var_stream_90 fill:transparent
+    66v1
 end
-subgraph var_stream_93 ["var <tt>stream_93</tt>"]
-style var_stream_93 fill:transparent
-    69v1
+subgraph var_stream_91 ["var <tt>stream_91</tt>"]
+style var_stream_91 fill:transparent
+    67v1
+end
+subgraph var_stream_94 ["var <tt>stream_94</tt>"]
+style var_stream_94 fill:transparent
+    68v1
 end
 subgraph var_stream_95 ["var <tt>stream_95</tt>"]
 style var_stream_95 fill:transparent
-    70v1
-end
-subgraph var_stream_96 ["var <tt>stream_96</tt>"]
-style var_stream_96 fill:transparent
-    71v1
+    69v1
 end
 subgraph var_stream_97 ["var <tt>stream_97</tt>"]
 style var_stream_97 fill:transparent
-    72v1
+    70v1
 end
 subgraph var_stream_98 ["var <tt>stream_98</tt>"]
 style var_stream_98 fill:transparent
-    73v1
+    71v1
+end
+subgraph var_stream_99 ["var <tt>stream_99</tt>"]
+style var_stream_99 fill:transparent
+    72v1
 end


### PR DESCRIPTION

`Bytes::clone` is ~O(1), so it's much better to clone after serialization than before (O(n) serialization cost and allocations).
