### PR TITLE
chore: update pinned nightly to 2025-04-05, clippy fixes

### DIFF
--- a/hydro_lang/src/location/cluster/mod.rs
+++ b/hydro_lang/src/location/cluster/mod.rs
@@ -28,7 +28,7 @@ impl<C> Debug for Cluster<'_, C> {
 impl<C> Eq for Cluster<'_, C> {}
 impl<C> PartialEq for Cluster<'_, C> {
     fn eq(&self, other: &Self) -> bool {
-        self.id == other.id && self.flow_state.as_ptr() == other.flow_state.as_ptr()
+        self.id == other.id && FlowState::ptr_eq(&self.flow_state, &other.flow_state)
     }
 }
 

--- a/hydro_lang/src/location/process.rs
+++ b/hydro_lang/src/location/process.rs
@@ -20,7 +20,7 @@ impl<P> Debug for Process<'_, P> {
 impl<P> Eq for Process<'_, P> {}
 impl<P> PartialEq for Process<'_, P> {
     fn eq(&self, other: &Self) -> bool {
-        self.id == other.id && self.flow_state.as_ptr() == other.flow_state.as_ptr()
+        self.id == other.id && FlowState::ptr_eq(&self.flow_state, &other.flow_state)
     }
 }
 

--- a/precheck.bash
+++ b/precheck.bash
@@ -71,10 +71,10 @@ fi
 set -x
 
 cargo +nightly fmt --all
-cargo clippy $TARGETS --features python -- -D warnings
+cargo clippy $TARGETS --features dfir_rs/python -- -D warnings
 [ "$TEST_ALL" = false ] || cargo check --all-targets --no-default-features
 
-INSTA_FORCE_PASS=1 INSTA_UPDATE=always TRYBUILD=overwrite cargo test $TARGETS --no-fail-fast --features python
+INSTA_FORCE_PASS=1 INSTA_UPDATE=always TRYBUILD=overwrite cargo test $TARGETS --no-fail-fast --features dfir_rs/python
 cargo test $TARGETS --doc
 
 [ "$TEST_DFIR" = false ] || CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=wasm-bindgen-test-runner cargo test -p dfir_rs --target wasm32-unknown-unknown --tests --no-fail-fast

--- a/precheck.bash
+++ b/precheck.bash
@@ -59,7 +59,7 @@ if [ "$TEST_HYDRO_CLI" = true ]; then
 fi
 
 if [ "$TEST_ALL" = true ]; then
-    TARGETS="--all-targets"
+    TARGETS="--workspace"
 elif [ "" = "$TARGETS" ]; then
     echo "$0: No targets specified.
 Try '$0 --help' for more information.
@@ -71,10 +71,11 @@ fi
 set -x
 
 cargo +nightly fmt --all
-cargo clippy $TARGETS --features dfir_rs/python -- -D warnings
+cargo clippy $TARGETS --all-targets --features dfir_rs/python -- -D warnings
 [ "$TEST_ALL" = false ] || cargo check --all-targets --no-default-features
 
-INSTA_FORCE_PASS=1 INSTA_UPDATE=always TRYBUILD=overwrite cargo test $TARGETS --no-fail-fast --features dfir_rs/python
+# `--all-targets` is everything except `--doc`: https://github.com/rust-lang/cargo/issues/6669.
+INSTA_FORCE_PASS=1 INSTA_UPDATE=always TRYBUILD=overwrite cargo test $TARGETS --all-targets --no-fail-fast --features dfir_rs/python
 cargo test $TARGETS --doc
 
 [ "$TEST_DFIR" = false ] || CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=wasm-bindgen-test-runner cargo test -p dfir_rs --target wasm32-unknown-unknown --tests --no-fail-fast

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-04-14" # Make sure to update `template/*/rust-toolchain.toml` as well.
+channel = "nightly-2025-04-05" # Make sure to update `template/*/rust-toolchain.toml` as well.
 components = [
     "rustfmt",
     "clippy",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-03-10" # Make sure to update `template/*/rust-toolchain.toml` as well.
+channel = "nightly-2025-04-14" # Make sure to update `template/*/rust-toolchain.toml` as well.
 components = [
     "rustfmt",
     "clippy",

--- a/template/dfir/rust-toolchain.toml
+++ b/template/dfir/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2025-04-14"
+channel = "nightly-2025-04-05"

--- a/template/dfir/rust-toolchain.toml
+++ b/template/dfir/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2025-03-10"
+channel = "nightly-2025-04-14"

--- a/template/hydro/rust-toolchain.toml
+++ b/template/hydro/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2025-04-14"
+channel = "nightly-2025-04-05"
 components = ["rustfmt", "clippy"]
 targets = ["x86_64-unknown-linux-musl"]

--- a/template/hydro/rust-toolchain.toml
+++ b/template/hydro/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2025-03-10"
+channel = "nightly-2025-04-14"
 components = ["rustfmt", "clippy"]
 targets = ["x86_64-unknown-linux-musl"]


### PR DESCRIPTION
Not going past 2024-04-05 due to rustc linker regression on windows: https://github.com/rust-lang/rust/issues/139821