### PR TITLE
feat(hydro_deploy): update how progress is displayed, fix #1415

### DIFF
--- a/hydro_deploy/core/src/progress.rs
+++ b/hydro_deploy/core/src/progress.rs
@@ -72,25 +72,20 @@ impl BarTree {
                     .iter()
                     .filter(|child| child.status() == LeafStatus::Started)
                     .count();
-                let queued_count =
-                    anticipated_total.map(|total| total - finished_count - started_count);
 
-                let progress_str =
-                    if anticipated_total.iter().any(|v| *v == 1) && started_count == 1 {
-                        "".to_string()
-                    } else {
-                        match queued_count {
-                            Some(queued_count) => {
-                                format!(
-                                    " ({}/{}/{})",
-                                    finished_count,
-                                    started_count,
-                                    queued_count + finished_count + started_count
-                                )
-                            }
-                            None => format!(" ({}/{}/?)", finished_count, started_count),
-                        }
-                    };
+                let progress_str = if Some(1) == *anticipated_total {
+                    String::new()
+                } else {
+                    let started_or_finished_count = finished_count + started_count;
+                    format!(
+                        " ({}/{}/{})",
+                        finished_count,
+                        started_or_finished_count,
+                        anticipated_total
+                            .filter(|&total| total <= started_or_finished_count)
+                            .map_or("?", |total| &*total.to_string()),
+                    )
+                };
 
                 if cur_path.is_empty() {
                     pb.set_prefix(format!("{}{}", name, progress_str));

--- a/hydro_deploy/core/src/progress.rs
+++ b/hydro_deploy/core/src/progress.rs
@@ -83,7 +83,7 @@ impl BarTree {
                         started_or_finished_count,
                         anticipated_total
                             .filter(|&total| started_or_finished_count <= total)
-                            .map_or("?", |total| &*total.to_string()),
+                            .map_or(|| "?".to_string(), |total| total.to_string()),
                     )
                 };
 

--- a/hydro_deploy/core/src/progress.rs
+++ b/hydro_deploy/core/src/progress.rs
@@ -83,7 +83,7 @@ impl BarTree {
                         started_or_finished_count,
                         anticipated_total
                             .filter(|&total| started_or_finished_count <= total)
-                            .map_or(|| "?".to_string(), |total| total.to_string()),
+                            .map_or_else(|| "?".to_string(), |total| total.to_string()),
                     )
                 };
 

--- a/hydro_deploy/core/src/progress.rs
+++ b/hydro_deploy/core/src/progress.rs
@@ -82,7 +82,7 @@ impl BarTree {
                         finished_count,
                         started_or_finished_count,
                         anticipated_total
-                            .filter(|&total| total <= started_or_finished_count)
+                            .filter(|&total| started_or_finished_count <= total)
                             .map_or("?", |total| &*total.to_string()),
                     )
                 };


### PR DESCRIPTION
Fix #1415

Changes the display of progress to be a bit more intuitive.  
Now the format is `finished / started_or_finished / total`  
Example progress:
1. `0/1/5`
2. `1/1/5`
3. `1/5/5`
4. `3/5/5`
5. `5/5/5` (complete)

This is more natural as all numbers increase as progress increases, and all numbers are 100% when complete.

A question mark `?` will be displayed as the total if no total is given or the given total is invalid.

---

### Previously...

Previously displayed as: `finished / started_but_not_finished / total`
Example progress:
1. `0/1/5`
2. `1/0/5`
3. `1/4/5`
4. `3/2/5`
5. `5/0/5` (complete)

This is confusing as the `started_but_not_finished` column goes up and down as progress increases, and ends at zero.


