### PR TITLE
refactor(hydro_lang): separate externals from other location kinds, clean up network operators

### DIFF
--- a/hydro_lang/src/graph/render.rs
+++ b/hydro_lang/src/graph/render.rs
@@ -277,7 +277,6 @@ fn extract_location_id(metadata: &crate::ir::HydroIrMetadata) -> (Option<usize>,
     match &metadata.location_kind {
         LocationId::Process(id) => (Some(*id), Some("Process".to_string())),
         LocationId::Cluster(id) => (Some(*id), Some("Cluster".to_string())),
-        LocationId::External(id) => (Some(*id), Some("External".to_string())),
         LocationId::Tick(_, inner) => match inner.as_ref() {
             LocationId::Process(id) => (Some(*id), Some("Process".to_string())),
             LocationId::Cluster(id) => (Some(*id), Some("Cluster".to_string())),
@@ -384,12 +383,12 @@ impl HydroLeaf {
             seen_tees: &mut HashMap<*const std::cell::RefCell<HydroNode>, usize>,
             config: &HydroWriteConfig,
             input: &HydroNode,
-            metadata: &crate::ir::HydroIrMetadata,
+            metadata: Option<&crate::ir::HydroIrMetadata>,
             label: NodeLabel,
             edge_type: HydroEdgeType,
         ) -> usize {
             let input_id = input.build_graph_structure(structure, seen_tees, config);
-            let location_id = setup_location(structure, metadata);
+            let location_id = metadata.and_then(|m| setup_location(structure, m));
             let sink_id = structure.add_node(label, HydroNodeType::Sink, location_id);
             structure.add_edge(input_id, sink_id, edge_type, None);
             sink_id
@@ -402,14 +401,28 @@ impl HydroLeaf {
                 seen_tees,
                 config,
                 input,
-                metadata,
+                Some(metadata),
                 NodeLabel::with_exprs("for_each".to_string(), vec![f.clone()]),
                 HydroEdgeType::Stream,
             ),
 
-            HydroLeaf::SendExternal { input, .. } => {
-                input.build_graph_structure(structure, seen_tees, config)
-            }
+            HydroLeaf::SendExternal {
+                to_external_id,
+                to_key,
+                input,
+                ..
+            } => build_sink_node(
+                structure,
+                seen_tees,
+                config,
+                input,
+                None,
+                NodeLabel::with_exprs(
+                    format!("send_external({}:{})", to_external_id, to_key),
+                    vec![],
+                ),
+                HydroEdgeType::Stream,
+            ),
 
             HydroLeaf::DestSink {
                 sink,
@@ -420,7 +433,7 @@ impl HydroLeaf {
                 seen_tees,
                 config,
                 input,
-                metadata,
+                Some(metadata),
                 NodeLabel::with_exprs("dest_sink".to_string(), vec![sink.clone()]),
                 HydroEdgeType::Stream,
             ),
@@ -436,7 +449,7 @@ impl HydroLeaf {
                 seen_tees,
                 config,
                 input,
-                metadata,
+                Some(metadata),
                 NodeLabel::static_label(format!("cycle_sink({})", ident)),
                 HydroEdgeType::Cycle,
             ),
@@ -561,9 +574,16 @@ impl HydroNode {
                 build_source_node(structure, metadata, label)
             }
 
-            HydroNode::ExternalInput { metadata, .. } => {
-                build_source_node(structure, metadata, "external_network()".to_string())
-            }
+            HydroNode::ExternalInput {
+                from_external_id,
+                from_key,
+                metadata,
+                ..
+            } => build_source_node(
+                structure,
+                metadata,
+                format!("external_input({}:{})", from_external_id, from_key),
+            ),
 
             HydroNode::CycleSource {
                 ident, metadata, ..
@@ -816,10 +836,6 @@ impl HydroNode {
                     }
                     LocationId::Cluster(id) => {
                         structure.add_location(*id, "Cluster".to_string());
-                        Some(*id)
-                    }
-                    LocationId::External(id) => {
-                        structure.add_location(*id, "External".to_string());
                         Some(*id)
                     }
                     _ => None,

--- a/hydro_lang/src/ir.rs
+++ b/hydro_lang/src/ir.rs
@@ -328,9 +328,8 @@ pub enum HydroLeaf {
         metadata: HydroIrMetadata,
     },
     SendExternal {
-        from_key: Option<usize>,
-        to_location: usize,
-        to_key: Option<usize>,
+        to_external_id: usize,
+        to_key: usize,
         serialize_fn: Option<DebugExpr>,
         instantiate_fn: DebugInstantiate,
         input: Box<HydroNode>,
@@ -363,24 +362,47 @@ impl HydroLeaf {
             &mut |l| {
                 if let HydroLeaf::SendExternal {
                     input,
-                    from_key,
-                    to_location,
+                    to_external_id,
                     to_key,
                     instantiate_fn,
                     ..
                 } = l
                 {
-                    let (sink_expr, source_expr, connect_fn) = match instantiate_fn {
-                        DebugInstantiate::Building => instantiate_network::<D>(
-                            input.metadata().location_kind.root(),
-                            *from_key,
-                            &LocationId::External(*to_location),
-                            *to_key,
-                            processes,
-                            clusters,
-                            externals,
-                            compile_env,
-                        ),
+                    let ((sink_expr, source_expr), connect_fn) = match instantiate_fn {
+                        DebugInstantiate::Building => {
+                            let to_node = externals
+                                .get(to_external_id)
+                                .unwrap_or_else(|| {
+                                    panic!("A external used in the graph was not instantiated: {}", to_external_id)
+                                })
+                                .clone();
+
+                            match input.metadata().location_kind.root() {
+                                LocationId::Process(process_id) => {
+                                    let from_node = processes
+                                        .get(process_id)
+                                        .unwrap_or_else(|| {
+                                            panic!("A process used in the graph was not instantiated: {}", process_id)
+                                        })
+                                        .clone();
+
+                                    let sink_port = D::allocate_process_port(&from_node);
+                                    let source_port = D::allocate_external_port(&to_node);
+
+                                    to_node.register(*to_key, source_port.clone());
+
+                                    (
+                                        (
+                                            D::o2e_sink(compile_env, &from_node, &sink_port, &to_node, &source_port),
+                                            parse_quote!(DUMMY),
+                                        ),
+                                        D::o2e_connect(&from_node, &sink_port, &to_node, &source_port),
+                                    )
+                                }
+                                LocationId::Cluster(_) => todo!(),
+                                _ => panic!()
+                            }
+                        },
 
                         DebugInstantiate::Finalized(_) => panic!("network already finalized"),
                     };
@@ -396,8 +418,6 @@ impl HydroLeaf {
             &mut |n| {
                 if let HydroNode::Network {
                     input,
-                    from_key,
-                    to_key,
                     instantiate_fn,
                     metadata,
                     ..
@@ -406,12 +426,9 @@ impl HydroLeaf {
                     let (sink_expr, source_expr, connect_fn) = match instantiate_fn {
                         DebugInstantiate::Building => instantiate_network::<D>(
                             input.metadata().location_kind.root(),
-                            *from_key,
                             metadata.location_kind.root(),
-                            *to_key,
                             processes,
                             clusters,
-                            externals,
                             compile_env,
                         ),
 
@@ -425,25 +442,51 @@ impl HydroLeaf {
                     }
                     .into();
                 } else if let HydroNode::ExternalInput {
-                    from_location,
+                    from_external_id,
                     from_key,
-                    to_key,
                     instantiate_fn,
                     metadata,
                     ..
                 } = n
                 {
-                    let (sink_expr, source_expr, connect_fn) = match instantiate_fn {
-                        DebugInstantiate::Building => instantiate_network::<D>(
-                            from_location,
-                            *from_key,
-                            &metadata.location_kind,
-                            *to_key,
-                            processes,
-                            clusters,
-                            externals,
-                            compile_env,
-                        ),
+                    let ((sink_expr, source_expr), connect_fn) = match instantiate_fn {
+                        DebugInstantiate::Building => {
+                            let from_node = externals
+                                .get(from_external_id)
+                                .unwrap_or_else(|| {
+                                    panic!(
+                                        "A external used in the graph was not instantiated: {}",
+                                        from_external_id
+                                    )
+                                })
+                                .clone();
+
+                            match metadata.location_kind.root() {
+                                LocationId::Process(process_id) => {
+                                    let to_node = processes
+                                        .get(process_id)
+                                        .unwrap_or_else(|| {
+                                            panic!("A process used in the graph was not instantiated: {}", process_id)
+                                        })
+                                        .clone();
+
+                                    let sink_port = D::allocate_external_port(&from_node);
+                                    let source_port = D::allocate_process_port(&to_node);
+
+                                    from_node.register(*from_key, sink_port.clone());
+
+                                    (
+                                        (
+                                            parse_quote!(DUMMY),
+                                            D::e2o_source(compile_env, &from_node, &sink_port, &to_node, &source_port),
+                                        ),
+                                        D::e2o_connect(&from_node, &sink_port, &to_node, &source_port),
+                                    )
+                                }
+                                LocationId::Cluster(_) => todo!(),
+                                _ => panic!()
+                            }
+                        },
 
                         DebugInstantiate::Finalized(_) => panic!("network already finalized"),
                     };
@@ -513,12 +556,10 @@ impl HydroLeaf {
         seen_tees: &mut SeenTees,
     ) {
         match self {
-            HydroLeaf::ForEach { f: _, input, .. }
+            HydroLeaf::ForEach { input, .. }
             | HydroLeaf::SendExternal { input, .. }
-            | HydroLeaf::DestSink { sink: _, input, .. }
-            | HydroLeaf::CycleSink {
-                ident: _, input, ..
-            } => {
+            | HydroLeaf::DestSink { input, .. }
+            | HydroLeaf::CycleSink { input, .. } => {
                 transform(input, seen_tees);
             }
         }
@@ -532,15 +573,13 @@ impl HydroLeaf {
                 metadata: metadata.clone(),
             },
             HydroLeaf::SendExternal {
-                from_key,
-                to_location,
+                to_external_id,
                 to_key,
                 serialize_fn,
                 instantiate_fn,
                 input,
             } => HydroLeaf::SendExternal {
-                from_key: *from_key,
-                to_location: *to_location,
+                to_external_id: *to_external_id,
                 to_key: *to_key,
                 serialize_fn: serialize_fn.clone(),
                 instantiate_fn: instantiate_fn.clone(),
@@ -1081,8 +1120,6 @@ pub enum HydroNode {
     },
 
     Network {
-        from_key: Option<usize>,
-        to_key: Option<usize>,
         serialize_fn: Option<DebugExpr>,
         instantiate_fn: DebugInstantiate,
         deserialize_fn: Option<DebugExpr>,
@@ -1091,9 +1128,8 @@ pub enum HydroNode {
     },
 
     ExternalInput {
-        from_location: LocationId,
-        from_key: Option<usize>,
-        to_key: Option<usize>,
+        from_external_id: usize,
+        from_key: usize,
         instantiate_fn: DebugInstantiate,
         deserialize_fn: Option<DebugExpr>,
         metadata: HydroIrMetadata,
@@ -1400,16 +1436,12 @@ impl HydroNode {
                 metadata: metadata.clone(),
             },
             HydroNode::Network {
-                from_key,
-                to_key,
                 serialize_fn,
                 instantiate_fn,
                 deserialize_fn,
                 input,
                 metadata,
             } => HydroNode::Network {
-                from_key: *from_key,
-                to_key: *to_key,
                 serialize_fn: serialize_fn.clone(),
                 instantiate_fn: instantiate_fn.clone(),
                 deserialize_fn: deserialize_fn.clone(),
@@ -1417,16 +1449,14 @@ impl HydroNode {
                 metadata: metadata.clone(),
             },
             HydroNode::ExternalInput {
-                from_location,
+                from_external_id,
                 from_key,
-                to_key,
                 instantiate_fn,
                 deserialize_fn,
                 metadata,
             } => HydroNode::ExternalInput {
-                from_location: from_location.clone(),
+                from_external_id: *from_external_id,
                 from_key: *from_key,
-                to_key: *to_key,
                 instantiate_fn: instantiate_fn.clone(),
                 deserialize_fn: deserialize_fn.clone(),
                 metadata: metadata.clone(),
@@ -1525,12 +1555,7 @@ impl HydroNode {
             HydroNode::Source {
                 source, metadata, ..
             } => {
-                let location_id = match metadata.location_kind.root().clone() {
-                    LocationId::Process(id) => id,
-                    LocationId::Cluster(id) => id,
-                    LocationId::Tick(_, _) => panic!(),
-                    LocationId::External(id) => id,
-                };
+                let location_id = metadata.location_kind.root().raw_id();
 
                 if let HydroSource::ExternalNetwork() = source {
                     (syn::Ident::new("DUMMY", Span::call_site()), location_id)
@@ -2262,8 +2287,6 @@ impl HydroNode {
             }
 
             HydroNode::Network {
-                from_key: _,
-                to_key: _,
                 serialize_fn: serialize_pipeline,
                 instantiate_fn,
                 deserialize_fn: deserialize_pipeline,
@@ -2338,8 +2361,6 @@ impl HydroNode {
             }
 
             HydroNode::ExternalInput {
-                from_key: _,
-                to_key: _,
                 instantiate_fn,
                 deserialize_fn: deserialize_pipeline,
                 metadata,
@@ -2685,15 +2706,11 @@ impl HydroNode {
 }
 
 #[cfg(feature = "build")]
-#[expect(clippy::too_many_arguments, reason = "networking internals")]
 fn instantiate_network<'a, D>(
     from_location: &LocationId,
-    from_key: Option<usize>,
     to_location: &LocationId,
-    to_key: Option<usize>,
     processes: &HashMap<usize, D::Process>,
     clusters: &HashMap<usize, D::Cluster>,
-    externals: &HashMap<usize, D::External>,
     compile_env: &D::CompileEnv,
 ) -> (syn::Expr, syn::Expr, Box<dyn FnOnce()>)
 where
@@ -2788,74 +2805,6 @@ where
                 D::m2m_connect(&from_node, &sink_port, &to_node, &source_port),
             )
         }
-        (LocationId::External(from), LocationId::Process(to)) => {
-            let from_node = externals
-                .get(from)
-                .unwrap_or_else(|| {
-                    panic!(
-                        "A external used in the graph was not instantiated: {}",
-                        from
-                    )
-                })
-                .clone();
-
-            let to_node = processes
-                .get(to)
-                .unwrap_or_else(|| {
-                    panic!("A process used in the graph was not instantiated: {}", to)
-                })
-                .clone();
-
-            let sink_port = D::allocate_external_port(&from_node);
-            let source_port = D::allocate_process_port(&to_node);
-
-            from_node.register(from_key.unwrap(), sink_port.clone());
-
-            (
-                (
-                    parse_quote!(DUMMY),
-                    D::e2o_source(compile_env, &from_node, &sink_port, &to_node, &source_port),
-                ),
-                D::e2o_connect(&from_node, &sink_port, &to_node, &source_port),
-            )
-        }
-        (LocationId::External(_from), LocationId::Cluster(_to)) => {
-            todo!("NYI")
-        }
-        (LocationId::External(_), LocationId::External(_)) => {
-            panic!("Cannot send from external to external")
-        }
-        (LocationId::Process(from), LocationId::External(to)) => {
-            let from_node = processes
-                .get(from)
-                .unwrap_or_else(|| {
-                    panic!("A process used in the graph was not instantiated: {}", from)
-                })
-                .clone();
-
-            let to_node = externals
-                .get(to)
-                .unwrap_or_else(|| {
-                    panic!("A external used in the graph was not instantiated: {}", to)
-                })
-                .clone();
-
-            let sink_port = D::allocate_process_port(&from_node);
-            let source_port = D::allocate_external_port(&to_node);
-
-            to_node.register(to_key.unwrap(), source_port.clone());
-
-            (
-                (
-                    D::o2e_sink(compile_env, &from_node, &sink_port, &to_node, &source_port),
-                    parse_quote!(DUMMY),
-                ),
-                D::o2e_connect(&from_node, &sink_port, &to_node, &source_port),
-            )
-        }
-        (LocationId::Cluster(_from), LocationId::External(_to)) => {
-            todo!("NYI")
-        }
         (LocationId::Tick(_, _), _) => panic!(),
         (_, LocationId::Tick(_, _)) => panic!(),
     };
@@ -2872,7 +2821,7 @@ mod test {
 
     #[test]
     fn hydro_node_size() {
-        insta::assert_snapshot!(size_of::<HydroNode>(), @"232");
+        insta::assert_snapshot!(size_of::<HydroNode>(), @"200");
     }
 
     #[test]

--- a/hydro_lang/src/location/mod.rs
+++ b/hydro_lang/src/location/mod.rs
@@ -37,7 +37,6 @@ pub enum LocationId {
     Process(usize),
     Cluster(usize),
     Tick(usize, Box<LocationId>),
-    External(usize),
 }
 
 impl LocationId {
@@ -46,13 +45,12 @@ impl LocationId {
             LocationId::Process(_) => self,
             LocationId::Cluster(_) => self,
             LocationId::Tick(_, id) => id.root(),
-            LocationId::External(_) => self,
         }
     }
 
     pub fn is_root(&self) -> bool {
         match self {
-            LocationId::Process(_) | LocationId::Cluster(_) | LocationId::External(_) => true,
+            LocationId::Process(_) | LocationId::Cluster(_) => true,
             LocationId::Tick(_, _) => false,
         }
     }
@@ -62,7 +60,6 @@ impl LocationId {
             LocationId::Process(id) => *id,
             LocationId::Cluster(id) => *id,
             LocationId::Tick(_, _) => panic!("cannot get raw id for tick"),
-            LocationId::External(id) => *id,
         }
     }
 
@@ -215,9 +212,8 @@ pub trait Location<'a>: Clone {
                 self.clone(),
                 HydroNode::Persist {
                     inner: Box::new(HydroNode::ExternalInput {
-                        from_location: LocationId::External(from.id),
-                        from_key: Some(next_external_port_id),
-                        to_key: None,
+                        from_external_id: from.id,
+                        from_key: next_external_port_id,
                         instantiate_fn: DebugInstantiate::Building,
                         deserialize_fn: Some(deser_expr.into()),
                         metadata: self.new_node_metadata::<Bytes>(),
@@ -256,9 +252,8 @@ pub trait Location<'a>: Clone {
                 self.clone(),
                 HydroNode::Persist {
                     inner: Box::new(HydroNode::ExternalInput {
-                        from_location: LocationId::External(from.id),
-                        from_key: Some(next_external_port_id),
-                        to_key: None,
+                        from_external_id: from.id,
+                        from_key: next_external_port_id,
                         instantiate_fn: DebugInstantiate::Building,
                         deserialize_fn: Some(crate::stream::deserialize_bincode::<T>(None).into()),
                         metadata: self.new_node_metadata::<T>(),

--- a/hydro_lang/src/rewrites/persist_pullup.rs
+++ b/hydro_lang/src/rewrites/persist_pullup.rs
@@ -120,8 +120,6 @@ fn persist_pullup_node(
             },
 
             HydroNode::Network {
-                from_key,
-                to_key,
                 serialize_fn,
                 instantiate_fn,
                 deserialize_fn,
@@ -129,8 +127,6 @@ fn persist_pullup_node(
                 metadata,
             } => HydroNode::Persist {
                 inner: Box::new(HydroNode::Network {
-                    from_key,
-                    to_key,
                     serialize_fn,
                     instantiate_fn,
                     deserialize_fn,

--- a/hydro_lang/src/stream.rs
+++ b/hydro_lang/src/stream.rs
@@ -2445,8 +2445,6 @@ where
         Stream::new(
             other.clone(),
             HydroNode::Network {
-                from_key: None,
-                to_key: None,
                 serialize_fn: serialize_pipeline.map(|e| e.into()),
                 instantiate_fn: DebugInstantiate::Building,
                 deserialize_fn: deserialize_pipeline.map(|e| e.into()),
@@ -2476,9 +2474,8 @@ where
         let leaves = flow_state_borrow.leaves.as_mut().expect("Attempted to add a leaf to a flow that has already been finalized. No leaves can be added after the flow has been compiled()");
 
         leaves.push(HydroLeaf::SendExternal {
-            from_key: None,
-            to_location: other.id,
-            to_key: Some(external_key),
+            to_external_id: other.id,
+            to_key: external_key,
             serialize_fn: serialize_pipeline.map(|e| e.into()),
             instantiate_fn: DebugInstantiate::Building,
             input: Box::new(HydroNode::Unpersist {
@@ -2511,8 +2508,6 @@ where
         Stream::new(
             other.clone(),
             HydroNode::Network {
-                from_key: None,
-                to_key: None,
                 serialize_fn: None,
                 instantiate_fn: DebugInstantiate::Building,
                 deserialize_fn: if let Some(c_type) = L::Root::tagged_type() {
@@ -2540,9 +2535,8 @@ where
         let leaves = flow_state_borrow.leaves.as_mut().expect("Attempted to add a leaf to a flow that has already been finalized. No leaves can be added after the flow has been compiled()");
 
         leaves.push(HydroLeaf::SendExternal {
-            from_key: None,
-            to_location: other.id,
-            to_key: Some(external_key),
+            to_external_id: other.id,
+            to_key: external_key,
             serialize_fn: None,
             instantiate_fn: DebugInstantiate::Building,
             input: Box::new(HydroNode::Unpersist {

--- a/hydro_optimize/src/decoupler.rs
+++ b/hydro_optimize/src/decoupler.rs
@@ -61,8 +61,6 @@ fn add_network(node: &mut HydroNode, new_location: &LocationId) {
     // Set up the network node
     let output_type = output_debug_type.clone().0;
     let network_node = HydroNode::Network {
-        from_key: None,
-        to_key: None,
         serialize_fn: Some(serialize_bincode_with_type(true, &output_type)).map(|e| e.into()),
         instantiate_fn: DebugInstantiate::Building,
         deserialize_fn: Some(deserialize_bincode_with_type(

--- a/hydro_optimize/src/snapshots/hydro_optimize__decoupler__tests__decouple_after_source_ir.snap
+++ b/hydro_optimize/src/snapshots/hydro_optimize__decoupler__tests__decouple_after_source_ir.snap
@@ -8,8 +8,6 @@ expression: built.ir()
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: cluster :: cluster_id :: ClusterId < () > , i32) , i32 > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
             input: Network {
-                from_key: None,
-                to_key: None,
                 serialize_fn: Some(
                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , i32) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                 ),
@@ -24,8 +22,6 @@ expression: built.ir()
                         input: Map {
                             f: | (_ , b) | b,
                             input: Network {
-                                from_key: None,
-                                to_key: None,
                                 serialize_fn: Some(
                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , i32) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                 ),

--- a/hydro_optimize/src/snapshots/hydro_optimize__decoupler__tests__move_source_decouple_map_ir.snap
+++ b/hydro_optimize/src/snapshots/hydro_optimize__decoupler__tests__move_source_decouple_map_ir.snap
@@ -8,8 +8,6 @@ expression: built.ir()
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: cluster :: cluster_id :: ClusterId < () > , i32) , i32 > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
             input: Network {
-                from_key: None,
-                to_key: None,
                 serialize_fn: Some(
                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , i32) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                 ),
@@ -22,8 +20,6 @@ expression: built.ir()
                     input: Map {
                         f: | (_ , b) | b,
                         input: Network {
-                            from_key: None,
-                            to_key: None,
                             serialize_fn: Some(
                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , i32) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                             ),

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__compute_pi__tests__compute_pi_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__compute_pi__tests__compute_pi_ir.snap
@@ -14,8 +14,6 @@ expression: built.ir()
                         inner: Map {
                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: compute_pi :: Worker > , (u64 , u64)) , (u64 , u64) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                             input: Network {
-                                from_key: None,
-                                to_key: None,
                                 serialize_fn: Some(
                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (u64 , u64) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                                 ),

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__compute_pi__tests__decoupled_compute_pi_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__compute_pi__tests__decoupled_compute_pi_ir.snap
@@ -14,8 +14,6 @@ expression: built.ir()
                         inner: Map {
                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: compute_pi :: Worker > , (u64 , u64)) , (u64 , u64) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                             input: Network {
-                                from_key: None,
-                                to_key: None,
                                 serialize_fn: Some(
                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (u64 , u64) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                                 ),
@@ -29,8 +27,6 @@ expression: built.ir()
                                     input: Map {
                                         f: | (_ , b) | b,
                                         input: Network {
-                                            from_key: None,
-                                            to_key: None,
                                             serialize_fn: Some(
                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , bool) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                             ),

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__many_to_many__tests__many_to_many_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__many_to_many__tests__many_to_many_ir.snap
@@ -7,8 +7,6 @@ expression: built.ir()
         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < () > , i32) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: many_to_many :: * ; | n | println ! ("cluster received: {:?}" , n) }),
         input: Unpersist {
             inner: Network {
-                from_key: None,
-                to_key: None,
                 serialize_fn: Some(
                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , i32) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                 ),

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__map_reduce__tests__map_reduce_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__map_reduce__tests__map_reduce_ir.snap
@@ -11,8 +11,6 @@ expression: built.ir()
                 inner: Map {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: map_reduce :: Worker > , (std :: string :: String , i32)) , (std :: string :: String , i32) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                     input: Network {
-                        from_key: None,
-                        to_key: None,
                         serialize_fn: Some(
                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (std :: string :: String , i32) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                         ),
@@ -28,8 +26,6 @@ expression: built.ir()
                                 input: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < std :: string :: String , (std :: string :: String , ()) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: map_reduce :: * ; | string | (string , ()) }),
                                     input: Network {
-                                        from_key: None,
-                                        to_key: None,
                                         serialize_fn: Some(
                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , std :: string :: String) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                         ),

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir.snap
@@ -372,8 +372,6 @@ expression: built.ir()
             inner: <tee 2>: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                 input: Network {
-                    from_key: None,
-                    to_key: None,
                     serialize_fn: Some(
                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                     ),
@@ -643,8 +641,6 @@ expression: built.ir()
                                             input: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                                                 input: Network {
-                                                    from_key: None,
-                                                    to_key: None,
                                                     serialize_fn: Some(
                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                     ),
@@ -660,8 +656,6 @@ expression: built.ir()
                                                                     inner: <tee 8>: Map {
                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                                                                         input: Network {
-                                                                            from_key: None,
-                                                                            to_key: None,
                                                                             serialize_fn: Some(
                                                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                             ),
@@ -1881,8 +1875,6 @@ expression: built.ir()
                                                     input: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                                                         input: Network {
-                                                            from_key: None,
-                                                            to_key: None,
                                                             serialize_fn: Some(
                                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                             ),
@@ -2254,8 +2246,6 @@ expression: built.ir()
                                                     left: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) >) , hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                                                         input: Network {
-                                                            from_key: None,
-                                                            to_key: None,
                                                             serialize_fn: Some(
                                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) >) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                             ),
@@ -2855,8 +2845,6 @@ expression: built.ir()
                                             inner: <tee 26>: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                                                 input: Network {
-                                                    from_key: None,
-                                                    to_key: None,
                                                     serialize_fn: Some(
                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                     ),
@@ -2871,8 +2859,6 @@ expression: built.ir()
                                                                 inner: <tee 27>: Map {
                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer >) , hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                                                                     input: Network {
-                                                                        from_key: None,
-                                                                        to_key: None,
                                                                         serialize_fn: Some(
                                                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer >) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                         ),
@@ -4085,8 +4071,6 @@ expression: built.ir()
                                         input: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >)) , (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                                             input: Network {
-                                                from_key: None,
-                                                to_key: None,
                                                 serialize_fn: Some(
                                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                 ),
@@ -4835,8 +4819,6 @@ expression: built.ir()
                                 f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; | curr_seq , seq | { if seq > * curr_seq { * curr_seq = seq ; } } }),
                                 input: Persist {
                                     inner: Network {
-                                        from_key: None,
-                                        to_key: None,
                                         serialize_fn: Some(
                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , usize) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                         ),
@@ -5056,8 +5038,6 @@ expression: built.ir()
                             inner: <tee 40>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: kv_replica :: Replica > , ((u32 , u32) , core :: result :: Result < () , () >)) , ((u32 , u32) , core :: result :: Result < () , () >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                                 input: Network {
-                                    from_key: None,
-                                    to_key: None,
                                     serialize_fn: Some(
                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , ((u32 , u32) , core :: result :: Result < () , () >)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                     ),
@@ -5569,8 +5549,6 @@ expression: built.ir()
                                 inner: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 >) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (id , histogram) | (id , histogram . histogram . borrow_mut () . clone ()) }),
                                     input: Network {
-                                        from_key: None,
-                                        to_key: None,
                                         serialize_fn: Some(
                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                                         ),
@@ -5890,8 +5868,6 @@ expression: built.ir()
                             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | combined , new | { * combined = new ; } }),
                             input: Persist {
                                 inner: Network {
-                                    from_key: None,
-                                    to_key: None,
                                     serialize_fn: Some(
                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                                     ),

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__simple_cluster__tests__partitioned_simple_cluster_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__simple_cluster__tests__partitioned_simple_cluster_ir.snap
@@ -8,8 +8,6 @@ expression: built.ir()
         input: Map {
             f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
             input: Network {
-                from_key: None,
-                to_key: None,
                 serialize_fn: Some(
                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < () > , i32) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                 ),
@@ -20,8 +18,6 @@ expression: built.ir()
                 input: Inspect {
                     f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < () > , i32) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: simple_cluster :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: ClusterId :: < () > :: from_raw ({ __hydro_lang_cluster_self_id_1 / 3usize as u32 }) ; move | n | println ! ("cluster received: {:?} (self cluster id: {})" , n , CLUSTER_SELF_ID__free) }),
                     input: Network {
-                        from_key: None,
-                        to_key: None,
                         serialize_fn: Some(
                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < () > , i32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                         ),

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__simple_cluster__tests__simple_cluster_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__simple_cluster__tests__simple_cluster_ir.snap
@@ -7,8 +7,6 @@ expression: built.ir()
         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < () > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < () > , i32)) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: simple_cluster :: * ; | (id , d) | println ! ("node received: ({}, {:?})" , id , d) }),
         input: Unpersist {
             inner: Network {
-                from_key: None,
-                to_key: None,
                 serialize_fn: Some(
                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < () > , i32) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                 ),
@@ -21,8 +19,6 @@ expression: built.ir()
                         f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < () > , i32) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: simple_cluster :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: ClusterId :: < () > :: from_raw (__hydro_lang_cluster_self_id_1) ; move | n | println ! ("cluster received: {:?} (self cluster id: {})" , n , CLUSTER_SELF_ID__free) }),
                         input: Unpersist {
                             inner: Network {
-                                from_key: None,
-                                to_key: None,
                                 serialize_fn: Some(
                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < () > , i32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                 ),

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__two_pc_bench__tests__two_pc_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__two_pc_bench__tests__two_pc_ir.snap
@@ -33,8 +33,6 @@ expression: built.ir()
                                 input: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                                     input: Network {
-                                        from_key: None,
-                                        to_key: None,
                                         serialize_fn: Some(
                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                                         ),
@@ -43,8 +41,6 @@ expression: built.ir()
                                             | res | { let (id , b) = res . unwrap () ; (hydro_lang :: ClusterId :: < hydro_test :: __staged :: cluster :: two_pc :: Participant > :: from_raw (id) , hydro_lang :: runtime_support :: bincode :: deserialize :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) > (& b) . unwrap ()) },
                                         ),
                                         input: Network {
-                                            from_key: None,
-                                            to_key: None,
                                             serialize_fn: Some(
                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                             ),
@@ -55,8 +51,6 @@ expression: built.ir()
                                             input: FlatMap {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , std :: iter :: Map < std :: slice :: Iter < hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant >] > (__hydro_lang_cluster_ids_1) } ; | v | { ids__free . iter () . map (move | id | (* id , v . clone ())) } }),
                                                 input: Network {
-                                                    from_key: None,
-                                                    to_key: None,
                                                     serialize_fn: Some(
                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , u32) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                                                     ),
@@ -302,8 +296,6 @@ expression: built.ir()
                                 input: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                                     input: Network {
-                                        from_key: None,
-                                        to_key: None,
                                         serialize_fn: Some(
                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                                         ),
@@ -312,8 +304,6 @@ expression: built.ir()
                                             | res | { let (id , b) = res . unwrap () ; (hydro_lang :: ClusterId :: < hydro_test :: __staged :: cluster :: two_pc :: Participant > :: from_raw (id) , hydro_lang :: runtime_support :: bincode :: deserialize :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) > (& b) . unwrap ()) },
                                         ),
                                         input: Network {
-                                            from_key: None,
-                                            to_key: None,
                                             serialize_fn: Some(
                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                             ),
@@ -578,8 +568,6 @@ expression: built.ir()
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , u32) , (u32 , u32) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | payload | (payload . 0 , payload . 1 + 1) }),
                 input: Tee {
                     inner: <tee 9>: Network {
-                        from_key: None,
-                        to_key: None,
                         serialize_fn: Some(
                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                         ),
@@ -851,8 +839,6 @@ expression: built.ir()
                                 inner: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 >) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (id , histogram) | (id , histogram . histogram . borrow_mut () . clone ()) }),
                                     input: Network {
-                                        from_key: None,
-                                        to_key: None,
                                         serialize_fn: Some(
                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                                         ),
@@ -1172,8 +1158,6 @@ expression: built.ir()
                             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | combined , new | { * combined = new ; } }),
                             input: Persist {
                                 inner: Network {
-                                    from_key: None,
-                                    to_key: None,
                                     serialize_fn: Some(
                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                                     ),

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__two_pc_bench__tests__two_pc_partition.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__two_pc_bench__tests__two_pc_partition.snap
@@ -35,8 +35,6 @@ expression: "&ir"
                                     input: Map {
                                         f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                         input: Network {
-                                            from_key: None,
-                                            to_key: None,
                                             serialize_fn: Some(
                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                             ),
@@ -49,8 +47,6 @@ expression: "&ir"
                                                 input: Map {
                                                     f: | (_sender_id , b) | b,
                                                     input: Network {
-                                                        from_key: None,
-                                                        to_key: None,
                                                         serialize_fn: Some(
                                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                         ),
@@ -63,8 +59,6 @@ expression: "&ir"
                                                             input: FlatMap {
                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , std :: iter :: Map < std :: slice :: Iter < hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = { let all_ids = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant >] > (__hydro_lang_cluster_ids_2) } ; & all_ids [0 .. all_ids . len () / 3usize] } ; | v | { ids__free . iter () . map (move | id | (* id , v . clone ())) } }),
                                                                 input: Network {
-                                                                    from_key: None,
-                                                                    to_key: None,
                                                                     serialize_fn: Some(
                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                     ),
@@ -255,8 +249,6 @@ expression: "&ir"
                                                     input: Map {
                                                         f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                         input: Network {
-                                                            from_key: None,
-                                                            to_key: None,
                                                             serialize_fn: Some(
                                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                             ),
@@ -269,8 +261,6 @@ expression: "&ir"
                                                                 input: Map {
                                                                     f: | (_sender_id , b) | b,
                                                                     input: Network {
-                                                                        from_key: None,
-                                                                        to_key: None,
                                                                         serialize_fn: Some(
                                                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                         ),
@@ -283,8 +273,6 @@ expression: "&ir"
                                                                             input: FlatMap {
                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , std :: iter :: Map < std :: slice :: Iter < hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = { let all_ids = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant >] > (__hydro_lang_cluster_ids_2) } ; & all_ids [0 .. all_ids . len () / 3usize] } ; | v | { ids__free . iter () . map (move | id | (* id , v . clone ())) } }),
                                                                                 input: Network {
-                                                                                    from_key: None,
-                                                                                    to_key: None,
                                                                                     serialize_fn: Some(
                                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                     ),
@@ -558,8 +546,6 @@ expression: "&ir"
                                     input: Map {
                                         f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                         input: Network {
-                                            from_key: None,
-                                            to_key: None,
                                             serialize_fn: Some(
                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                             ),
@@ -572,8 +558,6 @@ expression: "&ir"
                                                 input: Map {
                                                     f: | (_sender_id , b) | b,
                                                     input: Network {
-                                                        from_key: None,
-                                                        to_key: None,
                                                         serialize_fn: Some(
                                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                         ),
@@ -618,8 +602,6 @@ expression: "&ir"
                                                                                                     input: Map {
                                                                                                         f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                                                                         input: Network {
-                                                                                                            from_key: None,
-                                                                                                            to_key: None,
                                                                                                             serialize_fn: Some(
                                                                                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                             ),
@@ -632,8 +614,6 @@ expression: "&ir"
                                                                                                                 input: Map {
                                                                                                                     f: | (_sender_id , b) | b,
                                                                                                                     input: Network {
-                                                                                                                        from_key: None,
-                                                                                                                        to_key: None,
                                                                                                                         serialize_fn: Some(
                                                                                                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                         ),
@@ -646,8 +626,6 @@ expression: "&ir"
                                                                                                                             input: FlatMap {
                                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , std :: iter :: Map < std :: slice :: Iter < hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = { let all_ids = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant >] > (__hydro_lang_cluster_ids_2) } ; & all_ids [0 .. all_ids . len () / 3usize] } ; | v | { ids__free . iter () . map (move | id | (* id , v . clone ())) } }),
                                                                                                                                 input: Network {
-                                                                                                                                    from_key: None,
-                                                                                                                                    to_key: None,
                                                                                                                                     serialize_fn: Some(
                                                                                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                     ),
@@ -1009,8 +987,6 @@ expression: "&ir"
                                                     input: Map {
                                                         f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                         input: Network {
-                                                            from_key: None,
-                                                            to_key: None,
                                                             serialize_fn: Some(
                                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                             ),
@@ -1023,8 +999,6 @@ expression: "&ir"
                                                                 input: Map {
                                                                     f: | (_sender_id , b) | b,
                                                                     input: Network {
-                                                                        from_key: None,
-                                                                        to_key: None,
                                                                         serialize_fn: Some(
                                                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                         ),
@@ -1069,8 +1043,6 @@ expression: "&ir"
                                                                                                                     input: Map {
                                                                                                                         f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                                                                                         input: Network {
-                                                                                                                            from_key: None,
-                                                                                                                            to_key: None,
                                                                                                                             serialize_fn: Some(
                                                                                                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                             ),
@@ -1083,8 +1055,6 @@ expression: "&ir"
                                                                                                                                 input: Map {
                                                                                                                                     f: | (_sender_id , b) | b,
                                                                                                                                     input: Network {
-                                                                                                                                        from_key: None,
-                                                                                                                                        to_key: None,
                                                                                                                                         serialize_fn: Some(
                                                                                                                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                         ),
@@ -1097,8 +1067,6 @@ expression: "&ir"
                                                                                                                                             input: FlatMap {
                                                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , std :: iter :: Map < std :: slice :: Iter < hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = { let all_ids = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant >] > (__hydro_lang_cluster_ids_2) } ; & all_ids [0 .. all_ids . len () / 3usize] } ; | v | { ids__free . iter () . map (move | id | (* id , v . clone ())) } }),
                                                                                                                                                 input: Network {
-                                                                                                                                                    from_key: None,
-                                                                                                                                                    to_key: None,
                                                                                                                                                     serialize_fn: Some(
                                                                                                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                                     ),
@@ -1565,8 +1533,6 @@ expression: "&ir"
                     inner: <tee>: Map {
                         f: | (_sender_id , b) | b,
                         input: Network {
-                            from_key: None,
-                            to_key: None,
                             serialize_fn: Some(
                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                             ),
@@ -1607,8 +1573,6 @@ expression: "&ir"
                                                                 input: Map {
                                                                     f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                                     input: Network {
-                                                                        from_key: None,
-                                                                        to_key: None,
                                                                         serialize_fn: Some(
                                                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                         ),
@@ -1621,8 +1585,6 @@ expression: "&ir"
                                                                             input: Map {
                                                                                 f: | (_sender_id , b) | b,
                                                                                 input: Network {
-                                                                                    from_key: None,
-                                                                                    to_key: None,
                                                                                     serialize_fn: Some(
                                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                     ),
@@ -1667,8 +1629,6 @@ expression: "&ir"
                                                                                                                                 input: Map {
                                                                                                                                     f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                                                                                                     input: Network {
-                                                                                                                                        from_key: None,
-                                                                                                                                        to_key: None,
                                                                                                                                         serialize_fn: Some(
                                                                                                                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                         ),
@@ -1681,8 +1641,6 @@ expression: "&ir"
                                                                                                                                             input: Map {
                                                                                                                                                 f: | (_sender_id , b) | b,
                                                                                                                                                 input: Network {
-                                                                                                                                                    from_key: None,
-                                                                                                                                                    to_key: None,
                                                                                                                                                     serialize_fn: Some(
                                                                                                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                                     ),
@@ -1695,8 +1653,6 @@ expression: "&ir"
                                                                                                                                                         input: FlatMap {
                                                                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , std :: iter :: Map < std :: slice :: Iter < hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = { let all_ids = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant >] > (__hydro_lang_cluster_ids_2) } ; & all_ids [0 .. all_ids . len () / 3usize] } ; | v | { ids__free . iter () . map (move | id | (* id , v . clone ())) } }),
                                                                                                                                                             input: Network {
-                                                                                                                                                                from_key: None,
-                                                                                                                                                                to_key: None,
                                                                                                                                                                 serialize_fn: Some(
                                                                                                                                                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                                                 ),
@@ -2250,8 +2206,6 @@ expression: "&ir"
                                 inner: <tee>: Map {
                                     f: | (_sender_id , b) | b,
                                     input: Network {
-                                        from_key: None,
-                                        to_key: None,
                                         serialize_fn: Some(
                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                         ),
@@ -2292,8 +2246,6 @@ expression: "&ir"
                                                                             input: Map {
                                                                                 f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                                                 input: Network {
-                                                                                    from_key: None,
-                                                                                    to_key: None,
                                                                                     serialize_fn: Some(
                                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                     ),
@@ -2306,8 +2258,6 @@ expression: "&ir"
                                                                                         input: Map {
                                                                                             f: | (_sender_id , b) | b,
                                                                                             input: Network {
-                                                                                                from_key: None,
-                                                                                                to_key: None,
                                                                                                 serialize_fn: Some(
                                                                                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                 ),
@@ -2352,8 +2302,6 @@ expression: "&ir"
                                                                                                                                             input: Map {
                                                                                                                                                 f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                                                                                                                 input: Network {
-                                                                                                                                                    from_key: None,
-                                                                                                                                                    to_key: None,
                                                                                                                                                     serialize_fn: Some(
                                                                                                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                                     ),
@@ -2366,8 +2314,6 @@ expression: "&ir"
                                                                                                                                                         input: Map {
                                                                                                                                                             f: | (_sender_id , b) | b,
                                                                                                                                                             input: Network {
-                                                                                                                                                                from_key: None,
-                                                                                                                                                                to_key: None,
                                                                                                                                                                 serialize_fn: Some(
                                                                                                                                                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                                                 ),
@@ -2380,8 +2326,6 @@ expression: "&ir"
                                                                                                                                                                     input: FlatMap {
                                                                                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , std :: iter :: Map < std :: slice :: Iter < hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = { let all_ids = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant >] > (__hydro_lang_cluster_ids_2) } ; & all_ids [0 .. all_ids . len () / 3usize] } ; | v | { ids__free . iter () . map (move | id | (* id , v . clone ())) } }),
                                                                                                                                                                         input: Network {
-                                                                                                                                                                            from_key: None,
-                                                                                                                                                                            to_key: None,
                                                                                                                                                                             serialize_fn: Some(
                                                                                                                                                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                                                             ),
@@ -2875,8 +2819,6 @@ expression: "&ir"
                                 inner: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 >) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (id , histogram) | (id , histogram . histogram . borrow_mut () . clone ()) }),
                                     input: Network {
-                                        from_key: None,
-                                        to_key: None,
                                         serialize_fn: Some(
                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                                         ),
@@ -2932,8 +2874,6 @@ expression: "&ir"
                                                                                 inner: <tee>: Map {
                                                                                     f: | (_sender_id , b) | b,
                                                                                     input: Network {
-                                                                                        from_key: None,
-                                                                                        to_key: None,
                                                                                         serialize_fn: Some(
                                                                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                         ),
@@ -2974,8 +2914,6 @@ expression: "&ir"
                                                                                                                             input: Map {
                                                                                                                                 f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                                                                                                 input: Network {
-                                                                                                                                    from_key: None,
-                                                                                                                                    to_key: None,
                                                                                                                                     serialize_fn: Some(
                                                                                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                     ),
@@ -2988,8 +2926,6 @@ expression: "&ir"
                                                                                                                                         input: Map {
                                                                                                                                             f: | (_sender_id , b) | b,
                                                                                                                                             input: Network {
-                                                                                                                                                from_key: None,
-                                                                                                                                                to_key: None,
                                                                                                                                                 serialize_fn: Some(
                                                                                                                                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                                 ),
@@ -3034,8 +2970,6 @@ expression: "&ir"
                                                                                                                                                                                             input: Map {
                                                                                                                                                                                                 f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                                                                                                                                                                 input: Network {
-                                                                                                                                                                                                    from_key: None,
-                                                                                                                                                                                                    to_key: None,
                                                                                                                                                                                                     serialize_fn: Some(
                                                                                                                                                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                                                                                     ),
@@ -3048,8 +2982,6 @@ expression: "&ir"
                                                                                                                                                                                                         input: Map {
                                                                                                                                                                                                             f: | (_sender_id , b) | b,
                                                                                                                                                                                                             input: Network {
-                                                                                                                                                                                                                from_key: None,
-                                                                                                                                                                                                                to_key: None,
                                                                                                                                                                                                                 serialize_fn: Some(
                                                                                                                                                                                                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                                                                                                 ),
@@ -3062,8 +2994,6 @@ expression: "&ir"
                                                                                                                                                                                                                     input: FlatMap {
                                                                                                                                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , std :: iter :: Map < std :: slice :: Iter < hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = { let all_ids = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant >] > (__hydro_lang_cluster_ids_2) } ; & all_ids [0 .. all_ids . len () / 3usize] } ; | v | { ids__free . iter () . map (move | id | (* id , v . clone ())) } }),
                                                                                                                                                                                                                         input: Network {
-                                                                                                                                                                                                                            from_key: None,
-                                                                                                                                                                                                                            to_key: None,
                                                                                                                                                                                                                             serialize_fn: Some(
                                                                                                                                                                                                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                                                                                                             ),
@@ -3766,8 +3696,6 @@ expression: "&ir"
                             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | combined , new | { * combined = new ; } }),
                             input: Persist {
                                 inner: Network {
-                                    from_key: None,
-                                    to_key: None,
                                     serialize_fn: Some(
                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                                     ),
@@ -3797,8 +3725,6 @@ expression: "&ir"
                                                                                 inner: <tee>: Map {
                                                                                     f: | (_sender_id , b) | b,
                                                                                     input: Network {
-                                                                                        from_key: None,
-                                                                                        to_key: None,
                                                                                         serialize_fn: Some(
                                                                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                         ),
@@ -3839,8 +3765,6 @@ expression: "&ir"
                                                                                                                             input: Map {
                                                                                                                                 f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                                                                                                 input: Network {
-                                                                                                                                    from_key: None,
-                                                                                                                                    to_key: None,
                                                                                                                                     serialize_fn: Some(
                                                                                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                     ),
@@ -3853,8 +3777,6 @@ expression: "&ir"
                                                                                                                                         input: Map {
                                                                                                                                             f: | (_sender_id , b) | b,
                                                                                                                                             input: Network {
-                                                                                                                                                from_key: None,
-                                                                                                                                                to_key: None,
                                                                                                                                                 serialize_fn: Some(
                                                                                                                                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                                 ),
@@ -3899,8 +3821,6 @@ expression: "&ir"
                                                                                                                                                                                             input: Map {
                                                                                                                                                                                                 f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                                                                                                                                                                 input: Network {
-                                                                                                                                                                                                    from_key: None,
-                                                                                                                                                                                                    to_key: None,
                                                                                                                                                                                                     serialize_fn: Some(
                                                                                                                                                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                                                                                     ),
@@ -3913,8 +3833,6 @@ expression: "&ir"
                                                                                                                                                                                                         input: Map {
                                                                                                                                                                                                             f: | (_sender_id , b) | b,
                                                                                                                                                                                                             input: Network {
-                                                                                                                                                                                                                from_key: None,
-                                                                                                                                                                                                                to_key: None,
                                                                                                                                                                                                                 serialize_fn: Some(
                                                                                                                                                                                                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                                                                                                 ),
@@ -3927,8 +3845,6 @@ expression: "&ir"
                                                                                                                                                                                                                     input: FlatMap {
                                                                                                                                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , std :: iter :: Map < std :: slice :: Iter < hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = { let all_ids = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant >] > (__hydro_lang_cluster_ids_2) } ; & all_ids [0 .. all_ids . len () / 3usize] } ; | v | { ids__free . iter () . map (move | id | (* id , v . clone ())) } }),
                                                                                                                                                                                                                         input: Network {
-                                                                                                                                                                                                                            from_key: None,
-                                                                                                                                                                                                                            to_key: None,
                                                                                                                                                                                                                             serialize_fn: Some(
                                                                                                                                                                                                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                                                                                                             ),

--- a/hydro_test/src/distributed/snapshots/hydro_test__distributed__first_ten__tests__first_ten_distributed_ir.snap
+++ b/hydro_test/src/distributed/snapshots/hydro_test__distributed__first_ten__tests__first_ten_distributed_ir.snap
@@ -8,13 +8,8 @@ expression: builder.finalize().ir()
         input: Unpersist {
             inner: Persist {
                 inner: ExternalInput {
-                    from_location: External(
-                        0,
-                    ),
-                    from_key: Some(
-                        0,
-                    ),
-                    to_key: None,
+                    from_external_id: 0,
+                    from_key: 0,
                     instantiate_fn: <network instantiate>,
                     deserialize_fn: Some(
                         | res | { hydro_lang :: runtime_support :: bincode :: deserialize :: < std :: string :: String > (& res . unwrap ()) . unwrap () },
@@ -59,8 +54,6 @@ expression: builder.finalize().ir()
         f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: distributed :: first_ten :: SendOverNetwork , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: distributed :: first_ten :: * ; | n | println ! ("{}" , n . n) }),
         input: Unpersist {
             inner: Network {
-                from_key: None,
-                to_key: None,
                 serialize_fn: Some(
                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: distributed :: first_ten :: SendOverNetwork , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                 ),


### PR DESCRIPTION

First, we remove externals from `LocationId`, to ensure that a `LocationId` only is used for locations where we can concretely place compiled logic. This simplifes a lot of pattern matching where we wanted to disallow externals.

Keys on network inputs / outputs (`from_key` and `to_key`) are only relevant to external networking. We extract the logic to instantiate external network collections, so that the core logic does not need to deal with keys.
