### PR TITLE
feat(hydro_lang,hydro_deploy)!: introduce support for receiving data from dynamic external clients

### DIFF
--- a/hydro_deploy/core/src/azure.rs
+++ b/hydro_deploy/core/src/azure.rs
@@ -1,5 +1,6 @@
 use std::any::Any;
 use std::collections::HashMap;
+use std::fmt::Debug;
 use std::sync::{Arc, Mutex, OnceLock};
 
 use anyhow::Result;
@@ -8,12 +9,9 @@ use nanoid::nanoid;
 use serde_json::json;
 
 use super::terraform::{TERRAFORM_ALPHABET, TerraformOutput, TerraformProvider};
-use super::{
-    ClientStrategy, Host, HostTargetType, LaunchedHost, ResourceBatch, ResourceResult,
-    ServerStrategy,
-};
-use crate::HostStrategyGetter;
+use super::{ClientStrategy, Host, HostTargetType, LaunchedHost, ResourceBatch, ResourceResult};
 use crate::ssh::LaunchedSshHost;
+use crate::{BaseServerStrategy, HostStrategyGetter};
 
 pub struct LaunchedVirtualMachine {
     resource_result: Arc<ResourceResult>,
@@ -82,17 +80,23 @@ impl AzureHost {
     }
 }
 
