### PR TITLE
refactor(hydro_cli)!: use direct `&dyn Any` upcasting for Rust 1.86, update pyo3, fix #1821

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,8 @@ jobs:
 
       - name: Run Python tests (Linux)
         if: ${{ matrix.os == 'ubuntu-latest' }}
+        env:
+          RUST_BACKTRACE: 1
         run: |
           cd hydro_deploy/hydro_cli
           source .venv/bin/activate
@@ -202,6 +204,8 @@ jobs:
 
       - name: Run Python tests (Windows)
         if: ${{ matrix.os == 'windows-latest' }}
+        env:
+          RUST_BACKTRACE: 1
         run: |
           cd hydro_deploy/hydro_cli
           .venv/Scripts/activate

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2196,7 +2196,7 @@ dependencies = [
  "hydro_deploy",
  "hydro_deploy_integration",
  "pyo3",
- "pyo3-asyncio",
+ "pyo3-async-runtimes",
  "pythonize",
  "tokio",
 ]
@@ -4126,9 +4126,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.20.3"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53bdbb96d49157e65d45cc287af5f32ffadd5f4761438b527b055fb0d4bb8233"
+checksum = "a5e00b96a521718e08e03b1a622f01c8a8deb50719335de3f60b3b3950f069d8"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -4143,35 +4143,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "pyo3-asyncio"
-version = "0.20.0"
+name = "pyo3-async-runtimes"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea6b68e93db3622f3bb3bf363246cf948ed5375afe7abff98ccbdd50b184995"
+checksum = "96fe0b015461c5136532f42908d6bf4b079da1aedfbffa8b0b5d4cbc59c2fdf8"
 dependencies = [
  "futures",
  "once_cell",
  "pin-project-lite",
  "pyo3",
- "pyo3-asyncio-macros",
  "tokio",
 ]
 
 [[package]]
