### PR TITLE
feat(hydro_deploy_integration,hydro_lang): allow running generated binaries with single-threaded Tokio runtime

### DIFF
--- a/hydro_deploy/core/src/custom_service.rs
+++ b/hydro_deploy/core/src/custom_service.rs
@@ -105,8 +105,8 @@ impl CustomClientPort {
             .load_instantiated(&|p| p)
             .await
             .instantiate()
-            .connect::<ConnectedDirect>()
             .await
+            .connect::<ConnectedDirect>()
     }
 }
 

--- a/hydro_deploy/hydro_deploy_examples/examples/stdout_receiver/main.rs
+++ b/hydro_deploy/hydro_deploy_examples/examples/stdout_receiver/main.rs
@@ -7,7 +7,6 @@ async fn main() {
     let echo_recv = ports
         .port("echo")
         .connect::<ConnectedDirect>()
-        .await
         .into_source();
 
     let df = dfir_syntax! {

--- a/hydro_deploy/hydro_deploy_examples/examples/tagged_stdout_receiver/main.rs
+++ b/hydro_deploy/hydro_deploy_examples/examples/tagged_stdout_receiver/main.rs
@@ -7,7 +7,6 @@ async fn main() {
     let echo_recv = ports
         .port("echo")
         .connect::<ConnectedTagged<ConnectedDirect>>()
-        .await
         .into_source();
 
     let df = dfir_syntax! {

--- a/hydro_deploy/hydro_deploy_examples/examples/ws_chat_server/main.rs
+++ b/hydro_deploy/hydro_deploy_examples/examples/ws_chat_server/main.rs
@@ -34,13 +34,11 @@ async fn main() {
     let from_peer = ports
         .port("from_peer")
         .connect::<dfir_rs::util::deploy::ConnectedDirect>()
-        .await
         .into_source();
 
     let to_peer = ports
         .port("to_peer")
         .connect::<dfir_rs::util::deploy::ConnectedDemux<dfir_rs::util::deploy::ConnectedDirect>>()
-        .await
         .into_sink();
 
     let number_of_nodes: u32 = std::env::args().nth(1).unwrap().parse().unwrap();

--- a/hydro_lang/src/deploy/trybuild.rs
+++ b/hydro_lang/src/deploy/trybuild.rs
@@ -164,7 +164,7 @@ pub fn compile_graph_trybuild(
             #dfir_expr
         }
 
-        #[hydro_lang::runtime_support::tokio::main(crate = "hydro_lang::runtime_support::tokio")]
+        #[hydro_lang::runtime_support::tokio::main(crate = "hydro_lang::runtime_support::tokio", flavor = "current_thread")]
         async fn main() {
             let ports = hydro_lang::runtime_support::dfir_rs::util::deploy::init_no_ack_start().await;
             let flow = __hydro_runtime(&ports);

--- a/hydro_lang/src/deploy_runtime.rs
+++ b/hydro_lang/src/deploy_runtime.rs
@@ -40,21 +40,9 @@ pub fn deploy_o2o(
     p2_port: &str,
 ) -> (syn::Expr, syn::Expr) {
     (
+        { q!(env.port(p1_port).connect::<ConnectedDirect>().into_sink()).splice_untyped_ctx(&()) },
         {
-            q!({
-                env.port(p1_port)
-                    .connect_local_blocking::<ConnectedDirect>()
-                    .into_sink()
-            })
-            .splice_untyped_ctx(&())
-        },
-        {
-            q!({
-                env.port(p2_port)
-                    .connect_local_blocking::<ConnectedDirect>()
-                    .into_source()
-            })
-            .splice_untyped_ctx(&())
+            q!(env.port(p2_port).connect::<ConnectedDirect>().into_source()).splice_untyped_ctx(&())
         },
     )
 }
@@ -68,18 +56,13 @@ pub fn deploy_o2m(
         {
             q!({
                 env.port(p1_port)
-                    .connect_local_blocking::<ConnectedDemux<ConnectedDirect>>()
+                    .connect::<ConnectedDemux<ConnectedDirect>>()
                     .into_sink()
             })
             .splice_untyped_ctx(&())
         },
         {
-            q!({
-                env.port(c2_port)
-                    .connect_local_blocking::<ConnectedDirect>()
-                    .into_source()
-            })
-            .splice_untyped_ctx(&())
+            q!(env.port(c2_port).connect::<ConnectedDirect>().into_source()).splice_untyped_ctx(&())
         },
     )
 }
@@ -90,18 +73,11 @@ pub fn deploy_m2o(
     p2_port: &str,
 ) -> (syn::Expr, syn::Expr) {
     (
-        {
-            q!({
-                env.port(c1_port)
-                    .connect_local_blocking::<ConnectedDirect>()
-                    .into_sink()
-            })
-            .splice_untyped_ctx(&())
-        },
+        { q!(env.port(c1_port).connect::<ConnectedDirect>().into_sink()).splice_untyped_ctx(&()) },
         {
             q!({
                 env.port(p2_port)
-                    .connect_local_blocking::<ConnectedTagged<ConnectedDirect>>()
+                    .connect::<ConnectedTagged<ConnectedDirect>>()
                     .into_source()
             })
             .splice_untyped_ctx(&())
@@ -118,7 +94,7 @@ pub fn deploy_m2m(
         {
             q!({
                 env.port(c1_port)
-                    .connect_local_blocking::<ConnectedDemux<ConnectedDirect>>()
+                    .connect::<ConnectedDemux<ConnectedDirect>>()
                     .into_sink()
             })
             .splice_untyped_ctx(&())
@@ -126,7 +102,7 @@ pub fn deploy_m2m(
         {
             q!({
                 env.port(c2_port)
-                    .connect_local_blocking::<ConnectedTagged<ConnectedDirect>>()
+                    .connect::<ConnectedTagged<ConnectedDirect>>()
                     .into_source()
             })
             .splice_untyped_ctx(&())
@@ -139,12 +115,7 @@ pub fn deploy_e2o(
     _e1_port: &str,
     p2_port: &str,
 ) -> syn::Expr {
-    q!({
-        env.port(p2_port)
-            .connect_local_blocking::<ConnectedDirect>()
-            .into_source()
-    })
-    .splice_untyped_ctx(&())
+    q!(env.port(p2_port).connect::<ConnectedDirect>().into_source()).splice_untyped_ctx(&())
 }
 
 pub fn deploy_o2e(
@@ -152,10 +123,5 @@ pub fn deploy_o2e(
     p1_port: &str,
     _e2_port: &str,
 ) -> syn::Expr {
-    q!({
-        env.port(p1_port)
-            .connect_local_blocking::<ConnectedDirect>()
-            .into_sink()
-    })
-    .splice_untyped_ctx(&())
+    q!(env.port(p1_port).connect::<ConnectedDirect>().into_sink()).splice_untyped_ctx(&())
 }

--- a/hydro_test/src/local/count_elems.rs
+++ b/hydro_test/src/local/count_elems.rs
@@ -44,12 +44,14 @@ mod tests {
         let mut input_send = nodes.connect_sink_bincode(input_send).await;
         let mut out_recv = nodes.connect_source_bincode(out_recv).await;
 
+        // send before starting so everything shows up in single tick
         input_send.send(1).await.unwrap();
         input_send.send(1).await.unwrap();
         input_send.send(1).await.unwrap();
 
-        deployment.start().await.unwrap(); // we start after sending so that everything appears in one tick
+        deployment.start().await.unwrap();
 
-        assert_eq!(out_recv.next().await.unwrap(), 3);
+        assert_eq!(out_recv.next().await.unwrap(), 0); // first tick (no data yet)
+        assert_eq!(out_recv.next().await.unwrap(), 3); // second tick
     }
 }

--- a/hydro_test/src/local/negation.rs
+++ b/hydro_test/src/local/negation.rs
@@ -10,7 +10,10 @@ pub fn test_difference<'a>(
 
     let mut source = unsafe {
         // SAFETY: intentionally using ticks
-        process.source_iter(q!(0..5)).tick_batch(&tick)
+        process
+            .source_iter(q!(0..5))
+            .tick_batch(&tick)
+            .continue_if(tick_trigger.clone().tick_batch(&tick).first())
     };
     if persist1 {
         source = source.persist();
@@ -18,7 +21,10 @@ pub fn test_difference<'a>(
 
     let mut source2 = unsafe {
         // SAFETY: intentionally using ticks
-        process.source_iter(q!(3..6)).tick_batch(&tick)
+        process
+            .source_iter(q!(3..6))
+            .tick_batch(&tick)
+            .continue_if(tick_trigger.clone().tick_batch(&tick).first())
     };
     if persist2 {
         source2 = source2.persist();
@@ -44,6 +50,7 @@ pub fn test_anti_join<'a>(
             .source_iter(q!(0..5))
             .map(q!(|v| (v, v)))
             .tick_batch(&tick)
+            .continue_if(tick_trigger.clone().tick_batch(&tick).first())
     };
     if persist1 {
         source = source.persist();
@@ -51,7 +58,10 @@ pub fn test_anti_join<'a>(
 
     let mut source2 = unsafe {
         // SAFETY: intentionally using ticks
-        process.source_iter(q!(3..6)).tick_batch(&tick)
+        process
+            .source_iter(q!(3..6))
+            .tick_batch(&tick)
+            .continue_if(tick_trigger.clone().tick_batch(&tick).first())
     };
     if persist2 {
         source2 = source2.persist();

--- a/topolotree/src/latency_measure.rs
+++ b/topolotree/src/latency_measure.rs
@@ -19,13 +19,11 @@ async fn main() {
     let mut start_node = ports
         .port("increment_start_node")
         .connect::<ConnectedDirect>()
-        .await
         .into_sink();
 
     let mut end_node = ports
         .port("end_node_query")
         .connect::<ConnectedDirect>()
-        .await
         .into_source();
 
     let num_clients: u64 = std::env::args().nth(1).unwrap().parse().unwrap();

--- a/topolotree/src/main.rs
+++ b/topolotree/src/main.rs
@@ -223,26 +223,22 @@ async fn main() {
         .port("from_peer")
         // connect to the port with a single recipient
         .connect::<ConnectedTagged<ConnectedDirect>>()
-        .await
         .into_source();
 
     let mut output_send = ports
         .port("to_peer")
         .connect::<ConnectedDemux<ConnectedDirect>>()
-        .await
         .into_sink();
 
     let operations_send = ports
         .port("increment_requests")
         // connect to the port with a single recipient
         .connect::<ConnectedDirect>()
-        .await
         .into_source();
 
     let mut query_responses = ports
         .port("query_responses")
         .connect::<ConnectedDirect>()
-        .await
         .into_sink();
 
     let (chan_tx, mut chan_rx) = tokio::sync::mpsc::unbounded_channel();

--- a/topolotree/src/pn.rs
+++ b/topolotree/src/pn.rs
@@ -34,25 +34,21 @@ async fn main() {
     let increment_requests = ports
         .port("increment_requests")
         .connect::<ConnectedDirect>()
-        .await
         .into_source();
 
     let query_responses = ports
         .port("query_responses")
         .connect::<ConnectedDirect>()
-        .await
         .into_sink();
 
     let to_peer = ports
         .port("to_peer")
         .connect::<ConnectedDemux<ConnectedDirect>>()
-        .await
         .into_sink();
 
     let from_peer = ports
         .port("from_peer")
         .connect::<ConnectedTagged<ConnectedDirect>>()
-        .await
         .into_source();
 
     let f1 = async move {

--- a/topolotree/src/pn_delta.rs
+++ b/topolotree/src/pn_delta.rs
@@ -34,25 +34,21 @@ async fn main() {
     let increment_requests = ports
         .port("increment_requests")
         .connect::<ConnectedDirect>()
-        .await
         .into_source();
 
     let query_responses = ports
         .port("query_responses")
         .connect::<ConnectedDirect>()
-        .await
         .into_sink();
 
     let to_peer = ports
         .port("to_peer")
         .connect::<ConnectedDemux<ConnectedDirect>>()
-        .await
         .into_sink();
 
     let from_peer = ports
         .port("from_peer")
         .connect::<ConnectedTagged<ConnectedDirect>>()
-        .await
         .into_source();
 
     let f1 = async move {


### PR DESCRIPTION

Before, we had a janky architecture for establishing network connections which relied on blocking on futures outside an async context, which required a multi-threaded runtime. Now, we establish all connections before launching the DFIR code, so that no blocking is required there.

Fixes #1807
