### PR TITLE
fix(docs): fix for latest node: `docusaurus.config.js` use mjs

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -1,11 +1,10 @@
 // @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
 
-const lightCodeTheme = require("prism-react-renderer").themes.github;
-const darkCodeTheme = require("prism-react-renderer").themes.dracula;
+import { themes } from "prism-react-renderer";
 
-const math = require("remark-math");
-const katex = require("rehype-katex");
+import remarkMath from "remark-math";
+import rehypeKatex from "rehype-katex";
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -65,8 +64,8 @@ const config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl: "https://github.com/hydro-project/hydro/tree/main/docs/",
-          remarkPlugins: [math],
-          rehypePlugins: [katex],
+          remarkPlugins: [remarkMath],
+          rehypePlugins: [rehypeKatex],
         },
         // blog: {
         //   showReadingTime: true,
@@ -200,8 +199,8 @@ const config = {
         copyright: `Hydro is a project in the <a href="https://sky.cs.berkeley.edu">Sky Computing Lab</a> at UC Berkeley. We are grateful to be supported by <a href="https://shv.com">Sutter Hill Ventures</a>.`,
       },
       prism: {
-        theme: lightCodeTheme,
-        darkTheme: darkCodeTheme,
+        theme: themes.github,
+        darkTheme: themes.dracula,
         additionalLanguages: ["rust", "bash"],
         magicComments: [
           {


### PR DESCRIPTION
Not sure why exactly this was happening, but this fixes it:

Was getting this issue on windows w/ node 23.11.0 and 24.1.0: https://github.com/facebook/docusaurus/discussions/10904

> [ERROR] Error: Expected usable value but received an empty preset, which is probably a mistake: presets typically come with `plugins` and sometimes with `settings`, but this has neither
    at addPreset (file:///F:/Projects/hydroflow/docs/node_modules/unified/lib/index.js:1111:15)
    at add (file:///F:/Projects/hydroflow/docs/node_modules/unified/lib/index.js:1097:11)
    at addList (file:///F:/Projects/hydroflow/docs/node_modules/unified/lib/index.js:1135:11)
    at Function.use (file:///F:/Projects/hydroflow/docs/node_modules/unified/lib/index.js:1074:9)
    at createProcessor (file:///F:/Projects/hydroflow/docs/node_modules/@mdx-js/mdx/lib/core.js:209:6)
    at createProcessorSync (F:\Projects\hydroflow\docs\node_modules\@docusaurus\mdx-loader\lib\processor.js:130:30)
    at createProcessors (F:\Projects\hydroflow\docs\node_modules\@docusaurus\mdx-loader\lib\processor.js:165:22)
    at async normalizeOptions (F:\Projects\hydroflow\docs\node_modules\@docusaurus\mdx-loader\lib\createMDXLoader.js:21:45)
    at async createMDXLoaderItem (F:\Projects\hydroflow\docs\node_modules\@docusaurus\mdx-loader\lib\createMDXLoader.js:38:18)
    at async createMDXLoaderRule (F:\Projects\hydroflow\docs\node_modules\@docusaurus\mdx-loader\lib\createMDXLoader.js:45:15)