### PR TITLE
feat(hydro_lang): make it easier to open trybuild-generated files with Rust Analyzer

### DIFF
--- a/hydro_lang/src/deploy/trybuild.rs
+++ b/hydro_lang/src/deploy/trybuild.rs
@@ -307,6 +307,13 @@ pub fn create_trybuild()
                 &path!(dot_cargo_folder / "config.toml"),
             )?;
         }
+
+        let vscode_folder = path!(project.dir / ".vscode");
+        fs::create_dir_all(&vscode_folder)?;
+        write_atomic(
+            include_bytes!("./vscode-trybuild.json"),
+            &path!(vscode_folder / "settings.json"),
+        )?;
     }
 
     Ok((

--- a/hydro_lang/src/deploy/vscode-trybuild.json
+++ b/hydro_lang/src/deploy/vscode-trybuild.json
@@ -1,0 +1,5 @@
+{
+    "rust-analyzer.cargo.extraEnv": {
+        "STAGELEFT_TRYBUILD_BUILD_STAGED": "1"
+    }
+}


### PR DESCRIPTION

To fully compile the generated sources without error, the Stageleft environment variable needt to be passed to build scripts, so pre-configure that in workspace settings.
