### PR TITLE
refactor(hydro_deploy): Encapsulate stdout/stderr handling in new `PriorityBroadcast` type, fix #1357

### DIFF
--- a/hydro_deploy/core/src/localhost/launched_binary.rs
+++ b/hydro_deploy/core/src/localhost/launched_binary.rs
@@ -1,7 +1,7 @@
 #[cfg(unix)]
 use std::os::unix::process::ExitStatusExt;
 use std::process::{ExitStatus, Stdio};
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
 use anyhow::{Result, bail};
 use async_process::Command;
@@ -21,8 +21,7 @@ use super::samply::{FxProfile, samply_to_folded};
 use crate::progress::ProgressTracker;
 use crate::rust_crate::flamegraph::handle_fold_data;
 use crate::rust_crate::tracing_options::TracingOptions;
-use crate::ssh::PrefixFilteredChannel;
-use crate::util::prioritized_broadcast;
+use crate::util::{PriorityBroadcast, prioritized_broadcast};
 use crate::{LaunchedBinary, TracingResults};
 
 pub(super) struct TracingDataLocal {
@@ -35,9 +34,8 @@ pub struct LaunchedLocalhostBinary {
     tracing_data_local: Option<TracingDataLocal>,
     tracing_results: Option<TracingResults>,
     stdin_sender: mpsc::UnboundedSender<String>,
-    stdout_deploy_receivers: Arc<Mutex<Option<oneshot::Sender<String>>>>,
-    stdout_receivers: Arc<Mutex<Vec<PrefixFilteredChannel>>>,
-    stderr_receivers: Arc<Mutex<Vec<PrefixFilteredChannel>>>,
+    stdout_broadcast: PriorityBroadcast,
+    stderr_broadcast: PriorityBroadcast,
 }
 
 #[cfg(unix)]
@@ -79,11 +77,11 @@ impl LaunchedLocalhostBinary {
         });
 
         let id_clone = id.clone();
-        let (stdout_deploy_receivers, stdout_receivers) = prioritized_broadcast(
+        let stdout_broadcast = prioritized_broadcast(
             FuturesBufReader::new(child.stdout.take().unwrap()).lines(),
             move |s| ProgressTracker::println(format!("[{id_clone}] {s}")),
         );
-        let (_, stderr_receivers) = prioritized_broadcast(
+        let stderr_broadcast = prioritized_broadcast(
             FuturesBufReader::new(child.stderr.take().unwrap()).lines(),
             move |s| ProgressTracker::println(format!("[{id} stderr] {s}")),
         );
@@ -94,9 +92,9 @@ impl LaunchedLocalhostBinary {
             tracing_data_local,
             tracing_results: None,
             stdin_sender,
-            stdout_deploy_receivers,
-            stdout_receivers,
-            stderr_receivers,
+            // stdout_deploy_receivers,
+            stdout_broadcast,
+            stderr_broadcast,
         }
     }
 }
