### PR TITLE
chore(hydro_optimize): clean up dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2401,14 +2401,10 @@ name = "hydro_optimize"
 version = "0.13.0"
 dependencies = [
  "ctor 0.2.9",
- "dfir_lang",
- "dfir_rs",
  "grb",
  "hydro_deploy",
  "hydro_lang",
- "hydro_std",
  "insta",
- "proc-macro-crate",
  "proc-macro2",
  "regex",
  "serde",
@@ -2416,7 +2412,6 @@ dependencies = [
  "stageleft_tool",
  "syn 2.0.101",
  "tokio",
- "trybuild-internals-api",
 ]
 
 [[package]]

--- a/hydro_optimize/Cargo.toml
+++ b/hydro_optimize/Cargo.toml
@@ -21,9 +21,7 @@ all-features = true
 [dependencies]
 hydro_deploy = { path = "../hydro_deploy/core", version = "^0.13.0" }
 hydro_lang = { path = "../hydro_lang", version = "^0.13.2", features = ["deploy"] }
-hydro_std = { path = "../hydro_std", version = "^0.13.0" }
 grb = { version = "3.0.1", features = ['gurobi12'], optional = true }
-proc-macro-crate = "1.0.0"
 proc-macro2 = "1.0.95"
 regex = "1.11.1"
 serde = { version = "1.0.197", features = ["derive"] }
@@ -34,13 +32,10 @@ syn = { version = "2.0.46", features = [
     "visit-mut",
 ] }
 tokio = { version = "1.29.0", features = ["full"] }
-trybuild-internals-api = "1.0.99"
 
 [build-dependencies]
 stageleft_tool.workspace = true
 
 [dev-dependencies]
 ctor = "0.2"
-dfir_rs = { path = "../dfir_rs", version = "^0.13.0", default-features = false }
-dfir_lang = { path = "../dfir_lang", version = "^0.13.0" }
 insta = "1.39"

--- a/hydro_optimize/src/lib.rs
+++ b/hydro_optimize/src/lib.rs
@@ -1,7 +1,5 @@
 stageleft::stageleft_no_entry_crate!();
 
-pub use stageleft::q;
-
 pub mod debug;
 pub mod decoupler;
 pub mod deploy;

--- a/hydro_test/Cargo.toml
+++ b/hydro_test/Cargo.toml
@@ -13,7 +13,6 @@ ilp = ["hydro_optimize/ilp"]
 [dependencies]
 hydro_lang = { path = "../hydro_lang", version = "^0.13.2" }
 hydro_std = { path = "../hydro_std", version = "^0.13.0" }
-hydro_optimize = { path = "../hydro_optimize", version = "^0.13.0" }
 stageleft.workspace = true
 rand = "0.8.0"
 serde = { version = "1.0.197", features = ["derive"] }
@@ -31,6 +30,7 @@ dfir_lang = { path = "../dfir_lang", version = "^0.13.0" }
 example_test = { path = "../example_test", version = "^0.0.0" }
 futures = "0.3.0"
 hydro_deploy = { path = "../hydro_deploy/core", version = "^0.13.0" }
+hydro_optimize = { path = "../hydro_optimize", version = "^0.13.0" }
 hydro_lang = { path = "../hydro_lang", version = "^0.13.2", features = [
     "deploy",
 ] }


### PR DESCRIPTION

Using `hydro_optimize` as a regular dependency in `hydro_test` results in leaking many dependencies including `hydro_deploy`, so this moves it to a dev-dependency
