### PR TITLE
feat(hydro_lang)!: add stream markers for tracking non-deterministic retries

### DIFF
--- a/hydro_lang/src/lib.rs
+++ b/hydro_lang/src/lib.rs
@@ -61,7 +61,7 @@ pub mod rewrites;
 mod staging_util;
 
 #[cfg(feature = "deploy")]
-#[cfg_attr(docsrs, doc(cfg(feature = "build")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "deploy")))]
 pub mod test_util;
 
 #[cfg(test)]

--- a/hydro_lang/src/location/external_process.rs
+++ b/hydro_lang/src/location/external_process.rs
@@ -8,7 +8,8 @@ use super::{Location, LocationId, NoTick};
 use crate::builder::FlowState;
 use crate::ir::{DebugInstantiate, HydroNode, HydroSource};
 use crate::staging_util::Invariant;
-use crate::{Stream, Unbounded};
+use crate::stream::ExactlyOnce;
+use crate::{Stream, TotalOrder, Unbounded};
 
 pub struct ExternalBytesPort {
     #[cfg_attr(
@@ -99,7 +100,10 @@ impl<'a, P> ExternalProcess<'a, P> {
     pub fn source_external_bytes<L>(
         &self,
         to: &L,
-    ) -> (ExternalBytesPort, Stream<Bytes, L, Unbounded>)
+    ) -> (
+        ExternalBytesPort,
+        Stream<Bytes, L, Unbounded, TotalOrder, ExactlyOnce>,
+    )
     where
         L: Location<'a> + NoTick,
     {
@@ -143,7 +147,10 @@ impl<'a, P> ExternalProcess<'a, P> {
     pub fn source_external_bincode<L, T>(
         &self,
         to: &L,
-    ) -> (ExternalBincodeSink<T>, Stream<T, L, Unbounded>)
+    ) -> (
+        ExternalBincodeSink<T>,
+        Stream<T, L, Unbounded, TotalOrder, ExactlyOnce>,
+    )
     where
         L: Location<'a> + NoTick,
         T: Serialize + DeserializeOwned,

--- a/hydro_lang/src/location/mod.rs
+++ b/hydro_lang/src/location/mod.rs
@@ -9,7 +9,8 @@ use stageleft::{QuotedWithContext, q};
 use super::builder::FlowState;
 use crate::cycle::{CycleCollection, ForwardRef, ForwardRefMarker};
 use crate::ir::{HydroIrMetadata, HydroNode, HydroSource};
-use crate::{Singleton, Stream, Unbounded};
+use crate::stream::ExactlyOnce;
+use crate::{Singleton, Stream, TotalOrder, Unbounded};
 
 pub mod external_process;
 pub use external_process::ExternalProcess;
@@ -96,7 +97,7 @@ pub trait Location<'a>: Clone {
         }
     }
 
-    fn spin(&self) -> Stream<(), Self, Unbounded>
+    fn spin(&self) -> Stream<(), Self, Unbounded, TotalOrder, ExactlyOnce>
     where
         Self: Sized + NoTick,
     {
@@ -116,7 +117,7 @@ pub trait Location<'a>: Clone {
     fn source_stream<T, E>(
         &self,
         e: impl QuotedWithContext<'a, E, Self>,
-    ) -> Stream<T, Self, Unbounded>
+    ) -> Stream<T, Self, Unbounded, TotalOrder, ExactlyOnce>
     where
         E: FuturesStream<Item = T> + Unpin,
         Self: Sized + NoTick,
@@ -139,7 +140,7 @@ pub trait Location<'a>: Clone {
     fn source_iter<T, E>(
         &self,
         e: impl QuotedWithContext<'a, E, Self>,
-    ) -> Stream<T, Self, Unbounded>
+    ) -> Stream<T, Self, Unbounded, TotalOrder, ExactlyOnce>
     where
         E: IntoIterator<Item = T>,
         Self: Sized + NoTick,
@@ -203,7 +204,7 @@ pub trait Location<'a>: Clone {
     unsafe fn source_interval(
         &self,
         interval: impl QuotedWithContext<'a, Duration, Self> + Copy + 'a,
-    ) -> Stream<tokio::time::Instant, Self, Unbounded>
+    ) -> Stream<tokio::time::Instant, Self, Unbounded, TotalOrder, ExactlyOnce>
     where
         Self: Sized + NoTick,
     {
@@ -226,7 +227,7 @@ pub trait Location<'a>: Clone {
         &self,
         delay: impl QuotedWithContext<'a, Duration, Self> + Copy + 'a,
         interval: impl QuotedWithContext<'a, Duration, Self> + Copy + 'a,
-    ) -> Stream<tokio::time::Instant, Self, Unbounded>
+    ) -> Stream<tokio::time::Instant, Self, Unbounded, TotalOrder, ExactlyOnce>
     where
         Self: Sized + NoTick,
     {

--- a/hydro_lang/src/location/tick.rs
+++ b/hydro_lang/src/location/tick.rs
@@ -11,7 +11,8 @@ use crate::cycle::{
     TickCycle, TickCycleMarker,
 };
 use crate::ir::{HydroIrMetadata, HydroNode, HydroSource};
-use crate::{Bounded, Optional, Singleton, Stream};
+use crate::stream::ExactlyOnce;
+use crate::{Bounded, Optional, Singleton, Stream, TotalOrder};
 
 #[sealed]
 pub trait NoTick {}
@@ -109,7 +110,7 @@ where
     pub fn spin_batch(
         &self,
         batch_size: impl QuotedWithContext<'a, usize, L> + Copy + 'a,
-    ) -> Stream<(), Self, Bounded>
+    ) -> Stream<(), Self, Bounded, TotalOrder, ExactlyOnce>
     where
         L: NoTick + NoAtomic,
     {

--- a/hydro_lang/src/test_util.rs
+++ b/hydro_lang/src/test_util.rs
@@ -7,8 +7,8 @@ use serde::de::DeserializeOwned;
 
 use crate::{FlowBuilder, Process, Stream, Unbounded};
 
-pub async fn multi_location_test<'a, T, C, O>(
-    thunk: impl FnOnce(&FlowBuilder<'a>, &Process<'a, ()>) -> Stream<T, Process<'a>, Unbounded, O>,
+pub async fn multi_location_test<'a, T, C, O, R>(
+    thunk: impl FnOnce(&FlowBuilder<'a>, &Process<'a, ()>) -> Stream<T, Process<'a>, Unbounded, O, R>,
     check: impl FnOnce(Pin<Box<dyn futures::Stream<Item = T>>>) -> C,
 ) where
     T: Serialize + DeserializeOwned + 'static,
