### PR TITLE
refactor(hydro_lang): use `fs2` file locking to fix stable build testing #1780

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,4 +27,12 @@
     "evenBetterToml.formatter.compactArrays": true,
     "evenBetterToml.formatter.allowedBlankLines": 2,
     "evenBetterToml.formatter.trailingNewline": true,
+    "evenBetterToml.formatter.arrayAutoCollapse": true,
+    "evenBetterToml.formatter.arrayAutoExpand": true,
+    "evenBetterToml.formatter.arrayTrailingComma": true,
+    "evenBetterToml.formatter.compactEntries": false,
+    "evenBetterToml.formatter.compactInlineTables": false,
+    "evenBetterToml.formatter.crlf": false,
+    "evenBetterToml.formatter.indentEntries": false,
+    "evenBetterToml.formatter.indentTables": false,
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,4 +23,8 @@
     "files.watcherExclude": {
         "**/target": true
     },
+    "evenBetterToml.formatter.columnWidth": 80,
+    "evenBetterToml.formatter.compactArrays": true,
+    "evenBetterToml.formatter.allowedBlankLines": 2,
+    "evenBetterToml.formatter.trailingNewline": true,
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1419,6 +1419,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fs4"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1960,6 +1970,7 @@ dependencies = [
  "ctor 0.2.9",
  "dfir_lang",
  "dfir_rs",
+ "fs2",
  "futures",
  "hydro_deploy",
  "hydro_deploy_integration",

--- a/hydro_lang/Cargo.toml
+++ b/hydro_lang/Cargo.toml
@@ -65,6 +65,12 @@ tokio-stream = { version = "0.1.3", default-features = false, features = [
 toml = { version = "0.8.0", optional = true }
 trybuild-internals-api = { version = "1.0.99", optional = true }
 
+[target.'cfg(not(nightly))'.dependencies]
+# TODO(mingwei): remove once file locking is stable: https://github.com/rust-lang/rust/issues/130994
+# build.rs `println!("cargo:rustc-cfg=nightly")` doens't affect this (happens
+# after dependency resolution), but this doesn't hurt to have.
+fs2 = "0.4.0"
+
 [target.'cfg(target_os = "linux")'.dependencies]
 chrono = { version = "0.4.39", optional = true }
 procfs = { version = "0.17.0", optional = true }

--- a/hydro_lang/Cargo.toml
+++ b/hydro_lang/Cargo.toml
@@ -65,10 +65,10 @@ tokio-stream = { version = "0.1.3", default-features = false, features = [
 toml = { version = "0.8.0", optional = true }
 trybuild-internals-api = { version = "1.0.99", optional = true }
 
-[target.'cfg(not(nightly))'.dependencies]
 # TODO(mingwei): remove once file locking is stable: https://github.com/rust-lang/rust/issues/130994
-# build.rs `println!("cargo:rustc-cfg=nightly")` doesn't affect this (happens
+# build.rs `println!("cargo:rustc-cfg=nightly")` doesn't gate this (happens
 # after dependency resolution), but this doesn't hurt to have.
+[target.'cfg(not(nightly))'.dependencies]
 fs2 = "0.4.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/hydro_lang/Cargo.toml
+++ b/hydro_lang/Cargo.toml
@@ -67,7 +67,7 @@ trybuild-internals-api = { version = "1.0.99", optional = true }
 
 [target.'cfg(not(nightly))'.dependencies]
 # TODO(mingwei): remove once file locking is stable: https://github.com/rust-lang/rust/issues/130994
-# build.rs `println!("cargo:rustc-cfg=nightly")` doens't affect this (happens
+# build.rs `println!("cargo:rustc-cfg=nightly")` doesn't affect this (happens
 # after dependency resolution), but this doesn't hurt to have.
 fs2 = "0.4.0"
 


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/130994