### PR TITLE
refactor(hydro_deploy): use `blake3` hash intead of random for build `unique_id`, fix #1337

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,6 +527,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "blake3"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -943,6 +962,12 @@ dependencies = [
  "once_cell",
  "tiny-keccak",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "convert_case"
@@ -2223,6 +2248,7 @@ dependencies = [
  "async-recursion",
  "async-ssh2-russh",
  "async-trait",
+ "blake3",
  "buildstructor",
  "bytes",
  "cargo_metadata",

--- a/hydro_deploy/core/Cargo.toml
+++ b/hydro_deploy/core/Cargo.toml
@@ -17,6 +17,7 @@ async-ssh2-russh = { version = "0.1.0", features = [ "sftp" ] }
 async-process = "2.0.0"
 async-recursion = "1.0.0"
 async-trait = "0.1.54"
+blake3 = "1.8.2"
 buildstructor = "0.6.0"
 bytes = "1.1.0"
 cargo_metadata = "0.18.0"

--- a/hydro_deploy/core/src/rust_crate/build.rs
+++ b/hydro_deploy/core/src/rust_crate/build.rs
@@ -76,10 +76,7 @@ pub struct BuildOutput {
     pub bin_path: PathBuf,
 }
 impl BuildOutput {
-    pub fn new(bin_data: Vec<u8>, bin_path: PathBuf) -> Self {
-        Self { bin_data, bin_path }
-    }
-
+    /// A unique ID for the binary, based its contents.
     pub fn unique_id(&self) -> impl use<> + Display {
         blake3::hash(&self.bin_data).to_hex()
     }

--- a/hydro_deploy/core/src/rust_crate/build.rs
+++ b/hydro_deploy/core/src/rust_crate/build.rs
@@ -7,7 +7,6 @@ use std::sync::OnceLock;
 
 use cargo_metadata::diagnostic::Diagnostic;
 use memo_map::MemoMap;
-use nanoid::nanoid;
 use tokio::sync::OnceCell;
 
 use crate::HostTargetType;
@@ -71,12 +70,19 @@ impl BuildParams {
 
 /// Information about a built crate. See [`build_crate`].
 pub struct BuildOutput {
-    /// A unique but meaningless id.
-    pub unique_id: String,
     /// The binary contents as a byte array.
     pub bin_data: Vec<u8>,
     /// The path to the binary file. [`Self::bin_data`] has a copy of the content.
     pub bin_path: PathBuf,
+}
+impl BuildOutput {
+    pub fn new(bin_data: Vec<u8>, bin_path: PathBuf) -> Self {
+        Self { bin_data, bin_path }
+    }
+
+    pub fn unique_id(&self) -> impl use<> + Display {
+        blake3::hash(&self.bin_data).to_hex()
+    }
 }
 
 /// Build memoization cache.
@@ -170,7 +176,6 @@ pub async fn build_crate_memoized(params: BuildParams) -> Result<&'static BuildO
                                     let data = std::fs::read(path).unwrap();
                                     assert!(spawned.wait().unwrap().success());
                                     return Ok(BuildOutput {
-                                        unique_id: nanoid!(8),
                                         bin_data: data,
                                         bin_path: path_buf,
                                     });

--- a/hydro_deploy/core/src/ssh.rs
+++ b/hydro_deploy/core/src/ssh.rs
@@ -348,7 +348,7 @@ impl<T: LaunchedSshHost> LaunchedHost for T {
 
         let user = self.ssh_user();
         // we may be deploying multiple binaries, so give each a unique name
-        let binary_path = format!("/home/{user}/hydro-{}", binary.unique_id);
+        let binary_path = format!("/home/{user}/hydro-{}", binary.unique_id());
 
         if sftp.metadata(&binary_path).await.is_err() {
             let random = nanoid!(8);
@@ -413,7 +413,7 @@ impl<T: LaunchedSshHost> LaunchedHost for T {
         let session = self.open_ssh_session().await?;
 
         let user = self.ssh_user();
-        let binary_path = PathBuf::from(format!("/home/{user}/hydro-{}", binary.unique_id));
+        let binary_path = PathBuf::from(format!("/home/{user}/hydro-{}", binary.unique_id()));
 
         let mut command = binary_path.to_str().unwrap().to_owned();
         for arg in args {


### PR DESCRIPTION
Fix #1337

Chose `blake3` which is designed to be as fast a possible, faster than MD5, SHA-1 while being more secure.