-name = "pyo3-asyncio-macros"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c467178e1da6252c95c29ecf898b133f742e9181dca5def15dc24e19d45a39"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "pyo3-build-config"
-version = "0.20.3"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7"
+checksum = "7883df5835fafdad87c0d888b266c8ec0f4c9ca48a5bed6bbb592e8dedee1b50"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -4179,9 +4167,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.20.3"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b42531d03e08d4ef1f6e85a2ed422eb678b8cd62b762e53891c05faf0d4afa"
+checksum = "01be5843dc60b916ab4dad1dca6d20b9b4e6ddc8e15f50c47fe6d85f1fb97403"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -4189,9 +4177,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.20.3"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7305c720fa01b8055ec95e484a6eca7a83c841267f0dd5280f0c8b8551d2c158"
+checksum = "77b34069fc0682e11b31dbd10321cbf94808394c56fd996796ce45217dfac53c"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -4201,9 +4189,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.20.3"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7e9b68bb9c3149c5b0cade5d07f953d6d125eb4337723c4ccdb665f1f96185"
+checksum = "08260721f32db5e1a5beae69a55553f56b99bd0e1c3e6e0a5e8851a9d0f5a85c"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
@@ -4214,9 +4202,9 @@ dependencies = [
 
 [[package]]
 name = "pythonize"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd1c3ef39c725d63db5f9bc455461bafd80540cb7824c61afb823501921a850"
+checksum = "9d0664248812c38cc55a4ed07f88e4df516ce82604b93b1ffdc041aa77a6cb3c"
 dependencies = [
  "pyo3",
  "serde",

--- a/dfir_rs/Cargo.toml
+++ b/dfir_rs/Cargo.toml
@@ -42,7 +42,7 @@ hydro_deploy_integration = { optional = true, path = "../hydro_deploy/hydro_depl
 itertools = "0.13.0"
 lattices = { path = "../lattices", version = "^0.6.1", features = [ "serde" ] }
 pusherator = { path = "../pusherator", version = "^0.0.12" }
-pyo3 = { optional = true, version = "0.20.0" }
+pyo3 = { optional = true, version = "0.21.0", features = [ "gil-refs" ] }
 ref-cast = "1.0.0"
 regex = "1.10.4"
 rustc-hash = "1.1.0"

--- a/dfir_rs/src/scheduled/graph.rs
+++ b/dfir_rs/src/scheduled/graph.rs
@@ -65,11 +65,8 @@ impl Dfir<'_> {
         let tee_root_data_name = tee_root_data.name.clone();
 
         // Insert new handoff output.
-        let teeing_handoff = tee_root_data
-            .handoff
-            .any_ref()
-            .downcast_ref::<TeeingHandoff<T>>()
-            .unwrap();
+        let teeing_handoff =
+            <dyn Any>::downcast_ref::<TeeingHandoff<T>>(&*tee_root_data.handoff).unwrap();
         let new_handoff = teeing_handoff.tee();
 
         // Handoff ID of new tee output.
@@ -111,11 +108,7 @@ impl Dfir<'_> {
         T: Clone,
     {
         let data = &self.handoffs[tee_port.handoff_id];
-        let teeing_handoff = data
-            .handoff
-            .any_ref()
-            .downcast_ref::<TeeingHandoff<T>>()
-            .unwrap();
+        let teeing_handoff = <dyn Any>::downcast_ref::<TeeingHandoff<T>>(&*data.handoff).unwrap();
         teeing_handoff.drop();
 
         let tee_root = data.pred_handoffs[0];
@@ -875,10 +868,7 @@ impl<'a> Dfir<'a> {
                         .map(|hid| hid.handoff_id)
                         .map(|hid| handoffs.get(hid).unwrap())
                         .map(|h_data| {
-                            h_data
-                                .handoff
-                                .any_ref()
-                                .downcast_ref()
+                            <dyn Any>::downcast_ref(&*h_data.handoff)
                                 .expect("Attempted to cast handoff to wrong type.")
                         })
                         .map(RefCast::ref_cast)
@@ -889,10 +879,7 @@ impl<'a> Dfir<'a> {
                         .map(|hid| hid.handoff_id)
                         .map(|hid| handoffs.get(hid).unwrap())
                         .map(|h_data| {
-                            h_data
-                                .handoff
-                                .any_ref()
-                                .downcast_ref()
+                            <dyn Any>::downcast_ref(&*h_data.handoff)
                                 .expect("Attempted to cast handoff to wrong type.")
                         })
                         .map(RefCast::ref_cast)

--- a/dfir_rs/src/scheduled/handoff/mod.rs
+++ b/dfir_rs/src/scheduled/handoff/mod.rs
@@ -27,12 +27,6 @@ pub trait CanReceive<T> {
 
 /// A handle onto the metadata part of a [Handoff], with no element type.
 pub trait HandoffMeta: Any {
-    /// Helper to cast an instance of `HandoffMeta` to [`Any`]. In general you cannot cast between
-    /// traits, including [`Any`], but this helper method works around that limitation.
-    ///
-    /// For implementors: the body of this method will generally just be `{ self }`.
-    fn any_ref(&self) -> &dyn Any;
-
     // TODO(justin): more fine-grained info here.
     /// Return if the handoff is empty.
     fn is_bottom(&self) -> bool;
@@ -42,10 +36,6 @@ impl<H> HandoffMeta for Rc<RefCell<H>>
 where
     H: HandoffMeta,
 {
-    fn any_ref(&self) -> &dyn Any {
-        self
-    }
-
     fn is_bottom(&self) -> bool {
         self.borrow().is_bottom()
     }

--- a/dfir_rs/src/scheduled/handoff/tee.rs
+++ b/dfir_rs/src/scheduled/handoff/tee.rs
@@ -1,6 +1,5 @@
 //! Module for teeing handoffs, not currently used much.
 
-use std::any::Any;
 use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::rc::Rc;
@@ -71,10 +70,6 @@ where
 }
 
 impl<T> HandoffMeta for TeeingHandoff<T> {
-    fn any_ref(&self) -> &dyn Any {
-        self
-    }
-
     /// If this output's buffer is empty, return true.
     fn is_bottom(&self) -> bool {
         self.internal.borrow().readers[self.read_from]

--- a/dfir_rs/src/scheduled/handoff/vector.rs
+++ b/dfir_rs/src/scheduled/handoff/vector.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::cell::{RefCell, RefMut};
 use std::rc::Rc;
 
@@ -65,10 +64,6 @@ impl<T> CanReceive<Vec<T>> for VecHandoff<T> {
 }
 
 impl<T> HandoffMeta for VecHandoff<T> {
-    fn any_ref(&self) -> &dyn Any {
-        self
-    }
-
     fn is_bottom(&self) -> bool {
         (*self.input).borrow_mut().is_empty()
     }

--- a/hydro_deploy/core/src/azure.rs
+++ b/hydro_deploy/core/src/azure.rs
@@ -1,3 +1,4 @@
+use std::any::Any;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, OnceLock};
 
@@ -123,10 +124,6 @@ impl Host for AzureHost {
 
     fn id(&self) -> usize {
         self.id
-    }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
     }
 
     fn collect_resources(&self, resource_batch: &mut ResourceBatch) {
@@ -474,7 +471,7 @@ impl Host for AzureHost {
                 }
             }
             ClientStrategy::InternalTcpPort(target_host) => {
-                if let Some(provider_target) = target_host.as_any().downcast_ref::<AzureHost>() {
+                if let Some(provider_target) = <dyn Any>::downcast_ref::<AzureHost>(target_host) {
                     self.project == provider_target.project
                 } else {
                     false

--- a/hydro_deploy/core/src/custom_service.rs
+++ b/hydro_deploy/core/src/custom_service.rs
@@ -1,3 +1,4 @@
+use std::any::TypeId;
 use std::ops::Deref;
 use std::sync::{Arc, OnceLock, Weak};
 
@@ -155,6 +156,11 @@ impl RustCrateSink for CustomClientPort {
         let client_port = wrap_client_port(ServerConfig::from_strategy(&conn_type, server_sink));
 
         Ok(Box::new(move |me| {
+            assert_eq!(
+                me.type_id(),
+                TypeId::of::<CustomClientPort>(),
+                "`instantiate_reverse` received different type than expected."
+            );
             me.downcast_ref::<CustomClientPort>()
                 .unwrap()
                 .record_server_config(client_port);

--- a/hydro_deploy/core/src/custom_service.rs
+++ b/hydro_deploy/core/src/custom_service.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::ops::Deref;
 use std::sync::{Arc, OnceLock, Weak};
 
@@ -136,10 +135,6 @@ impl RustCrateSource for CustomClientPort {
 }
 
 impl RustCrateSink for CustomClientPort {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn instantiate(&self, _client_path: &SourcePath) -> Result<Box<dyn FnOnce() -> ServerConfig>> {
         bail!("Custom services cannot be used as the server")
     }
@@ -163,7 +158,7 @@ impl RustCrateSink for CustomClientPort {
             me.downcast_ref::<CustomClientPort>()
                 .unwrap()
                 .record_server_config(client_port);
-            bind_type(server_host.as_any())
+            bind_type(&*server_host)
         }))
     }
 }

--- a/hydro_deploy/core/src/gcp.rs
+++ b/hydro_deploy/core/src/gcp.rs
@@ -1,3 +1,4 @@
+use std::any::Any;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, OnceLock};
 
@@ -248,10 +249,6 @@ impl Host for GcpComputeEngineHost {
 
     fn id(&self) -> usize {
         self.id
-    }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
     }
 
     fn collect_resources(&self, resource_batch: &mut ResourceBatch) {
@@ -508,7 +505,7 @@ impl Host for GcpComputeEngineHost {
             }
             ClientStrategy::InternalTcpPort(target_host) => {
                 if let Some(gcp_target) =
-                    target_host.as_any().downcast_ref::<GcpComputeEngineHost>()
+                    <dyn Any>::downcast_ref::<GcpComputeEngineHost>(target_host)
                 {
                     self.project == gcp_target.project
                 } else {

--- a/hydro_deploy/core/src/lib.rs
+++ b/hydro_deploy/core/src/lib.rs
@@ -1,3 +1,4 @@
+use std::any::Any;
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -154,9 +155,9 @@ pub enum HostTargetType {
     Linux,
 }
 
-pub type HostStrategyGetter = Box<dyn FnOnce(&dyn std::any::Any) -> ServerStrategy>;
+pub type HostStrategyGetter = Box<dyn FnOnce(&dyn Any) -> ServerStrategy>;
 
-pub trait Host: Send + Sync {
+pub trait Host: Any + Send + Sync {
     fn target_type(&self) -> HostTargetType;
 
     fn request_port(&self, bind_type: &ServerStrategy);
@@ -188,9 +189,6 @@ pub trait Host: Send + Sync {
 
     /// Determines whether this host can connect to another host using the given strategy.
     fn can_connect_to(&self, typ: ClientStrategy) -> bool;
-
-    /// Returns a reference to the host as a trait object.
-    fn as_any(&self) -> &dyn std::any::Any;
 }
 
 #[async_trait]

--- a/hydro_deploy/core/src/localhost/mod.rs
+++ b/hydro_deploy/core/src/localhost/mod.rs
@@ -55,10 +55,6 @@ impl Host for LocalhostHost {
         self.id
     }
 
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn launched(&self) -> Option<Arc<dyn LaunchedHost>> {
         Some(Arc::new(LaunchedLocalhost))
     }

--- a/hydro_deploy/core/src/rust_crate/service.rs
+++ b/hydro_deploy/core/src/rust_crate/service.rs
@@ -146,8 +146,7 @@ impl RustCrateService {
             )?;
 
             assert!(!self.port_to_bind.contains_key(&my_port));
-            self.port_to_bind
-                .insert(my_port, instantiated(sink.as_any()));
+            self.port_to_bind.insert(my_port, (instantiated)(sink));
 
             Ok(())
         }

--- a/hydro_deploy/hydro_cli/Cargo.toml
+++ b/hydro_deploy/hydro_cli/Cargo.toml
@@ -23,7 +23,8 @@ clap = { version = "4.5.4", features = ["derive"] }
 futures = "0.3.0"
 hydro_deploy = { path = "../core", version = "^0.13.0" }
 hydro_deploy_integration = { path = "../hydro_deploy_integration", version = "^0.13.0" }
-pyo3 = { version = "0.20.0", features = ["abi3-py37"] }
-pyo3-asyncio = { version = "0.20.0", features = ["attributes", "tokio-runtime"] }
-pythonize = "0.20.0"
+pyo3 = { version = "0.21.0", features = ["abi3-py37"] }
+pyo3-async-runtimes = { version = "0.21.0", features = ["tokio-runtime"] }
+# pyo3-asyncio-macros-0-21 = "0.21.0"
+pythonize = "0.21.0"
 tokio = { version = "1.29.0", features = [ "full" ] }

--- a/hydro_deploy/hydro_cli/Cargo.toml
+++ b/hydro_deploy/hydro_cli/Cargo.toml
@@ -25,6 +25,5 @@ hydro_deploy = { path = "../core", version = "^0.13.0" }
 hydro_deploy_integration = { path = "../hydro_deploy_integration", version = "^0.13.0" }
 pyo3 = { version = "0.21.0", features = ["abi3-py37"] }
 pyo3-async-runtimes = { version = "0.21.0", features = ["tokio-runtime"] }
-# pyo3-asyncio-macros-0-21 = "0.21.0"
 pythonize = "0.21.0"
 tokio = { version = "1.29.0", features = [ "full" ] }

--- a/hydro_deploy/hydro_cli/src/lib.rs
+++ b/hydro_deploy/hydro_cli/src/lib.rs
@@ -1,9 +1,4 @@
-#![expect(
-    unused_qualifications,
-    non_local_definitions,
-    unsafe_op_in_unsafe_fn,
-    reason = "for pyo3 generated code"
-)]
+#![expect(unsafe_op_in_unsafe_fn, reason = "for pyo3 generated code")]
 
 use core::rust_crate::ports::RustCrateSource;
 use std::cell::OnceCell;
@@ -808,7 +803,7 @@ pub fn _core(py: Python<'_>, module: Bound<'_, PyModule>) -> PyResult<()> {
 
     CONVERTERS_MODULE
         .set(
-            PyModule::from_code(
+            PyModule::from_code_bound(
                 py,
                 "
 import asyncio
@@ -828,10 +823,10 @@ async def coroutine_to_safely_cancellable(c, cancel_token):
         .unwrap();
 
     *TOKIO_RUNTIME.write().unwrap() = Some(tokio::runtime::Runtime::new().unwrap());
-    let atexit = PyModule::import(py, "atexit")?;
+    let atexit = PyModule::import_bound(py, "atexit")?;
     atexit.call_method1("register", (wrap_pyfunction!(cleanup_runtime, &module)?,))?;
 
-    module.add("AnyhowError", py.get_type::<AnyhowError>())?;
+    module.add("AnyhowError", py.get_type_bound::<AnyhowError>())?;
     module.add_class::<AnyhowWrapper>()?;
 
     module.add_class::<HydroflowSink>()?;

--- a/precheck.bash
+++ b/precheck.bash
@@ -48,8 +48,10 @@ Try '$0 --help' for more information.
 done
 
 TARGETS=""
+FEATURES=""
 if [ "$TEST_DFIR" = true ]; then
     TARGETS="$TARGETS -p dfir_lang -p dfir_rs -p dfir_macro"
+    FEATURES="$FEATURES --features dfir_rs/python"
 fi
 if [ "$TEST_HYDRO" = true ]; then
     TARGETS="$TARGETS -p hydro_lang -p hydro_std -p hydro_test -p hydro_test_local -p hydro_test_local_macro -p hydro_deploy -p hydro_deploy_integration"
@@ -71,11 +73,11 @@ fi
 set -x
 
 cargo +nightly fmt --all
-cargo clippy $TARGETS --all-targets --features dfir_rs/python -- -D warnings
+cargo clippy $TARGETS --all-targets $FEATURES -- -D warnings
 [ "$TEST_ALL" = false ] || cargo check --all-targets --no-default-features
 
 # `--all-targets` is everything except `--doc`: https://github.com/rust-lang/cargo/issues/6669.
-INSTA_FORCE_PASS=1 INSTA_UPDATE=always TRYBUILD=overwrite cargo test $TARGETS --all-targets --no-fail-fast --features dfir_rs/python
+INSTA_FORCE_PASS=1 INSTA_UPDATE=always TRYBUILD=overwrite cargo test $TARGETS --all-targets --no-fail-fast $FEATURES
 cargo test $TARGETS --doc
 
 [ "$TEST_DFIR" = false ] || CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=wasm-bindgen-test-runner cargo test -p dfir_rs --target wasm32-unknown-unknown --tests --no-fail-fast


### PR DESCRIPTION
Fix #1821

https://pyo3.rs/v0.23.0/migration#from-020-to-021

BREAKING CHANGE: Now uses pyo3 0.24