### PR TITLE
refactor(hydro_lang): rename `ExternalProcess` to `External`

### DIFF
--- a/hydro_lang/src/builder/built.rs
+++ b/hydro_lang/src/builder/built.rs
@@ -10,7 +10,7 @@ use crate::deploy::{ClusterSpec, Deploy, ExternalSpec, IntoProcessSpec};
 #[cfg(feature = "viz")]
 use crate::graph::api::GraphApi;
 use crate::ir::{HydroLeaf, emit};
-use crate::location::{Cluster, ExternalProcess, Process};
+use crate::location::{Cluster, External, Process};
 use crate::staging_util::Invariant;
 
 pub struct BuiltFlow<'a> {
@@ -268,7 +268,7 @@ impl<'a> BuiltFlow<'a> {
 
     pub fn with_external<P, D: Deploy<'a>>(
         self,
-        process: &ExternalProcess<P>,
+        process: &External<P>,
         spec: impl ExternalSpec<'a, D>,
     ) -> DeployFlow<'a, D> {
         self.into_deploy().with_external(process, spec)

--- a/hydro_lang/src/builder/deploy.rs
+++ b/hydro_lang/src/builder/deploy.rs
@@ -20,7 +20,7 @@ use crate::ir::HydroLeaf;
 use crate::location::external_process::{
     ExternalBincodeSink, ExternalBincodeStream, ExternalBytesPort,
 };
-use crate::location::{Cluster, ExternalProcess, Location, LocationId, Process};
+use crate::location::{Cluster, External, Location, LocationId, Process};
 use crate::staging_util::Invariant;
 
 pub struct DeployFlow<'a, D>
@@ -39,7 +39,7 @@ where
     /// but with the type name of the tag.
     pub(super) process_id_name: Vec<(usize, String)>,
 
-    pub(super) externals: HashMap<usize, D::ExternalProcess>,
+    pub(super) externals: HashMap<usize, D::External>,
     pub(super) external_id_name: Vec<(usize, String)>,
 
     pub(super) clusters: HashMap<usize, D::Cluster>,
@@ -87,7 +87,7 @@ impl<'a, D: Deploy<'a>> DeployFlow<'a, D> {
 
     pub fn with_external<P>(
         mut self,
-        process: &ExternalProcess<P>,
+        process: &External<P>,
         spec: impl ExternalSpec<'a, D>,
     ) -> Self {
         let tag_name = std::any::type_name::<P>().to_string();
@@ -313,7 +313,7 @@ impl<'a, D: Deploy<'a, CompileEnv = ()>> DeployFlow<'a, D> {
 pub struct DeployResult<'a, D: Deploy<'a>> {
     processes: HashMap<usize, D::Process>,
     clusters: HashMap<usize, D::Cluster>,
-    externals: HashMap<usize, D::ExternalProcess>,
+    externals: HashMap<usize, D::External>,
     cluster_id_name: HashMap<usize, String>,
     process_id_name: HashMap<usize, String>,
 }
@@ -357,7 +357,7 @@ impl<'a, D: Deploy<'a>> DeployResult<'a, D> {
         })
     }
 
-    pub fn get_external<P>(&self, p: &ExternalProcess<P>) -> &D::ExternalProcess {
+    pub fn get_external<P>(&self, p: &External<P>) -> &D::External {
         self.externals.get(&p.id).unwrap()
     }
 

--- a/hydro_lang/src/builder/mod.rs
+++ b/hydro_lang/src/builder/mod.rs
@@ -12,7 +12,7 @@ use stageleft::*;
 #[cfg(feature = "build")]
 use crate::deploy::{ClusterSpec, Deploy, ExternalSpec, IntoProcessSpec};
 use crate::ir::HydroLeaf;
-use crate::location::{Cluster, ExternalProcess, Process};
+use crate::location::{Cluster, External, Process};
 use crate::staging_util::Invariant;
 
 #[cfg(feature = "build")]
@@ -173,7 +173,7 @@ impl<'a> FlowBuilder<'a> {
         }
     }
 
-    pub fn external_process<P>(&self) -> ExternalProcess<'a, P> {
+    pub fn external_process<P>(&self) -> External<'a, P> {
         let mut next_location_id = self.next_location_id.borrow_mut();
         let id = *next_location_id;
         *next_location_id += 1;
