### PR TITLE
fix(hydro_deploy_integration): leftover logging when setting up Unix sockets

### DIFF
--- a/hydro_deploy/hydro_deploy_integration/src/lib.rs
+++ b/hydro_deploy/hydro_deploy_integration/src/lib.rs
@@ -258,7 +258,6 @@ pub async fn accept_bound(bound: BoundServer) -> AcceptedServer {
             #[cfg(unix)]
             {
                 let stream = listener.accept().await.unwrap().0;
-                eprintln!("accepted");
                 AcceptedServer::UnixSocket(stream)
             }
 


### PR DESCRIPTION

Oops!
