### PR TITLE
chore: remove remaining custom VSCode config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,10 +8,6 @@
     "rust-analyzer.runnables.extraTestBinaryArgs": [
         "--nocapture"
     ],
-    "rust-analyzer.cargo.features": [
-        "hydro_lang/deploy",
-        "dfir_rs/deploy_integration",
-    ],
     "editor.semanticTokenColorCustomizations": {
         "enabled": true,
         "rules": {


### PR DESCRIPTION

Now that we don't compile any Stageleft stuff in Rust Analyzer, we don't need to customize the default feature set.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydro-project/hydro/pull/1950).
* #1951
* __->__ #1950