+impl Debug for AzureHost {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("AzureHost({})", self.id))
+    }
+}
+
 #[async_trait]
 impl Host for AzureHost {
     fn target_type(&self) -> HostTargetType {
         HostTargetType::Linux
     }
 
-    fn request_port(&self, bind_type: &ServerStrategy) {
+    fn request_port_base(&self, bind_type: &BaseServerStrategy) {
         match bind_type {
-            ServerStrategy::UnixSocket => {}
-            ServerStrategy::InternalTcpPort => {}
-            ServerStrategy::ExternalTcpPort(port) => {
+            BaseServerStrategy::UnixSocket => {}
+            BaseServerStrategy::InternalTcpPort => {}
+            BaseServerStrategy::ExternalTcpPort(port) => {
                 let mut external_ports = self.external_ports.lock().unwrap();
                 if !external_ports.contains(port) {
                     if self.launched.get().is_some() {
@@ -101,25 +105,11 @@ impl Host for AzureHost {
                     external_ports.push(*port);
                 }
             }
-            ServerStrategy::Demux(demux) => {
-                for bind_type in demux.values() {
-                    self.request_port(bind_type);
-                }
-            }
-            ServerStrategy::Merge(merge) => {
-                for bind_type in merge {
-                    self.request_port(bind_type);
-                }
-            }
-            ServerStrategy::Tagged(underlying, _) => {
-                self.request_port(underlying);
-            }
-            ServerStrategy::Null => {}
         }
     }
 
     fn request_custom_binary(&self) {
-        self.request_port(&ServerStrategy::ExternalTcpPort(22));
+        self.request_port_base(&BaseServerStrategy::ExternalTcpPort(22));
     }
 
     fn id(&self) -> usize {
@@ -434,12 +424,12 @@ impl Host for AzureHost {
         if client_host.can_connect_to(ClientStrategy::UnixSocket(self.id)) {
             Ok((
                 ClientStrategy::UnixSocket(self.id),
-                Box::new(|_| ServerStrategy::UnixSocket),
+                Box::new(|_| BaseServerStrategy::UnixSocket),
             ))
         } else if client_host.can_connect_to(ClientStrategy::InternalTcpPort(self)) {
             Ok((
                 ClientStrategy::InternalTcpPort(self),
-                Box::new(|_| ServerStrategy::InternalTcpPort),
+                Box::new(|_| BaseServerStrategy::InternalTcpPort),
             ))
         } else if client_host.can_connect_to(ClientStrategy::ForwardedTcpPort(self)) {
             Ok((
@@ -447,8 +437,8 @@ impl Host for AzureHost {
                 Box::new(|me| {
                     me.downcast_ref::<AzureHost>()
                         .unwrap()
-                        .request_port(&ServerStrategy::ExternalTcpPort(22)); // needed to forward
-                    ServerStrategy::InternalTcpPort
+                        .request_port_base(&BaseServerStrategy::ExternalTcpPort(22)); // needed to forward
+                    BaseServerStrategy::InternalTcpPort
                 }),
             ))
         } else {

--- a/hydro_deploy/core/src/custom_service.rs
+++ b/hydro_deploy/core/src/custom_service.rs
@@ -11,7 +11,9 @@ use crate::rust_crate::ports::{
     ReverseSinkInstantiator, RustCrateServer, RustCrateSink, RustCrateSource, ServerConfig,
     SourcePath,
 };
-use crate::{Host, LaunchedHost, ResourceBatch, ResourceResult, ServerStrategy, Service};
+use crate::{
+    BaseServerStrategy, Host, LaunchedHost, ResourceBatch, ResourceResult, ServerStrategy, Service,
+};
 
 /// Represents an unknown, third-party service that is not part of the Hydroflow ecosystem.
 pub struct CustomService {
@@ -35,7 +37,11 @@ impl CustomService {
     }
 
     pub fn declare_client(&self, self_arc: &Arc<RwLock<Self>>) -> CustomClientPort {
-        CustomClientPort::new(Arc::downgrade(self_arc))
+        CustomClientPort::new(Arc::downgrade(self_arc), false)
+    }
+
+    pub fn declare_many_client(&self, self_arc: &Arc<RwLock<Self>>) -> CustomClientPort {
+        CustomClientPort::new(Arc::downgrade(self_arc), true)
     }
 }
 
@@ -49,7 +55,7 @@ impl Service for CustomService {
         let host = &self.on;
 
         for port in self.external_ports.iter() {
-            host.request_port(&ServerStrategy::ExternalTcpPort(*port));
+            host.request_port_base(&BaseServerStrategy::ExternalTcpPort(*port));
         }
     }
 
@@ -77,15 +83,18 @@ impl Service for CustomService {
     }
 }
 
+#[derive(Clone)]
 pub struct CustomClientPort {
     pub on: Weak<RwLock<CustomService>>,
+    many: bool,
     client_port: OnceLock<ServerConfig>,
 }
 
 impl CustomClientPort {
-    pub fn new(on: Weak<RwLock<CustomService>>) -> Self {
+    fn new(on: Weak<RwLock<CustomService>>, many: bool) -> Self {
         Self {
             on,
+            many,
             client_port: OnceLock::new(),
         }
     }
@@ -112,7 +121,11 @@ impl CustomClientPort {
 
 impl RustCrateSource for CustomClientPort {
     fn source_path(&self) -> SourcePath {
-        SourcePath::Direct(self.on.upgrade().unwrap().try_read().unwrap().on.clone())
+        if self.many {
+            SourcePath::Many(self.on.upgrade().unwrap().try_read().unwrap().on.clone())
+        } else {
+            SourcePath::Direct(self.on.upgrade().unwrap().try_read().unwrap().on.clone())
+        }
     }
 
     fn host(&self) -> Arc<dyn Host> {
@@ -164,7 +177,7 @@ impl RustCrateSink for CustomClientPort {
             me.downcast_ref::<CustomClientPort>()
                 .unwrap()
                 .record_server_config(client_port);
-            bind_type(&*server_host)
+            ServerStrategy::Direct(bind_type(&*server_host))
         }))
     }
 }

--- a/hydro_deploy/core/src/gcp.rs
+++ b/hydro_deploy/core/src/gcp.rs
@@ -1,5 +1,6 @@
 use std::any::Any;
 use std::collections::HashMap;
+use std::fmt::Debug;
 use std::sync::{Arc, Mutex, OnceLock};
 
 use anyhow::Result;
@@ -9,12 +10,9 @@ use serde_json::json;
 use tokio::sync::RwLock;
 
 use super::terraform::{TERRAFORM_ALPHABET, TerraformOutput, TerraformProvider};
-use super::{
-    ClientStrategy, Host, HostTargetType, LaunchedHost, ResourceBatch, ResourceResult,
-    ServerStrategy,
-};
-use crate::HostStrategyGetter;
+use super::{ClientStrategy, Host, HostTargetType, LaunchedHost, ResourceBatch, ResourceResult};
 use crate::ssh::LaunchedSshHost;
+use crate::{BaseServerStrategy, HostStrategyGetter};
 
 pub struct LaunchedComputeEngine {
     resource_result: Arc<ResourceResult>,
@@ -184,6 +182,15 @@ pub struct GcpComputeEngineHost {
     external_ports: Mutex<Vec<u16>>,
 }
 
+impl Debug for GcpComputeEngineHost {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!(
+            "GcpComputeEngineHost({} ({:?}))",
+            self.id, &self.display_name
+        ))
+    }
+}
+
 impl GcpComputeEngineHost {
     #[expect(clippy::too_many_arguments, reason = "Mainly for internal use.")]
     pub fn new(
@@ -217,11 +224,11 @@ impl Host for GcpComputeEngineHost {
         HostTargetType::Linux
     }
 
-    fn request_port(&self, bind_type: &ServerStrategy) {
+    fn request_port_base(&self, bind_type: &BaseServerStrategy) {
         match bind_type {
-            ServerStrategy::UnixSocket => {}
-            ServerStrategy::InternalTcpPort => {}
-            ServerStrategy::ExternalTcpPort(port) => {
+            BaseServerStrategy::UnixSocket => {}
+            BaseServerStrategy::InternalTcpPort => {}
+            BaseServerStrategy::ExternalTcpPort(port) => {
                 let mut external_ports = self.external_ports.lock().unwrap();
                 if !external_ports.contains(port) {
                     if self.launched.get().is_some() {
@@ -230,25 +237,11 @@ impl Host for GcpComputeEngineHost {
                     external_ports.push(*port);
                 }
             }
-            ServerStrategy::Demux(demux) => {
-                for bind_type in demux.values() {
-                    self.request_port(bind_type);
-                }
-            }
-            ServerStrategy::Merge(merge) => {
-                for bind_type in merge {
-                    self.request_port(bind_type);
-                }
-            }
-            ServerStrategy::Tagged(underlying, _) => {
-                self.request_port(underlying);
-            }
-            ServerStrategy::Null => {}
         }
     }
 
     fn request_custom_binary(&self) {
-        self.request_port(&ServerStrategy::ExternalTcpPort(22));
+        self.request_port_base(&BaseServerStrategy::ExternalTcpPort(22));
     }
 
     fn id(&self) -> usize {
@@ -477,12 +470,12 @@ impl Host for GcpComputeEngineHost {
         if client_host.can_connect_to(ClientStrategy::UnixSocket(self.id)) {
             Ok((
                 ClientStrategy::UnixSocket(self.id),
-                Box::new(|_| ServerStrategy::UnixSocket),
+                Box::new(|_| BaseServerStrategy::UnixSocket),
             ))
         } else if client_host.can_connect_to(ClientStrategy::InternalTcpPort(self)) {
             Ok((
                 ClientStrategy::InternalTcpPort(self),
-                Box::new(|_| ServerStrategy::InternalTcpPort),
+                Box::new(|_| BaseServerStrategy::InternalTcpPort),
             ))
         } else if client_host.can_connect_to(ClientStrategy::ForwardedTcpPort(self)) {
             Ok((
@@ -490,8 +483,8 @@ impl Host for GcpComputeEngineHost {
                 Box::new(|me| {
                     me.downcast_ref::<GcpComputeEngineHost>()
                         .unwrap()
-                        .request_port(&ServerStrategy::ExternalTcpPort(22)); // needed to forward
-                    ServerStrategy::InternalTcpPort
+                        .request_port_base(&BaseServerStrategy::ExternalTcpPort(22)); // needed to forward
+                    BaseServerStrategy::InternalTcpPort
                 }),
             ))
         } else {

--- a/hydro_deploy/core/src/lib.rs
+++ b/hydro_deploy/core/src/lib.rs
@@ -1,5 +1,6 @@
 use std::any::Any;
 use std::collections::HashMap;
+use std::fmt::Debug;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
@@ -104,7 +105,36 @@ pub trait LaunchedBinary: Send + Sync {
 pub trait LaunchedHost: Send + Sync {
     /// Given a pre-selected network type, computes concrete information needed for a service
     /// to listen to network connections (such as the IP address to bind to).
-    fn server_config(&self, strategy: &ServerStrategy) -> ServerBindConfig;
+    fn base_server_config(&self, strategy: &BaseServerStrategy) -> ServerBindConfig;
+
+    fn server_config(&self, strategy: &ServerStrategy) -> ServerBindConfig {
+        match strategy {
+            ServerStrategy::Direct(b) => self.base_server_config(b),
+            ServerStrategy::Many(b) => {
+                ServerBindConfig::MultiConnection(Box::new(self.base_server_config(b)))
+            }
+            ServerStrategy::Demux(demux) => {
+                let mut config_map = HashMap::new();
+                for (key, underlying) in demux {
+                    config_map.insert(*key, self.server_config(underlying));
+                }
+
+                ServerBindConfig::Demux(config_map)
+            }
+            ServerStrategy::Merge(merge) => {
+                let mut configs = vec![];
+                for underlying in merge {
+                    configs.push(self.server_config(underlying));
+                }
+
+                ServerBindConfig::Merge(configs)
+            }
+            ServerStrategy::Tagged(underlying, id) => {
+                ServerBindConfig::Tagged(Box::new(self.server_config(underlying)), *id)
+            }
+            ServerStrategy::Null => ServerBindConfig::Null,
+        }
+    }
 
     async fn copy_binary(&self, binary: &BuildOutput) -> Result<()>;
 
@@ -119,14 +149,19 @@ pub trait LaunchedHost: Send + Sync {
     async fn forward_port(&self, addr: &SocketAddr) -> Result<SocketAddr>;
 }
 
-/// Types of connections that a host can make to another host.
-pub enum ServerStrategy {
+pub enum BaseServerStrategy {
     UnixSocket,
     InternalTcpPort,
     ExternalTcpPort(
         /// The port number to bind to, which must be explicit to open the firewall.
         u16,
     ),
+}
+
+/// Types of connection that a service can receive when configured as the server.
+pub enum ServerStrategy {
+    Direct(BaseServerStrategy),
+    Many(BaseServerStrategy),
     Demux(HashMap<u32, ServerStrategy>),
     Merge(Vec<ServerStrategy>),
     Tagged(Box<ServerStrategy>, u32),
@@ -155,12 +190,33 @@ pub enum HostTargetType {
     Linux,
 }
 
-pub type HostStrategyGetter = Box<dyn FnOnce(&dyn Any) -> ServerStrategy>;
+pub type HostStrategyGetter = Box<dyn FnOnce(&dyn Any) -> BaseServerStrategy>;
 
-pub trait Host: Any + Send + Sync {
+pub trait Host: Any + Send + Sync + Debug {
     fn target_type(&self) -> HostTargetType;
 
-    fn request_port(&self, bind_type: &ServerStrategy);
+    fn request_port_base(&self, bind_type: &BaseServerStrategy);
+
+    fn request_port(&self, bind_type: &ServerStrategy) {
+        match bind_type {
+            ServerStrategy::Direct(base) => self.request_port_base(base),
+            ServerStrategy::Many(base) => self.request_port_base(base),
+            ServerStrategy::Demux(demux) => {
+                for bind_type in demux.values() {
+                    self.request_port(bind_type);
+                }
+            }
+            ServerStrategy::Merge(merge) => {
+                for bind_type in merge {
+                    self.request_port(bind_type);
+                }
+            }
+            ServerStrategy::Tagged(underlying, _) => {
+                self.request_port(underlying);
+            }
+            ServerStrategy::Null => {}
+        }
+    }
 
     /// An identifier for this host, which is unique within a deployment.
     fn id(&self) -> usize;

--- a/hydro_deploy/core/src/localhost/mod.rs
+++ b/hydro_deploy/core/src/localhost/mod.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
@@ -11,8 +10,8 @@ use crate::progress::ProgressTracker;
 use crate::rust_crate::build::BuildOutput;
 use crate::rust_crate::tracing_options::TracingOptions;
 use crate::{
-    ClientStrategy, Host, HostStrategyGetter, HostTargetType, LaunchedBinary, LaunchedHost,
-    ResourceBatch, ResourceResult, ServerStrategy,
+    BaseServerStrategy, ClientStrategy, Host, HostStrategyGetter, HostTargetType, LaunchedBinary,
+    LaunchedHost, ResourceBatch, ResourceResult,
 };
 
 pub mod launched_binary;
@@ -47,7 +46,7 @@ impl Host for LocalhostHost {
         HostTargetType::Local
     }
 
-    fn request_port(&self, _bind_type: &ServerStrategy) {}
+    fn request_port_base(&self, _bind_type: &BaseServerStrategy) {}
     fn collect_resources(&self, _resource_batch: &mut ResourceBatch) {}
     fn request_custom_binary(&self) {}
 
@@ -74,12 +73,12 @@ impl Host for LocalhostHost {
         if connection_from.can_connect_to(ClientStrategy::UnixSocket(self.id)) {
             Ok((
                 ClientStrategy::UnixSocket(self.id),
-                Box::new(|_| ServerStrategy::UnixSocket),
+                Box::new(|_| BaseServerStrategy::UnixSocket),
             ))
         } else if connection_from.can_connect_to(ClientStrategy::InternalTcpPort(self)) {
             Ok((
                 ClientStrategy::InternalTcpPort(self),
-                Box::new(|_| ServerStrategy::InternalTcpPort),
+                Box::new(|_| BaseServerStrategy::InternalTcpPort),
             ))
         } else {
             anyhow::bail!("Could not find a strategy to connect to localhost")
@@ -110,31 +109,13 @@ struct LaunchedLocalhost;
 
 #[async_trait]
 impl LaunchedHost for LaunchedLocalhost {
-    fn server_config(&self, bind_type: &ServerStrategy) -> ServerBindConfig {
+    fn base_server_config(&self, bind_type: &BaseServerStrategy) -> ServerBindConfig {
         match bind_type {
-            ServerStrategy::UnixSocket => ServerBindConfig::UnixSocket,
-            ServerStrategy::InternalTcpPort => ServerBindConfig::TcpPort("127.0.0.1".to_string()),
-            ServerStrategy::ExternalTcpPort(_) => panic!("Cannot bind to external port"),
-            ServerStrategy::Demux(demux) => {
-                let mut config_map = HashMap::new();
-                for (key, underlying) in demux {
-                    config_map.insert(*key, self.server_config(underlying));
-                }
-
-                ServerBindConfig::Demux(config_map)
+            BaseServerStrategy::UnixSocket => ServerBindConfig::UnixSocket,
+            BaseServerStrategy::InternalTcpPort => {
+                ServerBindConfig::TcpPort("127.0.0.1".to_string())
             }
-            ServerStrategy::Merge(merge) => {
-                let mut configs = vec![];
-                for underlying in merge {
-                    configs.push(self.server_config(underlying));
-                }
-
-                ServerBindConfig::Merge(configs)
-            }
-            ServerStrategy::Tagged(underlying, id) => {
-                ServerBindConfig::Tagged(Box::new(self.server_config(underlying)), *id)
-            }
-            ServerStrategy::Null => ServerBindConfig::Null,
+            BaseServerStrategy::ExternalTcpPort(_) => panic!("Cannot bind to external port"),
         }
     }
 

--- a/hydro_deploy/core/src/rust_crate/ports.rs
+++ b/hydro_deploy/core/src/rust_crate/ports.rs
@@ -1,5 +1,6 @@
 use std::any::Any;
 use std::collections::HashMap;
+use std::fmt::Debug;
 use std::ops::Deref;
 use std::sync::{Arc, Weak};
 
@@ -11,7 +12,7 @@ use hydro_deploy_integration::ServerPort;
 use tokio::sync::RwLock;
 
 use super::RustCrateService;
-use crate::{ClientStrategy, Host, HostStrategyGetter, LaunchedHost, ServerStrategy};
+use crate::{ClientStrategy, Host, LaunchedHost, ServerStrategy};
 
 pub trait RustCrateSource: Send + Sync {
     fn source_path(&self) -> SourcePath;
@@ -41,7 +42,7 @@ pub trait RustCrateSource: Send + Sync {
     }
 }
 
-pub trait RustCrateServer: DynClone + Send + Sync {
+pub trait RustCrateServer: DynClone + Debug + Send + Sync {
     fn get_port(&self) -> ServerPort;
     fn launched_host(&self) -> Arc<dyn LaunchedHost>;
 }
@@ -180,7 +181,7 @@ impl RustCrateSink for DemuxSink {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct RustCratePortConfig {
     pub service: Weak<RwLock<RustCrateService>>,
     pub service_host: Arc<dyn Host>,
@@ -268,6 +269,7 @@ impl RustCrateServer for RustCratePortConfig {
 pub enum SourcePath {
     Null,
     Direct(Arc<dyn Host>),
+    Many(Arc<dyn Host>),
     Tagged(Box<SourcePath>, u32),
 }
 
@@ -276,29 +278,36 @@ impl SourcePath {
         &self,
         server: &T,
         server_host: &dyn Host,
-    ) -> Result<(HostStrategyGetter, ServerConfig)> {
+    ) -> Result<(Box<dyn FnOnce(&dyn Any) -> ServerStrategy>, ServerConfig)> {
         match self {
             SourcePath::Direct(client_host) => {
                 let (conn_type, bind_type) = server_host.strategy_as_server(client_host.deref())?;
                 let base_config = ServerConfig::from_strategy(&conn_type, Arc::new(server.clone()));
-                Ok((bind_type, base_config))
+                Ok((
+                    Box::new(|host| ServerStrategy::Direct(bind_type(host))),
+                    base_config,
+                ))
+            }
+
+            SourcePath::Many(client_host) => {
+                let (conn_type, bind_type) = server_host.strategy_as_server(client_host.deref())?;
+                let base_config = ServerConfig::from_strategy(&conn_type, Arc::new(server.clone()));
+                Ok((
+                    Box::new(|host| ServerStrategy::Many(bind_type(host))),
+                    base_config,
+                ))
             }
 
             SourcePath::Tagged(underlying, tag) => {
                 let (bind_type, base_config) = underlying.plan(server, server_host)?;
                 let tag = *tag;
-                let strategy_getter: HostStrategyGetter =
-                    Box::new(move |host| ServerStrategy::Tagged(Box::new(bind_type(host)), tag));
                 Ok((
-                    strategy_getter,
+                    Box::new(move |host| ServerStrategy::Tagged(Box::new(bind_type(host)), tag)),
                     ServerConfig::TaggedUnwrap(Box::new(base_config)),
                 ))
             }
 
-            SourcePath::Null => {
-                let strategy_getter: HostStrategyGetter = Box::new(|_| ServerStrategy::Null);
-                Ok((strategy_getter, ServerConfig::Null))
-            }
+            SourcePath::Null => Ok((Box::new(|_| ServerStrategy::Null), ServerConfig::Null)),
         }
     }
 }
@@ -378,12 +387,12 @@ impl RustCrateSink for RustCratePortConfig {
                     .insert(port.clone(), client_port);
             };
 
-            (bind_type)(&*client_write.on)
+            ServerStrategy::Direct((bind_type)(&*client_write.on))
         }))
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum ServerConfig {
     Direct(Arc<dyn RustCrateServer>),
     Forwarded(Arc<dyn RustCrateServer>),

--- a/hydro_deploy/core/src/rust_crate/service.rs
+++ b/hydro_deploy/core/src/rust_crate/service.rs
@@ -15,8 +15,8 @@ use super::ports::{self, RustCratePortConfig, RustCrateSink, SourcePath};
 use super::tracing_options::TracingOptions;
 use crate::progress::ProgressTracker;
 use crate::{
-    Host, LaunchedBinary, LaunchedHost, ResourceBatch, ResourceResult, ServerStrategy, Service,
-    TracingResults,
+    BaseServerStrategy, Host, LaunchedBinary, LaunchedHost, ResourceBatch, ResourceResult,
+    ServerStrategy, Service, TracingResults,
 };
 
 pub struct RustCrateService {
@@ -205,7 +205,7 @@ impl Service for RustCrateService {
         }
 
         for port in self.external_ports.iter() {
-            host.request_port(&ServerStrategy::ExternalTcpPort(*port));
+            host.request_port_base(&BaseServerStrategy::ExternalTcpPort(*port));
         }
     }
 

--- a/hydro_deploy/core/src/ssh.rs
+++ b/hydro_deploy/core/src/ssh.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -28,7 +27,7 @@ use crate::rust_crate::build::BuildOutput;
 use crate::rust_crate::flamegraph::handle_fold_data;
 use crate::rust_crate::tracing_options::TracingOptions;
 use crate::util::{PriorityBroadcast, async_retry, prioritized_broadcast};
-use crate::{LaunchedBinary, LaunchedHost, ResourceResult, ServerStrategy, TracingResults};
+use crate::{BaseServerStrategy, LaunchedBinary, LaunchedHost, ResourceResult, TracingResults};
 
 const PERF_OUTFILE: &str = "__profile.perf.data";
 
@@ -222,37 +221,6 @@ pub trait LaunchedSshHost: Send + Sync {
             .join("vm_instance_ssh_key_pem")
     }
 
-    fn server_config(&self, bind_type: &ServerStrategy) -> ServerBindConfig {
-        match bind_type {
-            ServerStrategy::UnixSocket => ServerBindConfig::UnixSocket,
-            ServerStrategy::InternalTcpPort => {
-                ServerBindConfig::TcpPort(self.get_internal_ip().clone())
-            }
-            ServerStrategy::ExternalTcpPort(_) => todo!(),
-            ServerStrategy::Demux(demux) => {
-                let mut config_map = HashMap::new();
-                for (key, underlying) in demux {
-                    config_map.insert(*key, LaunchedSshHost::server_config(self, underlying));
-                }
-
-                ServerBindConfig::Demux(config_map)
-            }
-            ServerStrategy::Merge(merge) => {
-                let mut configs = vec![];
-                for underlying in merge {
-                    configs.push(LaunchedSshHost::server_config(self, underlying));
-                }
-
-                ServerBindConfig::Merge(configs)
-            }
-            ServerStrategy::Tagged(underlying, id) => ServerBindConfig::Tagged(
-                Box::new(LaunchedSshHost::server_config(self, underlying)),
-                *id,
-            ),
-            ServerStrategy::Null => ServerBindConfig::Null,
-        }
-    }
-
     async fn open_ssh_session(&self) -> Result<AsyncSession<NoCheckHandler>> {
         let target_addr = SocketAddr::new(
             self.get_external_ip()
@@ -314,8 +282,14 @@ where
 
 #[async_trait]
 impl<T: LaunchedSshHost> LaunchedHost for T {
-    fn server_config(&self, bind_type: &ServerStrategy) -> ServerBindConfig {
-        LaunchedSshHost::server_config(self, bind_type)
+    fn base_server_config(&self, bind_type: &BaseServerStrategy) -> ServerBindConfig {
+        match bind_type {
+            BaseServerStrategy::UnixSocket => ServerBindConfig::UnixSocket,
+            BaseServerStrategy::InternalTcpPort => {
+                ServerBindConfig::TcpPort(self.get_internal_ip().clone())
+            }
+            BaseServerStrategy::ExternalTcpPort(_) => todo!(),
+        }
     }
 
     async fn copy_binary(&self, binary: &BuildOutput) -> Result<()> {

--- a/hydro_deploy/hydro_deploy_integration/src/lib.rs
+++ b/hydro_deploy/hydro_deploy_integration/src/lib.rs
@@ -12,16 +12,17 @@ use async_trait::async_trait;
 use bytes::{Bytes, BytesMut};
 use futures::sink::Buffer;
 use futures::stream::FuturesUnordered;
-use futures::{Future, Sink, SinkExt, Stream, ready, stream};
+use futures::{Future, Sink, SinkExt, Stream, StreamExt, ready, stream};
 use pin_project_lite::pin_project;
 use serde::{Deserialize, Serialize};
 use tokio::io;
 use tokio::net::{TcpListener, TcpStream};
 #[cfg(unix)]
 use tokio::net::{UnixListener, UnixStream};
-use tokio_stream::StreamExt;
 use tokio_stream::wrappers::TcpListenerStream;
 use tokio_util::codec::{Framed, LengthDelimitedCodec};
+
+pub mod multi_connection;
 
 pub type InitConfig = (HashMap<String, ServerBindConfig>, Option<String>);
 
@@ -139,6 +140,7 @@ pub enum ServerBindConfig {
     Demux(HashMap<u32, ServerBindConfig>),
     Merge(Vec<ServerBindConfig>),
     Tagged(Box<ServerBindConfig>, u32),
+    MultiConnection(Box<ServerBindConfig>),
     Null,
 }
 
@@ -181,6 +183,9 @@ impl ServerBindConfig {
             }
             ServerBindConfig::Tagged(underlying, id) => {
                 BoundServer::Tagged(Box::new(underlying.bind().await), id)
+            }
+            ServerBindConfig::MultiConnection(underlying) => {
+                BoundServer::MultiConnection(Box::new(underlying.bind().await))
             }
             ServerBindConfig::Null => BoundServer::Null,
         }
@@ -231,6 +236,16 @@ pub trait ConnectedSource {
     fn into_source(self) -> Self::Stream;
 }
 
+pub trait ConnectedSourceSink {
+    type Output: Send;
+    type Stream: Stream<Item = Result<Self::Output, io::Error>> + Send + Sync;
+
+    type Input: Send;
+    type Sink: Sink<Self::Input, Error = io::Error> + Send + Sync;
+
+    fn into_source_sink(self) -> (Self::Stream, Self::Sink);
+}
+
 #[derive(Debug)]
 pub enum BoundServer {
     UnixSocket(UnixListener, tempfile::TempDir),
@@ -238,6 +253,7 @@ pub enum BoundServer {
     Demux(HashMap<u32, BoundServer>),
     Merge(Vec<BoundServer>),
     Tagged(Box<BoundServer>, u32),
+    MultiConnection(Box<BoundServer>),
     Null,
 }
 
@@ -248,6 +264,7 @@ pub enum AcceptedServer {
     Demux(HashMap<u32, AcceptedServer>),
     Merge(Vec<AcceptedServer>),
     Tagged(Box<AcceptedServer>, u32),
+    MultiConnection(Box<BoundServer>),
     Null,
 }
 
@@ -258,7 +275,6 @@ pub async fn accept_bound(bound: BoundServer) -> AcceptedServer {
             #[cfg(unix)]
             {
                 let stream = listener.accept().await.unwrap().0;
-                eprintln!("accepted");
                 AcceptedServer::UnixSocket(stream)
             }
 
@@ -293,6 +309,7 @@ pub async fn accept_bound(bound: BoundServer) -> AcceptedServer {
         BoundServer::Tagged(underlying, id) => {
             AcceptedServer::Tagged(Box::new(accept_bound(*underlying).await), id)
         }
+        BoundServer::MultiConnection(underlying) => AcceptedServer::MultiConnection(underlying),
         BoundServer::Null => AcceptedServer::Null,
     }
 }
@@ -335,6 +352,8 @@ impl BoundServer {
             BoundServer::Tagged(underlying, id) => {
                 ServerPort::Tagged(Box::new(underlying.server_port()), *id)
             }
+
+            BoundServer::MultiConnection(underlying) => underlying.server_port(),
 
             BoundServer::Null => ServerPort::Null,
         }
@@ -383,6 +402,9 @@ fn accept(bound: AcceptedServer) -> ConnectedDirect {
         }
         AcceptedServer::Demux(_) => panic!("Cannot connect to a demux pipe directly"),
         AcceptedServer::Tagged(_, _) => panic!("Cannot connect to a tagged pipe directly"),
+        AcceptedServer::MultiConnection(_) => {
+            panic!("Cannot connect to a multi-connection pipe directly")
+        }
         AcceptedServer::Null => {
             ConnectedDirect::from_defn(Connection::AsClient(ClientConnection::Null))
         }

--- a/hydro_deploy/hydro_deploy_integration/src/multi_connection.rs
+++ b/hydro_deploy/hydro_deploy_integration/src/multi_connection.rs
@@ -1,0 +1,315 @@
+use std::collections::HashMap;
+use std::io;
+use std::ops::DerefMut;
+use std::pin::Pin;
+use std::task::{Context, Poll, ready};
+
+use bytes::{Bytes, BytesMut};
+use futures::{Sink, SinkExt, Stream, StreamExt};
+use tokio::net::TcpListener;
+#[cfg(unix)]
+use tokio::net::UnixListener;
+use tokio::sync::mpsc;
+
+use crate::{AcceptedServer, BoundServer, Connected, ConnectedSourceSink, Connection, tcp_bytes};
+
+pub struct ConnectedMultiConnection {
+    source: Pin<Box<dyn Stream<Item = Result<(u64, BytesMut), io::Error>> + Send + Sync>>,
+    sink: Pin<Box<dyn Sink<(u64, Bytes), Error = io::Error> + Send + Sync>>,
+}
+
+impl Connected for ConnectedMultiConnection {
+    fn from_defn(pipe: Connection) -> Self {
+        match pipe {
+            Connection::AsServer(AcceptedServer::MultiConnection(bound_server)) => {
+                let (source, sink) = MultiConnectionStream::new(*bound_server);
+                ConnectedMultiConnection {
+                    source: Box::pin(source),
+                    sink: Box::pin(sink),
+                }
+            }
+            _ => panic!("Cannot connect to a non-multi-connection pipe as a multi-connection"),
+        }
+    }
+}
+
+impl ConnectedSourceSink for ConnectedMultiConnection {
+    type Output = (u64, BytesMut);
+    type Stream = Pin<Box<dyn Stream<Item = Result<Self::Output, io::Error>> + Send + Sync>>;
+
+    type Input = (u64, Bytes);
+    type Sink = Pin<Box<dyn Sink<Self::Input, Error = io::Error> + Send + Sync>>;
+
+    fn into_source_sink(self) -> (Self::Stream, Self::Sink) {
+        (self.source, self.sink)
+    }
+}
+
+type NewSinkSender = mpsc::UnboundedSender<(
+    u64,
+    Pin<Box<dyn Sink<Bytes, Error = io::Error> + Send + Sync>>,
+)>;
+type NewSinkReceiver = mpsc::UnboundedReceiver<(
+    u64,
+    Pin<Box<dyn Sink<Bytes, Error = io::Error> + Send + Sync>>,
+)>;
+type ConnectionMap = HashMap<u64, Pin<Box<dyn Sink<Bytes, Error = io::Error> + Send + Sync>>>;
+
+struct MultiConnectionSource {
+    #[cfg(unix)]
+    unix_listener: Option<UnixListener>,
+    tcp_listener: Option<TcpListener>,
+    next_connection_id: u64,
+    active_connections:
+        HashMap<u64, Pin<Box<dyn Stream<Item = Result<BytesMut, io::Error>> + Send + Sync>>>,
+    new_sink_sender: NewSinkSender,
+}
+
+struct MultiConnectionSink {
+    connection_sinks: ConnectionMap,
+    new_sink_receiver: NewSinkReceiver,
+}
+
+struct MultiConnectionStream;
+
+impl MultiConnectionStream {
+    fn new(bound_server: BoundServer) -> (MultiConnectionSource, MultiConnectionSink) {
+        let (new_sink_sender, new_sink_receiver) = mpsc::unbounded_channel();
+
+        let source = match bound_server {
+            #[cfg(unix)]
+            BoundServer::UnixSocket(listener, _) => MultiConnectionSource {
+                unix_listener: Some(listener),
+                tcp_listener: None,
+                next_connection_id: 0,
+                active_connections: HashMap::new(),
+                new_sink_sender,
+            },
+            BoundServer::TcpPort(listener, _) => MultiConnectionSource {
+                #[cfg(unix)]
+                unix_listener: None,
+                tcp_listener: Some(listener.into_inner()),
+                next_connection_id: 0,
+                active_connections: HashMap::new(),
+                new_sink_sender,
+            },
+            _ => panic!("MultiConnection only supports UnixSocket and TcpPort"),
+        };
+
+        let sink = MultiConnectionSink {
+            connection_sinks: HashMap::new(),
+            new_sink_receiver,
+        };
+
+        (source, sink)
+    }
+}
+
+impl Stream for MultiConnectionSource {
+    type Item = Result<(u64, BytesMut), io::Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let me = self.deref_mut();
+        // Handle Unix socket accepts
+        #[cfg(unix)]
+        if let Some(listener) = me.unix_listener.as_mut() {
+            loop {
+                match listener.poll_accept(cx) {
+                    Poll::Ready(Ok((stream, _))) => {
+                        use futures::{SinkExt, StreamExt};
+
+                        use crate::unix_bytes;
+
+                        let connection_id = me.next_connection_id;
+                        me.next_connection_id += 1;
+
+                        let framed = unix_bytes(stream);
+                        let (sink, stream) = framed.split();
+
+                        let boxed_stream: Pin<
+                            Box<dyn Stream<Item = Result<BytesMut, io::Error>> + Send + Sync>,
+                        > = Box::pin(stream);
+
+                        // Buffer so that a stalled output does not prevent sending to others
+                        let boxed_sink: Pin<Box<dyn Sink<Bytes, Error = io::Error> + Send + Sync>> =
+                            Box::pin(sink.buffer(1024));
+
+                        me.active_connections.insert(connection_id, boxed_stream);
+
+                        let _ = me.new_sink_sender.send((connection_id, boxed_sink));
+                    }
+                    Poll::Ready(Err(e)) => {
+                        if me.active_connections.is_empty() {
+                            return Poll::Ready(Some(Err(e)));
+                        }
+                    }
+                    Poll::Pending => {
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Handle TCP socket accepts
+        if let Some(listener) = me.tcp_listener.as_mut() {
+            loop {
+                match listener.poll_accept(cx) {
+                    Poll::Ready(Ok((stream, _))) => {
+                        let connection_id = me.next_connection_id;
+                        me.next_connection_id += 1;
+
+                        let framed = tcp_bytes(stream);
+                        let (sink, stream) = framed.split();
+
+                        let boxed_stream: Pin<
+                            Box<dyn Stream<Item = Result<BytesMut, io::Error>> + Send + Sync>,
+                        > = Box::pin(stream);
+                        let boxed_sink: Pin<Box<dyn Sink<Bytes, Error = io::Error> + Send + Sync>> =
+                            Box::pin(sink.buffer(1024));
+
+                        me.active_connections.insert(connection_id, boxed_stream);
+
+                        let _ = me.new_sink_sender.send((connection_id, boxed_sink));
+                    }
+                    Poll::Ready(Err(e)) => {
+                        if me.active_connections.is_empty() {
+                            return Poll::Ready(Some(Err(e)));
+                        }
+                    }
+                    Poll::Pending => {
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Poll all active connections for data
+        let mut connections_to_remove = Vec::new();
+        let mut out = Poll::Pending;
+        for (&connection_id, stream) in self.active_connections.iter_mut() {
+            match stream.as_mut().poll_next(cx) {
+                Poll::Ready(Some(Ok(data))) => {
+                    out = Poll::Ready(Some(Ok((connection_id, data))));
+                    break;
+                }
+                Poll::Ready(Some(Err(_))) | Poll::Ready(None) => {
+                    connections_to_remove.push(connection_id);
+                }
+                Poll::Pending => {}
+            }
+        }
+
+        for connection_id in connections_to_remove {
+            self.active_connections.remove(&connection_id);
+        }
+
+        out
+    }
+}
+
+impl Sink<(u64, Bytes)> for MultiConnectionSink {
+    type Error = io::Error;
+
+    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // Poll for new sinks
+        loop {
+            match self.new_sink_receiver.poll_recv(cx) {
+                Poll::Ready(Some((connection_id, sink))) => {
+                    self.connection_sinks.insert(connection_id, sink);
+                }
+                Poll::Ready(None) => {
+                    if self.connection_sinks.is_empty() {
+                        return Poll::Ready(Err(io::Error::new(
+                            io::ErrorKind::BrokenPipe,
+                            "No additional sinks are available (was the stream dropped)?",
+                        )));
+                    } else {
+                        break;
+                    }
+                }
+                Poll::Pending => {}
+            }
+        }
+
+        // Check if all sinks are ready, removing any that are closed
+        let mut closed_connections = Vec::new();
+        for (&connection_id, sink) in self.connection_sinks.iter_mut() {
+            match ready!(sink.as_mut().poll_ready(cx)) {
+                Ok(()) => {}
+                Err(_) => {
+                    closed_connections.push(connection_id);
+                }
+            }
+        }
+
+        for connection_id in closed_connections {
+            self.connection_sinks.remove(&connection_id);
+        }
+
+        Poll::Ready(Ok(())) // always ready, because we drop messages if there is no sink
+    }
+
+    fn start_send(mut self: Pin<&mut Self>, item: (u64, Bytes)) -> Result<(), Self::Error> {
+        if let Some(sink) = self.connection_sinks.get_mut(&item.0) {
+            let _ = sink.as_mut().start_send(item.1); // silently ignore send errors
+        }
+        // If connection doesn't exist, silently drop (connection may have closed)
+        Ok(())
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        let mut closed_connections = Vec::new();
+        let mut any_pending = false;
+
+        for (&connection_id, sink) in self.connection_sinks.iter_mut() {
+            match sink.as_mut().poll_flush(cx) {
+                Poll::Ready(Ok(())) => {}
+                Poll::Ready(Err(_)) => {
+                    closed_connections.push(connection_id);
+                }
+                Poll::Pending => {
+                    any_pending = true;
+                }
+            }
+        }
+
+        for connection_id in closed_connections {
+            self.connection_sinks.remove(&connection_id);
+        }
+
+        if any_pending {
+            Poll::Pending
+        } else {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        let mut closed_connections = Vec::new();
+        let mut any_pending = false;
+
+        for (&connection_id, sink) in self.connection_sinks.iter_mut() {
+            match sink.as_mut().poll_close(cx) {
+                Poll::Ready(Ok(())) => {
+                    closed_connections.push(connection_id);
+                }
+                Poll::Ready(Err(_)) => {
+                    closed_connections.push(connection_id);
+                }
+                Poll::Pending => {
+                    any_pending = true;
+                }
+            }
+        }
+
+        for connection_id in closed_connections {
+            self.connection_sinks.remove(&connection_id);
+        }
+
+        if any_pending {
+            Poll::Pending
+        } else {
+            Poll::Ready(Ok(()))
+        }
+    }
+}

--- a/hydro_lang/Cargo.toml
+++ b/hydro_lang/Cargo.toml
@@ -32,7 +32,7 @@ deploy = [
     "dep:stageleft_tool",
     "dep:nameof",
 ]
-build = ["dep:dfir_lang", "dep:backtrace"]
+build = ["dep:dfir_lang", "dep:backtrace", "dep:ctor"]
 runtime_measure = ["dep:chrono", "dep:procfs"]
 runtime_support = ["dep:dfir_rs", "dfir_rs/deploy_integration"]
 dfir_context = ["dep:dfir_rs"]
@@ -73,6 +73,8 @@ tokio-stream = { version = "0.1.3", default-features = false, features = [
 ] }
 toml = { version = "0.8.0", optional = true }
 trybuild-internals-api = { version = "1.0.99", optional = true }
+
+ctor = { version = "0.2", optional = true }
 
 # Optional dependencies for graph rendering (now behind viz feature)
 auto_impl = { version = "1.2.0", optional = true }

--- a/hydro_lang/src/builder/deploy.rs
+++ b/hydro_lang/src/builder/deploy.rs
@@ -364,9 +364,9 @@ impl<'a, D: Deploy<'a>> DeployResult<'a, D> {
             .raw_port(port.port_id)
     }
 
-    pub async fn connect_sink_bytes(
+    pub async fn connect_sink_bytes<M>(
         &self,
-        port: ExternalBytesPort,
+        port: ExternalBytesPort<M>,
     ) -> Pin<Box<dyn Sink<Bytes, Error = Error>>> {
         self.externals
             .get(&port.process_id)
@@ -375,9 +375,9 @@ impl<'a, D: Deploy<'a>> DeployResult<'a, D> {
             .await
     }
 
-    pub async fn connect_sink_bincode<T: Serialize + DeserializeOwned + 'static>(
+    pub async fn connect_sink_bincode<T: Serialize + DeserializeOwned + 'static, Many>(
         &self,
-        port: ExternalBincodeSink<T>,
+        port: ExternalBincodeSink<T, Many>,
     ) -> Pin<Box<dyn Sink<T, Error = Error>>> {
         self.externals
             .get(&port.process_id)

--- a/hydro_lang/src/deploy/deploy_graph.rs
+++ b/hydro_lang/src/deploy/deploy_graph.rs
@@ -271,6 +271,7 @@ impl<'a> Deploy<'a> for HydroDeploy {
         p1_port: &Self::Port,
         _p2: &Self::Process,
         p2_port: &Self::Port,
+        many: bool,
     ) -> syn::Expr {
         let p1_port = p1_port.as_str();
         let p2_port = p2_port.as_str();
@@ -278,6 +279,7 @@ impl<'a> Deploy<'a> for HydroDeploy {
             RuntimeData::new("__hydro_lang_trybuild_cli"),
             p1_port,
             p2_port,
+            many,
         )
     }
 
@@ -286,6 +288,7 @@ impl<'a> Deploy<'a> for HydroDeploy {
         p1_port: &Self::Port,
         p2: &Self::Process,
         p2_port: &Self::Port,
+        many: bool,
     ) -> Box<dyn FnOnce()> {
         let p1 = p1.clone();
         let p1_port = p1_port.clone();
@@ -295,10 +298,17 @@ impl<'a> Deploy<'a> for HydroDeploy {
         Box::new(move || {
             let self_underlying_borrow = p1.underlying.borrow();
             let self_underlying = self_underlying_borrow.as_ref().unwrap();
-            let source_port = self_underlying
-                .try_read()
-                .unwrap()
-                .declare_client(self_underlying);
+            let source_port = if many {
+                self_underlying
+                    .try_read()
+                    .unwrap()
+                    .declare_many_client(self_underlying)
+            } else {
+                self_underlying
+                    .try_read()
+                    .unwrap()
+                    .declare_client(self_underlying)
+            };
 
             let other_underlying_borrow = p2.underlying.borrow();
             let other_underlying = other_underlying_borrow.as_ref().unwrap();
@@ -573,9 +583,10 @@ impl<'a> RegisterPort<'a, HydroDeploy> for DeployExternal {
 
     fn raw_port(&self, key: usize) -> <HydroDeploy as Deploy>::ExternalRawPort {
         self.client_ports
-            .borrow_mut()
-            .remove(self.allocated_ports.borrow().get(&key).unwrap())
+            .borrow()
+            .get(self.allocated_ports.borrow().get(&key).unwrap())
             .unwrap()
+            .clone()
     }
 
     fn as_bytes_sink(

--- a/hydro_lang/src/deploy/mod.rs
+++ b/hydro_lang/src/deploy/mod.rs
@@ -129,12 +129,14 @@ pub trait Deploy<'a> {
         p1_port: &Self::Port,
         p2: &Self::Process,
         p2_port: &Self::Port,
+        many: bool,
     ) -> syn::Expr;
     fn e2o_connect(
         p1: &Self::External,
         p1_port: &Self::Port,
         p2: &Self::Process,
         p2_port: &Self::Port,
+        many: bool,
     ) -> Box<dyn FnOnce()>;
 
     fn o2e_sink(

--- a/hydro_lang/src/deploy_runtime.rs
+++ b/hydro_lang/src/deploy_runtime.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 
+use hydro_deploy_integration::multi_connection::ConnectedMultiConnection;
 use hydro_deploy_integration::{
-    ConnectedDemux, ConnectedDirect, ConnectedSink, ConnectedSource, ConnectedTagged, DeployPorts,
+    ConnectedDemux, ConnectedDirect, ConnectedSink, ConnectedSource, ConnectedSourceSink,
+    ConnectedTagged, DeployPorts,
 };
 use serde::{Deserialize, Serialize};
 use stageleft::{QuotedWithContext, RuntimeData, q};
@@ -114,8 +116,18 @@ pub fn deploy_e2o(
     env: RuntimeData<&DeployPorts<HydroMeta>>,
     _e1_port: &str,
     p2_port: &str,
+    many: bool,
 ) -> syn::Expr {
-    q!(env.port(p2_port).connect::<ConnectedDirect>().into_source()).splice_untyped_ctx(&())
+    if many {
+        q!(env
+            .port(p2_port)
+            .connect::<ConnectedMultiConnection>()
+            .into_source_sink()
+            .0)
+        .splice_untyped_ctx(&())
+    } else {
+        q!(env.port(p2_port).connect::<ConnectedDirect>().into_source()).splice_untyped_ctx(&())
+    }
 }
 
 pub fn deploy_o2e(

--- a/hydro_lang/src/graph/render.rs
+++ b/hydro_lang/src/graph/render.rs
@@ -277,7 +277,6 @@ fn extract_location_id(metadata: &crate::ir::HydroIrMetadata) -> (Option<usize>,
     match &metadata.location_kind {
         LocationId::Process(id) => (Some(*id), Some("Process".to_string())),
         LocationId::Cluster(id) => (Some(*id), Some("Cluster".to_string())),
-        LocationId::External(id) => (Some(*id), Some("External".to_string())),
         LocationId::Tick(_, inner) => match inner.as_ref() {
             LocationId::Process(id) => (Some(*id), Some("Process".to_string())),
             LocationId::Cluster(id) => (Some(*id), Some("Cluster".to_string())),
@@ -384,12 +383,12 @@ impl HydroLeaf {
             seen_tees: &mut HashMap<*const std::cell::RefCell<HydroNode>, usize>,
             config: &HydroWriteConfig,
             input: &HydroNode,
-            metadata: &crate::ir::HydroIrMetadata,
+            metadata: Option<&crate::ir::HydroIrMetadata>,
             label: NodeLabel,
             edge_type: HydroEdgeType,
         ) -> usize {
             let input_id = input.build_graph_structure(structure, seen_tees, config);
-            let location_id = setup_location(structure, metadata);
+            let location_id = metadata.and_then(|m| setup_location(structure, m));
             let sink_id = structure.add_node(label, HydroNodeType::Sink, location_id);
             structure.add_edge(input_id, sink_id, edge_type, None);
             sink_id
@@ -402,14 +401,28 @@ impl HydroLeaf {
                 seen_tees,
                 config,
                 input,
-                metadata,
+                Some(metadata),
                 NodeLabel::with_exprs("for_each".to_string(), vec![f.clone()]),
                 HydroEdgeType::Stream,
             ),
 
-            HydroLeaf::SendExternal { input, .. } => {
-                input.build_graph_structure(structure, seen_tees, config)
-            }
+            HydroLeaf::SendExternal {
+                to_external_id,
+                to_key,
+                input,
+                ..
+            } => build_sink_node(
+                structure,
+                seen_tees,
+                config,
+                input,
+                None,
+                NodeLabel::with_exprs(
+                    format!("send_external({}:{})", to_external_id, to_key),
+                    vec![],
+                ),
+                HydroEdgeType::Stream,
+            ),
 
             HydroLeaf::DestSink {
                 sink,
@@ -420,7 +433,7 @@ impl HydroLeaf {
                 seen_tees,
                 config,
                 input,
-                metadata,
+                Some(metadata),
                 NodeLabel::with_exprs("dest_sink".to_string(), vec![sink.clone()]),
                 HydroEdgeType::Stream,
             ),
@@ -436,7 +449,7 @@ impl HydroLeaf {
                 seen_tees,
                 config,
                 input,
-                metadata,
+                Some(metadata),
                 NodeLabel::static_label(format!("cycle_sink({})", ident)),
                 HydroEdgeType::Cycle,
             ),
@@ -561,9 +574,16 @@ impl HydroNode {
                 build_source_node(structure, metadata, label)
             }
 
-            HydroNode::ExternalInput { metadata, .. } => {
-                build_source_node(structure, metadata, "external_network()".to_string())
-            }
+            HydroNode::ExternalInput {
+                from_external_id,
+                from_key,
+                metadata,
+                ..
+            } => build_source_node(
+                structure,
+                metadata,
+                format!("external_input({}:{})", from_external_id, from_key),
+            ),
 
             HydroNode::CycleSource {
                 ident, metadata, ..
@@ -816,10 +836,6 @@ impl HydroNode {
                     }
                     LocationId::Cluster(id) => {
                         structure.add_location(*id, "Cluster".to_string());
-                        Some(*id)
-                    }
-                    LocationId::External(id) => {
-                        structure.add_location(*id, "External".to_string());
                         Some(*id)
                     }
                     _ => None,

--- a/hydro_lang/src/ir.rs
+++ b/hydro_lang/src/ir.rs
@@ -328,9 +328,8 @@ pub enum HydroLeaf {
         metadata: HydroIrMetadata,
     },
     SendExternal {
-        from_key: Option<usize>,
-        to_location: usize,
-        to_key: Option<usize>,
+        to_external_id: usize,
+        to_key: usize,
         serialize_fn: Option<DebugExpr>,
         instantiate_fn: DebugInstantiate,
         input: Box<HydroNode>,
@@ -363,24 +362,47 @@ impl HydroLeaf {
             &mut |l| {
                 if let HydroLeaf::SendExternal {
                     input,
-                    from_key,
-                    to_location,
+                    to_external_id,
                     to_key,
                     instantiate_fn,
                     ..
                 } = l
                 {
-                    let (sink_expr, source_expr, connect_fn) = match instantiate_fn {
-                        DebugInstantiate::Building => instantiate_network::<D>(
-                            input.metadata().location_kind.root(),
-                            *from_key,
-                            &LocationId::External(*to_location),
-                            *to_key,
-                            processes,
-                            clusters,
-                            externals,
-                            compile_env,
-                        ),
+                    let ((sink_expr, source_expr), connect_fn) = match instantiate_fn {
+                        DebugInstantiate::Building => {
+                            let to_node = externals
+                                .get(to_external_id)
+                                .unwrap_or_else(|| {
+                                    panic!("A external used in the graph was not instantiated: {}", to_external_id)
+                                })
+                                .clone();
+
+                            match input.metadata().location_kind.root() {
+                                LocationId::Process(process_id) => {
+                                    let from_node = processes
+                                        .get(process_id)
+                                        .unwrap_or_else(|| {
+                                            panic!("A process used in the graph was not instantiated: {}", process_id)
+                                        })
+                                        .clone();
+
+                                    let sink_port = D::allocate_process_port(&from_node);
+                                    let source_port = D::allocate_external_port(&to_node);
+
+                                    to_node.register(*to_key, source_port.clone());
+
+                                    (
+                                        (
+                                            D::o2e_sink(compile_env, &from_node, &sink_port, &to_node, &source_port),
+                                            parse_quote!(DUMMY),
+                                        ),
+                                        D::o2e_connect(&from_node, &sink_port, &to_node, &source_port),
+                                    )
+                                }
+                                LocationId::Cluster(_) => todo!(),
+                                _ => panic!()
+                            }
+                        },
 
                         DebugInstantiate::Finalized(_) => panic!("network already finalized"),
                     };
@@ -396,8 +418,6 @@ impl HydroLeaf {
             &mut |n| {
                 if let HydroNode::Network {
                     input,
-                    from_key,
-                    to_key,
                     instantiate_fn,
                     metadata,
                     ..
@@ -406,12 +426,9 @@ impl HydroLeaf {
                     let (sink_expr, source_expr, connect_fn) = match instantiate_fn {
                         DebugInstantiate::Building => instantiate_network::<D>(
                             input.metadata().location_kind.root(),
-                            *from_key,
                             metadata.location_kind.root(),
-                            *to_key,
                             processes,
                             clusters,
-                            externals,
                             compile_env,
                         ),
 
@@ -425,25 +442,51 @@ impl HydroLeaf {
                     }
                     .into();
                 } else if let HydroNode::ExternalInput {
-                    from_location,
+                    from_external_id,
                     from_key,
-                    to_key,
                     instantiate_fn,
                     metadata,
                     ..
                 } = n
                 {
-                    let (sink_expr, source_expr, connect_fn) = match instantiate_fn {
-                        DebugInstantiate::Building => instantiate_network::<D>(
-                            from_location,
-                            *from_key,
-                            &metadata.location_kind,
-                            *to_key,
-                            processes,
-                            clusters,
-                            externals,
-                            compile_env,
-                        ),
+                    let ((sink_expr, source_expr), connect_fn) = match instantiate_fn {
+                        DebugInstantiate::Building => {
+                            let from_node = externals
+                                .get(from_external_id)
+                                .unwrap_or_else(|| {
+                                    panic!(
+                                        "A external used in the graph was not instantiated: {}",
+                                        from_external_id
+                                    )
+                                })
+                                .clone();
+
+                            match metadata.location_kind.root() {
+                                LocationId::Process(process_id) => {
+                                    let to_node = processes
+                                        .get(process_id)
+                                        .unwrap_or_else(|| {
+                                            panic!("A process used in the graph was not instantiated: {}", process_id)
+                                        })
+                                        .clone();
+
+                                    let sink_port = D::allocate_external_port(&from_node);
+                                    let source_port = D::allocate_process_port(&to_node);
+
+                                    from_node.register(*from_key, sink_port.clone());
+
+                                    (
+                                        (
+                                            parse_quote!(DUMMY),
+                                            D::e2o_source(compile_env, &from_node, &sink_port, &to_node, &source_port),
+                                        ),
+                                        D::e2o_connect(&from_node, &sink_port, &to_node, &source_port),
+                                    )
+                                }
+                                LocationId::Cluster(_) => todo!(),
+                                _ => panic!()
+                            }
+                        },
 
                         DebugInstantiate::Finalized(_) => panic!("network already finalized"),
                     };
@@ -513,12 +556,10 @@ impl HydroLeaf {
         seen_tees: &mut SeenTees,
     ) {
         match self {
-            HydroLeaf::ForEach { f: _, input, .. }
+            HydroLeaf::ForEach { input, .. }
             | HydroLeaf::SendExternal { input, .. }
-            | HydroLeaf::DestSink { sink: _, input, .. }
-            | HydroLeaf::CycleSink {
-                ident: _, input, ..
-            } => {
+            | HydroLeaf::DestSink { input, .. }
+            | HydroLeaf::CycleSink { input, .. } => {
                 transform(input, seen_tees);
             }
         }
@@ -532,15 +573,13 @@ impl HydroLeaf {
                 metadata: metadata.clone(),
             },
             HydroLeaf::SendExternal {
-                from_key,
-                to_location,
+                to_external_id,
                 to_key,
                 serialize_fn,
                 instantiate_fn,
                 input,
             } => HydroLeaf::SendExternal {
-                from_key: *from_key,
-                to_location: *to_location,
+                to_external_id: *to_external_id,
                 to_key: *to_key,
                 serialize_fn: serialize_fn.clone(),
                 instantiate_fn: instantiate_fn.clone(),
@@ -1081,8 +1120,6 @@ pub enum HydroNode {
     },
 
     Network {
-        from_key: Option<usize>,
-        to_key: Option<usize>,
         serialize_fn: Option<DebugExpr>,
         instantiate_fn: DebugInstantiate,
         deserialize_fn: Option<DebugExpr>,
@@ -1091,9 +1128,8 @@ pub enum HydroNode {
     },
 
     ExternalInput {
-        from_location: LocationId,
-        from_key: Option<usize>,
-        to_key: Option<usize>,
+        from_external_id: usize,
+        from_key: usize,
         instantiate_fn: DebugInstantiate,
         deserialize_fn: Option<DebugExpr>,
         metadata: HydroIrMetadata,
@@ -1400,16 +1436,12 @@ impl HydroNode {
                 metadata: metadata.clone(),
             },
             HydroNode::Network {
-                from_key,
-                to_key,
                 serialize_fn,
                 instantiate_fn,
                 deserialize_fn,
                 input,
                 metadata,
             } => HydroNode::Network {
-                from_key: *from_key,
-                to_key: *to_key,
                 serialize_fn: serialize_fn.clone(),
                 instantiate_fn: instantiate_fn.clone(),
                 deserialize_fn: deserialize_fn.clone(),
@@ -1417,16 +1449,14 @@ impl HydroNode {
                 metadata: metadata.clone(),
             },
             HydroNode::ExternalInput {
-                from_location,
+                from_external_id,
                 from_key,
-                to_key,
                 instantiate_fn,
                 deserialize_fn,
                 metadata,
             } => HydroNode::ExternalInput {
-                from_location: from_location.clone(),
+                from_external_id: *from_external_id,
                 from_key: *from_key,
-                to_key: *to_key,
                 instantiate_fn: instantiate_fn.clone(),
                 deserialize_fn: deserialize_fn.clone(),
                 metadata: metadata.clone(),
@@ -1525,12 +1555,7 @@ impl HydroNode {
             HydroNode::Source {
                 source, metadata, ..
             } => {
-                let location_id = match metadata.location_kind.root().clone() {
-                    LocationId::Process(id) => id,
-                    LocationId::Cluster(id) => id,
-                    LocationId::Tick(_, _) => panic!(),
-                    LocationId::External(id) => id,
-                };
+                let location_id = metadata.location_kind.root().raw_id();
 
                 if let HydroSource::ExternalNetwork() = source {
                     (syn::Ident::new("DUMMY", Span::call_site()), location_id)
@@ -2262,8 +2287,6 @@ impl HydroNode {
             }
 
             HydroNode::Network {
-                from_key: _,
-                to_key: _,
                 serialize_fn: serialize_pipeline,
                 instantiate_fn,
                 deserialize_fn: deserialize_pipeline,
@@ -2338,8 +2361,6 @@ impl HydroNode {
             }
 
             HydroNode::ExternalInput {
-                from_key: _,
-                to_key: _,
                 instantiate_fn,
                 deserialize_fn: deserialize_pipeline,
                 metadata,
@@ -2685,15 +2706,11 @@ impl HydroNode {
 }
 
 #[cfg(feature = "build")]
-#[expect(clippy::too_many_arguments, reason = "networking internals")]
 fn instantiate_network<'a, D>(
     from_location: &LocationId,
-    from_key: Option<usize>,
     to_location: &LocationId,
-    to_key: Option<usize>,
     processes: &HashMap<usize, D::Process>,
     clusters: &HashMap<usize, D::Cluster>,
-    externals: &HashMap<usize, D::External>,
     compile_env: &D::CompileEnv,
 ) -> (syn::Expr, syn::Expr, Box<dyn FnOnce()>)
 where
@@ -2788,74 +2805,6 @@ where
                 D::m2m_connect(&from_node, &sink_port, &to_node, &source_port),
             )
         }
-        (LocationId::External(from), LocationId::Process(to)) => {
-            let from_node = externals
-                .get(from)
-                .unwrap_or_else(|| {
-                    panic!(
-                        "A external used in the graph was not instantiated: {}",
-                        from
-                    )
-                })
-                .clone();
-
-            let to_node = processes
-                .get(to)
-                .unwrap_or_else(|| {
-                    panic!("A process used in the graph was not instantiated: {}", to)
-                })
-                .clone();
-
-            let sink_port = D::allocate_external_port(&from_node);
-            let source_port = D::allocate_process_port(&to_node);
-
-            from_node.register(from_key.unwrap(), sink_port.clone());
-
-            (
-                (
-                    parse_quote!(DUMMY),
-                    D::e2o_source(compile_env, &from_node, &sink_port, &to_node, &source_port),
-                ),
-                D::e2o_connect(&from_node, &sink_port, &to_node, &source_port),
-            )
-        }
-        (LocationId::External(_from), LocationId::Cluster(_to)) => {
-            todo!("NYI")
-        }
-        (LocationId::External(_), LocationId::External(_)) => {
-            panic!("Cannot send from external to external")
-        }
-        (LocationId::Process(from), LocationId::External(to)) => {
-            let from_node = processes
-                .get(from)
-                .unwrap_or_else(|| {
-                    panic!("A process used in the graph was not instantiated: {}", from)
-                })
-                .clone();
-
-            let to_node = externals
-                .get(to)
-                .unwrap_or_else(|| {
-                    panic!("A external used in the graph was not instantiated: {}", to)
-                })
-                .clone();
-
-            let sink_port = D::allocate_process_port(&from_node);
-            let source_port = D::allocate_external_port(&to_node);
-
-            to_node.register(to_key.unwrap(), source_port.clone());
-
-            (
-                (
-                    D::o2e_sink(compile_env, &from_node, &sink_port, &to_node, &source_port),
-                    parse_quote!(DUMMY),
-                ),
-                D::o2e_connect(&from_node, &sink_port, &to_node, &source_port),
-            )
-        }
-        (LocationId::Cluster(_from), LocationId::External(_to)) => {
-            todo!("NYI")
-        }
         (LocationId::Tick(_, _), _) => panic!(),
         (_, LocationId::Tick(_, _)) => panic!(),
     };
@@ -2872,7 +2821,7 @@ mod test {
 
     #[test]
     fn hydro_node_size() {
-        insta::assert_snapshot!(size_of::<HydroNode>(), @"232");
+        insta::assert_snapshot!(size_of::<HydroNode>(), @"200");
     }
 
     #[test]

--- a/hydro_lang/src/ir.rs
+++ b/hydro_lang/src/ir.rs
@@ -444,6 +444,7 @@ impl HydroLeaf {
                 } else if let HydroNode::ExternalInput {
                     from_external_id,
                     from_key,
+                    from_many,
                     instantiate_fn,
                     metadata,
                     ..
@@ -478,9 +479,9 @@ impl HydroLeaf {
                                     (
                                         (
                                             parse_quote!(DUMMY),
-                                            D::e2o_source(compile_env, &from_node, &sink_port, &to_node, &source_port),
+                                            D::e2o_source(compile_env, &from_node, &sink_port, &to_node, &source_port, *from_many),
                                         ),
-                                        D::e2o_connect(&from_node, &sink_port, &to_node, &source_port),
+                                        D::e2o_connect(&from_node, &sink_port, &to_node, &source_port, *from_many),
                                     )
                                 }
                                 LocationId::Cluster(_) => todo!(),
@@ -1130,6 +1131,7 @@ pub enum HydroNode {
     ExternalInput {
         from_external_id: usize,
         from_key: usize,
+        from_many: bool,
         instantiate_fn: DebugInstantiate,
         deserialize_fn: Option<DebugExpr>,
         metadata: HydroIrMetadata,
@@ -1451,12 +1453,14 @@ impl HydroNode {
             HydroNode::ExternalInput {
                 from_external_id,
                 from_key,
+                from_many,
                 instantiate_fn,
                 deserialize_fn,
                 metadata,
             } => HydroNode::ExternalInput {
                 from_external_id: *from_external_id,
                 from_key: *from_key,
+                from_many: *from_many,
                 instantiate_fn: instantiate_fn.clone(),
                 deserialize_fn: deserialize_fn.clone(),
                 metadata: metadata.clone(),
@@ -2821,7 +2825,7 @@ mod test {
 
     #[test]
     fn hydro_node_size() {
-        insta::assert_snapshot!(size_of::<HydroNode>(), @"200");
+        insta::assert_snapshot!(size_of::<HydroNode>(), @"208");
     }
 
     #[test]

--- a/hydro_lang/src/lib.rs
+++ b/hydro_lang/src/lib.rs
@@ -73,6 +73,20 @@ pub mod backtrace;
 #[cfg_attr(docsrs, doc(cfg(feature = "deploy")))]
 pub mod test_util;
 
+#[cfg(feature = "build")]
+#[ctor::ctor]
+fn setup_rewrites() {
+    stageleft::add_private_reexport(
+        vec!["std", "io", "error"],
+        vec!["std", "io"],
+    );
+
+    stageleft::add_private_reexport(
+        vec!["bytes", "bytes_mut"],
+        vec!["bytes"],
+    );
+}
+
 #[cfg(test)]
 mod test_init {
     #[ctor::ctor]

--- a/hydro_lang/src/location/external_process.rs
+++ b/hydro_lang/src/location/external_process.rs
@@ -6,7 +6,10 @@ use serde::de::DeserializeOwned;
 use crate::builder::FlowState;
 use crate::staging_util::Invariant;
 
-pub struct ExternalBytesPort {
+pub enum NotMany {}
+pub enum Many {}
+
+pub struct ExternalBytesPort<Many = NotMany> {
     #[cfg_attr(
         not(feature = "build"),
         expect(unused, reason = "unused without feature")
@@ -17,9 +20,20 @@ pub struct ExternalBytesPort {
         expect(unused, reason = "unused without feature")
     )]
     pub(crate) port_id: usize,
+    pub(crate) _phantom: PhantomData<Many>
 }
 
-pub struct ExternalBincodeSink<Type>
+impl Clone for ExternalBytesPort<Many> {
+    fn clone(&self) -> Self {
+        Self {
+            process_id: self.process_id,
+            port_id: self.port_id,
+            _phantom: Default::default()
+        }
+    }
+}
+
+pub struct ExternalBincodeSink<Type, Many = NotMany>
 where
     Type: Serialize,
 {
@@ -33,7 +47,17 @@ where
         expect(unused, reason = "unused without feature")
     )]
     pub(crate) port_id: usize,
-    pub(crate) _phantom: PhantomData<Type>,
+    pub(crate) _phantom: PhantomData<(Type, Many)>,
+}
+
+impl<T: Serialize> Clone for ExternalBincodeSink<T, Many> {
+    fn clone(&self) -> Self {
+        Self {
+            process_id: self.process_id,
+            port_id: self.port_id,
+            _phantom: Default::default(),
+        }
+    }
 }
 
 pub struct ExternalBincodeStream<Type>

--- a/hydro_lang/src/location/mod.rs
+++ b/hydro_lang/src/location/mod.rs
@@ -37,7 +37,6 @@ pub enum LocationId {
     Process(usize),
     Cluster(usize),
     Tick(usize, Box<LocationId>),
-    External(usize),
 }
 
 impl LocationId {
@@ -46,13 +45,12 @@ impl LocationId {
             LocationId::Process(_) => self,
             LocationId::Cluster(_) => self,
             LocationId::Tick(_, id) => id.root(),
-            LocationId::External(_) => self,
         }
     }
 
     pub fn is_root(&self) -> bool {
         match self {
-            LocationId::Process(_) | LocationId::Cluster(_) | LocationId::External(_) => true,
+            LocationId::Process(_) | LocationId::Cluster(_) => true,
             LocationId::Tick(_, _) => false,
         }
     }
@@ -62,7 +60,6 @@ impl LocationId {
             LocationId::Process(id) => *id,
             LocationId::Cluster(id) => *id,
             LocationId::Tick(_, _) => panic!("cannot get raw id for tick"),
-            LocationId::External(id) => *id,
         }
     }
 
@@ -215,9 +212,8 @@ pub trait Location<'a>: Clone {
                 self.clone(),
                 HydroNode::Persist {
                     inner: Box::new(HydroNode::ExternalInput {
-                        from_location: LocationId::External(from.id),
-                        from_key: Some(next_external_port_id),
-                        to_key: None,
+                        from_external_id: from.id,
+                        from_key: next_external_port_id,
                         instantiate_fn: DebugInstantiate::Building,
                         deserialize_fn: Some(deser_expr.into()),
                         metadata: self.new_node_metadata::<Bytes>(),
@@ -256,9 +252,8 @@ pub trait Location<'a>: Clone {
                 self.clone(),
                 HydroNode::Persist {
                     inner: Box::new(HydroNode::ExternalInput {
-                        from_location: LocationId::External(from.id),
-                        from_key: Some(next_external_port_id),
-                        to_key: None,
+                        from_external_id: from.id,
+                        from_key: next_external_port_id,
                         instantiate_fn: DebugInstantiate::Building,
                         deserialize_fn: Some(crate::stream::deserialize_bincode::<T>(None).into()),
                         metadata: self.new_node_metadata::<T>(),

--- a/hydro_lang/src/location/mod.rs
+++ b/hydro_lang/src/location/mod.rs
@@ -2,20 +2,21 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::time::Duration;
 
-use bytes::Bytes;
+use bytes::BytesMut;
 use futures::stream::Stream as FuturesStream;
 use proc_macro2::Span;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use stageleft::{QuotedWithContext, q};
+use stageleft::{QuotedWithContext, q, quote_type};
 
 use super::builder::FlowState;
 use crate::backtrace::get_backtrace;
 use crate::cycle::{CycleCollection, ForwardRef, ForwardRefMarker};
 use crate::ir::{DebugInstantiate, HydroIrMetadata, HydroNode, HydroSource};
-use crate::location::external_process::{ExternalBincodeSink, ExternalBytesPort};
+use crate::location::external_process::{ExternalBincodeSink, ExternalBytesPort, Many};
+use crate::staging_util::get_this_crate;
 use crate::stream::ExactlyOnce;
-use crate::{Singleton, Stream, TotalOrder, Unbounded};
+use crate::{NoOrder, Singleton, Stream, TotalOrder, Unbounded};
 
 pub mod external_process;
 pub use external_process::External;
@@ -114,7 +115,7 @@ pub trait Location<'a>: Clone {
         HydroIrMetadata {
             location_kind: self.id(),
             backtrace: get_backtrace(2),
-            output_type: Some(stageleft::quote_type::<T>().into()),
+            output_type: Some(quote_type::<T>().into()),
             cardinality: None,
             cpu_usage: None,
             network_recv_cpu_usage: None,
@@ -186,10 +187,10 @@ pub trait Location<'a>: Clone {
 
     fn source_external_bytes<L>(
         &self,
-        from: External<L>,
+        from: &External<L>,
     ) -> (
         ExternalBytesPort,
-        Stream<Bytes, Self, Unbounded, TotalOrder, ExactlyOnce>,
+        Stream<std::io::Result<BytesMut>, Self, Unbounded, TotalOrder, ExactlyOnce>,
     )
     where
         Self: Sized + NoTick,
@@ -201,12 +202,11 @@ pub trait Location<'a>: Clone {
             id
         };
 
-        let deser_expr: syn::Expr = syn::parse_quote!(|b| b.unwrap().freeze());
-
         (
             ExternalBytesPort {
                 process_id: from.id,
                 port_id: next_external_port_id,
+                _phantom: Default::default()
             },
             Stream::new(
                 self.clone(),
@@ -214,11 +214,52 @@ pub trait Location<'a>: Clone {
                     inner: Box::new(HydroNode::ExternalInput {
                         from_external_id: from.id,
                         from_key: next_external_port_id,
+                        from_many: false,
                         instantiate_fn: DebugInstantiate::Building,
-                        deserialize_fn: Some(deser_expr.into()),
-                        metadata: self.new_node_metadata::<Bytes>(),
+                        deserialize_fn: None,
+                        metadata: self.new_node_metadata::<std::io::Result<BytesMut>>(),
                     }),
-                    metadata: self.new_node_metadata::<Bytes>(),
+                    metadata: self.new_node_metadata::<std::io::Result<BytesMut>>(),
+                },
+            ),
+        )
+    }
+
+    fn source_external_many_bytes<L>(
+        &self,
+        from: &External<L>,
+    ) -> (
+        ExternalBytesPort<Many>,
+        Stream<std::io::Result<(u64, BytesMut)>, Self, Unbounded, NoOrder, ExactlyOnce>,
+    )
+    where
+        Self: Sized + NoTick,
+    {
+        let next_external_port_id = {
+            let mut flow_state = from.flow_state.borrow_mut();
+            let id = flow_state.next_external_out;
+            flow_state.next_external_out += 1;
+            id
+        };
+
+        (
+            ExternalBytesPort {
+                process_id: from.id,
+                port_id: next_external_port_id,
+                _phantom: PhantomData,
+            },
+            Stream::new(
+                self.clone(),
+                HydroNode::Persist {
+                    inner: Box::new(HydroNode::ExternalInput {
+                        from_external_id: from.id,
+                        from_key: next_external_port_id,
+                        from_many: true,
+                        instantiate_fn: DebugInstantiate::Building,
+                        deserialize_fn: None,
+                        metadata: self.new_node_metadata::<std::io::Result<(u64, BytesMut)>>(),
+                    }),
+                    metadata: self.new_node_metadata::<std::io::Result<(u64, BytesMut)>>(),
                 },
             ),
         )
@@ -254,11 +295,64 @@ pub trait Location<'a>: Clone {
                     inner: Box::new(HydroNode::ExternalInput {
                         from_external_id: from.id,
                         from_key: next_external_port_id,
+                        from_many: false,
                         instantiate_fn: DebugInstantiate::Building,
                         deserialize_fn: Some(crate::stream::deserialize_bincode::<T>(None).into()),
                         metadata: self.new_node_metadata::<T>(),
                     }),
                     metadata: self.new_node_metadata::<T>(),
+                },
+            ),
+        )
+    }
+
+    fn source_external_many_bincode<L, T>(
+        &self,
+        from: &External<L>,
+    ) -> (
+        ExternalBincodeSink<T, Many>,
+        Stream<(u64, T), Self, Unbounded, NoOrder, ExactlyOnce>,
+    )
+    where
+        Self: Sized + NoTick,
+        T: Serialize + DeserializeOwned,
+    {
+        let next_external_port_id = {
+            let mut flow_state = from.flow_state.borrow_mut();
+            let id = flow_state.next_external_out;
+            flow_state.next_external_out += 1;
+            id
+        };
+
+        let root = get_this_crate();
+        // let c_type = quote_type::<L>();
+        let t_type = quote_type::<T>();
+
+        let deser_fn: syn::Expr = syn::parse_quote! {
+            |res| {
+                let (id, b) = res.unwrap();
+                (id, #root::runtime_support::bincode::deserialize::<#t_type>(&b).unwrap())
+            }
+        };
+
+        (
+            ExternalBincodeSink {
+                process_id: from.id,
+                port_id: next_external_port_id,
+                _phantom: PhantomData,
+            },
+            Stream::new(
+                self.clone(),
+                HydroNode::Persist {
+                    inner: Box::new(HydroNode::ExternalInput {
+                        from_external_id: from.id,
+                        from_key: next_external_port_id,
+                        from_many: true,
+                        instantiate_fn: DebugInstantiate::Building,
+                        deserialize_fn: Some(deser_fn.into()),
+                        metadata: self.new_node_metadata::<(u64, T)>(),
+                    }),
+                    metadata: self.new_node_metadata::<(u64, T)>(),
                 },
             ),
         )
@@ -354,5 +448,143 @@ pub trait Location<'a>: Clone {
             },
             S::create_source(ident, self.clone()),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use futures::{SinkExt, StreamExt};
+    use hydro_deploy::Deployment;
+    use stageleft::q;
+
+    use crate::{FlowBuilder, Location};
+
+    #[tokio::test]
+    async fn external_bytes() {
+        let mut deployment = Deployment::new();
+
+        let flow = FlowBuilder::new();
+        let first_node = flow.process::<()>();
+        let external = flow.external::<()>();
+
+        let (in_port, input) = first_node.source_external_bytes(&external);
+        let out = input.map(q!(|r| r.unwrap())).send_bincode_external(&external);
+
+        let nodes = flow
+            .with_process(&first_node, deployment.Localhost())
+            .with_external(&external, deployment.Localhost())
+            .deploy(&mut deployment);
+
+        deployment.deploy().await.unwrap();
+
+        let mut external_in = nodes.connect_sink_bytes(in_port).await;
+        let mut external_out = nodes.connect_source_bincode(out).await;
+
+        deployment.start().await.unwrap();
+
+        external_in.send(vec![1, 2, 3].into()).await.unwrap();
+
+        assert_eq!(
+            external_out.next().await.unwrap(),
+            vec![1, 2, 3]
+        );
+    }
+
+    #[tokio::test]
+    async fn multi_external_source() {
+        let mut deployment = Deployment::new();
+
+        let flow = FlowBuilder::new();
+        let first_node = flow.process::<()>();
+        let external = flow.external::<()>();
+
+        let (in_port, input) = first_node.source_external_many_bincode(&external);
+        let out = input.send_bincode_external(&external);
+
+        let nodes = flow
+            .with_process(&first_node, deployment.Localhost())
+            .with_external(&external, deployment.Localhost())
+            .deploy(&mut deployment);
+
+        deployment.deploy().await.unwrap();
+
+        let mut external_in_1 = nodes.connect_sink_bincode(in_port.clone()).await;
+        let mut external_in_2 = nodes.connect_sink_bincode(in_port).await;
+        let external_out = nodes.connect_source_bincode(out).await;
+
+        deployment.start().await.unwrap();
+
+        external_in_1.send(123).await.unwrap();
+        external_in_2.send(456).await.unwrap();
+
+        assert_eq!(
+            external_out.take(2).collect::<HashSet<_>>().await,
+            vec![(0, 123), (1, 456)].into_iter().collect()
+        );
+    }
+
+    #[tokio::test]
+    async fn second_connection_only_multi_source() {
+        let mut deployment = Deployment::new();
+
+        let flow = FlowBuilder::new();
+        let first_node = flow.process::<()>();
+        let external = flow.external::<()>();
+
+        let (in_port, input) = first_node.source_external_many_bincode(&external);
+        let out = input.send_bincode_external(&external);
+
+        let nodes = flow
+            .with_process(&first_node, deployment.Localhost())
+            .with_external(&external, deployment.Localhost())
+            .deploy(&mut deployment);
+
+        deployment.deploy().await.unwrap();
+
+        // intentionally skipped to test stream waking logic
+        let mut _external_in_1 = nodes.connect_sink_bincode(in_port.clone()).await;
+        let mut external_in_2 = nodes.connect_sink_bincode(in_port).await;
+        let mut external_out = nodes.connect_source_bincode(out).await;
+
+        deployment.start().await.unwrap();
+
+        external_in_2.send(456).await.unwrap();
+
+        assert_eq!(external_out.next().await.unwrap(), (1, 456));
+    }
+
+    #[tokio::test]
+    async fn multi_external_bytes() {
+        let mut deployment = Deployment::new();
+
+        let flow = FlowBuilder::new();
+        let first_node = flow.process::<()>();
+        let external = flow.external::<()>();
+
+        let (in_port, input) = first_node.source_external_many_bytes(&external);
+        let out = input.map(q!(|r| r.unwrap())).send_bincode_external(&external);
+
+        let nodes = flow
+            .with_process(&first_node, deployment.Localhost())
+            .with_external(&external, deployment.Localhost())
+            .deploy(&mut deployment);
+
+        deployment.deploy().await.unwrap();
+
+        let mut external_in_1 = nodes.connect_sink_bytes(in_port.clone()).await;
+        let mut external_in_2 = nodes.connect_sink_bytes(in_port).await;
+        let external_out = nodes.connect_source_bincode(out).await;
+
+        deployment.start().await.unwrap();
+
+        external_in_1.send(vec![1, 2, 3].into()).await.unwrap();
+        external_in_2.send(vec![4, 5].into()).await.unwrap();
+
+        assert_eq!(
+            external_out.take(2).collect::<HashSet<_>>().await,
+            vec![(0, (&[1u8, 2, 3] as &[u8]).into()), (1, (&[4u8, 5] as &[u8]).into())].into_iter().collect()
+        );
     }
 }

--- a/hydro_lang/src/rewrites/persist_pullup.rs
+++ b/hydro_lang/src/rewrites/persist_pullup.rs
@@ -120,8 +120,6 @@ fn persist_pullup_node(
             },
 
             HydroNode::Network {
-                from_key,
-                to_key,
                 serialize_fn,
                 instantiate_fn,
                 deserialize_fn,
@@ -129,8 +127,6 @@ fn persist_pullup_node(
                 metadata,
             } => HydroNode::Persist {
                 inner: Box::new(HydroNode::Network {
-                    from_key,
-                    to_key,
                     serialize_fn,
                     instantiate_fn,
                     deserialize_fn,

--- a/hydro_lang/src/stream.rs
+++ b/hydro_lang/src/stream.rs
@@ -2445,8 +2445,6 @@ where
         Stream::new(
             other.clone(),
             HydroNode::Network {
-                from_key: None,
-                to_key: None,
                 serialize_fn: serialize_pipeline.map(|e| e.into()),
                 instantiate_fn: DebugInstantiate::Building,
                 deserialize_fn: deserialize_pipeline.map(|e| e.into()),
@@ -2476,9 +2474,8 @@ where
         let leaves = flow_state_borrow.leaves.as_mut().expect("Attempted to add a leaf to a flow that has already been finalized. No leaves can be added after the flow has been compiled()");
 
         leaves.push(HydroLeaf::SendExternal {
-            from_key: None,
-            to_location: other.id,
-            to_key: Some(external_key),
+            to_external_id: other.id,
+            to_key: external_key,
             serialize_fn: serialize_pipeline.map(|e| e.into()),
             instantiate_fn: DebugInstantiate::Building,
             input: Box::new(HydroNode::Unpersist {
@@ -2511,8 +2508,6 @@ where
         Stream::new(
             other.clone(),
             HydroNode::Network {
-                from_key: None,
-                to_key: None,
                 serialize_fn: None,
                 instantiate_fn: DebugInstantiate::Building,
                 deserialize_fn: if let Some(c_type) = L::Root::tagged_type() {
@@ -2540,9 +2535,8 @@ where
         let leaves = flow_state_borrow.leaves.as_mut().expect("Attempted to add a leaf to a flow that has already been finalized. No leaves can be added after the flow has been compiled()");
 
         leaves.push(HydroLeaf::SendExternal {
-            from_key: None,
-            to_location: other.id,
-            to_key: Some(external_key),
+            to_external_id: other.id,
+            to_key: external_key,
             serialize_fn: None,
             instantiate_fn: DebugInstantiate::Building,
             input: Box::new(HydroNode::Unpersist {

--- a/hydro_lang/src/stream.rs
+++ b/hydro_lang/src/stream.rs
@@ -2548,6 +2548,7 @@ where
         ExternalBytesPort {
             process_id: other.id,
             port_id: external_key,
+            _phantom: Default::default()
         }
     }
 

--- a/hydro_optimize/src/decoupler.rs
+++ b/hydro_optimize/src/decoupler.rs
@@ -61,8 +61,6 @@ fn add_network(node: &mut HydroNode, new_location: &LocationId) {
     // Set up the network node
     let output_type = output_debug_type.clone().0;
     let network_node = HydroNode::Network {
-        from_key: None,
-        to_key: None,
         serialize_fn: Some(serialize_bincode_with_type(true, &output_type)).map(|e| e.into()),
         instantiate_fn: DebugInstantiate::Building,
         deserialize_fn: Some(deserialize_bincode_with_type(

--- a/hydro_optimize/src/snapshots/hydro_optimize__decoupler__tests__decouple_after_source_ir.snap
+++ b/hydro_optimize/src/snapshots/hydro_optimize__decoupler__tests__decouple_after_source_ir.snap
@@ -8,8 +8,6 @@ expression: built.ir()
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: cluster :: cluster_id :: ClusterId < () > , i32) , i32 > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
             input: Network {
-                from_key: None,
-                to_key: None,
                 serialize_fn: Some(
                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , i32) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                 ),
@@ -24,8 +22,6 @@ expression: built.ir()
                         input: Map {
                             f: | (_ , b) | b,
                             input: Network {
-                                from_key: None,
-                                to_key: None,
                                 serialize_fn: Some(
                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , i32) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                 ),

--- a/hydro_optimize/src/snapshots/hydro_optimize__decoupler__tests__move_source_decouple_map_ir.snap
+++ b/hydro_optimize/src/snapshots/hydro_optimize__decoupler__tests__move_source_decouple_map_ir.snap
@@ -8,8 +8,6 @@ expression: built.ir()
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: cluster :: cluster_id :: ClusterId < () > , i32) , i32 > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
             input: Network {
-                from_key: None,
-                to_key: None,
                 serialize_fn: Some(
                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , i32) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                 ),
@@ -22,8 +20,6 @@ expression: built.ir()
                     input: Map {
                         f: | (_ , b) | b,
                         input: Network {
-                            from_key: None,
-                            to_key: None,
                             serialize_fn: Some(
                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , i32) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                             ),

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__compute_pi__tests__compute_pi_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__compute_pi__tests__compute_pi_ir.snap
@@ -14,8 +14,6 @@ expression: built.ir()
                         inner: Map {
                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: compute_pi :: Worker > , (u64 , u64)) , (u64 , u64) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                             input: Network {
-                                from_key: None,
-                                to_key: None,
                                 serialize_fn: Some(
                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (u64 , u64) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                                 ),

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__compute_pi__tests__decoupled_compute_pi_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__compute_pi__tests__decoupled_compute_pi_ir.snap
@@ -14,8 +14,6 @@ expression: built.ir()
                         inner: Map {
                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: compute_pi :: Worker > , (u64 , u64)) , (u64 , u64) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                             input: Network {
-                                from_key: None,
-                                to_key: None,
                                 serialize_fn: Some(
                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (u64 , u64) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                                 ),
@@ -29,8 +27,6 @@ expression: built.ir()
                                     input: Map {
                                         f: | (_ , b) | b,
                                         input: Network {
-                                            from_key: None,
-                                            to_key: None,
                                             serialize_fn: Some(
                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , bool) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                             ),

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__many_to_many__tests__many_to_many_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__many_to_many__tests__many_to_many_ir.snap
@@ -7,8 +7,6 @@ expression: built.ir()
         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < () > , i32) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: many_to_many :: * ; | n | println ! ("cluster received: {:?}" , n) }),
         input: Unpersist {
             inner: Network {
-                from_key: None,
-                to_key: None,
                 serialize_fn: Some(
                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , i32) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                 ),

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__map_reduce__tests__map_reduce_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__map_reduce__tests__map_reduce_ir.snap
@@ -11,8 +11,6 @@ expression: built.ir()
                 inner: Map {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: map_reduce :: Worker > , (std :: string :: String , i32)) , (std :: string :: String , i32) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                     input: Network {
-                        from_key: None,
-                        to_key: None,
                         serialize_fn: Some(
                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (std :: string :: String , i32) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                         ),
@@ -28,8 +26,6 @@ expression: built.ir()
                                 input: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < std :: string :: String , (std :: string :: String , ()) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: map_reduce :: * ; | string | (string , ()) }),
                                     input: Network {
-                                        from_key: None,
-                                        to_key: None,
                                         serialize_fn: Some(
                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , std :: string :: String) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                         ),

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir.snap
@@ -372,8 +372,6 @@ expression: built.ir()
             inner: <tee 2>: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                 input: Network {
-                    from_key: None,
-                    to_key: None,
                     serialize_fn: Some(
                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                     ),
@@ -643,8 +641,6 @@ expression: built.ir()
                                             input: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                                                 input: Network {
-                                                    from_key: None,
-                                                    to_key: None,
                                                     serialize_fn: Some(
                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                     ),
@@ -660,8 +656,6 @@ expression: built.ir()
                                                                     inner: <tee 8>: Map {
                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                                                                         input: Network {
-                                                                            from_key: None,
-                                                                            to_key: None,
                                                                             serialize_fn: Some(
                                                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                             ),
@@ -1881,8 +1875,6 @@ expression: built.ir()
                                                     input: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                                                         input: Network {
-                                                            from_key: None,
-                                                            to_key: None,
                                                             serialize_fn: Some(
                                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                             ),
@@ -2254,8 +2246,6 @@ expression: built.ir()
                                                     left: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) >) , hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                                                         input: Network {
-                                                            from_key: None,
-                                                            to_key: None,
                                                             serialize_fn: Some(
                                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) >) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                             ),
@@ -2855,8 +2845,6 @@ expression: built.ir()
                                             inner: <tee 26>: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                                                 input: Network {
-                                                    from_key: None,
-                                                    to_key: None,
                                                     serialize_fn: Some(
                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                     ),
@@ -2871,8 +2859,6 @@ expression: built.ir()
                                                                 inner: <tee 27>: Map {
                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer >) , hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                                                                     input: Network {
-                                                                        from_key: None,
-                                                                        to_key: None,
                                                                         serialize_fn: Some(
                                                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer >) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                         ),
@@ -4085,8 +4071,6 @@ expression: built.ir()
                                         input: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >)) , (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                                             input: Network {
-                                                from_key: None,
-                                                to_key: None,
                                                 serialize_fn: Some(
                                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                 ),
@@ -4835,8 +4819,6 @@ expression: built.ir()
                                 f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; | curr_seq , seq | { if seq > * curr_seq { * curr_seq = seq ; } } }),
                                 input: Persist {
                                     inner: Network {
-                                        from_key: None,
-                                        to_key: None,
                                         serialize_fn: Some(
                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , usize) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                         ),
@@ -5056,8 +5038,6 @@ expression: built.ir()
                             inner: <tee 40>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: kv_replica :: Replica > , ((u32 , u32) , core :: result :: Result < () , () >)) , ((u32 , u32) , core :: result :: Result < () , () >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                                 input: Network {
-                                    from_key: None,
-                                    to_key: None,
                                     serialize_fn: Some(
                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , ((u32 , u32) , core :: result :: Result < () , () >)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                     ),
@@ -5569,8 +5549,6 @@ expression: built.ir()
                                 inner: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 >) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (id , histogram) | (id , histogram . histogram . borrow_mut () . clone ()) }),
                                     input: Network {
-                                        from_key: None,
-                                        to_key: None,
                                         serialize_fn: Some(
                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                                         ),
@@ -5890,8 +5868,6 @@ expression: built.ir()
                             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | combined , new | { * combined = new ; } }),
                             input: Persist {
                                 inner: Network {
-                                    from_key: None,
-                                    to_key: None,
                                     serialize_fn: Some(
                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                                     ),

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__simple_cluster__tests__partitioned_simple_cluster_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__simple_cluster__tests__partitioned_simple_cluster_ir.snap
@@ -8,8 +8,6 @@ expression: built.ir()
         input: Map {
             f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
             input: Network {
-                from_key: None,
-                to_key: None,
                 serialize_fn: Some(
                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < () > , i32) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                 ),
@@ -20,8 +18,6 @@ expression: built.ir()
                 input: Inspect {
                     f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < () > , i32) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: simple_cluster :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: ClusterId :: < () > :: from_raw ({ __hydro_lang_cluster_self_id_1 / 3usize as u32 }) ; move | n | println ! ("cluster received: {:?} (self cluster id: {})" , n , CLUSTER_SELF_ID__free) }),
                     input: Network {
-                        from_key: None,
-                        to_key: None,
                         serialize_fn: Some(
                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < () > , i32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                         ),

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__simple_cluster__tests__simple_cluster_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__simple_cluster__tests__simple_cluster_ir.snap
@@ -7,8 +7,6 @@ expression: built.ir()
         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < () > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < () > , i32)) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: simple_cluster :: * ; | (id , d) | println ! ("node received: ({}, {:?})" , id , d) }),
         input: Unpersist {
             inner: Network {
-                from_key: None,
-                to_key: None,
                 serialize_fn: Some(
                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < () > , i32) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                 ),
@@ -21,8 +19,6 @@ expression: built.ir()
                         f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < () > , i32) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: simple_cluster :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: ClusterId :: < () > :: from_raw (__hydro_lang_cluster_self_id_1) ; move | n | println ! ("cluster received: {:?} (self cluster id: {})" , n , CLUSTER_SELF_ID__free) }),
                         input: Unpersist {
                             inner: Network {
-                                from_key: None,
-                                to_key: None,
                                 serialize_fn: Some(
                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < () > , i32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                 ),

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__two_pc_bench__tests__two_pc_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__two_pc_bench__tests__two_pc_ir.snap
@@ -33,8 +33,6 @@ expression: built.ir()
                                 input: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                                     input: Network {
-                                        from_key: None,
-                                        to_key: None,
                                         serialize_fn: Some(
                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                                         ),
@@ -43,8 +41,6 @@ expression: built.ir()
                                             | res | { let (id , b) = res . unwrap () ; (hydro_lang :: ClusterId :: < hydro_test :: __staged :: cluster :: two_pc :: Participant > :: from_raw (id) , hydro_lang :: runtime_support :: bincode :: deserialize :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) > (& b) . unwrap ()) },
                                         ),
                                         input: Network {
-                                            from_key: None,
-                                            to_key: None,
                                             serialize_fn: Some(
                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                             ),
@@ -55,8 +51,6 @@ expression: built.ir()
                                             input: FlatMap {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , std :: iter :: Map < std :: slice :: Iter < hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant >] > (__hydro_lang_cluster_ids_1) } ; | v | { ids__free . iter () . map (move | id | (* id , v . clone ())) } }),
                                                 input: Network {
-                                                    from_key: None,
-                                                    to_key: None,
                                                     serialize_fn: Some(
                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , u32) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                                                     ),
@@ -302,8 +296,6 @@ expression: built.ir()
                                 input: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; | (_ , b) | b }),
                                     input: Network {
-                                        from_key: None,
-                                        to_key: None,
                                         serialize_fn: Some(
                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                                         ),
@@ -312,8 +304,6 @@ expression: built.ir()
                                             | res | { let (id , b) = res . unwrap () ; (hydro_lang :: ClusterId :: < hydro_test :: __staged :: cluster :: two_pc :: Participant > :: from_raw (id) , hydro_lang :: runtime_support :: bincode :: deserialize :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) > (& b) . unwrap ()) },
                                         ),
                                         input: Network {
-                                            from_key: None,
-                                            to_key: None,
                                             serialize_fn: Some(
                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                             ),
@@ -578,8 +568,6 @@ expression: built.ir()
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , u32) , (u32 , u32) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | payload | (payload . 0 , payload . 1 + 1) }),
                 input: Tee {
                     inner: <tee 9>: Network {
-                        from_key: None,
-                        to_key: None,
                         serialize_fn: Some(
                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                         ),
@@ -851,8 +839,6 @@ expression: built.ir()
                                 inner: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 >) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (id , histogram) | (id , histogram . histogram . borrow_mut () . clone ()) }),
                                     input: Network {
-                                        from_key: None,
-                                        to_key: None,
                                         serialize_fn: Some(
                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                                         ),
@@ -1172,8 +1158,6 @@ expression: built.ir()
                             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | combined , new | { * combined = new ; } }),
                             input: Persist {
                                 inner: Network {
-                                    from_key: None,
-                                    to_key: None,
                                     serialize_fn: Some(
                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                                     ),

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__two_pc_bench__tests__two_pc_partition.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__two_pc_bench__tests__two_pc_partition.snap
@@ -35,8 +35,6 @@ expression: "&ir"
                                     input: Map {
                                         f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                         input: Network {
-                                            from_key: None,
-                                            to_key: None,
                                             serialize_fn: Some(
                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                             ),
@@ -49,8 +47,6 @@ expression: "&ir"
                                                 input: Map {
                                                     f: | (_sender_id , b) | b,
                                                     input: Network {
-                                                        from_key: None,
-                                                        to_key: None,
                                                         serialize_fn: Some(
                                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                         ),
@@ -63,8 +59,6 @@ expression: "&ir"
                                                             input: FlatMap {
                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , std :: iter :: Map < std :: slice :: Iter < hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = { let all_ids = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant >] > (__hydro_lang_cluster_ids_2) } ; & all_ids [0 .. all_ids . len () / 3usize] } ; | v | { ids__free . iter () . map (move | id | (* id , v . clone ())) } }),
                                                                 input: Network {
-                                                                    from_key: None,
-                                                                    to_key: None,
                                                                     serialize_fn: Some(
                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                     ),
@@ -255,8 +249,6 @@ expression: "&ir"
                                                     input: Map {
                                                         f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                         input: Network {
-                                                            from_key: None,
-                                                            to_key: None,
                                                             serialize_fn: Some(
                                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                             ),
@@ -269,8 +261,6 @@ expression: "&ir"
                                                                 input: Map {
                                                                     f: | (_sender_id , b) | b,
                                                                     input: Network {
-                                                                        from_key: None,
-                                                                        to_key: None,
                                                                         serialize_fn: Some(
                                                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                         ),
@@ -283,8 +273,6 @@ expression: "&ir"
                                                                             input: FlatMap {
                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , std :: iter :: Map < std :: slice :: Iter < hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = { let all_ids = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant >] > (__hydro_lang_cluster_ids_2) } ; & all_ids [0 .. all_ids . len () / 3usize] } ; | v | { ids__free . iter () . map (move | id | (* id , v . clone ())) } }),
                                                                                 input: Network {
-                                                                                    from_key: None,
-                                                                                    to_key: None,
                                                                                     serialize_fn: Some(
                                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                     ),
@@ -558,8 +546,6 @@ expression: "&ir"
                                     input: Map {
                                         f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                         input: Network {
-                                            from_key: None,
-                                            to_key: None,
                                             serialize_fn: Some(
                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                             ),
@@ -572,8 +558,6 @@ expression: "&ir"
                                                 input: Map {
                                                     f: | (_sender_id , b) | b,
                                                     input: Network {
-                                                        from_key: None,
-                                                        to_key: None,
                                                         serialize_fn: Some(
                                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                         ),
@@ -618,8 +602,6 @@ expression: "&ir"
                                                                                                     input: Map {
                                                                                                         f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                                                                         input: Network {
-                                                                                                            from_key: None,
-                                                                                                            to_key: None,
                                                                                                             serialize_fn: Some(
                                                                                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                             ),
@@ -632,8 +614,6 @@ expression: "&ir"
                                                                                                                 input: Map {
                                                                                                                     f: | (_sender_id , b) | b,
                                                                                                                     input: Network {
-                                                                                                                        from_key: None,
-                                                                                                                        to_key: None,
                                                                                                                         serialize_fn: Some(
                                                                                                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                         ),
@@ -646,8 +626,6 @@ expression: "&ir"
                                                                                                                             input: FlatMap {
                                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , std :: iter :: Map < std :: slice :: Iter < hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = { let all_ids = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant >] > (__hydro_lang_cluster_ids_2) } ; & all_ids [0 .. all_ids . len () / 3usize] } ; | v | { ids__free . iter () . map (move | id | (* id , v . clone ())) } }),
                                                                                                                                 input: Network {
-                                                                                                                                    from_key: None,
-                                                                                                                                    to_key: None,
                                                                                                                                     serialize_fn: Some(
                                                                                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                     ),
@@ -1009,8 +987,6 @@ expression: "&ir"
                                                     input: Map {
                                                         f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                         input: Network {
-                                                            from_key: None,
-                                                            to_key: None,
                                                             serialize_fn: Some(
                                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                             ),
@@ -1023,8 +999,6 @@ expression: "&ir"
                                                                 input: Map {
                                                                     f: | (_sender_id , b) | b,
                                                                     input: Network {
-                                                                        from_key: None,
-                                                                        to_key: None,
                                                                         serialize_fn: Some(
                                                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                         ),
@@ -1069,8 +1043,6 @@ expression: "&ir"
                                                                                                                     input: Map {
                                                                                                                         f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                                                                                         input: Network {
-                                                                                                                            from_key: None,
-                                                                                                                            to_key: None,
                                                                                                                             serialize_fn: Some(
                                                                                                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                             ),
@@ -1083,8 +1055,6 @@ expression: "&ir"
                                                                                                                                 input: Map {
                                                                                                                                     f: | (_sender_id , b) | b,
                                                                                                                                     input: Network {
-                                                                                                                                        from_key: None,
-                                                                                                                                        to_key: None,
                                                                                                                                         serialize_fn: Some(
                                                                                                                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                         ),
@@ -1097,8 +1067,6 @@ expression: "&ir"
                                                                                                                                             input: FlatMap {
                                                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , std :: iter :: Map < std :: slice :: Iter < hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = { let all_ids = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant >] > (__hydro_lang_cluster_ids_2) } ; & all_ids [0 .. all_ids . len () / 3usize] } ; | v | { ids__free . iter () . map (move | id | (* id , v . clone ())) } }),
                                                                                                                                                 input: Network {
-                                                                                                                                                    from_key: None,
-                                                                                                                                                    to_key: None,
                                                                                                                                                     serialize_fn: Some(
                                                                                                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                                     ),
@@ -1565,8 +1533,6 @@ expression: "&ir"
                     inner: <tee>: Map {
                         f: | (_sender_id , b) | b,
                         input: Network {
-                            from_key: None,
-                            to_key: None,
                             serialize_fn: Some(
                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                             ),
@@ -1607,8 +1573,6 @@ expression: "&ir"
                                                                 input: Map {
                                                                     f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                                     input: Network {
-                                                                        from_key: None,
-                                                                        to_key: None,
                                                                         serialize_fn: Some(
                                                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                         ),
@@ -1621,8 +1585,6 @@ expression: "&ir"
                                                                             input: Map {
                                                                                 f: | (_sender_id , b) | b,
                                                                                 input: Network {
-                                                                                    from_key: None,
-                                                                                    to_key: None,
                                                                                     serialize_fn: Some(
                                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                     ),
@@ -1667,8 +1629,6 @@ expression: "&ir"
                                                                                                                                 input: Map {
                                                                                                                                     f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                                                                                                     input: Network {
-                                                                                                                                        from_key: None,
-                                                                                                                                        to_key: None,
                                                                                                                                         serialize_fn: Some(
                                                                                                                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                         ),
@@ -1681,8 +1641,6 @@ expression: "&ir"
                                                                                                                                             input: Map {
                                                                                                                                                 f: | (_sender_id , b) | b,
                                                                                                                                                 input: Network {
-                                                                                                                                                    from_key: None,
-                                                                                                                                                    to_key: None,
                                                                                                                                                     serialize_fn: Some(
                                                                                                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                                     ),
@@ -1695,8 +1653,6 @@ expression: "&ir"
                                                                                                                                                         input: FlatMap {
                                                                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , std :: iter :: Map < std :: slice :: Iter < hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = { let all_ids = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant >] > (__hydro_lang_cluster_ids_2) } ; & all_ids [0 .. all_ids . len () / 3usize] } ; | v | { ids__free . iter () . map (move | id | (* id , v . clone ())) } }),
                                                                                                                                                             input: Network {
-                                                                                                                                                                from_key: None,
-                                                                                                                                                                to_key: None,
                                                                                                                                                                 serialize_fn: Some(
                                                                                                                                                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                                                 ),
@@ -2250,8 +2206,6 @@ expression: "&ir"
                                 inner: <tee>: Map {
                                     f: | (_sender_id , b) | b,
                                     input: Network {
-                                        from_key: None,
-                                        to_key: None,
                                         serialize_fn: Some(
                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                         ),
@@ -2292,8 +2246,6 @@ expression: "&ir"
                                                                             input: Map {
                                                                                 f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                                                 input: Network {
-                                                                                    from_key: None,
-                                                                                    to_key: None,
                                                                                     serialize_fn: Some(
                                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                     ),
@@ -2306,8 +2258,6 @@ expression: "&ir"
                                                                                         input: Map {
                                                                                             f: | (_sender_id , b) | b,
                                                                                             input: Network {
-                                                                                                from_key: None,
-                                                                                                to_key: None,
                                                                                                 serialize_fn: Some(
                                                                                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                 ),
@@ -2352,8 +2302,6 @@ expression: "&ir"
                                                                                                                                             input: Map {
                                                                                                                                                 f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                                                                                                                 input: Network {
-                                                                                                                                                    from_key: None,
-                                                                                                                                                    to_key: None,
                                                                                                                                                     serialize_fn: Some(
                                                                                                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                                     ),
@@ -2366,8 +2314,6 @@ expression: "&ir"
                                                                                                                                                         input: Map {
                                                                                                                                                             f: | (_sender_id , b) | b,
                                                                                                                                                             input: Network {
-                                                                                                                                                                from_key: None,
-                                                                                                                                                                to_key: None,
                                                                                                                                                                 serialize_fn: Some(
                                                                                                                                                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                                                 ),
@@ -2380,8 +2326,6 @@ expression: "&ir"
                                                                                                                                                                     input: FlatMap {
                                                                                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , std :: iter :: Map < std :: slice :: Iter < hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = { let all_ids = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant >] > (__hydro_lang_cluster_ids_2) } ; & all_ids [0 .. all_ids . len () / 3usize] } ; | v | { ids__free . iter () . map (move | id | (* id , v . clone ())) } }),
                                                                                                                                                                         input: Network {
-                                                                                                                                                                            from_key: None,
-                                                                                                                                                                            to_key: None,
                                                                                                                                                                             serialize_fn: Some(
                                                                                                                                                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                                                             ),
@@ -2875,8 +2819,6 @@ expression: "&ir"
                                 inner: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 >) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (id , histogram) | (id , histogram . histogram . borrow_mut () . clone ()) }),
                                     input: Network {
-                                        from_key: None,
-                                        to_key: None,
                                         serialize_fn: Some(
                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                                         ),
@@ -2932,8 +2874,6 @@ expression: "&ir"
                                                                                 inner: <tee>: Map {
                                                                                     f: | (_sender_id , b) | b,
                                                                                     input: Network {
-                                                                                        from_key: None,
-                                                                                        to_key: None,
                                                                                         serialize_fn: Some(
                                                                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                         ),
@@ -2974,8 +2914,6 @@ expression: "&ir"
                                                                                                                             input: Map {
                                                                                                                                 f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                                                                                                 input: Network {
-                                                                                                                                    from_key: None,
-                                                                                                                                    to_key: None,
                                                                                                                                     serialize_fn: Some(
                                                                                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                     ),
@@ -2988,8 +2926,6 @@ expression: "&ir"
                                                                                                                                         input: Map {
                                                                                                                                             f: | (_sender_id , b) | b,
                                                                                                                                             input: Network {
-                                                                                                                                                from_key: None,
-                                                                                                                                                to_key: None,
                                                                                                                                                 serialize_fn: Some(
                                                                                                                                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                                 ),
@@ -3034,8 +2970,6 @@ expression: "&ir"
                                                                                                                                                                                             input: Map {
                                                                                                                                                                                                 f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                                                                                                                                                                 input: Network {
-                                                                                                                                                                                                    from_key: None,
-                                                                                                                                                                                                    to_key: None,
                                                                                                                                                                                                     serialize_fn: Some(
                                                                                                                                                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                                                                                     ),
@@ -3048,8 +2982,6 @@ expression: "&ir"
                                                                                                                                                                                                         input: Map {
                                                                                                                                                                                                             f: | (_sender_id , b) | b,
                                                                                                                                                                                                             input: Network {
-                                                                                                                                                                                                                from_key: None,
-                                                                                                                                                                                                                to_key: None,
                                                                                                                                                                                                                 serialize_fn: Some(
                                                                                                                                                                                                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                                                                                                 ),
@@ -3062,8 +2994,6 @@ expression: "&ir"
                                                                                                                                                                                                                     input: FlatMap {
                                                                                                                                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , std :: iter :: Map < std :: slice :: Iter < hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = { let all_ids = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant >] > (__hydro_lang_cluster_ids_2) } ; & all_ids [0 .. all_ids . len () / 3usize] } ; | v | { ids__free . iter () . map (move | id | (* id , v . clone ())) } }),
                                                                                                                                                                                                                         input: Network {
-                                                                                                                                                                                                                            from_key: None,
-                                                                                                                                                                                                                            to_key: None,
                                                                                                                                                                                                                             serialize_fn: Some(
                                                                                                                                                                                                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                                                                                                             ),
@@ -3766,8 +3696,6 @@ expression: "&ir"
                             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | combined , new | { * combined = new ; } }),
                             input: Persist {
                                 inner: Network {
-                                    from_key: None,
-                                    to_key: None,
                                     serialize_fn: Some(
                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                                     ),
@@ -3797,8 +3725,6 @@ expression: "&ir"
                                                                                 inner: <tee>: Map {
                                                                                     f: | (_sender_id , b) | b,
                                                                                     input: Network {
-                                                                                        from_key: None,
-                                                                                        to_key: None,
                                                                                         serialize_fn: Some(
                                                                                             :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                         ),
@@ -3839,8 +3765,6 @@ expression: "&ir"
                                                                                                                             input: Map {
                                                                                                                                 f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                                                                                                 input: Network {
-                                                                                                                                    from_key: None,
-                                                                                                                                    to_key: None,
                                                                                                                                     serialize_fn: Some(
                                                                                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                     ),
@@ -3853,8 +3777,6 @@ expression: "&ir"
                                                                                                                                         input: Map {
                                                                                                                                             f: | (_sender_id , b) | b,
                                                                                                                                             input: Network {
-                                                                                                                                                from_key: None,
-                                                                                                                                                to_key: None,
                                                                                                                                                 serialize_fn: Some(
                                                                                                                                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                                 ),
@@ -3899,8 +3821,6 @@ expression: "&ir"
                                                                                                                                                                                             input: Map {
                                                                                                                                                                                                 f: | (sender_id , b) | (:: hydro_lang :: ClusterId :: < _ > :: from_raw (sender_id . raw_id / 3usize as u32) , b),
                                                                                                                                                                                                 input: Network {
-                                                                                                                                                                                                    from_key: None,
-                                                                                                                                                                                                    to_key: None,
                                                                                                                                                                                                     serialize_fn: Some(
                                                                                                                                                                                                         :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                                                                                     ),
@@ -3913,8 +3833,6 @@ expression: "&ir"
                                                                                                                                                                                                         input: Map {
                                                                                                                                                                                                             f: | (_sender_id , b) | b,
                                                                                                                                                                                                             input: Network {
-                                                                                                                                                                                                                from_key: None,
-                                                                                                                                                                                                                to_key: None,
                                                                                                                                                                                                                 serialize_fn: Some(
                                                                                                                                                                                                                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                                                                                                 ),
@@ -3927,8 +3845,6 @@ expression: "&ir"
                                                                                                                                                                                                                     input: FlatMap {
                                                                                                                                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , std :: iter :: Map < std :: slice :: Iter < hydro_test :: __staged :: __deps :: hydro_lang :: location :: cluster :: cluster_id :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant > > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: stream :: * ; let ids__free = { let all_ids = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: ClusterId < hydro_test :: __staged :: cluster :: two_pc :: Participant >] > (__hydro_lang_cluster_ids_2) } ; & all_ids [0 .. all_ids . len () / 3usize] } ; | v | { ids__free . iter () . map (move | id | (* id , v . clone ())) } }),
                                                                                                                                                                                                                         input: Network {
-                                                                                                                                                                                                                            from_key: None,
-                                                                                                                                                                                                                            to_key: None,
                                                                                                                                                                                                                             serialize_fn: Some(
                                                                                                                                                                                                                                 :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: ClusterId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                                                                                                                                                             ),

--- a/hydro_test/src/distributed/snapshots/hydro_test__distributed__first_ten__tests__first_ten_distributed_ir.snap
+++ b/hydro_test/src/distributed/snapshots/hydro_test__distributed__first_ten__tests__first_ten_distributed_ir.snap
@@ -8,13 +8,8 @@ expression: builder.finalize().ir()
         input: Unpersist {
             inner: Persist {
                 inner: ExternalInput {
-                    from_location: External(
-                        0,
-                    ),
-                    from_key: Some(
-                        0,
-                    ),
-                    to_key: None,
+                    from_external_id: 0,
+                    from_key: 0,
                     instantiate_fn: <network instantiate>,
                     deserialize_fn: Some(
                         | res | { hydro_lang :: runtime_support :: bincode :: deserialize :: < std :: string :: String > (& res . unwrap ()) . unwrap () },
@@ -59,8 +54,6 @@ expression: builder.finalize().ir()
         f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: distributed :: first_ten :: SendOverNetwork , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: distributed :: first_ten :: * ; | n | println ! ("{}" , n . n) }),
         input: Unpersist {
             inner: Network {
-                from_key: None,
-                to_key: None,
                 serialize_fn: Some(
                     :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: distributed :: first_ten :: SendOverNetwork , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                 ),


### PR DESCRIPTION

So far, Hydro has only supported deployments where there is a statically known number of single-connection external clients for sending / receiving data. This is not practical in production applications where external users will dynamically connect to the Hydro service.

This takes the first step towards addressing this, by setting up the networking mechanism for handling dynamically connected clients and adding an API for receiving data from these clients. Sending data will be handled in another PR, since that requires more changes to the compilation pipeline to handle split recv / send handles.

This also changes the `source_external_bytes` APIs to return the raw `BytesMut` sent over the network, rather than adding a freezing step.

Towards #1709