@@ -108,43 +106,23 @@ impl LaunchedBinary for LaunchedLocalhostBinary {
     }
 
     fn deploy_stdout(&self) -> oneshot::Receiver<String> {
-        let mut receivers = self.stdout_deploy_receivers.lock().unwrap();
-
-        if receivers.is_some() {
-            panic!("Only one deploy stdout receiver is allowed at a time");
-        }
-
-        let (sender, receiver) = oneshot::channel::<String>();
-        *receivers = Some(sender);
-        receiver
+        self.stdout_broadcast.receive_priority()
     }
 
     fn stdout(&self) -> mpsc::UnboundedReceiver<String> {
-        let mut receivers = self.stdout_receivers.lock().unwrap();
-        let (sender, receiver) = mpsc::unbounded_channel::<String>();
-        receivers.push((None, sender));
-        receiver
+        self.stdout_broadcast.receive(None)
     }
 
     fn stderr(&self) -> mpsc::UnboundedReceiver<String> {
-        let mut receivers = self.stderr_receivers.lock().unwrap();
-        let (sender, receiver) = mpsc::unbounded_channel::<String>();
-        receivers.push((None, sender));
-        receiver
+        self.stderr_broadcast.receive(None)
     }
 
     fn stdout_filter(&self, prefix: String) -> mpsc::UnboundedReceiver<String> {
-        let mut receivers = self.stdout_receivers.lock().unwrap();
-        let (sender, receiver) = mpsc::unbounded_channel::<String>();
-        receivers.push((Some(prefix), sender));
-        receiver
+        self.stdout_broadcast.receive(Some(prefix))
     }
 
     fn stderr_filter(&self, prefix: String) -> mpsc::UnboundedReceiver<String> {
-        let mut receivers = self.stderr_receivers.lock().unwrap();
-        let (sender, receiver) = mpsc::unbounded_channel::<String>();
-        receivers.push((Some(prefix), sender));
-        receiver
+        self.stderr_broadcast.receive(Some(prefix))
     }
 
     fn tracing_results(&self) -> Option<&TracingResults> {

--- a/hydro_deploy/core/src/localhost/launched_binary.rs
+++ b/hydro_deploy/core/src/localhost/launched_binary.rs
@@ -92,7 +92,6 @@ impl LaunchedLocalhostBinary {
             tracing_data_local,
             tracing_results: None,
             stdin_sender,
-            // stdout_deploy_receivers,
             stdout_broadcast,
             stderr_broadcast,
         }

--- a/hydro_deploy/core/src/rust_crate/service.rs
+++ b/hydro_deploy/core/src/rust_crate/service.rs
@@ -277,9 +277,9 @@ impl Service for RustCrateService {
                 .await
                 .context("Timed out waiting for ready")?
                 .context("Program unexpectedly quit")?;
-                if ready_line.starts_with("ready: ") {
+                if let Some(line_rest) = ready_line.strip_prefix("ready: ") {
                     *self.server_defns.try_write().unwrap() =
-                        serde_json::from_str(ready_line.trim_start_matches("ready: ")).unwrap();
+                        serde_json::from_str(line_rest).unwrap();
                 } else {
                     bail!("expected ready");
                 }

--- a/hydro_deploy/core/src/ssh.rs
+++ b/hydro_deploy/core/src/ssh.rs
@@ -479,7 +479,6 @@ impl<T: LaunchedSshHost> LaunchedHost for T {
             session: Some(session),
             channel,
             stdin_sender,
-            // stdout_deploy_receivers,
             stdout_broadcast,
             stderr_broadcast,
             tracing,

--- a/hydro_deploy/core/src/ssh.rs
+++ b/hydro_deploy/core/src/ssh.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context as _, Result};
@@ -27,12 +27,10 @@ use crate::progress::ProgressTracker;
 use crate::rust_crate::build::BuildOutput;
 use crate::rust_crate::flamegraph::handle_fold_data;
 use crate::rust_crate::tracing_options::TracingOptions;
-use crate::util::{async_retry, prioritized_broadcast};
+use crate::util::{PriorityBroadcast, async_retry, prioritized_broadcast};
 use crate::{LaunchedBinary, LaunchedHost, ResourceResult, ServerStrategy, TracingResults};
 
 const PERF_OUTFILE: &str = "__profile.perf.data";
-
-pub type PrefixFilteredChannel = (Option<String>, mpsc::UnboundedSender<String>);
 
 struct LaunchedSshBinary {
     _resource_result: Arc<ResourceResult>,
@@ -42,9 +40,8 @@ struct LaunchedSshBinary {
     session: Option<AsyncSession<NoCheckHandler>>,
     channel: AsyncChannel,
     stdin_sender: mpsc::UnboundedSender<String>,
-    stdout_receivers: Arc<Mutex<Vec<PrefixFilteredChannel>>>,
-    stdout_deploy_receivers: Arc<Mutex<Option<oneshot::Sender<String>>>>,
-    stderr_receivers: Arc<Mutex<Vec<PrefixFilteredChannel>>>,
+    stdout_broadcast: PriorityBroadcast,
+    stderr_broadcast: PriorityBroadcast,
     tracing: Option<TracingOptions>,
     tracing_results: Option<TracingResults>,
 }
@@ -56,43 +53,23 @@ impl LaunchedBinary for LaunchedSshBinary {
     }
 
     fn deploy_stdout(&self) -> oneshot::Receiver<String> {
-        let mut receivers = self.stdout_deploy_receivers.lock().unwrap();
-
-        if receivers.is_some() {
-            panic!("Only one deploy stdout receiver is allowed at a time");
-        }
-
-        let (sender, receiver) = oneshot::channel::<String>();
-        *receivers = Some(sender);
-        receiver
+        self.stdout_broadcast.receive_priority()
     }
 
     fn stdout(&self) -> mpsc::UnboundedReceiver<String> {
-        let mut receivers = self.stdout_receivers.lock().unwrap();
-        let (sender, receiver) = mpsc::unbounded_channel::<String>();
-        receivers.push((None, sender));
-        receiver
+        self.stdout_broadcast.receive(None)
     }
 
     fn stderr(&self) -> mpsc::UnboundedReceiver<String> {
-        let mut receivers = self.stderr_receivers.lock().unwrap();
-        let (sender, receiver) = mpsc::unbounded_channel::<String>();
-        receivers.push((None, sender));
-        receiver
+        self.stderr_broadcast.receive(None)
     }
 
     fn stdout_filter(&self, prefix: String) -> mpsc::UnboundedReceiver<String> {
-        let mut receivers = self.stdout_receivers.lock().unwrap();
-        let (sender, receiver) = mpsc::unbounded_channel::<String>();
-        receivers.push((Some(prefix), sender));
-        receiver
+        self.stdout_broadcast.receive(Some(prefix))
     }
 
     fn stderr_filter(&self, prefix: String) -> mpsc::UnboundedReceiver<String> {
-        let mut receivers = self.stderr_receivers.lock().unwrap();
-        let (sender, receiver) = mpsc::unbounded_channel::<String>();
-        receivers.push((Some(prefix), sender));
-        receiver
+        self.stderr_broadcast.receive(Some(prefix))
     }
 
     fn tracing_results(&self) -> Option<&TracingResults> {
@@ -490,23 +467,21 @@ impl<T: LaunchedSshHost> LaunchedHost for T {
         });
 
         let id_clone = id.clone();
-        let (stdout_deploy_receivers, stdout_receivers) =
-            prioritized_broadcast(LinesStream::new(stdout.lines()), move |s| {
-                ProgressTracker::println(format!("[{id_clone}] {s}"));
-            });
-        let (_, stderr_receivers) =
-            prioritized_broadcast(LinesStream::new(stderr.lines()), move |s| {
-                ProgressTracker::println(format!("[{id} stderr] {s}"));
-            });
+        let stdout_broadcast = prioritized_broadcast(LinesStream::new(stdout.lines()), move |s| {
+            ProgressTracker::println(format!("[{id_clone}] {s}"));
+        });
+        let stderr_broadcast = prioritized_broadcast(LinesStream::new(stderr.lines()), move |s| {
+            ProgressTracker::println(format!("[{id} stderr] {s}"));
+        });
 
         Ok(Box::new(LaunchedSshBinary {
             _resource_result: self.resource_result().clone(),
             session: Some(session),
             channel,
             stdin_sender,
-            stdout_deploy_receivers,
-            stdout_receivers,
-            stderr_receivers,
+            // stdout_deploy_receivers,
+            stdout_broadcast,
+            stderr_broadcast,
             tracing,
             tracing_results: None,
         }))

--- a/hydro_deploy/core/src/util.rs
+++ b/hydro_deploy/core/src/util.rs
@@ -21,19 +21,12 @@ pub async fn async_retry<T, E, F: Future<Output = Result<T, E>>>(
     thunk().await
 }
 
-pub type PrefixFilteredChannel = (Option<String>, mpsc::UnboundedSender<String>);
-
-// pub type PriorityBroadcast = (
-//     Arc<Mutex<Option<oneshot::Sender<String>>>>,
-//     Arc<Mutex<Vec<PrefixFilteredChannel>>>,
-// );
-
 #[derive(Clone)]
 pub struct PriorityBroadcast(Weak<Mutex<PriorityBroadcastInternal>>);
 
 struct PriorityBroadcastInternal {
     priority_sender: Option<oneshot::Sender<String>>,
-    senders: Vec<PrefixFilteredChannel>,
+    senders: Vec<(Option<String>, mpsc::UnboundedSender<String>)>,
 }
 
 impl PriorityBroadcast {

--- a/hydro_deploy/core/src/util.rs
+++ b/hydro_deploy/core/src/util.rs
@@ -42,12 +42,10 @@ impl PriorityBroadcast {
 
         if let Some(internal) = self.0.upgrade() {
             let mut internal = internal.lock().unwrap();
-            if let Some(priority_sender) = internal.priority_sender.take() {
-                priority_sender
-                    .send("Priority receiver already exists".to_string())
-                    .ok();
+            let prev_sender = internal.priority_sender.replace(sender);
+            if prev_sender.is_some() {
+                panic!("Only one deploy stdout receiver is allowed at a time");
             }
-            internal.priority_sender = Some(sender);
         }
 
         receiver

--- a/hydro_deploy/core/src/util.rs
+++ b/hydro_deploy/core/src/util.rs
@@ -74,6 +74,7 @@ pub fn prioritized_broadcast<T: Stream<Item = std::io::Result<String>> + Send + 
 
     let weak_internal = Arc::downgrade(&internal);
 
+    // TODO(mingwei): eliminate the need for a separate task.
     tokio::spawn(async move {
         while let Some(Ok(line)) = lines.next().await {
             let mut internal = internal.lock().unwrap();

--- a/hydro_deploy/core/src/util.rs
+++ b/hydro_deploy/core/src/util.rs
@@ -2,9 +2,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use futures::{Future, Stream, StreamExt};
-use tokio::sync::oneshot;
-
-use crate::ssh::PrefixFilteredChannel;
+use tokio::sync::{mpsc, oneshot};
 
 pub async fn async_retry<T, E, F: Future<Output = Result<T, E>>>(
     mut thunk: impl FnMut() -> F,
@@ -23,74 +21,94 @@ pub async fn async_retry<T, E, F: Future<Output = Result<T, E>>>(
     thunk().await
 }
 
-type PriorityBroadcast = (
-    Arc<Mutex<Option<oneshot::Sender<String>>>>,
-    Arc<Mutex<Vec<PrefixFilteredChannel>>>,
-);
+pub type PrefixFilteredChannel = (Option<String>, mpsc::UnboundedSender<String>);
+
+// pub type PriorityBroadcast = (
+//     Arc<Mutex<Option<oneshot::Sender<String>>>>,
+//     Arc<Mutex<Vec<PrefixFilteredChannel>>>,
+// );
+
+#[derive(Clone)]
+pub struct PriorityBroadcast(Arc<Mutex<PriorityBroadcastInternal>>);
+
+struct PriorityBroadcastInternal {
+    priority_sender: Option<oneshot::Sender<String>>,
+    senders: Vec<PrefixFilteredChannel>,
+}
+
+impl PriorityBroadcast {
+    pub fn receive_priority(&self) -> oneshot::Receiver<String> {
+        let mut this = self.0.lock().unwrap();
+        if this.priority_sender.is_some() {
+            panic!("Only one deploy priority receiver is allowed at a time");
+        }
+
+        let (sender, receiver) = oneshot::channel::<String>();
+        this.priority_sender = Some(sender);
+        receiver
+    }
+
+    pub fn receive(&self, prefix: Option<String>) -> mpsc::UnboundedReceiver<String> {
+        let mut this = self.0.lock().unwrap();
+        let (sender, receiver) = mpsc::unbounded_channel::<String>();
+        this.senders.push((prefix, sender));
+        receiver
+    }
+}
 
 pub fn prioritized_broadcast<T: Stream<Item = std::io::Result<String>> + Send + Unpin + 'static>(
     mut lines: T,
-    default: impl Fn(String) + Send + 'static,
+    fallback_receiver: impl Fn(String) + Send + 'static,
 ) -> PriorityBroadcast {
-    let priority_receivers = Arc::new(Mutex::new(None::<oneshot::Sender<String>>));
-    // Option<String> is the prefix to separate special stdout messages from regular ones
-    let receivers = Arc::new(Mutex::new(Vec::<PrefixFilteredChannel>::new()));
+    let internal = Arc::new(Mutex::new(PriorityBroadcastInternal {
+        priority_sender: None,
+        senders: Vec::new(),
+    }));
 
-    let weak_priority_receivers = Arc::downgrade(&priority_receivers);
-    let weak_receivers = Arc::downgrade(&receivers);
+    let weak_internal = Arc::downgrade(&internal);
 
     tokio::spawn(async move {
         while let Some(Ok(line)) = lines.next().await {
-            if let Some(deploy_receivers) = weak_priority_receivers.upgrade() {
-                let mut deploy_receivers = deploy_receivers.lock().unwrap();
-
-                let successful_send = if let Some(r) = deploy_receivers.take() {
-                    r.send(line.clone()).is_ok()
-                } else {
-                    false
-                };
-                drop(deploy_receivers);
-
-                if successful_send {
-                    continue;
-                }
-            }
-
-            if let Some(receivers) = weak_receivers.upgrade() {
-                let mut receivers = receivers.lock().unwrap();
-                receivers.retain(|receiver| !receiver.1.is_closed());
-
-                let mut successful_send = false;
-                // Send to specific receivers if the filter prefix matches
-                for (prefix_filter, receiver) in receivers.iter() {
-                    if prefix_filter
-                        .as_ref()
-                        .map(|prefix| line.starts_with(prefix))
-                        .unwrap_or(true)
-                    {
-                        successful_send |= receiver.send(line.clone()).is_ok();
-                    }
-                }
-                if !successful_send {
-                    (default)(line);
-                }
-            } else {
+            let Some(internal) = weak_internal.upgrade() else {
                 break;
+            };
+            let mut internal = internal.lock().unwrap();
+
+            // Priority receiver
+            if let Some(priority_sender) = internal.priority_sender.take() {
+                if priority_sender.send(line.clone()).is_ok() {
+                    continue; // Skip regular receivers if successfully sent to the priority receiver.
+                }
+            }
+
+            // Regular receivers
+            internal.senders.retain(|receiver| !receiver.1.is_closed());
+
+            let mut successful_send = false;
+            for (prefix_filter, sender) in internal.senders.iter() {
+                // Send to specific receivers if the filter prefix matches
+                if prefix_filter
+                    .as_ref()
+                    .is_none_or(|prefix| line.starts_with(prefix))
+                {
+                    successful_send |= sender.send(line.clone()).is_ok();
+                }
+            }
+
+            // If no receivers successfully received the line, use the fallback receiver.
+            if !successful_send {
+                (fallback_receiver)(line);
             }
         }
 
-        if let Some(deploy_receivers) = weak_priority_receivers.upgrade() {
-            let mut deploy_receivers = deploy_receivers.lock().unwrap();
-            drop(deploy_receivers.take());
-        }
-
-        if let Some(receivers) = weak_receivers.upgrade() {
-            let mut receivers = receivers.lock().unwrap();
-            receivers.clear();
-        }
+        if let Some(internal) = weak_internal.upgrade() {
+            let mut internal = internal.lock().unwrap();
+            drop(std::mem::take(&mut internal.priority_sender));
+            drop(std::mem::take(&mut internal.senders));
+        };
     });
 
-    (priority_receivers, receivers)
+    PriorityBroadcast(internal)
 }
 
 #[cfg(test)]
@@ -103,11 +121,9 @@ mod test {
     #[tokio::test]
     async fn broadcast_listeners_close_when_source_does() {
         let (tx, rx) = mpsc::unbounded_channel();
-        let (_, receivers) = prioritized_broadcast(UnboundedReceiverStream::new(rx), |_| {});
+        let priority_broadcast = prioritized_broadcast(UnboundedReceiverStream::new(rx), |_| {});
 
-        let (tx2, mut rx2) = mpsc::unbounded_channel();
-
-        receivers.lock().unwrap().push((None, tx2));
+        let mut rx2 = priority_broadcast.receive(None);
 
         tx.send(Ok("hello".to_string())).unwrap();
         assert_eq!(rx2.recv().await, Some("hello".to_string()));


### PR DESCRIPTION
Fix #1357