@@ -34,8 +34,8 @@ pub async fn multi_location_test<'a, T, C, O>(
     check(external_out).await;
 }
 
-pub async fn stream_transform_test<'a, T, C, O>(
-    thunk: impl FnOnce(&Process<'a>) -> Stream<T, Process<'a>, Unbounded, O>,
+pub async fn stream_transform_test<'a, T, C, O, R>(
+    thunk: impl FnOnce(&Process<'a>) -> Stream<T, Process<'a>, Unbounded, O, R>,
     check: impl FnOnce(Pin<Box<dyn futures::Stream<Item = T>>>) -> C,
 ) where
     T: Serialize + DeserializeOwned + 'static,

--- a/hydro_std/src/quorum.rs
+++ b/hydro_std/src/quorum.rs
@@ -105,7 +105,7 @@ pub fn collect_quorum<'a, L: Location<'a> + NoTick, Order, K: Clone + Eq + Hash,
     min: usize,
     max: usize,
 ) -> (
-    Stream<K, Atomic<L>, Unbounded, Order>,
+    Stream<K, Atomic<L>, Unbounded, NoOrder>,
     Stream<(K, E), Atomic<L>, Unbounded, Order>,
 ) {
     let tick = responses.atomic_source();

--- a/hydro_test/src/cluster/paxos.rs
+++ b/hydro_test/src/cluster/paxos.rs
@@ -3,6 +3,7 @@ use std::fmt::Debug;
 use std::hash::Hash;
 use std::time::Duration;
 
+use hydro_lang::stream::AtLeastOnce;
 use hydro_lang::*;
 use hydro_std::quorum::{collect_quorum, collect_quorum_with_response};
 use hydro_std::request_response::join_responses;
@@ -247,7 +248,7 @@ pub unsafe fn leader_election<'a, L: Clone + Debug + Serialize + DeserializeOwne
     let (p1b_fail_complete, p1b_fail) =
         proposers.forward_ref::<Stream<Ballot, _, Unbounded, NoOrder>>();
     let (p_to_proposers_i_am_leader_complete_cycle, p_to_proposers_i_am_leader_forward_ref) =
-        proposers.forward_ref::<Stream<_, _, _, NoOrder>>();
+        proposers.forward_ref::<Stream<_, _, _, NoOrder, AtLeastOnce>>();
     let (p_is_leader_complete_cycle, p_is_leader_forward_ref) =
         proposer_tick.forward_ref::<Optional<(), _, _>>();
     // a_to_proposers_p2b.clone().for_each(q!(|(_, p2b): (u32, P2b)| println!("Proposer received P2b: {:?}", p2b)));
@@ -369,7 +370,7 @@ unsafe fn p_leader_heartbeat<'a>(
     p_ballot: Singleton<Ballot, Tick<Cluster<'a, Proposer>>, Bounded>,
     paxos_config: PaxosConfig,
 ) -> (
-    Stream<Ballot, Cluster<'a, Proposer>, Unbounded, NoOrder>,
+    Stream<Ballot, Cluster<'a, Proposer>, Unbounded, NoOrder, AtLeastOnce>,
     Optional<(), Tick<Cluster<'a, Proposer>>, Bounded>,
 ) {
     let i_am_leader_send_timeout = paxos_config.i_am_leader_send_timeout;


### PR DESCRIPTION

This introduces an additional type paramter to `Stream` called `Retries`, which tracks the presence (or lack) of non-determinstic retries in the stream. `ExactlyOnce` means that each element has deterministic order, while `AtLeastOnce` means that there may be non-deterministic duplicates.

A `TotalOrder, AtLeastOnce` stream describes elements with consecutive duplication, but deterministic order if we ignore those immediate elements. A `NoOrder, AtLeastOnce` stream has set semantics.

Also fixes a bug in the return type for `*_keyed_*`, where the output type was previously `TotalOrder` but now is `NoOrder`. We stream the results of a keyed aggregation out of a `HashMap`, so the order will indeed be non-deterministic.

Fixes #1863