@@ -182,7 +182,7 @@ impl<'a> FlowBuilder<'a> {
             .borrow_mut()
             .push((id, type_name::<P>().to_string()));
 
-        ExternalProcess {
+        External {
             id,
             flow_state: self.flow_state().clone(),
             _phantom: PhantomData,
@@ -246,7 +246,7 @@ impl<'a> FlowBuilder<'a> {
 
     pub fn with_external<P, D: Deploy<'a>>(
         self,
-        process: &ExternalProcess<P>,
+        process: &External<P>,
         spec: impl ExternalSpec<'a, D>,
     ) -> DeployFlow<'a, D> {
         self.with_default_optimize().with_external(process, spec)

--- a/hydro_lang/src/deploy/deploy_graph.rs
+++ b/hydro_lang/src/deploy/deploy_graph.rs
@@ -32,7 +32,7 @@ impl<'a> Deploy<'a> for HydroDeploy {
     type CompileEnv = ();
     type Process = DeployNode;
     type Cluster = DeployCluster;
-    type ExternalProcess = DeployExternal;
+    type External = DeployExternal;
     type Meta = HashMap<usize, Vec<u32>>;
     type GraphId = ();
     type Port = String;
@@ -46,7 +46,7 @@ impl<'a> Deploy<'a> for HydroDeploy {
         cluster.next_port()
     }
 
-    fn allocate_external_port(external: &Self::ExternalProcess) -> Self::Port {
+    fn allocate_external_port(external: &Self::External) -> Self::Port {
         external.next_port()
     }
 
@@ -267,7 +267,7 @@ impl<'a> Deploy<'a> for HydroDeploy {
 
     fn e2o_source(
         _compile_env: &Self::CompileEnv,
-        _p1: &Self::ExternalProcess,
+        _p1: &Self::External,
         p1_port: &Self::Port,
         _p2: &Self::Process,
         p2_port: &Self::Port,
@@ -282,7 +282,7 @@ impl<'a> Deploy<'a> for HydroDeploy {
     }
 
     fn e2o_connect(
-        p1: &Self::ExternalProcess,
+        p1: &Self::External,
         p1_port: &Self::Port,
         p2: &Self::Process,
         p2_port: &Self::Port,
@@ -319,7 +319,7 @@ impl<'a> Deploy<'a> for HydroDeploy {
         _compile_env: &Self::CompileEnv,
         _p1: &Self::Process,
         p1_port: &Self::Port,
-        _p2: &Self::ExternalProcess,
+        _p2: &Self::External,
         p2_port: &Self::Port,
     ) -> syn::Expr {
         let p1_port = p1_port.as_str();
@@ -334,7 +334,7 @@ impl<'a> Deploy<'a> for HydroDeploy {
     fn o2e_connect(
         p1: &Self::Process,
         p1_port: &Self::Port,
-        p2: &Self::ExternalProcess,
+        p2: &Self::External,
         p2_port: &Self::Port,
     ) -> Box<dyn FnOnce()> {
         let p1 = p1.clone();

--- a/hydro_lang/src/deploy/mod.rs
+++ b/hydro_lang/src/deploy/mod.rs
@@ -38,7 +38,7 @@ pub trait Deploy<'a> {
 
     type Process: Node<Meta = Self::Meta, InstantiateEnv = Self::InstantiateEnv> + Clone;
     type Cluster: Node<Meta = Self::Meta, InstantiateEnv = Self::InstantiateEnv> + Clone;
-    type ExternalProcess: Node<Meta = Self::Meta, InstantiateEnv = Self::InstantiateEnv>
+    type External: Node<Meta = Self::Meta, InstantiateEnv = Self::InstantiateEnv>
         + RegisterPort<'a, Self>;
     type Port: Clone;
     type ExternalRawPort;
@@ -59,13 +59,13 @@ pub trait Deploy<'a> {
         panic!("No trivial cluster")
     }
 
-    fn trivial_external(_id: usize) -> Self::ExternalProcess {
+    fn trivial_external(_id: usize) -> Self::External {
         panic!("No trivial external process")
     }
 
     fn allocate_process_port(process: &Self::Process) -> Self::Port;
     fn allocate_cluster_port(cluster: &Self::Cluster) -> Self::Port;
-    fn allocate_external_port(external: &Self::ExternalProcess) -> Self::Port;
+    fn allocate_external_port(external: &Self::External) -> Self::Port;
 
     fn o2o_sink_source(
         compile_env: &Self::CompileEnv,
@@ -125,13 +125,13 @@ pub trait Deploy<'a> {
 
     fn e2o_source(
         compile_env: &Self::CompileEnv,
-        p1: &Self::ExternalProcess,
+        p1: &Self::External,
         p1_port: &Self::Port,
         p2: &Self::Process,
         p2_port: &Self::Port,
     ) -> syn::Expr;
     fn e2o_connect(
-        p1: &Self::ExternalProcess,
+        p1: &Self::External,
         p1_port: &Self::Port,
         p2: &Self::Process,
         p2_port: &Self::Port,
@@ -141,13 +141,13 @@ pub trait Deploy<'a> {
         compile_env: &Self::CompileEnv,
         p1: &Self::Process,
         p1_port: &Self::Port,
-        p2: &Self::ExternalProcess,
+        p2: &Self::External,
         p2_port: &Self::Port,
     ) -> syn::Expr;
     fn o2e_connect(
         p1: &Self::Process,
         p1_port: &Self::Port,
-        p2: &Self::ExternalProcess,
+        p2: &Self::External,
         p2_port: &Self::Port,
     ) -> Box<dyn FnOnce()>;
 
@@ -195,7 +195,7 @@ pub trait ExternalSpec<'a, D>
 where
     D: Deploy<'a> + ?Sized,
 {
-    fn build(self, id: usize, name_hint: &str) -> D::ExternalProcess;
+    fn build(self, id: usize, name_hint: &str) -> D::External;
 }
 
 pub trait Node {

--- a/hydro_lang/src/graph/render.rs
+++ b/hydro_lang/src/graph/render.rs
@@ -277,7 +277,7 @@ fn extract_location_id(metadata: &crate::ir::HydroIrMetadata) -> (Option<usize>,
     match &metadata.location_kind {
         LocationId::Process(id) => (Some(*id), Some("Process".to_string())),
         LocationId::Cluster(id) => (Some(*id), Some("Cluster".to_string())),
-        LocationId::ExternalProcess(id) => (Some(*id), Some("External".to_string())),
+        LocationId::External(id) => (Some(*id), Some("External".to_string())),
         LocationId::Tick(_, inner) => match inner.as_ref() {
             LocationId::Process(id) => (Some(*id), Some("Process".to_string())),
             LocationId::Cluster(id) => (Some(*id), Some("Cluster".to_string())),
@@ -811,7 +811,7 @@ impl HydroNode {
                         structure.add_location(*id, "Cluster".to_string());
                         Some(*id)
                     }
-                    LocationId::ExternalProcess(id) => {
+                    LocationId::External(id) => {
                         structure.add_location(*id, "External".to_string());
                         Some(*id)
                     }

--- a/hydro_lang/src/ir.rs
+++ b/hydro_lang/src/ir.rs
@@ -349,7 +349,7 @@ impl HydroLeaf {
         seen_tee_locations: &mut SeenTeeLocations,
         processes: &HashMap<usize, D::Process>,
         clusters: &HashMap<usize, D::Cluster>,
-        externals: &HashMap<usize, D::ExternalProcess>,
+        externals: &HashMap<usize, D::External>,
     ) where
         D: Deploy<'a>,
     {
@@ -528,7 +528,7 @@ impl HydroLeaf {
                     LocationId::Process(id) => id,
                     LocationId::Cluster(id) => id,
                     LocationId::Tick(_, _) => panic!(),
-                    LocationId::ExternalProcess(_) => panic!(),
+                    LocationId::External(_) => panic!(),
                 };
 
                 match builders_or_callback {
@@ -928,7 +928,7 @@ impl HydroNode {
         seen_tee_locations: &mut SeenTeeLocations,
         nodes: &HashMap<usize, D::Process>,
         clusters: &HashMap<usize, D::Cluster>,
-        externals: &HashMap<usize, D::ExternalProcess>,
+        externals: &HashMap<usize, D::External>,
     ) where
         D: Deploy<'a>,
     {
@@ -1405,7 +1405,7 @@ impl HydroNode {
                     LocationId::Process(id) => id,
                     LocationId::Cluster(id) => id,
                     LocationId::Tick(_, _) => panic!(),
-                    LocationId::ExternalProcess(id) => id,
+                    LocationId::External(id) => id,
                 };
 
                 if let HydroSource::ExternalNetwork() = source {
@@ -1463,7 +1463,7 @@ impl HydroNode {
                     LocationId::Process(id) => id,
                     LocationId::Cluster(id) => id,
                     LocationId::Tick(_, _) => panic!(),
-                    LocationId::ExternalProcess(_) => panic!(),
+                    LocationId::External(_) => panic!(),
                 };
 
                 let ident = ident.clone();
@@ -2161,7 +2161,7 @@ impl HydroNode {
                     LocationId::Process(id) => id,
                     LocationId::Cluster(id) => id,
                     LocationId::Tick(_, _) => panic!(),
-                    LocationId::ExternalProcess(id) => id,
+                    LocationId::External(id) => id,
                 };
 
                 let receiver_stream_ident =
@@ -2521,7 +2521,7 @@ fn instantiate_network<'a, D>(
     to_key: Option<usize>,
     nodes: &HashMap<usize, D::Process>,
     clusters: &HashMap<usize, D::Cluster>,
-    externals: &HashMap<usize, D::ExternalProcess>,
+    externals: &HashMap<usize, D::External>,
     compile_env: &D::CompileEnv,
 ) -> (syn::Expr, syn::Expr, Box<dyn FnOnce()>)
 where
@@ -2616,7 +2616,7 @@ where
                 D::m2m_connect(&from_node, &sink_port, &to_node, &source_port),
             )
         }
-        (LocationId::ExternalProcess(from), LocationId::Process(to)) => {
+        (LocationId::External(from), LocationId::Process(to)) => {
             let from_node = externals
                 .get(from)
                 .unwrap_or_else(|| {
@@ -2647,13 +2647,13 @@ where
                 D::e2o_connect(&from_node, &sink_port, &to_node, &source_port),
             )
         }
-        (LocationId::ExternalProcess(_from), LocationId::Cluster(_to)) => {
+        (LocationId::External(_from), LocationId::Cluster(_to)) => {
             todo!("NYI")
         }
-        (LocationId::ExternalProcess(_), LocationId::ExternalProcess(_)) => {
+        (LocationId::External(_), LocationId::External(_)) => {
             panic!("Cannot send from external to external")
         }
-        (LocationId::Process(from), LocationId::ExternalProcess(to)) => {
+        (LocationId::Process(from), LocationId::External(to)) => {
             let from_node = nodes
                 .get(from)
                 .unwrap_or_else(|| {
@@ -2681,7 +2681,7 @@ where
                 D::o2e_connect(&from_node, &sink_port, &to_node, &source_port),
             )
         }
-        (LocationId::Cluster(_from), LocationId::ExternalProcess(_to)) => {
+        (LocationId::Cluster(_from), LocationId::External(_to)) => {
             todo!("NYI")
         }
         (LocationId::Tick(_, _), _) => panic!(),

--- a/hydro_lang/src/lib.rs
+++ b/hydro_lang/src/lib.rs
@@ -41,7 +41,7 @@ pub use optional::Optional;
 
 pub mod location;
 pub use location::cluster::CLUSTER_SELF_ID;
-pub use location::{Atomic, Cluster, ClusterId, ExternalProcess, Location, Process, Tick};
+pub use location::{Atomic, Cluster, ClusterId, External, Location, Process, Tick};
 
 #[cfg(feature = "build")]
 #[cfg_attr(docsrs, doc(cfg(feature = "build")))]

--- a/hydro_lang/src/location/can_send.rs
+++ b/hydro_lang/src/location/can_send.rs
@@ -1,6 +1,6 @@
 use stageleft::quote_type;
 
-use super::{Cluster, ClusterId, ExternalProcess, Location, Process};
+use super::{Cluster, ClusterId, External, Location, Process};
 use crate::stream::NoOrder;
 
 pub trait CanSend<'a, To>: Location<'a>
@@ -74,7 +74,7 @@ impl<'a, C1, C2> CanSend<'a, Cluster<'a, C2>> for Cluster<'a, C1> {
     }
 }
 
-impl<'a, P1, E2> CanSend<'a, ExternalProcess<'a, E2>> for Process<'a, P1> {
+impl<'a, P1, E2> CanSend<'a, External<'a, E2>> for Process<'a, P1> {
     type In<T> = T;
     type Out<T> = T;
     type OutStrongestOrder<InOrder> = InOrder;

--- a/hydro_lang/src/location/external_process.rs
+++ b/hydro_lang/src/location/external_process.rs
@@ -58,17 +58,17 @@ where
     pub(crate) _phantom: PhantomData<Type>,
 }
 
-pub struct ExternalProcess<'a, ProcessTag> {
+pub struct External<'a, Tag> {
     pub(crate) id: usize,
 
     pub(crate) flow_state: FlowState,
 
-    pub(crate) _phantom: Invariant<'a, ProcessTag>,
+    pub(crate) _phantom: Invariant<'a, Tag>,
 }
 
-impl<P> Clone for ExternalProcess<'_, P> {
+impl<P> Clone for External<'_, P> {
     fn clone(&self) -> Self {
-        ExternalProcess {
+        External {
             id: self.id,
             flow_state: self.flow_state.clone(),
             _phantom: PhantomData,
@@ -76,7 +76,7 @@ impl<P> Clone for ExternalProcess<'_, P> {
     }
 }
 
-impl<'a, P> Location<'a> for ExternalProcess<'a, P> {
+impl<'a, P> Location<'a> for External<'a, P> {
     type Root = Self;
 
     fn root(&self) -> Self::Root {
@@ -84,7 +84,7 @@ impl<'a, P> Location<'a> for ExternalProcess<'a, P> {
     }
 
     fn id(&self) -> LocationId {
-        LocationId::ExternalProcess(self.id)
+        LocationId::External(self.id)
     }
 
     fn flow_state(&self) -> &FlowState {
@@ -96,7 +96,7 @@ impl<'a, P> Location<'a> for ExternalProcess<'a, P> {
     }
 }
 
-impl<'a, P> ExternalProcess<'a, P> {
+impl<'a, P> External<'a, P> {
     pub fn source_external_bytes<L>(
         &self,
         to: &L,
@@ -133,7 +133,7 @@ impl<'a, P> ExternalProcess<'a, P> {
                         deserialize_fn: Some(deser_expr.into()),
                         input: Box::new(HydroNode::Source {
                             source: HydroSource::ExternalNetwork(),
-                            location_kind: LocationId::ExternalProcess(self.id),
+                            location_kind: LocationId::External(self.id),
                             metadata: self.new_node_metadata::<Bytes>(),
                         }),
                         metadata: to.new_node_metadata::<Bytes>(),
@@ -180,7 +180,7 @@ impl<'a, P> ExternalProcess<'a, P> {
                         deserialize_fn: Some(crate::stream::deserialize_bincode::<T>(None).into()),
                         input: Box::new(HydroNode::Source {
                             source: HydroSource::ExternalNetwork(),
-                            location_kind: LocationId::ExternalProcess(self.id),
+                            location_kind: LocationId::External(self.id),
                             metadata: self.new_node_metadata::<T>(),
                         }),
                         metadata: to.new_node_metadata::<T>(),

--- a/hydro_lang/src/location/mod.rs
+++ b/hydro_lang/src/location/mod.rs
@@ -15,7 +15,7 @@ use crate::stream::ExactlyOnce;
 use crate::{Singleton, Stream, TotalOrder, Unbounded};
 
 pub mod external_process;
-pub use external_process::ExternalProcess;
+pub use external_process::External;
 
 pub mod process;
 pub use process::Process;
@@ -34,7 +34,7 @@ pub enum LocationId {
     Process(usize),
     Cluster(usize),
     Tick(usize, Box<LocationId>),
-    ExternalProcess(usize),
+    External(usize),
 }
 
 impl LocationId {
@@ -43,7 +43,7 @@ impl LocationId {
             LocationId::Process(_) => self,
             LocationId::Cluster(_) => self,
             LocationId::Tick(_, id) => id.root(),
-            LocationId::ExternalProcess(_) => self,
+            LocationId::External(_) => self,
         }
     }
 
@@ -52,7 +52,7 @@ impl LocationId {
             LocationId::Process(id) => *id,
             LocationId::Cluster(id) => *id,
             LocationId::Tick(_, _) => panic!("cannot get raw id for tick"),
-            LocationId::ExternalProcess(id) => *id,
+            LocationId::External(id) => *id,
         }
     }
 

--- a/hydro_lang/src/stream.rs
+++ b/hydro_lang/src/stream.rs
@@ -18,7 +18,7 @@ use crate::ir::{DebugInstantiate, HydroLeaf, HydroNode, TeeNode};
 use crate::location::external_process::{ExternalBincodeStream, ExternalBytesPort};
 use crate::location::tick::{Atomic, NoAtomic};
 use crate::location::{
-    CanSend, ExternalProcess, Location, LocationId, NoTick, Tick, check_matching_location,
+    CanSend, External, Location, LocationId, NoTick, Tick, check_matching_location,
 };
 use crate::staging_util::get_this_crate;
 use crate::{Bounded, Cluster, ClusterId, Optional, Singleton, Unbounded};
@@ -2475,10 +2475,10 @@ where
 
     pub fn send_bincode_external<L2, CoreType>(
         self,
-        other: &ExternalProcess<L2>,
+        other: &External<L2>,
     ) -> ExternalBincodeStream<L::Out<CoreType>>
     where
-        L: CanSend<'a, ExternalProcess<'a, L2>, In<CoreType> = T, Out<CoreType> = CoreType>,
+        L: CanSend<'a, External<'a, L2>, In<CoreType> = T, Out<CoreType> = CoreType>,
         L2: 'a,
         CoreType: Serialize + DeserializeOwned,
         // for now, we restirct Out<CoreType> to be CoreType, which means no tagged cluster -> external
@@ -2553,10 +2553,10 @@ where
         )
     }
 
-    pub fn send_bytes_external<L2>(self, other: &ExternalProcess<L2>) -> ExternalBytesPort
+    pub fn send_bytes_external<L2>(self, other: &External<L2>) -> ExternalBytesPort
     where
         L2: 'a,
-        L::Root: CanSend<'a, ExternalProcess<'a, L2>, In<Bytes> = T, Out<Bytes> = Bytes>,
+        L::Root: CanSend<'a, External<'a, L2>, In<Bytes> = T, Out<Bytes> = Bytes>,
     {
         let metadata = other.new_node_metadata::<Bytes>();
 

--- a/hydro_test/src/distributed/first_ten.rs
+++ b/hydro_test/src/distributed/first_ten.rs
@@ -11,7 +11,7 @@ pub struct P1 {}
 pub struct P2 {}
 
 pub fn first_ten_distributed<'a>(
-    external: &ExternalProcess<'a, ()>,
+    external: &External<'a, ()>,
     process: &Process<'a, P1>,
     second_process: &Process<'a, P2>,
 ) -> ExternalBincodeSink<String> {

--- a/hydro_test/src/distributed/snapshots/hydro_test__distributed__first_ten__tests__first_ten_distributed_ir.snap
+++ b/hydro_test/src/distributed/snapshots/hydro_test__distributed__first_ten__tests__first_ten_distributed_ir.snap
@@ -22,11 +22,11 @@ expression: builder.finalize().ir()
                     ),
                     input: Source {
                         source: ExternalNetwork,
-                        location_kind: ExternalProcess(
+                        location_kind: External(
                             0,
                         ),
                         metadata: HydroIrMetadata {
-                            location_kind: ExternalProcess(
+                            location_kind: External(
                                 0,
                             ),
                             output_type: Some(


### PR DESCRIPTION

In preparation of supporting multi-connection source / sink pairs. There is no need to distinguish a single external from multiple at the location level, instead we will have separate APIs for declaring a single vs multi connection input/output.
