### PR TITLE
refactor: minimize Tokio feature flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5696,7 +5696,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util",
 ]
 
 [[package]]

--- a/dfir_rs/Cargo.toml
+++ b/dfir_rs/Cargo.toml
@@ -50,7 +50,8 @@ serde = { version = "1.0.197", features = [ "derive" ] }
 serde_json = "1.0.115"
 slotmap = "1.0.0"
 smallvec = "1.6.1"
-tokio-stream = { version = "0.1.3", default-features = false, features = [ "time", "io-util", "sync" ] }
+tokio = { version = "1.29.0", features = [ "rt", "sync", "macros", "io-util", "time" ] }
+tokio-stream = { version = "0.1.3", default-features = false, features = [ "time", "io-util" ] }
 tracing = "0.1.37"
 variadics = { path = "../variadics", version = "^0.0.9" }
 web-time = "1.0.0"
@@ -60,11 +61,10 @@ multiplatform_test = { path = "../multiplatform_test", version = "^0.5.0", optio
 include_mdtests = { path = "../include_mdtests", version = "^0.0.0", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "1.29.0", features = [ "full" ] }
+tokio = { version = "1.29.0", features = [ "io-std" ] }
 tokio-util = { version = "0.7.5", features = [ "net", "codec" ] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-tokio = { version = "1.29.0", features = [ "rt" , "sync", "macros", "io-util", "time" ] }
 tokio-util = { version = "0.7.5", features = [ "codec" ] }
 # We depend on getrandom transitively through rand. To compile getrandom to
 # WASM, we need to enable its "js" feature. However, rand does not expose a

--- a/hydro_deploy/hydro_deploy_integration/Cargo.toml
+++ b/hydro_deploy/hydro_deploy_integration/Cargo.toml
@@ -21,10 +21,6 @@ serde = { version = "1.0.197", features = [ "derive" ] }
 tempfile = "3.0.0"
 
 # [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "1.29.0", features = [ "full" ] }
+tokio = { version = "1.29.0", features = [ "rt", "net", "time" ] }
 tokio-util = { version = "0.7.5", features = [ "net", "codec" ] }
 tokio-stream = { version = "0.1.3", default-features = false, features = [ "net" ] }
-
-# [target.'cfg(target_arch = "wasm32")'.dependencies]
-# tokio = { version = "1.29.0", features = [ "rt" , "sync", "macros", "io-util", "time" ] }
-# tokio-util = { version = "0.7.5", features = [ "codec" ] }

--- a/hydro_lang/Cargo.toml
+++ b/hydro_lang/Cargo.toml
@@ -56,7 +56,7 @@ syn = { version = "2.0.46", features = [
     "extra-traits",
     "visit-mut",
 ] }
-tokio = { version = "1.29.0", features = ["full"] }
+tokio = "1.29.0"
 tokio-stream = { version = "0.1.3", default-features = false, features = [
     "time",
 ] }


### PR DESCRIPTION

Now that `hydro_lang` no longer needs multi-threaded runtime, we can eliminate it from the features used in `trybuild` compilation. Minimizes Tokio features elsewhere too.
