### PR TITLE
chore: enable `viz` feature only in dev-dependencies

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,10 +8,6 @@
     "rust-analyzer.runnables.extraTestBinaryArgs": [
         "--nocapture"
     ],
-    "rust-analyzer.cargo.features": [
-        "hydro_lang/deploy",
-        "dfir_rs/deploy_integration",
-    ],
     "editor.semanticTokenColorCustomizations": {
         "enabled": true,
         "rules": {

--- a/hydro_test/Cargo.toml
+++ b/hydro_test/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 workspace = true
 
 [dependencies]
-hydro_lang = { path = "../hydro_lang", version = "^0.13.2", features = ["viz"] }
+hydro_lang = { path = "../hydro_lang", version = "^0.13.2" }
 hydro_std = { path = "../hydro_std", version = "^0.13.0" }
 stageleft.workspace = true
 rand = "0.8.0"
@@ -31,7 +31,7 @@ hydro_deploy = { path = "../hydro_deploy/core", version = "^0.13.0" }
 hydro_optimize = { path = "../hydro_optimize", version = "^0.13.0" }
 hydro_lang = { path = "../hydro_lang", version = "^0.13.2", features = [
     "deploy",
-    "build",
+    "viz",
 ] }
 include_mdtests = { path = "../include_mdtests", version = "^0.0.0" }
 insta = "1.39"

--- a/template/hydro/Cargo.toml
+++ b/template/hydro/Cargo.toml
@@ -17,6 +17,7 @@ ctor = "0.2"
 hydro_deploy = { git = "{{ hydro_git | default: 'https://github.com/hydro-project/hydro.git' }}", branch = "{{ hydro_branch | default: 'main' }}" }
 hydro_lang = { git = "{{ hydro_git | default: 'https://github.com/hydro-project/hydro.git' }}", branch = "{{ hydro_branch | default: 'main' }}", features = [
     "deploy",
+    "viz",
 ] }
 tokio = { version = "1.29.0", features = ["full"] }
 tokio-stream = { version = "0.1.3", default-features = false }


### PR DESCRIPTION

Reduces compilation burden when running `hydro_test` examples.
