### PR TITLE
refactor(hydro_lang)!: invert external sources and clean up locations in IR

### DIFF
--- a/hydro_lang/src/builder/deploy.rs
+++ b/hydro_lang/src/builder/deploy.rs
@@ -157,12 +157,10 @@ impl<'a, D: Deploy<'a>> DeployFlow<'a, D> {
 impl<'a, D: Deploy<'a>> DeployFlow<'a, D> {
     pub fn compile(mut self, env: &D::CompileEnv) -> CompiledFlow<'a, D::GraphId> {
         let mut seen_tees: HashMap<_, _> = HashMap::new();
-        let mut seen_tee_locations: HashMap<_, _> = HashMap::new();
         self.ir.get_mut().iter_mut().for_each(|leaf| {
             leaf.compile_network::<D>(
                 env,
                 &mut seen_tees,
-                &mut seen_tee_locations,
                 &self.processes,
                 &self.clusters,
                 &self.externals,
@@ -216,12 +214,10 @@ impl<'a, D: Deploy<'a, CompileEnv = ()>> DeployFlow<'a, D> {
     #[must_use]
     pub fn deploy(mut self, env: &mut D::InstantiateEnv) -> DeployResult<'a, D> {
         let mut seen_tees_instantiate: HashMap<_, _> = HashMap::new();
-        let mut seen_tee_locations: HashMap<_, _> = HashMap::new();
         self.ir.get_mut().iter_mut().for_each(|leaf| {
             leaf.compile_network::<D>(
                 &(),
                 &mut seen_tees_instantiate,
-                &mut seen_tee_locations,
                 &self.processes,
                 &self.clusters,
                 &self.externals,
@@ -271,7 +267,7 @@ impl<'a, D: Deploy<'a, CompileEnv = ()>> DeployFlow<'a, D> {
                     external.instantiate(
                         env,
                         &mut meta,
-                        compiled.remove(&external_id).unwrap(),
+                        Default::default(),
                         extra_stmts.remove(&external_id).unwrap_or_default(),
                     );
                     (external_id, external)

--- a/hydro_lang/src/builder/mod.rs
+++ b/hydro_lang/src/builder/mod.rs
@@ -173,7 +173,7 @@ impl<'a> FlowBuilder<'a> {
         }
     }
 
-    pub fn external_process<P>(&self) -> External<'a, P> {
+    pub fn external<P>(&self) -> External<'a, P> {
         let mut next_location_id = self.next_location_id.borrow_mut();
         let id = *next_location_id;
         *next_location_id += 1;

--- a/hydro_lang/src/graph/render.rs
+++ b/hydro_lang/src/graph/render.rs
@@ -407,6 +407,10 @@ impl HydroLeaf {
                 HydroEdgeType::Stream,
             ),
 
+            HydroLeaf::SendExternal { input, .. } => {
+                input.build_graph_structure(structure, seen_tees, config)
+            }
+
             HydroLeaf::DestSink {
                 sink,
                 input,
@@ -555,6 +559,10 @@ impl HydroNode {
                     HydroSource::Spin() => "spin()".to_string(),
                 };
                 build_source_node(structure, metadata, label)
+            }
+
+            HydroNode::ExternalInput { metadata, .. } => {
+                build_source_node(structure, metadata, "external_network()".to_string())
             }
 
             HydroNode::CycleSource {
@@ -792,7 +800,6 @@ impl HydroNode {
             }
 
             HydroNode::Network {
-                to_location,
                 serialize_fn,
                 deserialize_fn,
                 input,
@@ -802,7 +809,7 @@ impl HydroNode {
                 let input_id = input.build_graph_structure(structure, seen_tees, config);
                 let _from_location_id = setup_location(structure, metadata);
 
-                let to_location_id = match to_location {
+                let to_location_id = match metadata.location_kind.root() {
                     LocationId::Process(id) => {
                         structure.add_location(*id, "Process".to_string());
                         Some(*id)

--- a/hydro_lang/src/location/can_send.rs
+++ b/hydro_lang/src/location/can_send.rs
@@ -1,12 +1,9 @@
 use stageleft::quote_type;
 
-use super::{Cluster, ClusterId, External, Location, Process};
+use super::{Cluster, ClusterId, External, Process};
 use crate::stream::NoOrder;
 
-pub trait CanSend<'a, To>: Location<'a>
-where
-    To: Location<'a>,
-{
+pub trait CanSend<'a, To> {
     type In<Type>;
     type Out<Type>;
 

--- a/hydro_lang/src/location/external_process.rs
+++ b/hydro_lang/src/location/external_process.rs
@@ -1,15 +1,10 @@
 use std::marker::PhantomData;
 
-use bytes::Bytes;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
-use super::{Location, LocationId, NoTick};
 use crate::builder::FlowState;
-use crate::ir::{DebugInstantiate, HydroNode, HydroSource};
 use crate::staging_util::Invariant;
-use crate::stream::ExactlyOnce;
-use crate::{Stream, TotalOrder, Unbounded};
 
 pub struct ExternalBytesPort {
     #[cfg_attr(
@@ -73,121 +68,5 @@ impl<P> Clone for External<'_, P> {
             flow_state: self.flow_state.clone(),
             _phantom: PhantomData,
         }
-    }
-}
-
-impl<'a, P> Location<'a> for External<'a, P> {
-    type Root = Self;
-
-    fn root(&self) -> Self::Root {
-        self.clone()
-    }
-
-    fn id(&self) -> LocationId {
-        LocationId::External(self.id)
-    }
-
-    fn flow_state(&self) -> &FlowState {
-        &self.flow_state
-    }
-
-    fn is_top_level() -> bool {
-        true
-    }
-}
-
-impl<'a, P> External<'a, P> {
-    pub fn source_external_bytes<L>(
-        &self,
-        to: &L,
-    ) -> (
-        ExternalBytesPort,
-        Stream<Bytes, L, Unbounded, TotalOrder, ExactlyOnce>,
-    )
-    where
-        L: Location<'a> + NoTick,
-    {
-        let next_external_port_id = {
-            let mut flow_state = self.flow_state.borrow_mut();
-            let id = flow_state.next_external_out;
-            flow_state.next_external_out += 1;
-            id
-        };
-
-        let deser_expr: syn::Expr = syn::parse_quote!(|b| b.unwrap().freeze());
-
-        (
-            ExternalBytesPort {
-                process_id: self.id,
-                port_id: next_external_port_id,
-            },
-            Stream::new(
-                to.clone(),
-                HydroNode::Persist {
-                    inner: Box::new(HydroNode::Network {
-                        from_key: Some(next_external_port_id),
-                        to_location: to.id(),
-                        to_key: None,
-                        serialize_fn: None,
-                        instantiate_fn: DebugInstantiate::Building,
-                        deserialize_fn: Some(deser_expr.into()),
-                        input: Box::new(HydroNode::Source {
-                            source: HydroSource::ExternalNetwork(),
-                            location_kind: LocationId::External(self.id),
-                            metadata: self.new_node_metadata::<Bytes>(),
-                        }),
-                        metadata: to.new_node_metadata::<Bytes>(),
-                    }),
-                    metadata: to.new_node_metadata::<Bytes>(),
-                },
-            ),
-        )
-    }
-
-    pub fn source_external_bincode<L, T>(
-        &self,
-        to: &L,
-    ) -> (
-        ExternalBincodeSink<T>,
-        Stream<T, L, Unbounded, TotalOrder, ExactlyOnce>,
-    )
-    where
-        L: Location<'a> + NoTick,
-        T: Serialize + DeserializeOwned,
-    {
-        let next_external_port_id = {
-            let mut flow_state = self.flow_state.borrow_mut();
-            let id = flow_state.next_external_out;
-            flow_state.next_external_out += 1;
-            id
-        };
-
-        (
-            ExternalBincodeSink {
-                process_id: self.id,
-                port_id: next_external_port_id,
-                _phantom: PhantomData,
-            },
-            Stream::new(
-                to.clone(),
-                HydroNode::Persist {
-                    inner: Box::new(HydroNode::Network {
-                        from_key: Some(next_external_port_id),
-                        to_location: to.id(),
-                        to_key: None,
-                        serialize_fn: None,
-                        instantiate_fn: DebugInstantiate::Building,
-                        deserialize_fn: Some(crate::stream::deserialize_bincode::<T>(None).into()),
-                        input: Box::new(HydroNode::Source {
-                            source: HydroSource::ExternalNetwork(),
-                            location_kind: LocationId::External(self.id),
-                            metadata: self.new_node_metadata::<T>(),
-                        }),
-                        metadata: to.new_node_metadata::<T>(),
-                    }),
-                    metadata: to.new_node_metadata::<T>(),
-                },
-            ),
-        )
     }
 }

--- a/hydro_lang/src/location/tick.rs
+++ b/hydro_lang/src/location/tick.rs
@@ -145,7 +145,6 @@ where
             self.clone(),
             HydroNode::Source {
                 source: HydroSource::Iter(e.into()),
-                location_kind: self.l.id(),
                 metadata: self.new_node_metadata::<T>(),
             },
         )

--- a/hydro_lang/src/optional.rs
+++ b/hydro_lang/src/optional.rs
@@ -37,10 +37,6 @@ where
     pub fn some(singleton: Singleton<T, L, B>) -> Self {
         Optional::new(singleton.location, singleton.ir_node.into_inner())
     }
-
-    fn location_kind(&self) -> LocationId {
-        self.location.id()
-    }
 }
 
 impl<'a, T, L> DeferTick for Optional<T, Tick<L>, Bounded>
@@ -59,12 +55,10 @@ where
     type Location = Tick<L>;
 
     fn create_source(ident: syn::Ident, location: Tick<L>) -> Self {
-        let location_id = location.id();
         Optional::new(
             location.clone(),
             HydroNode::CycleSource {
                 ident,
-                location_kind: location_id,
                 metadata: location.new_node_metadata::<T>(),
             },
         )
@@ -89,7 +83,6 @@ where
             .expect(FLOW_USED_MESSAGE)
             .push(HydroLeaf::CycleSink {
                 ident,
-                location_kind: self.location_kind(),
                 input: Box::new(self.ir_node.into_inner()),
                 metadata: self.location.new_node_metadata::<T>(),
             });
@@ -103,12 +96,10 @@ where
     type Location = Tick<L>;
 
     fn create_source(ident: syn::Ident, location: Tick<L>) -> Self {
-        let location_id = location.id();
         Optional::new(
             location.clone(),
             HydroNode::CycleSource {
                 ident,
-                location_kind: location_id,
                 metadata: location.new_node_metadata::<T>(),
             },
         )
@@ -133,7 +124,6 @@ where
             .expect(FLOW_USED_MESSAGE)
             .push(HydroLeaf::CycleSink {
                 ident,
-                location_kind: self.location_kind(),
                 input: Box::new(self.ir_node.into_inner()),
                 metadata: self.location.new_node_metadata::<T>(),
             });
@@ -147,13 +137,11 @@ where
     type Location = L;
 
     fn create_source(ident: syn::Ident, location: L) -> Self {
-        let location_id = location.id();
         Optional::new(
             location.clone(),
             HydroNode::Persist {
                 inner: Box::new(HydroNode::CycleSource {
                     ident,
-                    location_kind: location_id,
                     metadata: location.new_node_metadata::<T>(),
                 }),
                 metadata: location.new_node_metadata::<T>(),
@@ -181,7 +169,6 @@ where
             .expect(FLOW_USED_MESSAGE)
             .push(HydroLeaf::CycleSink {
                 ident,
-                location_kind: self.location_kind(),
                 input: Box::new(HydroNode::Unpersist {
                     inner: Box::new(self.ir_node.into_inner()),
                     metadata: metadata.clone(),
@@ -469,8 +456,7 @@ where
         let core_ir = HydroNode::Persist {
             inner: Box::new(HydroNode::Source {
                 source: HydroSource::Iter(none.into()),
-                location_kind: self.location.id().root().clone(),
-                metadata: self.location.new_node_metadata::<Option<T>>(),
+                metadata: self.location.root().new_node_metadata::<Option<T>>(),
             }),
             metadata: self.location.new_node_metadata::<Option<T>>(),
         };

--- a/hydro_lang/src/rewrites/persist_pullup.rs
+++ b/hydro_lang/src/rewrites/persist_pullup.rs
@@ -121,7 +121,6 @@ fn persist_pullup_node(
 
             HydroNode::Network {
                 from_key,
-                to_location,
                 to_key,
                 serialize_fn,
                 instantiate_fn,
@@ -131,7 +130,6 @@ fn persist_pullup_node(
             } => HydroNode::Persist {
                 inner: Box::new(HydroNode::Network {
                     from_key,
-                    to_location,
                     to_key,
                     serialize_fn,
                     instantiate_fn,
@@ -200,9 +198,12 @@ fn persist_pullup_node(
 
 pub fn persist_pullup(ir: &mut [HydroLeaf]) {
     let mut persist_pulled_tees = Default::default();
-    transform_bottom_up(ir, &mut |_| (), &mut |node| {
-        persist_pullup_node(node, &mut persist_pulled_tees)
-    });
+    transform_bottom_up(
+        ir,
+        &mut |_| (),
+        &mut |node| persist_pullup_node(node, &mut persist_pulled_tees),
+        false,
+    );
 }
 
 #[cfg(stageleft_runtime)]

--- a/hydro_lang/src/rewrites/properties.rs
+++ b/hydro_lang/src/rewrites/properties.rs
@@ -57,9 +57,12 @@ fn properties_optimize_node(node: &mut HydroNode, db: &mut PropertyDatabase) {
 }
 
 pub fn properties_optimize(ir: &mut [HydroLeaf], db: &mut PropertyDatabase) {
-    transform_bottom_up(ir, &mut |_| (), &mut |node| {
-        properties_optimize_node(node, db)
-    });
+    transform_bottom_up(
+        ir,
+        &mut |_| (),
+        &mut |node| properties_optimize_node(node, db),
+        false,
+    );
 }
 
 #[cfg(stageleft_runtime)]

--- a/hydro_lang/src/rewrites/snapshots/hydro_lang__rewrites__persist_pullup__tests__persist_pullup_behind_tee-2.snap
+++ b/hydro_lang/src/rewrites/snapshots/hydro_lang__rewrites__persist_pullup__tests__persist_pullup_behind_tee-2.snap
@@ -13,9 +13,6 @@ expression: optimized.ir()
                         source: Iter(
                             { use crate :: __staged :: __deps :: * ; use crate :: __staged :: rewrites :: persist_pullup :: tests :: * ; 0 .. 10 },
                         ),
-                        location_kind: Process(
-                            0,
-                        ),
                         metadata: HydroIrMetadata {
                             location_kind: Process(
                                 0,
@@ -79,9 +76,6 @@ expression: optimized.ir()
                     inner: <tee>: Source {
                         source: Iter(
                             { use crate :: __staged :: __deps :: * ; use crate :: __staged :: rewrites :: persist_pullup :: tests :: * ; 0 .. 10 },
-                        ),
-                        location_kind: Process(
-                            0,
                         ),
                         metadata: HydroIrMetadata {
                             location_kind: Process(

--- a/hydro_lang/src/rewrites/snapshots/hydro_lang__rewrites__persist_pullup__tests__persist_pullup_behind_tee.snap
+++ b/hydro_lang/src/rewrites/snapshots/hydro_lang__rewrites__persist_pullup__tests__persist_pullup_behind_tee.snap
@@ -17,9 +17,6 @@ expression: built.ir()
                                         source: Iter(
                                             { use crate :: __staged :: __deps :: * ; use crate :: __staged :: rewrites :: persist_pullup :: tests :: * ; 0 .. 10 },
                                         ),
-                                        location_kind: Process(
-                                            0,
-                                        ),
                                         metadata: HydroIrMetadata {
                                             location_kind: Process(
                                                 0,
@@ -129,9 +126,6 @@ expression: built.ir()
                                     inner: Source {
                                         source: Iter(
                                             { use crate :: __staged :: __deps :: * ; use crate :: __staged :: rewrites :: persist_pullup :: tests :: * ; 0 .. 10 },
-                                        ),
-                                        location_kind: Process(
-                                            0,
                                         ),
                                         metadata: HydroIrMetadata {
                                             location_kind: Process(

--- a/hydro_lang/src/rewrites/snapshots/hydro_lang__rewrites__persist_pullup__tests__persist_pullup_through_map-2.snap
+++ b/hydro_lang/src/rewrites/snapshots/hydro_lang__rewrites__persist_pullup__tests__persist_pullup_through_map-2.snap
@@ -11,9 +11,6 @@ expression: optimized.ir()
                 source: Iter(
                     { use crate :: __staged :: __deps :: * ; use crate :: __staged :: rewrites :: persist_pullup :: tests :: * ; 0 .. 10 },
                 ),
-                location_kind: Process(
-                    0,
-                ),
                 metadata: HydroIrMetadata {
                     location_kind: Process(
                         0,

--- a/hydro_lang/src/rewrites/snapshots/hydro_lang__rewrites__persist_pullup__tests__persist_pullup_through_map.snap
+++ b/hydro_lang/src/rewrites/snapshots/hydro_lang__rewrites__persist_pullup__tests__persist_pullup_through_map.snap
@@ -13,9 +13,6 @@ expression: built.ir()
                         source: Iter(
                             { use crate :: __staged :: __deps :: * ; use crate :: __staged :: rewrites :: persist_pullup :: tests :: * ; 0 .. 10 },
                         ),
-                        location_kind: Process(
-                            0,
-                        ),
                         metadata: HydroIrMetadata {
                             location_kind: Process(
                                 0,

--- a/hydro_lang/src/rewrites/snapshots/hydro_lang__rewrites__properties__tests__property_optimized.snap
+++ b/hydro_lang/src/rewrites/snapshots/hydro_lang__rewrites__properties__tests__property_optimized.snap
@@ -14,9 +14,6 @@ expression: built.ir()
                     source: Iter(
                         { use crate :: __staged :: __deps :: * ; use crate :: __staged :: rewrites :: properties :: tests :: * ; vec ! [] },
                     ),
-                    location_kind: Process(
-                        0,
-                    ),
                     metadata: HydroIrMetadata {
                         location_kind: Process(
                             0,

--- a/hydro_lang/src/test_util.rs
+++ b/hydro_lang/src/test_util.rs
@@ -17,7 +17,7 @@ pub async fn multi_location_test<'a, T, C, O, R>(
     let mut deployment = hydro_deploy::Deployment::new();
     let flow = FlowBuilder::new();
     let process = flow.process::<()>();
-    let external = flow.external_process::<()>();
+    let external = flow.external::<()>();
     let out = thunk(&flow, &process);
     let out_port = out.send_bincode_external(&external);
     let nodes = flow
@@ -44,7 +44,7 @@ pub async fn stream_transform_test<'a, T, C, O, R>(
     let mut deployment = hydro_deploy::Deployment::new();
     let flow = FlowBuilder::new();
     let process = flow.process::<()>();
-    let external = flow.external_process::<()>();
+    let external = flow.external::<()>();
     let out = thunk(&process);
     let out_port = out.send_bincode_external(&external);
     let nodes = flow

--- a/hydro_optimize/src/decoupler.rs
+++ b/hydro_optimize/src/decoupler.rs
@@ -62,7 +62,6 @@ fn add_network(node: &mut HydroNode, new_location: &LocationId) {
     let output_type = output_debug_type.clone().0;
     let network_node = HydroNode::Network {
         from_key: None,
-        to_location: new_location.clone(),
         to_key: None,
         serialize_fn: Some(serialize_bincode_with_type(true, &output_type)).map(|e| e.into()),
         instantiate_fn: DebugInstantiate::Building,
@@ -142,23 +141,13 @@ fn decouple_node(
     // Replace location of sources, if necessary
     if decoupler.place_on_decoupled_machine.contains(next_stmt_id) {
         match node {
-            HydroNode::Source {
-                location_kind,
-                metadata,
-                ..
-            }
-            | HydroNode::Network {
-                to_location: location_kind,
-                metadata,
-                ..
-            } => {
+            HydroNode::Source { metadata, .. } | HydroNode::Network { metadata, .. } => {
                 println!(
                     "Changing source/network destination from {:?} to location {:?}, id: {}",
-                    location_kind,
+                    metadata.location_kind,
                     decoupler.decoupled_location.clone(),
                     next_stmt_id
                 );
-                *location_kind = decoupler.decoupled_location.clone();
                 metadata
                     .location_kind
                     .swap_root(decoupler.decoupled_location.clone());
@@ -270,6 +259,7 @@ pub fn decouple(ir: &mut [HydroLeaf], decoupler: &Decoupler) {
         &mut |node| {
             fix_cluster_self_id_node(node, locations);
         },
+        true,
     );
 }
 

--- a/hydro_optimize/src/deploy_and_analyze.rs
+++ b/hydro_optimize/src/deploy_and_analyze.rs
@@ -48,6 +48,7 @@ fn insert_counter_node(node: &mut HydroNode, next_stmt_id: &mut usize, duration:
         | HydroNode::FoldKeyed { metadata, .. }
         | HydroNode::ReduceKeyed { metadata, .. }
         | HydroNode::Network { metadata, .. }
+        | HydroNode::ExternalInput { metadata, .. }
          => {
             let metadata = metadata.clone();
             let node_content = std::mem::replace(node, HydroNode::Placeholder);

--- a/hydro_optimize/src/partition_node_analysis.rs
+++ b/hydro_optimize/src/partition_node_analysis.rs
@@ -192,7 +192,8 @@ fn input_dependency_analysis_node(
         | HydroNode::AntiJoin { .. } // [(a,1),(b,2)] anti-join [a] = [(b,2)]. Similar to Difference
         | HydroNode::Filter { .. } // Although it contains a function f, the output is just a subset of the input, so just inherit from the parent
         | HydroNode::Inspect { .. }
-        | HydroNode::Network { .. } => {
+        | HydroNode::Network { .. }
+        | HydroNode::ExternalInput { .. } => {
             // For each input the first (and potentially only) parent depends on, take its dependency
             for input_id in input_taint_entry.iter() {
                 if let Some(parent_dependencies_on_input) = parent_input_dependencies.get(input_id) {

--- a/hydro_optimize/src/partitioner.rs
+++ b/hydro_optimize/src/partitioner.rs
@@ -295,14 +295,6 @@ fn replace_process_node_location(node: &mut HydroNode, partitioner: &Partitioner
     if let Some(new_id) = new_cluster_id {
         // Change any HydroNodes with a location field
         match node {
-            HydroNode::Source { location_kind, .. }
-            | HydroNode::CycleSource { location_kind, .. }
-            | HydroNode::Network {
-                to_location: location_kind,
-                ..
-            } => {
-                replace_process_location_id(location_kind, *location_id, *new_id);
-            }
             // Update Persist's location as well (we won't see it during traversal)
             HydroNode::CrossProduct { left, right, .. } | HydroNode::Join { left, right, .. } => {
                 replace_process_input_persist_location_id(left, *location_id, *new_id);
@@ -340,11 +332,6 @@ fn replace_process_leaf_location(leaf: &mut HydroLeaf, partitioner: &Partitioner
     } = partitioner;
 
     if let Some(new_id) = new_cluster_id {
-        // Change any HydroLeafs with a location field
-        if let HydroLeaf::CycleSink { location_kind, .. } = leaf {
-            replace_process_location_id(location_kind, *location_id, *new_id);
-        }
-
         // Modify the metadata
         replace_process_location_id(
             &mut leaf.metadata_mut().location_kind,

--- a/hydro_optimize/src/rewrites.rs
+++ b/hydro_optimize/src/rewrites.rs
@@ -141,14 +141,11 @@ pub fn get_network_type(node: &HydroNode, location: usize) -> Option<NetworkType
     let mut is_to_us = false;
     let mut is_from_us = false;
 
-    if let HydroNode::Network {
-        input, to_location, ..
-    } = node
-    {
+    if let HydroNode::Network { input, .. } = node {
         if input.metadata().location_kind.root().raw_id() == location {
             is_from_us = true;
         }
-        if to_location.root().raw_id() == location {
+        if node.metadata().location_kind.root().raw_id() == location {
             is_to_us = true;
         }
 

--- a/hydro_optimize/src/snapshots/hydro_optimize__decoupler__tests__decouple_after_source_ir.snap
+++ b/hydro_optimize/src/snapshots/hydro_optimize__decoupler__tests__decouple_after_source_ir.snap
@@ -9,9 +9,6 @@ expression: built.ir()
             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: cluster :: cluster_id :: ClusterId < () > , i32) , i32 > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
             input: Network {
                 from_key: None,
-                to_location: Cluster(
-                    1,
-                ),
                 to_key: None,
                 serialize_fn: Some(
                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , i32) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -28,9 +25,6 @@ expression: built.ir()
                             f: | (_ , b) | b,
                             input: Network {
                                 from_key: None,
-                                to_location: Cluster(
-                                    2,
-                                ),
                                 to_key: None,
                                 serialize_fn: Some(
                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , i32) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -44,9 +38,6 @@ expression: built.ir()
                                     input: Source {
                                         source: Iter(
                                             { use crate :: __staged :: __deps :: * ; use crate :: __staged :: decoupler :: tests :: * ; 0 .. 10 },
-                                        ),
-                                        location_kind: Cluster(
-                                            0,
                                         ),
                                         metadata: HydroIrMetadata {
                                             location_kind: Cluster(

--- a/hydro_optimize/src/snapshots/hydro_optimize__decoupler__tests__move_source_decouple_map_ir.snap
+++ b/hydro_optimize/src/snapshots/hydro_optimize__decoupler__tests__move_source_decouple_map_ir.snap
@@ -9,9 +9,6 @@ expression: built.ir()
             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: cluster :: cluster_id :: ClusterId < () > , i32) , i32 > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
             input: Network {
                 from_key: None,
-                to_location: Cluster(
-                    1,
-                ),
                 to_key: None,
                 serialize_fn: Some(
                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , i32) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -26,9 +23,6 @@ expression: built.ir()
                         f: | (_ , b) | b,
                         input: Network {
                             from_key: None,
-                            to_location: Cluster(
-                                0,
-                            ),
                             to_key: None,
                             serialize_fn: Some(
                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , i32) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -44,9 +38,6 @@ expression: built.ir()
                                     input: Source {
                                         source: Iter(
                                             { use crate :: __staged :: __deps :: * ; use crate :: __staged :: decoupler :: tests :: * ; 0 .. 10 },
-                                        ),
-                                        location_kind: Cluster(
-                                            2,
                                         ),
                                         metadata: HydroIrMetadata {
                                             location_kind: Cluster(

--- a/hydro_test/examples/first_ten_distributed.rs
+++ b/hydro_test/examples/first_ten_distributed.rs
@@ -51,7 +51,7 @@ async fn main() {
     };
 
     let builder = hydro_lang::FlowBuilder::new();
-    let external = builder.external_process();
+    let external = builder.external();
     let p1 = builder.process();
     let p2 = builder.process();
     let external_port =

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__compute_pi__tests__compute_pi_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__compute_pi__tests__compute_pi_ir.snap
@@ -15,9 +15,6 @@ expression: built.ir()
                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: compute_pi :: Worker > , (u64 , u64)) , (u64 , u64) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                             input: Network {
                                 from_key: None,
-                                to_location: Process(
-                                    1,
-                                ),
                                 to_key: None,
                                 serialize_fn: Some(
                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (u64 , u64) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
@@ -39,9 +36,6 @@ expression: built.ir()
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , std :: ops :: Range < usize > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: tick :: * ; let batch_size__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: compute_pi :: * ; let batch_size__free = 8192usize ; batch_size__free } ; move | _ | 0 .. batch_size__free }),
                                                     input: Source {
                                                         source: Spin,
-                                                        location_kind: Cluster(
-                                                            0,
-                                                        ),
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Cluster(
                                                                 0,
@@ -148,9 +142,6 @@ expression: built.ir()
                         input: Source {
                             source: Stream(
                                 { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let interval__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: compute_pi :: * ; Duration :: from_secs (1) } ; tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval (interval__free)) },
-                            ),
-                            location_kind: Process(
-                                1,
                             ),
                             metadata: HydroIrMetadata {
                                 location_kind: Process(

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__compute_pi__tests__decoupled_compute_pi_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__compute_pi__tests__decoupled_compute_pi_ir.snap
@@ -15,9 +15,6 @@ expression: built.ir()
                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: compute_pi :: Worker > , (u64 , u64)) , (u64 , u64) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                             input: Network {
                                 from_key: None,
-                                to_location: Process(
-                                    1,
-                                ),
                                 to_key: None,
                                 serialize_fn: Some(
                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (u64 , u64) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
@@ -33,9 +30,6 @@ expression: built.ir()
                                         f: | (_ , b) | b,
                                         input: Network {
                                             from_key: None,
-                                            to_location: Cluster(
-                                                2,
-                                            ),
                                             to_key: None,
                                             serialize_fn: Some(
                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , bool) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -56,9 +50,6 @@ expression: built.ir()
                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , std :: ops :: Range < usize > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: tick :: * ; let batch_size__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: compute_pi :: * ; let batch_size__free = 8192usize ; batch_size__free } ; move | _ | 0 .. batch_size__free }),
                                                                 input: Source {
                                                                     source: Spin,
-                                                                    location_kind: Cluster(
-                                                                        0,
-                                                                    ),
                                                                     metadata: HydroIrMetadata {
                                                                         location_kind: Cluster(
                                                                             0,
@@ -192,9 +183,6 @@ expression: built.ir()
                         input: Source {
                             source: Stream(
                                 { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let interval__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: compute_pi :: * ; Duration :: from_secs (1) } ; tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval (interval__free)) },
-                            ),
-                            location_kind: Process(
-                                1,
                             ),
                             metadata: HydroIrMetadata {
                                 location_kind: Process(

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__many_to_many__tests__many_to_many_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__many_to_many__tests__many_to_many_ir.snap
@@ -8,9 +8,6 @@ expression: built.ir()
         input: Unpersist {
             inner: Network {
                 from_key: None,
-                to_location: Cluster(
-                    0,
-                ),
                 to_key: None,
                 serialize_fn: Some(
                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , i32) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -25,9 +22,6 @@ expression: built.ir()
                         inner: Source {
                             source: Iter(
                                 { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: many_to_many :: * ; 0 .. 2 },
-                            ),
-                            location_kind: Cluster(
-                                0,
                             ),
                             metadata: HydroIrMetadata {
                                 location_kind: Cluster(

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__map_reduce__tests__map_reduce_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__map_reduce__tests__map_reduce_ir.snap
@@ -12,9 +12,6 @@ expression: built.ir()
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: map_reduce :: Worker > , (std :: string :: String , i32)) , (std :: string :: String , i32) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                     input: Network {
                         from_key: None,
-                        to_location: Process(
-                            0,
-                        ),
                         to_key: None,
                         serialize_fn: Some(
                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (std :: string :: String , i32) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
@@ -32,9 +29,6 @@ expression: built.ir()
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < std :: string :: String , (std :: string :: String , ()) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: map_reduce :: * ; | string | (string , ()) }),
                                     input: Network {
                                         from_key: None,
-                                        to_location: Cluster(
-                                            1,
-                                        ),
                                         to_key: None,
                                         serialize_fn: Some(
                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , std :: string :: String) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -52,9 +46,6 @@ expression: built.ir()
                                                     input: Source {
                                                         source: Iter(
                                                             { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: map_reduce :: * ; vec ! ["abc" , "abc" , "xyz" , "abc"] },
-                                                        ),
-                                                        location_kind: Process(
-                                                            0,
                                                         ),
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Process(

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir.snap
@@ -9,9 +9,6 @@ expression: built.ir()
             source: Iter(
                 { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; ["Proposers say hello"] },
             ),
-            location_kind: Cluster(
-                0,
-            ),
             metadata: HydroIrMetadata {
                 location_kind: Cluster(
                     0,
@@ -36,9 +33,6 @@ expression: built.ir()
             source: Iter(
                 { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; ["Acceptors say hello"] },
             ),
-            location_kind: Cluster(
-                1,
-            ),
             metadata: HydroIrMetadata {
                 location_kind: Cluster(
                     1,
@@ -61,12 +55,6 @@ expression: built.ir()
         ident: Ident {
             sym: cycle_7,
         },
-        location_kind: Tick(
-            1,
-            Cluster(
-                0,
-            ),
-        ),
         input: DeferTick {
             input: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , u32) , u32 > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: ClusterId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_raw (__hydro_lang_cluster_self_id_0) ; move | (received_max_ballot , ballot_num) | { if received_max_ballot > (Ballot { num : ballot_num , proposer_id : CLUSTER_SELF_ID__free , }) { received_max_ballot . num + 1 } else { ballot_num } } }),
@@ -82,9 +70,6 @@ expression: built.ir()
                                                 ident: Ident {
                                                     sym: cycle_4,
                                                 },
-                                                location_kind: Cluster(
-                                                    0,
-                                                ),
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Cluster(
                                                         0,
@@ -98,9 +83,6 @@ expression: built.ir()
                                                 ident: Ident {
                                                     sym: cycle_2,
                                                 },
-                                                location_kind: Cluster(
-                                                    0,
-                                                ),
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Cluster(
                                                         0,
@@ -126,9 +108,6 @@ expression: built.ir()
                                             ident: Ident {
                                                 sym: cycle_5,
                                             },
-                                            location_kind: Cluster(
-                                                0,
-                                            ),
                                             metadata: HydroIrMetadata {
                                                 location_kind: Cluster(
                                                     0,
@@ -176,9 +155,6 @@ expression: built.ir()
                                     source: Iter(
                                         { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let e__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; Ballot { num : 0 , proposer_id : ClusterId :: from_raw (0) } } ; [e__free] },
                                     ),
-                                    location_kind: Cluster(
-                                        0,
-                                    ),
                                     metadata: HydroIrMetadata {
                                         location_kind: Cluster(
                                             0,
@@ -224,12 +200,6 @@ expression: built.ir()
                                 ident: Ident {
                                     sym: cycle_7,
                                 },
-                                location_kind: Tick(
-                                    1,
-                                    Cluster(
-                                        0,
-                                    ),
-                                ),
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
                                         1,
@@ -249,9 +219,6 @@ expression: built.ir()
                                         inner: Source {
                                             source: Iter(
                                                 { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let e__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; 0 } ; [e__free] },
-                                            ),
-                                            location_kind: Cluster(
-                                                0,
                                             ),
                                             metadata: HydroIrMetadata {
                                                 location_kind: Cluster(
@@ -276,9 +243,6 @@ expression: built.ir()
                                         input: Source {
                                             source: Iter(
                                                 { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: tick :: * ; let e__free = { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: singleton :: * ; () } ; [e__free] },
-                                            ),
-                                            location_kind: Cluster(
-                                                0,
                                             ),
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
@@ -404,17 +368,11 @@ expression: built.ir()
         ident: Ident {
             sym: cycle_5,
         },
-        location_kind: Cluster(
-            0,
-        ),
         input: Tee {
             inner: <tee 2>: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                 input: Network {
                     from_key: None,
-                    to_location: Cluster(
-                        0,
-                    ),
                     to_key: None,
                     serialize_fn: Some(
                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -479,12 +437,6 @@ expression: built.ir()
                                                     ident: Ident {
                                                         sym: cycle_6,
                                                     },
-                                                    location_kind: Tick(
-                                                        1,
-                                                        Cluster(
-                                                            0,
-                                                        ),
-                                                    ),
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Tick(
                                                             1,
@@ -552,9 +504,6 @@ expression: built.ir()
                                         input: Source {
                                             source: Stream(
                                                 { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let interval__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let i_am_leader_send_timeout__free = 5u64 ; Duration :: from_secs (i_am_leader_send_timeout__free) } ; tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval (interval__free)) },
-                                            ),
-                                            location_kind: Cluster(
-                                                0,
                                             ),
                                             metadata: HydroIrMetadata {
                                                 location_kind: Cluster(
@@ -662,12 +611,6 @@ expression: built.ir()
         ident: Ident {
             sym: cycle_9,
         },
-        location_kind: Tick(
-            1,
-            Cluster(
-                0,
-            ),
-        ),
         input: DeferTick {
             input: Difference {
                 pos: FilterMap {
@@ -682,12 +625,6 @@ expression: built.ir()
                                         ident: Ident {
                                             sym: cycle_8,
                                         },
-                                        location_kind: Tick(
-                                            1,
-                                            Cluster(
-                                                0,
-                                            ),
-                                        ),
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
                                                 1,
@@ -707,9 +644,6 @@ expression: built.ir()
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                                                 input: Network {
                                                     from_key: None,
-                                                    to_location: Cluster(
-                                                        0,
-                                                    ),
                                                     to_key: None,
                                                     serialize_fn: Some(
                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -727,9 +661,6 @@ expression: built.ir()
                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                                                                         input: Network {
                                                                             from_key: None,
-                                                                            to_location: Cluster(
-                                                                                1,
-                                                                            ),
                                                                             to_key: None,
                                                                             serialize_fn: Some(
                                                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -902,9 +833,6 @@ expression: built.ir()
                                                                                                                 input: Source {
                                                                                                                     source: Stream(
                                                                                                                         { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let delay__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: ClusterId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_raw (__hydro_lang_cluster_self_id_0) ; let i_am_leader_check_timeout_delay_multiplier__free = 15usize ; Duration :: from_secs ((CLUSTER_SELF_ID__free . raw_id * i_am_leader_check_timeout_delay_multiplier__free as u32) . into ()) } ; let interval__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let i_am_leader_check_timeout__free = 10u64 ; Duration :: from_secs (i_am_leader_check_timeout__free) } ; tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval_at (tokio :: time :: Instant :: now () + delay__free , interval__free)) },
-                                                                                                                    ),
-                                                                                                                    location_kind: Cluster(
-                                                                                                                        0,
                                                                                                                     ),
                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                         location_kind: Cluster(
@@ -1109,9 +1037,6 @@ expression: built.ir()
                                                                                 source: Iter(
                                                                                     { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let e__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; Ballot { num : 0 , proposer_id : ClusterId :: from_raw (0) } } ; [e__free] },
                                                                                 ),
-                                                                                location_kind: Cluster(
-                                                                                    1,
-                                                                                ),
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_kind: Cluster(
                                                                                         1,
@@ -1170,12 +1095,6 @@ expression: built.ir()
                                                                 ident: Ident {
                                                                     sym: cycle_3,
                                                                 },
-                                                                location_kind: Tick(
-                                                                    2,
-                                                                    Cluster(
-                                                                        1,
-                                                                    ),
-                                                                ),
                                                                 metadata: HydroIrMetadata {
                                                                     location_kind: Tick(
                                                                         2,
@@ -1392,12 +1311,6 @@ expression: built.ir()
         ident: Ident {
             sym: cycle_8,
         },
-        location_kind: Tick(
-            1,
-            Cluster(
-                0,
-            ),
-        ),
         input: DeferTick {
             input: AntiJoin {
                 pos: Tee {
@@ -1468,12 +1381,6 @@ expression: built.ir()
         ident: Ident {
             sym: cycle_6,
         },
-        location_kind: Tick(
-            1,
-            Cluster(
-                0,
-            ),
-        ),
         input: Tee {
             inner: <tee 11>: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (() , ()) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: optional :: * ; | (d , _signal) | d }),
@@ -1552,12 +1459,6 @@ expression: built.ir()
                                                             ident: Ident {
                                                                 sym: cycle_9,
                                                             },
-                                                            location_kind: Tick(
-                                                                1,
-                                                                Cluster(
-                                                                    0,
-                                                                ),
-                                                            ),
                                                             metadata: HydroIrMetadata {
                                                                 location_kind: Tick(
                                                                     1,
@@ -1840,9 +1741,6 @@ expression: built.ir()
         ident: Ident {
             sym: cycle_4,
         },
-        location_kind: Cluster(
-            0,
-        ),
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (_ , ballot) | ballot }),
             input: FilterMap {
@@ -1895,12 +1793,6 @@ expression: built.ir()
         ident: Ident {
             sym: cycle_10,
         },
-        location_kind: Tick(
-            7,
-            Cluster(
-                2,
-            ),
-        ),
         input: DeferTick {
             input: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , ()) , hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (d , _signal) | d }),
@@ -1911,12 +1803,6 @@ expression: built.ir()
                                 ident: Ident {
                                     sym: cycle_10,
                                 },
-                                location_kind: Tick(
-                                    7,
-                                    Cluster(
-                                        2,
-                                    ),
-                                ),
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
                                         7,
@@ -1935,9 +1821,6 @@ expression: built.ir()
                                     ident: Ident {
                                         sym: cycle_0,
                                     },
-                                    location_kind: Cluster(
-                                        2,
-                                    ),
                                     metadata: HydroIrMetadata {
                                         location_kind: Cluster(
                                             2,
@@ -1999,9 +1882,6 @@ expression: built.ir()
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                                                         input: Network {
                                                             from_key: None,
-                                                            to_location: Cluster(
-                                                                2,
-                                                            ),
                                                             to_key: None,
                                                             serialize_fn: Some(
                                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -2354,12 +2234,6 @@ expression: built.ir()
         ident: Ident {
             sym: cycle_11,
         },
-        location_kind: Tick(
-            1,
-            Cluster(
-                0,
-            ),
-        ),
         input: DeferTick {
             input: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , usize) , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (num_payloads , base_slot) | base_slot + num_payloads }),
@@ -2381,9 +2255,6 @@ expression: built.ir()
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) >) , hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                                                         input: Network {
                                                             from_key: None,
-                                                            to_location: Cluster(
-                                                                0,
-                                                            ),
                                                             to_key: None,
                                                             serialize_fn: Some(
                                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) >) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -2699,12 +2570,6 @@ expression: built.ir()
                                                         ident: Ident {
                                                             sym: cycle_11,
                                                         },
-                                                        location_kind: Tick(
-                                                            1,
-                                                            Cluster(
-                                                                0,
-                                                            ),
-                                                        ),
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Tick(
                                                                 1,
@@ -2724,9 +2589,6 @@ expression: built.ir()
                                                                 inner: Source {
                                                                     source: Iter(
                                                                         { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let e__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; 0 } ; [e__free] },
-                                                                    ),
-                                                                    location_kind: Cluster(
-                                                                        0,
                                                                     ),
                                                                     metadata: HydroIrMetadata {
                                                                         location_kind: Cluster(
@@ -2751,9 +2613,6 @@ expression: built.ir()
                                                                 input: Source {
                                                                     source: Iter(
                                                                         { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: tick :: * ; let e__free = { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: singleton :: * ; () } ; [e__free] },
-                                                                    ),
-                                                                    location_kind: Cluster(
-                                                                        0,
                                                                     ),
                                                                     metadata: HydroIrMetadata {
                                                                         location_kind: Tick(
@@ -2965,12 +2824,6 @@ expression: built.ir()
         ident: Ident {
             sym: cycle_13,
         },
-        location_kind: Tick(
-            1,
-            Cluster(
-                0,
-            ),
-        ),
         input: DeferTick {
             input: Difference {
                 pos: Tee {
@@ -2986,12 +2839,6 @@ expression: built.ir()
                                             ident: Ident {
                                                 sym: cycle_12,
                                             },
-                                            location_kind: Tick(
-                                                1,
-                                                Cluster(
-                                                    0,
-                                                ),
-                                            ),
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
                                                     1,
@@ -3009,9 +2856,6 @@ expression: built.ir()
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                                                 input: Network {
                                                     from_key: None,
-                                                    to_location: Cluster(
-                                                        0,
-                                                    ),
                                                     to_key: None,
                                                     serialize_fn: Some(
                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -3028,9 +2872,6 @@ expression: built.ir()
                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer >) , hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                                                                     input: Network {
                                                                         from_key: None,
-                                                                        to_location: Cluster(
-                                                                            1,
-                                                                        ),
                                                                         to_key: None,
                                                                         serialize_fn: Some(
                                                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer >) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -3211,15 +3052,9 @@ expression: built.ir()
                                                                                                                             source: Iter(
                                                                                                                                 [:: std :: option :: Option :: None],
                                                                                                                             ),
-                                                                                                                            location_kind: Cluster(
-                                                                                                                                0,
-                                                                                                                            ),
                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                location_kind: Tick(
-                                                                                                                                    1,
-                                                                                                                                    Cluster(
-                                                                                                                                        0,
-                                                                                                                                    ),
+                                                                                                                                location_kind: Cluster(
+                                                                                                                                    0,
                                                                                                                                 ),
                                                                                                                                 output_type: Some(
                                                                                                                                     core :: option :: Option < usize >,
@@ -3780,12 +3615,6 @@ expression: built.ir()
         ident: Ident {
             sym: cycle_12,
         },
-        location_kind: Tick(
-            1,
-            Cluster(
-                0,
-            ),
-        ),
         input: DeferTick {
             input: AntiJoin {
                 pos: Tee {
@@ -3856,12 +3685,6 @@ expression: built.ir()
         ident: Ident {
             sym: cycle_14,
         },
-        location_kind: Tick(
-            1,
-            Cluster(
-                0,
-            ),
-        ),
         input: DeferTick {
             input: AntiJoin {
                 pos: Tee {
@@ -3870,12 +3693,6 @@ expression: built.ir()
                             ident: Ident {
                                 sym: cycle_14,
                             },
-                            location_kind: Tick(
-                                1,
-                                Cluster(
-                                    0,
-                                ),
-                            ),
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
                                     1,
@@ -3950,12 +3767,6 @@ expression: built.ir()
                                     ident: Ident {
                                         sym: cycle_13,
                                     },
-                                    location_kind: Tick(
-                                        1,
-                                        Cluster(
-                                            0,
-                                        ),
-                                    ),
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
                                             1,
@@ -4056,12 +3867,6 @@ expression: built.ir()
         ident: Ident {
             sym: cycle_3,
         },
-        location_kind: Tick(
-            2,
-            Cluster(
-                1,
-            ),
-        ),
         input: Fold {
             init: stageleft :: runtime_support :: fn0_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | | (None , HashMap :: new ()) }),
             acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: CheckpointOrP2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (prev_checkpoint , log) , checkpoint_or_p2a | { match checkpoint_or_p2a { CheckpointOrP2a :: Checkpoint (new_checkpoint) => { if prev_checkpoint . map (| prev | new_checkpoint > prev) . unwrap_or (true) { for slot in (prev_checkpoint . unwrap_or (0)) .. new_checkpoint { log . remove (& slot) ; } * prev_checkpoint = Some (new_checkpoint) ; } } CheckpointOrP2a :: P2a (p2a) => { if prev_checkpoint . map (| prev | p2a . slot > prev) . unwrap_or (true) && log . get (& p2a . slot) . map (| prev_p2a : & LogValue < _ > | p2a . ballot > prev_p2a . ballot) . unwrap_or (true) { log . insert (p2a . slot , LogValue { ballot : p2a . ballot , value : p2a . value , } ,) ; } } } } }),
@@ -4129,9 +3934,6 @@ expression: built.ir()
                                 ident: Ident {
                                     sym: cycle_1,
                                 },
-                                location_kind: Cluster(
-                                    1,
-                                ),
                                 metadata: HydroIrMetadata {
                                     location_kind: Cluster(
                                         1,
@@ -4217,9 +4019,6 @@ expression: built.ir()
         ident: Ident {
             sym: cycle_2,
         },
-        location_kind: Cluster(
-            0,
-        ),
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (_ , ballot) | ballot }),
             input: FilterMap {
@@ -4272,12 +4071,6 @@ expression: built.ir()
         ident: Ident {
             sym: cycle_15,
         },
-        location_kind: Tick(
-            8,
-            Cluster(
-                4,
-            ),
-        ),
         input: DeferTick {
             input: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , usize) , hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; | (sorted_payload , _) | { sorted_payload } }),
@@ -4293,9 +4086,6 @@ expression: built.ir()
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >)) , (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                                             input: Network {
                                                 from_key: None,
-                                                to_location: Cluster(
-                                                    4,
-                                                ),
                                                 to_key: None,
                                                 serialize_fn: Some(
                                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -4412,12 +4202,6 @@ expression: built.ir()
                                         ident: Ident {
                                             sym: cycle_15,
                                         },
-                                        location_kind: Tick(
-                                            8,
-                                            Cluster(
-                                                4,
-                                            ),
-                                        ),
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
                                                 8,
@@ -4491,12 +4275,6 @@ expression: built.ir()
                                                 ident: Ident {
                                                     sym: cycle_16,
                                                 },
-                                                location_kind: Tick(
-                                                    8,
-                                                    Cluster(
-                                                        4,
-                                                    ),
-                                                ),
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
                                                         8,
@@ -4516,9 +4294,6 @@ expression: built.ir()
                                                         inner: Source {
                                                             source: Iter(
                                                                 { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let e__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; 0 } ; [e__free] },
-                                                            ),
-                                                            location_kind: Cluster(
-                                                                4,
                                                             ),
                                                             metadata: HydroIrMetadata {
                                                                 location_kind: Cluster(
@@ -4543,9 +4318,6 @@ expression: built.ir()
                                                         input: Source {
                                                             source: Iter(
                                                                 { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: tick :: * ; let e__free = { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: singleton :: * ; () } ; [e__free] },
-                                                            ),
-                                                            location_kind: Cluster(
-                                                                4,
                                                             ),
                                                             metadata: HydroIrMetadata {
                                                                 location_kind: Tick(
@@ -4719,12 +4491,6 @@ expression: built.ir()
         ident: Ident {
             sym: cycle_16,
         },
-        location_kind: Tick(
-            8,
-            Cluster(
-                4,
-            ),
-        ),
         input: DeferTick {
             input: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: collections :: hash_map :: HashMap < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , usize) , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; | (_kv_store , next_slot) | next_slot }),
@@ -4878,12 +4644,6 @@ expression: built.ir()
         ident: Ident {
             sym: cycle_17,
         },
-        location_kind: Tick(
-            8,
-            Cluster(
-                4,
-            ),
-        ),
         input: DeferTick {
             input: Tee {
                 inner: <tee 37>: FilterMap {
@@ -4899,12 +4659,6 @@ expression: built.ir()
                                             ident: Ident {
                                                 sym: cycle_17,
                                             },
-                                            location_kind: Tick(
-                                                8,
-                                                Cluster(
-                                                    4,
-                                                ),
-                                            ),
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
                                                     8,
@@ -4958,15 +4712,9 @@ expression: built.ir()
                                     source: Iter(
                                         [:: std :: option :: Option :: None],
                                     ),
-                                    location_kind: Cluster(
-                                        4,
-                                    ),
                                     metadata: HydroIrMetadata {
-                                        location_kind: Tick(
-                                            8,
-                                            Cluster(
-                                                4,
-                                            ),
+                                        location_kind: Cluster(
+                                            4,
                                         ),
                                         output_type: Some(
                                             core :: option :: Option < usize >,
@@ -5075,9 +4823,6 @@ expression: built.ir()
         ident: Ident {
             sym: cycle_1,
         },
-        location_kind: Cluster(
-            1,
-        ),
         input: Reduce {
             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | curr , new | { if new < * curr { * curr = new ; } } }),
             input: Map {
@@ -5091,9 +4836,6 @@ expression: built.ir()
                                 input: Persist {
                                     inner: Network {
                                         from_key: None,
-                                        to_location: Cluster(
-                                            1,
-                                        ),
                                         to_key: None,
                                         serialize_fn: Some(
                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , usize) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -5290,12 +5032,6 @@ expression: built.ir()
         ident: Ident {
             sym: cycle_18,
         },
-        location_kind: Tick(
-            10,
-            Cluster(
-                2,
-            ),
-        ),
         input: DeferTick {
             input: AntiJoin {
                 pos: Tee {
@@ -5304,12 +5040,6 @@ expression: built.ir()
                             ident: Ident {
                                 sym: cycle_18,
                             },
-                            location_kind: Tick(
-                                10,
-                                Cluster(
-                                    2,
-                                ),
-                            ),
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
                                     10,
@@ -5327,9 +5057,6 @@ expression: built.ir()
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: kv_replica :: Replica > , ((u32 , u32) , core :: result :: Result < () , () >)) , ((u32 , u32) , core :: result :: Result < () , () >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                                 input: Network {
                                     from_key: None,
-                                    to_location: Cluster(
-                                        2,
-                                    ),
                                     to_key: None,
                                     serialize_fn: Some(
                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , ((u32 , u32) , core :: result :: Result < () , () >)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -5540,9 +5267,6 @@ expression: built.ir()
         ident: Ident {
             sym: cycle_0,
         },
-        location_kind: Cluster(
-            2,
-        ),
         input: Chain {
             first: FlatMap {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , std :: iter :: Map < std :: ops :: Range < usize > , _ > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: ClusterId :: < hydro_test :: __staged :: cluster :: paxos_bench :: Client > :: from_raw (__hydro_lang_cluster_self_id_2) ; let num_clients_per_node__free = 100usize ; move | _ | (0 .. num_clients_per_node__free) . map (move | i | ((CLUSTER_SELF_ID__free . raw_id * (num_clients_per_node__free as u32)) + i as u32 , 0)) }),
@@ -5550,9 +5274,6 @@ expression: built.ir()
                     inner: <tee 43>: Source {
                         source: Iter(
                             { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: tick :: * ; let e__free = { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; () } ; [e__free] },
-                        ),
-                        location_kind: Cluster(
-                            2,
                         ),
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
@@ -5656,12 +5377,6 @@ expression: built.ir()
         ident: Ident {
             sym: cycle_19,
         },
-        location_kind: Tick(
-            0,
-            Cluster(
-                2,
-            ),
-        ),
         input: DeferTick {
             input: ReduceKeyed {
                 f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: time :: Instant , std :: time :: Instant , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | curr_time , new_time | { if new_time > * curr_time { * curr_time = new_time ; } } }),
@@ -5672,12 +5387,6 @@ expression: built.ir()
                                 ident: Ident {
                                     sym: cycle_19,
                                 },
-                                location_kind: Tick(
-                                    0,
-                                    Cluster(
-                                        2,
-                                    ),
-                                ),
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
                                         0,
@@ -5861,9 +5570,6 @@ expression: built.ir()
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 >) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (id , histogram) | (id , histogram . histogram . borrow_mut () . clone ()) }),
                                     input: Network {
                                         from_key: None,
-                                        to_location: Process(
-                                            3,
-                                        ),
                                         to_key: None,
                                         serialize_fn: Some(
                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
@@ -5964,9 +5670,6 @@ expression: built.ir()
                                                             input: Source {
                                                                 source: Stream(
                                                                     { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let interval__free = { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; Duration :: from_millis (1000) } ; tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval (interval__free)) },
-                                                                ),
-                                                                location_kind: Cluster(
-                                                                    2,
                                                                 ),
                                                                 metadata: HydroIrMetadata {
                                                                     location_kind: Cluster(
@@ -6108,9 +5811,6 @@ expression: built.ir()
                             source: Stream(
                                 { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let interval__free = { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; Duration :: from_millis (1000) } ; tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval (interval__free)) },
                             ),
-                            location_kind: Process(
-                                3,
-                            ),
                             metadata: HydroIrMetadata {
                                 location_kind: Process(
                                     3,
@@ -6191,9 +5891,6 @@ expression: built.ir()
                             input: Persist {
                                 inner: Network {
                                     from_key: None,
-                                    to_location: Process(
-                                        3,
-                                    ),
                                     to_key: None,
                                     serialize_fn: Some(
                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
@@ -6259,9 +5956,6 @@ expression: built.ir()
                                                                                             input: Source {
                                                                                                 source: Stream(
                                                                                                     { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let interval__free = { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; Duration :: from_secs (1) } ; tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval (interval__free)) },
-                                                                                                ),
-                                                                                                location_kind: Cluster(
-                                                                                                    2,
                                                                                                 ),
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_kind: Cluster(
@@ -6459,9 +6153,6 @@ expression: built.ir()
                                                         source: Stream(
                                                             { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let interval__free = { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; Duration :: from_millis (1000) } ; tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval (interval__free)) },
                                                         ),
-                                                        location_kind: Cluster(
-                                                            2,
-                                                        ),
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Cluster(
                                                                 2,
@@ -6583,9 +6274,6 @@ expression: built.ir()
                         input: Source {
                             source: Stream(
                                 { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let interval__free = { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; Duration :: from_millis (1000) } ; tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval (interval__free)) },
-                            ),
-                            location_kind: Process(
-                                3,
                             ),
                             metadata: HydroIrMetadata {
                                 location_kind: Process(

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__simple_cluster__tests__partitioned_simple_cluster_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__simple_cluster__tests__partitioned_simple_cluster_ir.snap
@@ -9,9 +9,6 @@ expression: built.ir()
             f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
             input: Network {
                 from_key: None,
-                to_location: Process(
-                    0,
-                ),
                 to_key: None,
                 serialize_fn: Some(
                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < () > , i32) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
@@ -24,9 +21,6 @@ expression: built.ir()
                     f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < () > , i32) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: simple_cluster :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: ClusterId :: < () > :: from_raw ({ __hydro_lang_cluster_self_id_1 / 3usize as u32 }) ; move | n | println ! ("cluster received: {:?} (self cluster id: {})" , n , CLUSTER_SELF_ID__free) }),
                     input: Network {
                         from_key: None,
-                        to_location: Cluster(
-                            1,
-                        ),
                         to_key: None,
                         serialize_fn: Some(
                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < () > , i32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -47,9 +41,6 @@ expression: built.ir()
                                                 input: Source {
                                                     source: Iter(
                                                         { let all_ids = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < () >] > (__hydro_lang_cluster_ids_1) } ; & all_ids [0 .. all_ids . len () / 3usize] },
-                                                    ),
-                                                    location_kind: Process(
-                                                        0,
                                                     ),
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Process(
@@ -82,9 +73,6 @@ expression: built.ir()
                                             inner: Source {
                                                 source: Iter(
                                                     { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: simple_cluster :: * ; 0 .. 5 },
-                                                ),
-                                                location_kind: Process(
-                                                    0,
                                                 ),
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Process(

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__simple_cluster__tests__simple_cluster_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__simple_cluster__tests__simple_cluster_ir.snap
@@ -8,9 +8,6 @@ expression: built.ir()
         input: Unpersist {
             inner: Network {
                 from_key: None,
-                to_location: Process(
-                    0,
-                ),
                 to_key: None,
                 serialize_fn: Some(
                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < () > , i32) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
@@ -25,9 +22,6 @@ expression: built.ir()
                         input: Unpersist {
                             inner: Network {
                                 from_key: None,
-                                to_location: Cluster(
-                                    1,
-                                ),
                                 to_key: None,
                                 serialize_fn: Some(
                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < () > , i32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -45,9 +39,6 @@ expression: built.ir()
                                                 inner: Source {
                                                     source: Iter(
                                                         unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < () >] > (__hydro_lang_cluster_ids_1) },
-                                                    ),
-                                                    location_kind: Process(
-                                                        0,
                                                     ),
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Process(
@@ -80,9 +71,6 @@ expression: built.ir()
                                             inner: Source {
                                                 source: Iter(
                                                     { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: simple_cluster :: * ; 0 .. 5 },
-                                                ),
-                                                location_kind: Process(
-                                                    0,
                                                 ),
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Process(

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__two_pc_bench__tests__two_pc_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__two_pc_bench__tests__two_pc_ir.snap
@@ -7,12 +7,6 @@ expression: built.ir()
         ident: Ident {
             sym: cycle_1,
         },
-        location_kind: Tick(
-            1,
-            Process(
-                0,
-            ),
-        ),
         input: DeferTick {
             input: AntiJoin {
                 pos: Tee {
@@ -21,12 +15,6 @@ expression: built.ir()
                             ident: Ident {
                                 sym: cycle_1,
                             },
-                            location_kind: Tick(
-                                1,
-                                Process(
-                                    0,
-                                ),
-                            ),
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
                                     1,
@@ -46,9 +34,6 @@ expression: built.ir()
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                                     input: Network {
                                         from_key: None,
-                                        to_location: Process(
-                                            0,
-                                        ),
                                         to_key: None,
                                         serialize_fn: Some(
                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
@@ -59,9 +44,6 @@ expression: built.ir()
                                         ),
                                         input: Network {
                                             from_key: None,
-                                            to_location: Cluster(
-                                                1,
-                                            ),
                                             to_key: None,
                                             serialize_fn: Some(
                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -74,9 +56,6 @@ expression: built.ir()
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , std :: iter :: Map < std :: slice :: Iter < hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant >] > (__hydro_lang_cluster_ids_1) } ; | v | { ids__free . iter () . map (move | id | (* id , v . clone ())) } }),
                                                 input: Network {
                                                     from_key: None,
-                                                    to_location: Process(
-                                                        0,
-                                                    ),
                                                     to_key: None,
                                                     serialize_fn: Some(
                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , u32) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
@@ -89,9 +68,6 @@ expression: built.ir()
                                                         ident: Ident {
                                                             sym: cycle_0,
                                                         },
-                                                        location_kind: Cluster(
-                                                            2,
-                                                        ),
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Cluster(
                                                                 2,
@@ -300,12 +276,6 @@ expression: built.ir()
         ident: Ident {
             sym: cycle_2,
         },
-        location_kind: Tick(
-            1,
-            Process(
-                0,
-            ),
-        ),
         input: DeferTick {
             input: AntiJoin {
                 pos: Tee {
@@ -314,12 +284,6 @@ expression: built.ir()
                             ident: Ident {
                                 sym: cycle_2,
                             },
-                            location_kind: Tick(
-                                1,
-                                Process(
-                                    0,
-                                ),
-                            ),
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
                                     1,
@@ -339,9 +303,6 @@ expression: built.ir()
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                                     input: Network {
                                         from_key: None,
-                                        to_location: Process(
-                                            0,
-                                        ),
                                         to_key: None,
                                         serialize_fn: Some(
                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
@@ -352,9 +313,6 @@ expression: built.ir()
                                         ),
                                         input: Network {
                                             from_key: None,
-                                            to_location: Cluster(
-                                                1,
-                                            ),
                                             to_key: None,
                                             serialize_fn: Some(
                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -572,9 +530,6 @@ expression: built.ir()
         ident: Ident {
             sym: cycle_0,
         },
-        location_kind: Cluster(
-            2,
-        ),
         input: Chain {
             first: FlatMap {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , std :: iter :: Map < std :: ops :: Range < usize > , _ > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: ClusterId :: < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > :: from_raw (__hydro_lang_cluster_self_id_2) ; let num_clients_per_node__free = 100usize ; move | _ | (0 .. num_clients_per_node__free) . map (move | i | ((CLUSTER_SELF_ID__free . raw_id * (num_clients_per_node__free as u32)) + i as u32 , 0)) }),
@@ -582,9 +537,6 @@ expression: built.ir()
                     inner: <tee 8>: Source {
                         source: Iter(
                             { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: tick :: * ; let e__free = { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; () } ; [e__free] },
-                        ),
-                        location_kind: Cluster(
-                            2,
                         ),
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
@@ -627,9 +579,6 @@ expression: built.ir()
                 input: Tee {
                     inner: <tee 9>: Network {
                         from_key: None,
-                        to_location: Cluster(
-                            2,
-                        ),
                         to_key: None,
                         serialize_fn: Some(
                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -710,12 +659,6 @@ expression: built.ir()
         ident: Ident {
             sym: cycle_3,
         },
-        location_kind: Tick(
-            0,
-            Cluster(
-                2,
-            ),
-        ),
         input: DeferTick {
             input: ReduceKeyed {
                 f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: time :: Instant , std :: time :: Instant , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | curr_time , new_time | { if new_time > * curr_time { * curr_time = new_time ; } } }),
@@ -726,12 +669,6 @@ expression: built.ir()
                                 ident: Ident {
                                     sym: cycle_3,
                                 },
-                                location_kind: Tick(
-                                    0,
-                                    Cluster(
-                                        2,
-                                    ),
-                                ),
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
                                         0,
@@ -915,9 +852,6 @@ expression: built.ir()
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 >) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (id , histogram) | (id , histogram . histogram . borrow_mut () . clone ()) }),
                                     input: Network {
                                         from_key: None,
-                                        to_location: Process(
-                                            3,
-                                        ),
                                         to_key: None,
                                         serialize_fn: Some(
                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
@@ -1018,9 +952,6 @@ expression: built.ir()
                                                             input: Source {
                                                                 source: Stream(
                                                                     { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let interval__free = { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; Duration :: from_millis (1000) } ; tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval (interval__free)) },
-                                                                ),
-                                                                location_kind: Cluster(
-                                                                    2,
                                                                 ),
                                                                 metadata: HydroIrMetadata {
                                                                     location_kind: Cluster(
@@ -1162,9 +1093,6 @@ expression: built.ir()
                             source: Stream(
                                 { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let interval__free = { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; Duration :: from_millis (1000) } ; tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval (interval__free)) },
                             ),
-                            location_kind: Process(
-                                3,
-                            ),
                             metadata: HydroIrMetadata {
                                 location_kind: Process(
                                     3,
@@ -1245,9 +1173,6 @@ expression: built.ir()
                             input: Persist {
                                 inner: Network {
                                     from_key: None,
-                                    to_location: Process(
-                                        3,
-                                    ),
                                     to_key: None,
                                     serialize_fn: Some(
                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
@@ -1313,9 +1238,6 @@ expression: built.ir()
                                                                                             input: Source {
                                                                                                 source: Stream(
                                                                                                     { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let interval__free = { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; Duration :: from_secs (1) } ; tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval (interval__free)) },
-                                                                                                ),
-                                                                                                location_kind: Cluster(
-                                                                                                    2,
                                                                                                 ),
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_kind: Cluster(
@@ -1513,9 +1435,6 @@ expression: built.ir()
                                                         source: Stream(
                                                             { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let interval__free = { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; Duration :: from_millis (1000) } ; tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval (interval__free)) },
                                                         ),
-                                                        location_kind: Cluster(
-                                                            2,
-                                                        ),
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Cluster(
                                                                 2,
@@ -1637,9 +1556,6 @@ expression: built.ir()
                         input: Source {
                             source: Stream(
                                 { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let interval__free = { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; Duration :: from_millis (1000) } ; tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval (interval__free)) },
-                            ),
-                            location_kind: Process(
-                                3,
                             ),
                             metadata: HydroIrMetadata {
                                 location_kind: Process(

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__two_pc_bench__tests__two_pc_partition.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__two_pc_bench__tests__two_pc_partition.snap
@@ -7,9 +7,6 @@ expression: "&ir"
         ident: Ident {
             sym: cycle_1,
         },
-        location_kind: Cluster(
-            1,
-        ),
         input: DeferTick {
             input: AntiJoin {
                 pos: Tee {
@@ -18,12 +15,6 @@ expression: "&ir"
                             ident: Ident {
                                 sym: cycle_1,
                             },
-                            location_kind: Tick(
-                                1,
-                                Cluster(
-                                    1,
-                                ),
-                            ),
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
                                     1,
@@ -45,9 +36,6 @@ expression: "&ir"
                                         f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                         input: Network {
                                             from_key: None,
-                                            to_location: Cluster(
-                                                1,
-                                            ),
                                             to_key: None,
                                             serialize_fn: Some(
                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -62,9 +50,6 @@ expression: "&ir"
                                                     f: | (_sender_id , b) | b,
                                                     input: Network {
                                                         from_key: None,
-                                                        to_location: Cluster(
-                                                            2,
-                                                        ),
                                                         to_key: None,
                                                         serialize_fn: Some(
                                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -79,9 +64,6 @@ expression: "&ir"
                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , std :: iter :: Map < std :: slice :: Iter < hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = { let all_ids = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant >] > (__hydro_lang_cluster_ids_2) } ; & all_ids [0 .. all_ids . len () / 3usize] } ; | v | { ids__free . iter () . map (move | id | (* id , v . clone ())) } }),
                                                                 input: Network {
                                                                     from_key: None,
-                                                                    to_location: Cluster(
-                                                                        1,
-                                                                    ),
                                                                     to_key: None,
                                                                     serialize_fn: Some(
                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -96,9 +78,6 @@ expression: "&ir"
                                                                             ident: Ident {
                                                                                 sym: cycle_0,
                                                                             },
-                                                                            location_kind: Cluster(
-                                                                                3,
-                                                                            ),
                                                                             metadata: HydroIrMetadata {
                                                                                 location_kind: Cluster(
                                                                                     3,
@@ -256,12 +235,6 @@ expression: "&ir"
                                             ident: Ident {
                                                 sym: cycle_1,
                                             },
-                                            location_kind: Tick(
-                                                1,
-                                                Cluster(
-                                                    1,
-                                                ),
-                                            ),
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
                                                     1,
@@ -283,9 +256,6 @@ expression: "&ir"
                                                         f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                         input: Network {
                                                             from_key: None,
-                                                            to_location: Cluster(
-                                                                1,
-                                                            ),
                                                             to_key: None,
                                                             serialize_fn: Some(
                                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -300,9 +270,6 @@ expression: "&ir"
                                                                     f: | (_sender_id , b) | b,
                                                                     input: Network {
                                                                         from_key: None,
-                                                                        to_location: Cluster(
-                                                                            2,
-                                                                        ),
                                                                         to_key: None,
                                                                         serialize_fn: Some(
                                                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -317,9 +284,6 @@ expression: "&ir"
                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , std :: iter :: Map < std :: slice :: Iter < hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = { let all_ids = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant >] > (__hydro_lang_cluster_ids_2) } ; & all_ids [0 .. all_ids . len () / 3usize] } ; | v | { ids__free . iter () . map (move | id | (* id , v . clone ())) } }),
                                                                                 input: Network {
                                                                                     from_key: None,
-                                                                                    to_location: Cluster(
-                                                                                        1,
-                                                                                    ),
                                                                                     to_key: None,
                                                                                     serialize_fn: Some(
                                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -334,9 +298,6 @@ expression: "&ir"
                                                                                             ident: Ident {
                                                                                                 sym: cycle_0,
                                                                                             },
-                                                                                            location_kind: Cluster(
-                                                                                                3,
-                                                                                            ),
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_kind: Cluster(
                                                                                                     3,
@@ -569,9 +530,6 @@ expression: "&ir"
         ident: Ident {
             sym: cycle_2,
         },
-        location_kind: Cluster(
-            1,
-        ),
         input: DeferTick {
             input: AntiJoin {
                 pos: Tee {
@@ -580,12 +538,6 @@ expression: "&ir"
                             ident: Ident {
                                 sym: cycle_2,
                             },
-                            location_kind: Tick(
-                                1,
-                                Cluster(
-                                    1,
-                                ),
-                            ),
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
                                     1,
@@ -607,9 +559,6 @@ expression: "&ir"
                                         f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                         input: Network {
                                             from_key: None,
-                                            to_location: Cluster(
-                                                1,
-                                            ),
                                             to_key: None,
                                             serialize_fn: Some(
                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -624,9 +573,6 @@ expression: "&ir"
                                                     f: | (_sender_id , b) | b,
                                                     input: Network {
                                                         from_key: None,
-                                                        to_location: Cluster(
-                                                            2,
-                                                        ),
                                                         to_key: None,
                                                         serialize_fn: Some(
                                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -652,12 +598,6 @@ expression: "&ir"
                                                                                             ident: Ident {
                                                                                                 sym: cycle_1,
                                                                                             },
-                                                                                            location_kind: Tick(
-                                                                                                1,
-                                                                                                Cluster(
-                                                                                                    1,
-                                                                                                ),
-                                                                                            ),
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_kind: Tick(
                                                                                                     1,
@@ -679,9 +619,6 @@ expression: "&ir"
                                                                                                         f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                                                                         input: Network {
                                                                                                             from_key: None,
-                                                                                                            to_location: Cluster(
-                                                                                                                1,
-                                                                                                            ),
                                                                                                             to_key: None,
                                                                                                             serialize_fn: Some(
                                                                                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -696,9 +633,6 @@ expression: "&ir"
                                                                                                                     f: | (_sender_id , b) | b,
                                                                                                                     input: Network {
                                                                                                                         from_key: None,
-                                                                                                                        to_location: Cluster(
-                                                                                                                            2,
-                                                                                                                        ),
                                                                                                                         to_key: None,
                                                                                                                         serialize_fn: Some(
                                                                                                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -713,9 +647,6 @@ expression: "&ir"
                                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , std :: iter :: Map < std :: slice :: Iter < hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = { let all_ids = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant >] > (__hydro_lang_cluster_ids_2) } ; & all_ids [0 .. all_ids . len () / 3usize] } ; | v | { ids__free . iter () . map (move | id | (* id , v . clone ())) } }),
                                                                                                                                 input: Network {
                                                                                                                                     from_key: None,
-                                                                                                                                    to_location: Cluster(
-                                                                                                                                        1,
-                                                                                                                                    ),
                                                                                                                                     to_key: None,
                                                                                                                                     serialize_fn: Some(
                                                                                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -730,9 +661,6 @@ expression: "&ir"
                                                                                                                                             ident: Ident {
                                                                                                                                                 sym: cycle_0,
                                                                                                                                             },
-                                                                                                                                            location_kind: Cluster(
-                                                                                                                                                3,
-                                                                                                                                            ),
                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                 location_kind: Cluster(
                                                                                                                                                     3,
@@ -1061,12 +989,6 @@ expression: "&ir"
                                             ident: Ident {
                                                 sym: cycle_2,
                                             },
-                                            location_kind: Tick(
-                                                1,
-                                                Cluster(
-                                                    1,
-                                                ),
-                                            ),
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
                                                     1,
@@ -1088,9 +1010,6 @@ expression: "&ir"
                                                         f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                         input: Network {
                                                             from_key: None,
-                                                            to_location: Cluster(
-                                                                1,
-                                                            ),
                                                             to_key: None,
                                                             serialize_fn: Some(
                                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -1105,9 +1024,6 @@ expression: "&ir"
                                                                     f: | (_sender_id , b) | b,
                                                                     input: Network {
                                                                         from_key: None,
-                                                                        to_location: Cluster(
-                                                                            2,
-                                                                        ),
                                                                         to_key: None,
                                                                         serialize_fn: Some(
                                                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -1133,12 +1049,6 @@ expression: "&ir"
                                                                                                             ident: Ident {
                                                                                                                 sym: cycle_1,
                                                                                                             },
-                                                                                                            location_kind: Tick(
-                                                                                                                1,
-                                                                                                                Cluster(
-                                                                                                                    1,
-                                                                                                                ),
-                                                                                                            ),
                                                                                                             metadata: HydroIrMetadata {
                                                                                                                 location_kind: Tick(
                                                                                                                     1,
@@ -1160,9 +1070,6 @@ expression: "&ir"
                                                                                                                         f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                                                                                         input: Network {
                                                                                                                             from_key: None,
-                                                                                                                            to_location: Cluster(
-                                                                                                                                1,
-                                                                                                                            ),
                                                                                                                             to_key: None,
                                                                                                                             serialize_fn: Some(
                                                                                                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -1177,9 +1084,6 @@ expression: "&ir"
                                                                                                                                     f: | (_sender_id , b) | b,
                                                                                                                                     input: Network {
                                                                                                                                         from_key: None,
-                                                                                                                                        to_location: Cluster(
-                                                                                                                                            2,
-                                                                                                                                        ),
                                                                                                                                         to_key: None,
                                                                                                                                         serialize_fn: Some(
                                                                                                                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -1194,9 +1098,6 @@ expression: "&ir"
                                                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , std :: iter :: Map < std :: slice :: Iter < hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = { let all_ids = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant >] > (__hydro_lang_cluster_ids_2) } ; & all_ids [0 .. all_ids . len () / 3usize] } ; | v | { ids__free . iter () . map (move | id | (* id , v . clone ())) } }),
                                                                                                                                                 input: Network {
                                                                                                                                                     from_key: None,
-                                                                                                                                                    to_location: Cluster(
-                                                                                                                                                        1,
-                                                                                                                                                    ),
                                                                                                                                                     to_key: None,
                                                                                                                                                     serialize_fn: Some(
                                                                                                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -1211,9 +1112,6 @@ expression: "&ir"
                                                                                                                                                             ident: Ident {
                                                                                                                                                                 sym: cycle_0,
                                                                                                                                                             },
-                                                                                                                                                            location_kind: Cluster(
-                                                                                                                                                                3,
-                                                                                                                                                            ),
                                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                                 location_kind: Cluster(
                                                                                                                                                                     3,
@@ -1617,9 +1515,6 @@ expression: "&ir"
         ident: Ident {
             sym: cycle_0,
         },
-        location_kind: Cluster(
-            3,
-        ),
         input: Chain {
             first: FlatMap {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , std :: iter :: Map < std :: ops :: Range < usize > , _ > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: ClusterId :: < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > :: from_raw (__hydro_lang_cluster_self_id_3) ; let num_clients_per_node__free = 100usize ; move | _ | (0 .. num_clients_per_node__free) . map (move | i | ((CLUSTER_SELF_ID__free . raw_id * (num_clients_per_node__free as u32)) + i as u32 , 0)) }),
@@ -1627,9 +1522,6 @@ expression: "&ir"
                     inner: <tee>: Source {
                         source: Iter(
                             { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: tick :: * ; let e__free = { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; () } ; [e__free] },
-                        ),
-                        location_kind: Cluster(
-                            3,
                         ),
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
@@ -1674,9 +1566,6 @@ expression: "&ir"
                         f: | (_sender_id , b) | b,
                         input: Network {
                             from_key: None,
-                            to_location: Cluster(
-                                3,
-                            ),
                             to_key: None,
                             serialize_fn: Some(
                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -1698,12 +1587,6 @@ expression: "&ir"
                                                         ident: Ident {
                                                             sym: cycle_2,
                                                         },
-                                                        location_kind: Tick(
-                                                            1,
-                                                            Cluster(
-                                                                1,
-                                                            ),
-                                                        ),
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Tick(
                                                                 1,
@@ -1725,9 +1608,6 @@ expression: "&ir"
                                                                     f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                                     input: Network {
                                                                         from_key: None,
-                                                                        to_location: Cluster(
-                                                                            1,
-                                                                        ),
                                                                         to_key: None,
                                                                         serialize_fn: Some(
                                                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -1742,9 +1622,6 @@ expression: "&ir"
                                                                                 f: | (_sender_id , b) | b,
                                                                                 input: Network {
                                                                                     from_key: None,
-                                                                                    to_location: Cluster(
-                                                                                        2,
-                                                                                    ),
                                                                                     to_key: None,
                                                                                     serialize_fn: Some(
                                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -1770,12 +1647,6 @@ expression: "&ir"
                                                                                                                         ident: Ident {
                                                                                                                             sym: cycle_1,
                                                                                                                         },
-                                                                                                                        location_kind: Tick(
-                                                                                                                            1,
-                                                                                                                            Cluster(
-                                                                                                                                1,
-                                                                                                                            ),
-                                                                                                                        ),
                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                             location_kind: Tick(
                                                                                                                                 1,
@@ -1797,9 +1668,6 @@ expression: "&ir"
                                                                                                                                     f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                                                                                                     input: Network {
                                                                                                                                         from_key: None,
-                                                                                                                                        to_location: Cluster(
-                                                                                                                                            1,
-                                                                                                                                        ),
                                                                                                                                         to_key: None,
                                                                                                                                         serialize_fn: Some(
                                                                                                                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -1814,9 +1682,6 @@ expression: "&ir"
                                                                                                                                                 f: | (_sender_id , b) | b,
                                                                                                                                                 input: Network {
                                                                                                                                                     from_key: None,
-                                                                                                                                                    to_location: Cluster(
-                                                                                                                                                        2,
-                                                                                                                                                    ),
                                                                                                                                                     to_key: None,
                                                                                                                                                     serialize_fn: Some(
                                                                                                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -1831,9 +1696,6 @@ expression: "&ir"
                                                                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , std :: iter :: Map < std :: slice :: Iter < hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = { let all_ids = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant >] > (__hydro_lang_cluster_ids_2) } ; & all_ids [0 .. all_ids . len () / 3usize] } ; | v | { ids__free . iter () . map (move | id | (* id , v . clone ())) } }),
                                                                                                                                                             input: Network {
                                                                                                                                                                 from_key: None,
-                                                                                                                                                                to_location: Cluster(
-                                                                                                                                                                    1,
-                                                                                                                                                                ),
                                                                                                                                                                 to_key: None,
                                                                                                                                                                 serialize_fn: Some(
                                                                                                                                                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -1848,9 +1710,6 @@ expression: "&ir"
                                                                                                                                                                         ident: Ident {
                                                                                                                                                                             sym: cycle_0,
                                                                                                                                                                         },
-                                                                                                                                                                        location_kind: Cluster(
-                                                                                                                                                                            3,
-                                                                                                                                                                        ),
                                                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                                                             location_kind: Cluster(
                                                                                                                                                                                 3,
@@ -2281,9 +2140,6 @@ expression: "&ir"
         ident: Ident {
             sym: cycle_3,
         },
-        location_kind: Cluster(
-            3,
-        ),
         input: DeferTick {
             input: ReduceKeyed {
                 f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: time :: Instant , std :: time :: Instant , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | curr_time , new_time | { if new_time > * curr_time { * curr_time = new_time ; } } }),
@@ -2294,12 +2150,6 @@ expression: "&ir"
                                 ident: Ident {
                                     sym: cycle_3,
                                 },
-                                location_kind: Tick(
-                                    0,
-                                    Cluster(
-                                        3,
-                                    ),
-                                ),
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
                                         0,
@@ -2332,9 +2182,6 @@ expression: "&ir"
                                     inner: <tee>: Source {
                                         source: Iter(
                                             { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: tick :: * ; let e__free = { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; () } ; [e__free] },
-                                        ),
-                                        location_kind: Cluster(
-                                            3,
                                         ),
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
@@ -2404,9 +2251,6 @@ expression: "&ir"
                                     f: | (_sender_id , b) | b,
                                     input: Network {
                                         from_key: None,
-                                        to_location: Cluster(
-                                            3,
-                                        ),
                                         to_key: None,
                                         serialize_fn: Some(
                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -2428,12 +2272,6 @@ expression: "&ir"
                                                                     ident: Ident {
                                                                         sym: cycle_2,
                                                                     },
-                                                                    location_kind: Tick(
-                                                                        1,
-                                                                        Cluster(
-                                                                            1,
-                                                                        ),
-                                                                    ),
                                                                     metadata: HydroIrMetadata {
                                                                         location_kind: Tick(
                                                                             1,
@@ -2455,9 +2293,6 @@ expression: "&ir"
                                                                                 f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                                                 input: Network {
                                                                                     from_key: None,
-                                                                                    to_location: Cluster(
-                                                                                        1,
-                                                                                    ),
                                                                                     to_key: None,
                                                                                     serialize_fn: Some(
                                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -2472,9 +2307,6 @@ expression: "&ir"
                                                                                             f: | (_sender_id , b) | b,
                                                                                             input: Network {
                                                                                                 from_key: None,
-                                                                                                to_location: Cluster(
-                                                                                                    2,
-                                                                                                ),
                                                                                                 to_key: None,
                                                                                                 serialize_fn: Some(
                                                                                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -2500,12 +2332,6 @@ expression: "&ir"
                                                                                                                                     ident: Ident {
                                                                                                                                         sym: cycle_1,
                                                                                                                                     },
-                                                                                                                                    location_kind: Tick(
-                                                                                                                                        1,
-                                                                                                                                        Cluster(
-                                                                                                                                            1,
-                                                                                                                                        ),
-                                                                                                                                    ),
                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                         location_kind: Tick(
                                                                                                                                             1,
@@ -2527,9 +2353,6 @@ expression: "&ir"
                                                                                                                                                 f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                                                                                                                 input: Network {
                                                                                                                                                     from_key: None,
-                                                                                                                                                    to_location: Cluster(
-                                                                                                                                                        1,
-                                                                                                                                                    ),
                                                                                                                                                     to_key: None,
                                                                                                                                                     serialize_fn: Some(
                                                                                                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -2544,9 +2367,6 @@ expression: "&ir"
                                                                                                                                                             f: | (_sender_id , b) | b,
                                                                                                                                                             input: Network {
                                                                                                                                                                 from_key: None,
-                                                                                                                                                                to_location: Cluster(
-                                                                                                                                                                    2,
-                                                                                                                                                                ),
                                                                                                                                                                 to_key: None,
                                                                                                                                                                 serialize_fn: Some(
                                                                                                                                                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -2561,9 +2381,6 @@ expression: "&ir"
                                                                                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , std :: iter :: Map < std :: slice :: Iter < hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = { let all_ids = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant >] > (__hydro_lang_cluster_ids_2) } ; & all_ids [0 .. all_ids . len () / 3usize] } ; | v | { ids__free . iter () . map (move | id | (* id , v . clone ())) } }),
                                                                                                                                                                         input: Network {
                                                                                                                                                                             from_key: None,
-                                                                                                                                                                            to_location: Cluster(
-                                                                                                                                                                                1,
-                                                                                                                                                                            ),
                                                                                                                                                                             to_key: None,
                                                                                                                                                                             serialize_fn: Some(
                                                                                                                                                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -2578,9 +2395,6 @@ expression: "&ir"
                                                                                                                                                                                     ident: Ident {
                                                                                                                                                                                         sym: cycle_0,
                                                                                                                                                                                     },
-                                                                                                                                                                                    location_kind: Cluster(
-                                                                                                                                                                                        3,
-                                                                                                                                                                                    ),
                                                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                                                         location_kind: Cluster(
                                                                                                                                                                                             3,
@@ -3062,9 +2876,6 @@ expression: "&ir"
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 >) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (id , histogram) | (id , histogram . histogram . borrow_mut () . clone ()) }),
                                     input: Network {
                                         from_key: None,
-                                        to_location: Process(
-                                            4,
-                                        ),
                                         to_key: None,
                                         serialize_fn: Some(
                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
@@ -3090,12 +2901,6 @@ expression: "&ir"
                                                                             ident: Ident {
                                                                                 sym: cycle_3,
                                                                             },
-                                                                            location_kind: Tick(
-                                                                                0,
-                                                                                Cluster(
-                                                                                    3,
-                                                                                ),
-                                                                            ),
                                                                             metadata: HydroIrMetadata {
                                                                                 location_kind: Tick(
                                                                                     0,
@@ -3128,9 +2933,6 @@ expression: "&ir"
                                                                                     f: | (_sender_id , b) | b,
                                                                                     input: Network {
                                                                                         from_key: None,
-                                                                                        to_location: Cluster(
-                                                                                            3,
-                                                                                        ),
                                                                                         to_key: None,
                                                                                         serialize_fn: Some(
                                                                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -3152,12 +2954,6 @@ expression: "&ir"
                                                                                                                     ident: Ident {
                                                                                                                         sym: cycle_2,
                                                                                                                     },
-                                                                                                                    location_kind: Tick(
-                                                                                                                        1,
-                                                                                                                        Cluster(
-                                                                                                                            1,
-                                                                                                                        ),
-                                                                                                                    ),
                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                         location_kind: Tick(
                                                                                                                             1,
@@ -3179,9 +2975,6 @@ expression: "&ir"
                                                                                                                                 f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                                                                                                 input: Network {
                                                                                                                                     from_key: None,
-                                                                                                                                    to_location: Cluster(
-                                                                                                                                        1,
-                                                                                                                                    ),
                                                                                                                                     to_key: None,
                                                                                                                                     serialize_fn: Some(
                                                                                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -3196,9 +2989,6 @@ expression: "&ir"
                                                                                                                                             f: | (_sender_id , b) | b,
                                                                                                                                             input: Network {
                                                                                                                                                 from_key: None,
-                                                                                                                                                to_location: Cluster(
-                                                                                                                                                    2,
-                                                                                                                                                ),
                                                                                                                                                 to_key: None,
                                                                                                                                                 serialize_fn: Some(
                                                                                                                                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -3224,12 +3014,6 @@ expression: "&ir"
                                                                                                                                                                                     ident: Ident {
                                                                                                                                                                                         sym: cycle_1,
                                                                                                                                                                                     },
-                                                                                                                                                                                    location_kind: Tick(
-                                                                                                                                                                                        1,
-                                                                                                                                                                                        Cluster(
-                                                                                                                                                                                            1,
-                                                                                                                                                                                        ),
-                                                                                                                                                                                    ),
                                                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                                                         location_kind: Tick(
                                                                                                                                                                                             1,
@@ -3251,9 +3035,6 @@ expression: "&ir"
                                                                                                                                                                                                 f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                                                                                                                                                                 input: Network {
                                                                                                                                                                                                     from_key: None,
-                                                                                                                                                                                                    to_location: Cluster(
-                                                                                                                                                                                                        1,
-                                                                                                                                                                                                    ),
                                                                                                                                                                                                     to_key: None,
                                                                                                                                                                                                     serialize_fn: Some(
                                                                                                                                                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -3268,9 +3049,6 @@ expression: "&ir"
                                                                                                                                                                                                             f: | (_sender_id , b) | b,
                                                                                                                                                                                                             input: Network {
                                                                                                                                                                                                                 from_key: None,
-                                                                                                                                                                                                                to_location: Cluster(
-                                                                                                                                                                                                                    2,
-                                                                                                                                                                                                                ),
                                                                                                                                                                                                                 to_key: None,
                                                                                                                                                                                                                 serialize_fn: Some(
                                                                                                                                                                                                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -3285,9 +3063,6 @@ expression: "&ir"
                                                                                                                                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , std :: iter :: Map < std :: slice :: Iter < hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = { let all_ids = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant >] > (__hydro_lang_cluster_ids_2) } ; & all_ids [0 .. all_ids . len () / 3usize] } ; | v | { ids__free . iter () . map (move | id | (* id , v . clone ())) } }),
                                                                                                                                                                                                                         input: Network {
                                                                                                                                                                                                                             from_key: None,
-                                                                                                                                                                                                                            to_location: Cluster(
-                                                                                                                                                                                                                                1,
-                                                                                                                                                                                                                            ),
                                                                                                                                                                                                                             to_key: None,
                                                                                                                                                                                                                             serialize_fn: Some(
                                                                                                                                                                                                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -3302,9 +3077,6 @@ expression: "&ir"
                                                                                                                                                                                                                                     ident: Ident {
                                                                                                                                                                                                                                         sym: cycle_0,
                                                                                                                                                                                                                                     },
-                                                                                                                                                                                                                                    location_kind: Cluster(
-                                                                                                                                                                                                                                        3,
-                                                                                                                                                                                                                                    ),
                                                                                                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                                                                                                         location_kind: Cluster(
                                                                                                                                                                                                                                             3,
@@ -3775,9 +3547,6 @@ expression: "&ir"
                                                                 source: Stream(
                                                                     { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let interval__free = { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; Duration :: from_millis (1000) } ; tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval (interval__free)) },
                                                                 ),
-                                                                location_kind: Cluster(
-                                                                    3,
-                                                                ),
                                                                 metadata: HydroIrMetadata {
                                                                     location_kind: Cluster(
                                                                         3,
@@ -3918,9 +3687,6 @@ expression: "&ir"
                             source: Stream(
                                 { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let interval__free = { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; Duration :: from_millis (1000) } ; tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval (interval__free)) },
                             ),
-                            location_kind: Process(
-                                4,
-                            ),
                             metadata: HydroIrMetadata {
                                 location_kind: Process(
                                     4,
@@ -4001,9 +3767,6 @@ expression: "&ir"
                             input: Persist {
                                 inner: Network {
                                     from_key: None,
-                                    to_location: Process(
-                                        4,
-                                    ),
                                     to_key: None,
                                     serialize_fn: Some(
                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
@@ -4035,9 +3798,6 @@ expression: "&ir"
                                                                                     f: | (_sender_id , b) | b,
                                                                                     input: Network {
                                                                                         from_key: None,
-                                                                                        to_location: Cluster(
-                                                                                            3,
-                                                                                        ),
                                                                                         to_key: None,
                                                                                         serialize_fn: Some(
                                                                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -4059,12 +3819,6 @@ expression: "&ir"
                                                                                                                     ident: Ident {
                                                                                                                         sym: cycle_2,
                                                                                                                     },
-                                                                                                                    location_kind: Tick(
-                                                                                                                        1,
-                                                                                                                        Cluster(
-                                                                                                                            1,
-                                                                                                                        ),
-                                                                                                                    ),
                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                         location_kind: Tick(
                                                                                                                             1,
@@ -4086,9 +3840,6 @@ expression: "&ir"
                                                                                                                                 f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                                                                                                 input: Network {
                                                                                                                                     from_key: None,
-                                                                                                                                    to_location: Cluster(
-                                                                                                                                        1,
-                                                                                                                                    ),
                                                                                                                                     to_key: None,
                                                                                                                                     serialize_fn: Some(
                                                                                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -4103,9 +3854,6 @@ expression: "&ir"
                                                                                                                                             f: | (_sender_id , b) | b,
                                                                                                                                             input: Network {
                                                                                                                                                 from_key: None,
-                                                                                                                                                to_location: Cluster(
-                                                                                                                                                    2,
-                                                                                                                                                ),
                                                                                                                                                 to_key: None,
                                                                                                                                                 serialize_fn: Some(
                                                                                                                                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -4131,12 +3879,6 @@ expression: "&ir"
                                                                                                                                                                                     ident: Ident {
                                                                                                                                                                                         sym: cycle_1,
                                                                                                                                                                                     },
-                                                                                                                                                                                    location_kind: Tick(
-                                                                                                                                                                                        1,
-                                                                                                                                                                                        Cluster(
-                                                                                                                                                                                            1,
-                                                                                                                                                                                        ),
-                                                                                                                                                                                    ),
                                                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                                                         location_kind: Tick(
                                                                                                                                                                                             1,
@@ -4158,9 +3900,6 @@ expression: "&ir"
                                                                                                                                                                                                 f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                                                                                                                                                                 input: Network {
                                                                                                                                                                                                     from_key: None,
-                                                                                                                                                                                                    to_location: Cluster(
-                                                                                                                                                                                                        1,
-                                                                                                                                                                                                    ),
                                                                                                                                                                                                     to_key: None,
                                                                                                                                                                                                     serialize_fn: Some(
                                                                                                                                                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -4175,9 +3914,6 @@ expression: "&ir"
                                                                                                                                                                                                             f: | (_sender_id , b) | b,
                                                                                                                                                                                                             input: Network {
                                                                                                                                                                                                                 from_key: None,
-                                                                                                                                                                                                                to_location: Cluster(
-                                                                                                                                                                                                                    2,
-                                                                                                                                                                                                                ),
                                                                                                                                                                                                                 to_key: None,
                                                                                                                                                                                                                 serialize_fn: Some(
                                                                                                                                                                                                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -4192,9 +3928,6 @@ expression: "&ir"
                                                                                                                                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , std :: iter :: Map < std :: slice :: Iter < hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = { let all_ids = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant >] > (__hydro_lang_cluster_ids_2) } ; & all_ids [0 .. all_ids . len () / 3usize] } ; | v | { ids__free . iter () . map (move | id | (* id , v . clone ())) } }),
                                                                                                                                                                                                                         input: Network {
                                                                                                                                                                                                                             from_key: None,
-                                                                                                                                                                                                                            to_location: Cluster(
-                                                                                                                                                                                                                                1,
-                                                                                                                                                                                                                            ),
                                                                                                                                                                                                                             to_key: None,
                                                                                                                                                                                                                             serialize_fn: Some(
                                                                                                                                                                                                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
@@ -4209,9 +3942,6 @@ expression: "&ir"
                                                                                                                                                                                                                                     ident: Ident {
                                                                                                                                                                                                                                         sym: cycle_0,
                                                                                                                                                                                                                                     },
-                                                                                                                                                                                                                                    location_kind: Cluster(
-                                                                                                                                                                                                                                        3,
-                                                                                                                                                                                                                                    ),
                                                                                                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                                                                                                         location_kind: Cluster(
                                                                                                                                                                                                                                             3,
@@ -4631,9 +4361,6 @@ expression: "&ir"
                                                                                                 source: Stream(
                                                                                                     { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let interval__free = { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; Duration :: from_secs (1) } ; tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval (interval__free)) },
                                                                                                 ),
-                                                                                                location_kind: Cluster(
-                                                                                                    3,
-                                                                                                ),
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_kind: Cluster(
                                                                                                         3,
@@ -4749,9 +4476,6 @@ expression: "&ir"
                                                                                 source: Stream(
                                                                                     { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let interval__free = { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; Duration :: from_secs (1) } ; tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval (interval__free)) },
                                                                                 ),
-                                                                                location_kind: Cluster(
-                                                                                    3,
-                                                                                ),
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_kind: Cluster(
                                                                                         3,
@@ -4858,9 +4582,6 @@ expression: "&ir"
                                                     input: Source {
                                                         source: Stream(
                                                             { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let interval__free = { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; Duration :: from_millis (1000) } ; tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval (interval__free)) },
-                                                        ),
-                                                        location_kind: Cluster(
-                                                            3,
                                                         ),
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Cluster(
@@ -4983,9 +4704,6 @@ expression: "&ir"
                         input: Source {
                             source: Stream(
                                 { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let interval__free = { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; Duration :: from_millis (1000) } ; tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval (interval__free)) },
-                            ),
-                            location_kind: Process(
-                                4,
                             ),
                             metadata: HydroIrMetadata {
                                 location_kind: Process(

--- a/hydro_test/src/distributed/first_ten.rs
+++ b/hydro_test/src/distributed/first_ten.rs
@@ -15,7 +15,7 @@ pub fn first_ten_distributed<'a>(
     process: &Process<'a, P1>,
     second_process: &Process<'a, P2>,
 ) -> ExternalBincodeSink<String> {
-    let (numbers_external_port, numbers_external) = external.source_external_bincode(process);
+    let (numbers_external_port, numbers_external) = process.source_external_bincode(external);
     numbers_external.for_each(q!(|n| println!("hi: {:?}", n)));
 
     let numbers = process.source_iter(q!(0..10));
@@ -36,7 +36,7 @@ mod tests {
     #[test]
     fn first_ten_distributed_ir() {
         let builder = hydro_lang::FlowBuilder::new();
-        let external = builder.external_process();
+        let external = builder.external();
         let p1 = builder.process();
         let p2 = builder.process();
         super::first_ten_distributed(&external, &p1, &p2);
@@ -49,7 +49,7 @@ mod tests {
         let mut deployment = Deployment::new();
 
         let builder = hydro_lang::FlowBuilder::new();
-        let external = builder.external_process();
+        let external = builder.external();
         let p1 = builder.process();
         let p2 = builder.process();
         let external_port = super::first_ten_distributed(&external, &p1, &p2);

--- a/hydro_test/src/distributed/snapshots/hydro_test__distributed__first_ten__tests__first_ten_distributed_ir.snap
+++ b/hydro_test/src/distributed/snapshots/hydro_test__distributed__first_ten__tests__first_ten_distributed_ir.snap
@@ -7,33 +7,18 @@ expression: builder.finalize().ir()
         f: stageleft :: runtime_support :: fn1_type_hint :: < std :: string :: String , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: distributed :: first_ten :: * ; | n | println ! ("hi: {:?}" , n) }),
         input: Unpersist {
             inner: Persist {
-                inner: Network {
+                inner: ExternalInput {
+                    from_location: External(
+                        0,
+                    ),
                     from_key: Some(
                         0,
                     ),
-                    to_location: Process(
-                        1,
-                    ),
                     to_key: None,
-                    serialize_fn: None,
                     instantiate_fn: <network instantiate>,
                     deserialize_fn: Some(
                         | res | { hydro_lang :: runtime_support :: bincode :: deserialize :: < std :: string :: String > (& res . unwrap ()) . unwrap () },
                     ),
-                    input: Source {
-                        source: ExternalNetwork,
-                        location_kind: External(
-                            0,
-                        ),
-                        metadata: HydroIrMetadata {
-                            location_kind: External(
-                                0,
-                            ),
-                            output_type: Some(
-                                std :: string :: String,
-                            ),
-                        },
-                    },
                     metadata: HydroIrMetadata {
                         location_kind: Process(
                             1,
@@ -75,9 +60,6 @@ expression: builder.finalize().ir()
         input: Unpersist {
             inner: Network {
                 from_key: None,
-                to_location: Process(
-                    2,
-                ),
                 to_key: None,
                 serialize_fn: Some(
                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: distributed :: first_ten :: SendOverNetwork , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
@@ -92,9 +74,6 @@ expression: builder.finalize().ir()
                         inner: Source {
                             source: Iter(
                                 { use crate :: __staged :: __deps :: * ; use crate :: __staged :: distributed :: first_ten :: * ; 0 .. 10 },
-                            ),
-                            location_kind: Process(
-                                1,
                             ),
                             metadata: HydroIrMetadata {
                                 location_kind: Process(

--- a/hydro_test/src/local/chat_app.rs
+++ b/hydro_test/src/local/chat_app.rs
@@ -43,6 +43,7 @@ pub fn chat_app<'a>(
 mod tests {
     use futures::{SinkExt, Stream, StreamExt};
     use hydro_deploy::Deployment;
+    use hydro_lang::Location;
 
     async fn take_next_n<T>(stream: &mut (impl Stream<Item = T> + Unpin), n: usize) -> Vec<T> {
         let mut out = Vec::with_capacity(n);
@@ -61,11 +62,11 @@ mod tests {
         let mut deployment = Deployment::new();
 
         let builder = hydro_lang::FlowBuilder::new();
-        let external = builder.external_process::<()>();
+        let external = builder.external::<()>();
         let p1 = builder.process();
 
-        let (users_send, users) = external.source_external_bincode(&p1);
-        let (messages_send, messages) = external.source_external_bincode(&p1);
+        let (users_send, users) = p1.source_external_bincode(&external);
+        let (messages_send, messages) = p1.source_external_bincode(&external);
         let out = super::chat_app(&p1, users, messages, false);
         let out_recv = out.send_bincode_external(&external);
 
@@ -126,11 +127,11 @@ mod tests {
         let mut deployment = Deployment::new();
 
         let builder = hydro_lang::FlowBuilder::new();
-        let external = builder.external_process::<()>();
+        let external = builder.external::<()>();
         let p1 = builder.process();
 
-        let (users_send, users) = external.source_external_bincode(&p1);
-        let (messages_send, messages) = external.source_external_bincode(&p1);
+        let (users_send, users) = p1.source_external_bincode(&external);
+        let (messages_send, messages) = p1.source_external_bincode(&external);
         let out = super::chat_app(&p1, users, messages, true);
         let out_recv = out.send_bincode_external(&external);
 

--- a/hydro_test/src/local/count_elems.rs
+++ b/hydro_test/src/local/count_elems.rs
@@ -20,16 +20,17 @@ pub fn count_elems<'a, T: 'a>(
 mod tests {
     use futures::{SinkExt, StreamExt};
     use hydro_deploy::Deployment;
+    use hydro_lang::Location;
 
     #[tokio::test]
     async fn test_count() {
         let mut deployment = Deployment::new();
 
         let builder = hydro_lang::FlowBuilder::new();
-        let external = builder.external_process::<()>();
+        let external = builder.external::<()>();
         let p1 = builder.process();
 
-        let (input_send, input) = external.source_external_bincode(&p1);
+        let (input_send, input) = p1.source_external_bincode(&external);
         let out = super::count_elems(&p1, input);
         let out_recv = out.send_bincode_external(&external);
 

--- a/hydro_test/src/local/futures.rs
+++ b/hydro_test/src/local/futures.rs
@@ -35,7 +35,7 @@ mod tests {
         let mut deployment = Deployment::new();
 
         let builder = hydro_lang::FlowBuilder::new();
-        let external = builder.external_process::<()>();
+        let external = builder.external::<()>();
         let p1 = builder.process();
 
         let out = super::unordered(&p1);
@@ -67,7 +67,7 @@ mod tests {
         let mut deployment = Deployment::new();
 
         let builder = hydro_lang::FlowBuilder::new();
-        let external = builder.external_process::<()>();
+        let external = builder.external::<()>();
         let p1 = builder.process();
 
         let out = super::ordered(&p1);

--- a/hydro_test/src/local/graph_reachability.rs
+++ b/hydro_test/src/local/graph_reachability.rs
@@ -29,6 +29,7 @@ pub fn graph_reachability<'a>(
 mod tests {
     use futures::{SinkExt, StreamExt};
     use hydro_deploy::Deployment;
+    use hydro_lang::Location;
 
     #[tokio::test]
     #[ignore = "broken because ticks in Hydro are only triggered by external input"]
@@ -36,11 +37,11 @@ mod tests {
         let mut deployment = Deployment::new();
 
         let builder = hydro_lang::FlowBuilder::new();
-        let external = builder.external_process::<()>();
+        let external = builder.external::<()>();
         let p1 = builder.process();
 
-        let (roots_send, roots) = external.source_external_bincode(&p1);
-        let (edges_send, edges) = external.source_external_bincode(&p1);
+        let (roots_send, roots) = p1.source_external_bincode(&external);
+        let (edges_send, edges) = p1.source_external_bincode(&external);
         let out = super::graph_reachability(&p1, roots, edges);
         let out_recv = out.send_bincode_external(&external);
 

--- a/hydro_test/src/local/negation.rs
+++ b/hydro_test/src/local/negation.rs
@@ -78,6 +78,7 @@ pub fn test_anti_join<'a>(
 mod tests {
     use futures::{SinkExt, Stream, StreamExt};
     use hydro_deploy::Deployment;
+    use hydro_lang::Location;
 
     async fn take_next_n<T>(stream: &mut (impl Stream<Item = T> + Unpin), n: usize) -> Vec<T> {
         let mut out = Vec::with_capacity(n);
@@ -96,10 +97,10 @@ mod tests {
         let mut deployment = Deployment::new();
 
         let builder = hydro_lang::FlowBuilder::new();
-        let external = builder.external_process::<()>();
+        let external = builder.external::<()>();
         let p1 = builder.process();
 
-        let (tick_send, tick_trigger) = external.source_external_bincode(&p1);
+        let (tick_send, tick_trigger) = p1.source_external_bincode(&external);
 
         let out = super::test_difference(&p1, false, false, tick_trigger);
         let out_recv = out.send_bincode_external(&external);
@@ -127,10 +128,10 @@ mod tests {
         let mut deployment = Deployment::new();
 
         let builder = hydro_lang::FlowBuilder::new();
-        let external = builder.external_process::<()>();
+        let external = builder.external::<()>();
         let p1 = builder.process();
 
-        let (tick_send, tick_trigger) = external.source_external_bincode(&p1);
+        let (tick_send, tick_trigger) = p1.source_external_bincode(&external);
 
         let out = super::test_difference(&p1, false, true, tick_trigger);
         let out_recv = out.send_bincode_external(&external);
@@ -158,10 +159,10 @@ mod tests {
         let mut deployment = Deployment::new();
 
         let builder = hydro_lang::FlowBuilder::new();
-        let external = builder.external_process::<()>();
+        let external = builder.external::<()>();
         let p1 = builder.process();
 
-        let (tick_send, tick_trigger) = external.source_external_bincode(&p1);
+        let (tick_send, tick_trigger) = p1.source_external_bincode(&external);
 
         let out = super::test_difference(&p1, true, false, tick_trigger);
         let out_recv = out.send_bincode_external(&external);
@@ -193,10 +194,10 @@ mod tests {
         let mut deployment = Deployment::new();
 
         let builder = hydro_lang::FlowBuilder::new();
-        let external = builder.external_process::<()>();
+        let external = builder.external::<()>();
         let p1 = builder.process();
 
-        let (tick_send, tick_trigger) = external.source_external_bincode(&p1);
+        let (tick_send, tick_trigger) = p1.source_external_bincode(&external);
 
         let out = super::test_difference(&p1, true, true, tick_trigger);
         let out_recv = out.send_bincode_external(&external);
@@ -228,10 +229,10 @@ mod tests {
         let mut deployment = Deployment::new();
 
         let builder = hydro_lang::FlowBuilder::new();
-        let external = builder.external_process::<()>();
+        let external = builder.external::<()>();
         let p1 = builder.process();
 
-        let (tick_send, tick_trigger) = external.source_external_bincode(&p1);
+        let (tick_send, tick_trigger) = p1.source_external_bincode(&external);
 
         let out = super::test_anti_join(&p1, false, false, tick_trigger);
         let out_recv = out.send_bincode_external(&external);
@@ -259,10 +260,10 @@ mod tests {
         let mut deployment = Deployment::new();
 
         let builder = hydro_lang::FlowBuilder::new();
-        let external = builder.external_process::<()>();
+        let external = builder.external::<()>();
         let p1 = builder.process();
 
-        let (tick_send, tick_trigger) = external.source_external_bincode(&p1);
+        let (tick_send, tick_trigger) = p1.source_external_bincode(&external);
 
         let out = super::test_anti_join(&p1, false, true, tick_trigger);
         let out_recv = out.send_bincode_external(&external);
@@ -290,10 +291,10 @@ mod tests {
         let mut deployment = Deployment::new();
 
         let builder = hydro_lang::FlowBuilder::new();
-        let external = builder.external_process::<()>();
+        let external = builder.external::<()>();
         let p1 = builder.process();
 
-        let (tick_send, tick_trigger) = external.source_external_bincode(&p1);
+        let (tick_send, tick_trigger) = p1.source_external_bincode(&external);
 
         let out = super::test_anti_join(&p1, true, false, tick_trigger);
         let out_recv = out.send_bincode_external(&external);
@@ -325,10 +326,10 @@ mod tests {
         let mut deployment = Deployment::new();
 
         let builder = hydro_lang::FlowBuilder::new();
-        let external = builder.external_process::<()>();
+        let external = builder.external::<()>();
         let p1 = builder.process();
 
-        let (tick_send, tick_trigger) = external.source_external_bincode(&p1);
+        let (tick_send, tick_trigger) = p1.source_external_bincode(&external);
 
         let out = super::test_anti_join(&p1, true, true, tick_trigger);
         let out_recv = out.send_bincode_external(&external);


### PR DESCRIPTION

First, instead of creating external sources by invoking `external.source_bincode_external(&p)`, we switch the API to `p.source_bincode_external(&external)` for symmetry with `source_iter` and `source_stream`.

The other, much larger change is to clean up how the IR handles external inputs and outputs and keeps track of locations. First, we introduce `HydroNode::ExternalInput` and `HydroLeaf::SendExternal` as specialized nodes for these, so that we no longer create dummy sources / sinks.

Then, we eliminate places where we have multiple sources of truth for where the output of an IR node is located, by instead referring to the metadata. Because it is easy in optimizer rewrites to corrupt this metadata, we also add a flag to `transform_bottom_up` that lets developers enable a metadata validity check. We disable it in most transformations for performance, but enable it in the decoupling rewrites since it manipulates locations in complex ways.
