### PR TITLE
handle -1 in samply data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1924,6 +1924,7 @@ dependencies = [
  "nix",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "shell-escape",
  "tempfile",
  "tokio",
@@ -4435,6 +4436,16 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+dependencies = [
+ "itoa",
  "serde",
 ]
 

--- a/cleanup-perf.bash
+++ b/cleanup-perf.bash
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-rm *.data.folded *.perf.data *.svg
+rm *.data.folded *.perf.data *.svg *.profile || true

--- a/dfir_lang/src/graph/ops/_counter.rs
+++ b/dfir_lang/src/graph/ops/_counter.rs
@@ -68,7 +68,7 @@ pub const _COUNTER: OperatorConstraints = OperatorConstraints {
         let duration_ident = wc.make_ident("duration");
 
         let write_prologue = quote_spanned! {op_span=>
-            let #write_ident = ::std::rc::Rc::new(::std::cell::Cell::new(0));
+            let #write_ident = ::std::rc::Rc::new(::std::cell::Cell::new(0_u64));
 
             let #read_ident = ::std::rc::Rc::clone(&#write_ident);
             let #duration_ident = #duration_expr;

--- a/dfir_lang/src/graph/ops/dest_sink.rs
+++ b/dfir_lang/src/graph/ops/dest_sink.rs
@@ -131,13 +131,13 @@ pub const DEST_SINK: OperatorConstraints = OperatorConstraints {
                     while let Some(item) = recv.recv().await {
                         sink.feed(item)
                             .await
-                            .expect("Error processing async sink item.");
+                            .expect("Error processing async sink item");
                         while let Ok(item) = recv.try_recv() {
                             sink.feed(item)
                                 .await
-                                .expect("Error processing async sink item.");
+                                .expect("Error processing async sink item");
                         }
-                        sink.flush().await.expect("Failed to flush sink.");
+                        sink.flush().await.expect("Failed to flush sink");
                     }
                 }
                 #df_ident
@@ -148,7 +148,7 @@ pub const DEST_SINK: OperatorConstraints = OperatorConstraints {
         let write_iterator = quote_spanned! {op_span=>
             let #ident = #root::pusherator::for_each::ForEach::new(|item| {
                 if let Err(err) = #send_ident.send(item) {
-                    panic!("Failed to send async write item for processing.: {}", err);
+                    panic!("Failed to send async write item for processing: {}", err);
                 }
             });
         };

--- a/hydro_deploy/core/Cargo.toml
+++ b/hydro_deploy/core/Cargo.toml
@@ -33,6 +33,7 @@ nanoid = "0.4.0"
 nix = { version = "0.29.0", features = ["signal"] }
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.115"
+serde_path_to_error = "0.1.0"
 shell-escape = "0.1.0"
 tempfile = "3.0.0"
 tokio = { version = "1.29.0", features = ["full"] }

--- a/hydro_deploy/core/src/localhost/launched_binary.rs
+++ b/hydro_deploy/core/src/localhost/launched_binary.rs
@@ -188,9 +188,10 @@ impl LaunchedBinary for LaunchedLocalhostBinary {
                 }
 
                 let fold_data = if cfg!(target_os = "macos") {
-                    let loaded = serde_json::from_reader::<_, FxProfile>(std::fs::File::open(
+                    let deserializer = &mut serde_json::Deserializer::from_reader(std::fs::File::open(
                         tracing_data.outfile.path(),
-                    )?)?;
+                    )?);
+                    let loaded = serde_path_to_error::deserialize::<_, FxProfile>(deserializer)?;
 
                     samply_to_folded(loaded).await.into()
                 } else if cfg!(target_family = "windows") {

--- a/hydro_lang/src/rewrites/analyze_counter.rs
+++ b/hydro_lang/src/rewrites/analyze_counter.rs
@@ -8,7 +8,12 @@ use crate::ir::*;
 /// Returns (op_id, count)
 pub fn parse_counter_usage(measurement: String) -> (usize, usize) {
     let regex = Regex::new(r"\((\d+)\): (\d+)").unwrap();
-    let matches = regex.captures_iter(&measurement).last().unwrap();
+    let matches = regex.captures_iter(&measurement).last().unwrap_or_else(|| {
+        ::core::panic!(
+            "Failed to parse counter usage from measurement: {:?}",
+            measurement
+        )
+    });
     let op_id = matches[1].parse::<usize>().unwrap();
     let count = matches[2].parse::<usize>().unwrap();
     (op_id, count)


### PR DESCRIPTION
<details>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| hydro_lang/src/rewrites/analyze_counter.rs | Adds custom panic with measurement details if regex matching fails. (Used to diagnose `_counter()` `i32` rollover) |
| hydro_deploy/core/src/localhost/samply.rs | Updates type for addresses/resources, refactors frame lookup to use asynchronous join_all, and adjusts string output for missing symbols. |
| hydro_deploy/core/src/localhost/mod.rs | Improves error handling during command spawning with conditional context messages for when `samply` or `dtrace` executables are not found. |
| hydro_deploy/core/src/localhost/launched_binary.rs | Uses serde_path_to_error for improved deserialization error context. |
| dfir_lang/src/graph/ops/dest_sink.rs | Standardizes error messages by removing extraneous punctuation. |
| dfir_lang/src/graph/ops/_counter.rs | Adds explicit type annotation for a cell initialization to prevent `i32` rollover. |
</details>