### PR TITLE
fix(docs): Replace broken stageleft import with GitHub link

### DIFF
--- a/docs/docs/hydro/stageleft.mdx
+++ b/docs/docs/hydro/stageleft.mdx
@@ -3,9 +3,7 @@ title: Stageleft
 sidebar_position: 10
 ---
 
-import StageleftDocs from 'stageleft/README.md'
-
-Under the hood, Hydro uses a library called Stageleft to power the `q!` macro and code generation logic. The following docs, from the Stageleft README, outline the core architecture of Stageleft.
+Under the hood, Hydro uses a library called Stageleft to power the `q!` macro and code generation logic. 
 
 :::note
 
@@ -14,4 +12,4 @@ interested in how its `q!` macro works.
 
 :::
 
-<StageleftDocs/>
+For detailed documentation on Stageleft's architecture and the `q!` macro, see the [Stageleft README](https://github.com/hydro-project/stageleft/blob/main/README.md).


### PR DESCRIPTION
The stageleft page in Hydro was referencing a local file that got moved to the new stageleft repo. This causes build errors when I add features to the docs. Fix is minor.