### PR TITLE
feat(hydro_lang): add `Stream::scan_keyed` and `Stream::fold_keyed_early_stop`

### DIFF
--- a/hydro_lang/src/lib.rs
+++ b/hydro_lang/src/lib.rs
@@ -54,6 +54,8 @@ pub mod cycle;
 pub mod builder;
 pub use builder::FlowBuilder;
 
+mod manual_expr;
+
 pub mod ir;
 
 #[cfg(feature = "viz")]

--- a/hydro_lang/src/manual_expr.rs
+++ b/hydro_lang/src/manual_expr.rs
@@ -1,0 +1,46 @@
+use std::marker::PhantomData;
+
+use quote::quote;
+use stageleft::QuotedWithContext;
+use stageleft::runtime_support::{FreeVariableWithContext, QuoteTokens};
+
+/// Utility for wrapping a quoted expression with a custom transformation, such as explicitly
+/// splicing it with a type hint.
+pub(crate) struct ManualExpr<T, F> {
+    fun: F,
+    _phantom: PhantomData<T>,
+}
+
+impl<'a, T, F: FnOnce(&Ctx) -> syn::Expr, Ctx> QuotedWithContext<'a, T, Ctx> for ManualExpr<T, F> {}
+
+impl<T, F: Copy> Copy for ManualExpr<T, F> {}
+
+impl<T, F: Clone> Clone for ManualExpr<T, F> {
+    fn clone(&self) -> Self {
+        Self {
+            fun: self.fun.clone(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T, F> ManualExpr<T, F> {
+    pub fn new(fun: F) -> ManualExpr<T, F> {
+        ManualExpr {
+            fun,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T, F: FnOnce(&Ctx) -> syn::Expr, Ctx> FreeVariableWithContext<Ctx> for ManualExpr<T, F> {
+    type O = T;
+
+    fn to_tokens(self, ctx: &Ctx) -> QuoteTokens {
+        let expr = (self.fun)(ctx);
+        QuoteTokens {
+            prelude: None,
+            expr: Some(quote!(#expr)),
+        }
+    }
+}


### PR DESCRIPTION

In preparation for a keyed variant of `Stream` that allows richer reasoning about interleaved ordering, we add a keyed variant of scan and a keyed variant of fold that are suitable for unbounded streams.

The latter is particularly interesting, as it allows an early-termination (inspired by Free Termination) to yield folded results (since without early termination, we can never yield anything if the input is unbounded). With this operator, the entire HTTP example is key-able which will eventually let us get rid of the `unsafe` blocks surrounding it.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydro-project/hydro/pull/1971).
* #1974
* __->__ #1971