### PR TITLE
fix: Enable file_lock feature in nightly builds

### DIFF
--- a/hydro_lang/src/lib.rs
+++ b/hydro_lang/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(nightly, feature(file_lock))]
 
 stageleft::stageleft_no_entry_crate!();
 


### PR DESCRIPTION
This appears to be a regression from the commit that uses fs2 on stable builds.