### PR TITLE
refactor(hydro_deploy_integration): eliminate `pin-project` proc macro dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2351,7 +2351,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures",
- "pin-project",
+ "pin-project-lite",
  "serde",
  "tempfile",
  "tokio",

--- a/hydro_deploy/hydro_deploy_integration/Cargo.toml
+++ b/hydro_deploy/hydro_deploy_integration/Cargo.toml
@@ -16,7 +16,7 @@ async-recursion = "1.0.0"
 async-trait = "0.1.54"
 bytes = "1.1.0"
 futures = "0.3.0"
-pin-project = "1.0.0"
+pin-project-lite = "0.2"
 serde = { version = "1.0.197", features = [ "derive" ] }
 tempfile = "3.0.0"
 


### PR DESCRIPTION

This was the only use of the proc-macro version along the Hydro dependencies, we can just use the declarative macro version.
