### PR TITLE
feat(hydro_lang): add `KeyedStream` to track steams with unordered keys but possibly-ordered values

### DIFF
--- a/hydro_lang/src/keyed_stream.rs
+++ b/hydro_lang/src/keyed_stream.rs
@@ -1,0 +1,319 @@
+use std::hash::Hash;
+use std::marker::PhantomData;
+
+use stageleft::{IntoQuotedMut, QuotedWithContext, q};
+
+use crate::cycle::{CycleCollection, CycleComplete, ForwardRefMarker};
+use crate::location::{LocationId, NoTick};
+use crate::manual_expr::ManualExpr;
+use crate::stream::ExactlyOnce;
+use crate::{Location, NoOrder, Stream, TotalOrder};
+
+pub struct KeyedStream<K, V, Loc, Bound, Order = TotalOrder, Retries = ExactlyOnce> {
+    pub(crate) underlying: Stream<(K, V), Loc, Bound, NoOrder, Retries>,
+    pub(crate) _phantom_order: PhantomData<Order>,
+}
+
+impl<'a, K, V, L, B, O, R> CycleCollection<'a, ForwardRefMarker> for KeyedStream<K, V, L, B, O, R>
+where
+    L: Location<'a> + NoTick,
+{
+    type Location = L;
+
+    fn create_source(ident: syn::Ident, location: L) -> Self {
+        Stream::create_source(ident, location).into_keyed()
+    }
+}
+
+impl<'a, K, V, L, B, O, R> CycleComplete<'a, ForwardRefMarker> for KeyedStream<K, V, L, B, O, R>
+where
+    L: Location<'a> + NoTick,
+{
+    fn complete(self, ident: syn::Ident, expected_location: LocationId) {
+        self.underlying.complete(ident, expected_location);
+    }
+}
+
+impl<'a, K, V, L: Location<'a>, B, O, R> KeyedStream<K, V, L, B, O, R> {
+    /// Flattens the keyed stream into a single stream of key-value pairs, with non-deterministic
+    /// interleaving across keys.
+    ///
+    /// # Example
+    /// ```rust
+    /// # use hydro_lang::*;
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// process
+    ///     .source_iter(q!(vec![(1, 2), (1, 3), (2, 4)]))
+    ///     .into_keyed()
+    ///     .interleave()
+    /// # }, |mut stream| async move {
+    /// // (1, 2), (1, 3), (2, 4) in any order, but (1, 2) will always appear before (1, 3)
+    /// # for w in vec![(1, 2), (1, 3), (2, 4)] {
+    /// #     assert_eq!(stream.next().await.unwrap(), w);
+    /// # }
+    /// # }));
+    /// ```
+    pub fn interleave(self) -> Stream<(K, V), L, B, NoOrder, R> {
+        self.underlying
+    }
+
+    /// Transforms each value by invoking `f` on each element, with keys staying the same
+    /// after transformation. If you need access to the key, see [`KeyedStream::map_with_key`].
+    ///
+    /// If you do not want to modify the stream and instead only want to view
+    /// each item use [`KeyedStream::inspect`] instead.
+    ///
+    /// # Example
+    /// ```rust
+    /// # use hydro_lang::*;
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// process
+    ///     .source_iter(q!(vec![(1, 2), (1, 3), (2, 4)]))
+    ///     .into_keyed()
+    ///     .map(q!(|v| v + 1))
+    /// #   .interleave()
+    /// # }, |mut stream| async move {
+    /// // { 1: [3, 4], 2: [5] }
+    /// # for w in vec![(1, 3), (1, 4), (2, 5)] {
+    /// #     assert_eq!(stream.next().await.unwrap(), w);
+    /// # }
+    /// # }));
+    /// ```
+    pub fn map<U, F>(self, f: impl IntoQuotedMut<'a, F, L> + Copy) -> KeyedStream<K, U, L, B, O, R>
+    where
+        F: Fn(V) -> U + 'a,
+    {
+        let f: ManualExpr<F, _> = ManualExpr::new(move |ctx: &L| f.splice_fn1_ctx(ctx));
+        KeyedStream {
+            underlying: self.underlying.map(q!({
+                let orig = f;
+                move |(k, v)| (k, orig(v))
+            })),
+            _phantom_order: Default::default(),
+        }
+    }
+
+    /// Transforms each value by invoking `f` on each key-value pair. The resulting values are **not**
+    /// re-grouped even they are tuples; instead they will be grouped under the original key.
+    ///
+    /// If you do not want to modify the stream and instead only want to view
+    /// each item use [`KeyedStream::inspect_with_key`] instead.
+    ///
+    /// # Example
+    /// ```rust
+    /// # use hydro_lang::*;
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// process
+    ///     .source_iter(q!(vec![(1, 2), (1, 3), (2, 4)]))
+    ///     .into_keyed()
+    ///     .map_with_key(q!(|(k, v)| k + v))
+    /// #   .interleave()
+    /// # }, |mut stream| async move {
+    /// // { 1: [3, 4], 2: [6] }
+    /// # for w in vec![(1, 3), (1, 4), (2, 6)] {
+    /// #     assert_eq!(stream.next().await.unwrap(), w);
+    /// # }
+    /// # }));
+    /// ```
+    pub fn map_with_key<U, F>(
+        self,
+        f: impl IntoQuotedMut<'a, F, L> + Copy,
+    ) -> KeyedStream<K, U, L, B, O, R>
+    where
+        F: Fn((K, V)) -> U + 'a,
+        K: Clone,
+    {
+        let f: ManualExpr<F, _> = ManualExpr::new(move |ctx: &L| f.splice_fn1_ctx(ctx));
+        KeyedStream {
+            underlying: self.underlying.map(q!({
+                let orig = f;
+                move |(k, v)| {
+                    let out = orig((k.clone(), v));
+                    (k, out)
+                }
+            })),
+            _phantom_order: Default::default(),
+        }
+    }
+
+    /// An operator which allows you to "inspect" each element of a stream without
+    /// modifying it. The closure `f` is called on a reference to each value. This is
+    /// mainly useful for debugging, and should not be used to generate side-effects.
+    ///
+    /// # Example
+    /// ```rust
+    /// # use hydro_lang::*;
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// process
+    ///     .source_iter(q!(vec![(1, 2), (1, 3), (2, 4)]))
+    ///     .into_keyed()
+    ///     .inspect(q!(|v| println!("{}", v)))
+    /// #   .interleave()
+    /// # }, |mut stream| async move {
+    /// # for w in vec![(1, 2), (1, 3), (2, 4)] {
+    /// #     assert_eq!(stream.next().await.unwrap(), w);
+    /// # }
+    /// # }));
+    /// ```
+    pub fn inspect<F>(self, f: impl IntoQuotedMut<'a, F, L> + Copy) -> KeyedStream<K, V, L, B, O, R>
+    where
+        F: Fn(&V) + 'a,
+    {
+        let f: ManualExpr<F, _> = ManualExpr::new(move |ctx: &L| f.splice_fn1_borrow_ctx(ctx));
+        KeyedStream {
+            underlying: self.underlying.inspect(q!({
+                let orig = f;
+                move |(_k, v)| orig(v)
+            })),
+            _phantom_order: Default::default(),
+        }
+    }
+
+    /// An operator which allows you to "inspect" each element of a stream without
+    /// modifying it. The closure `f` is called on a reference to each key-value pair. This is
+    /// mainly useful for debugging, and should not be used to generate side-effects.
+    ///
+    /// # Example
+    /// ```rust
+    /// # use hydro_lang::*;
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// process
+    ///     .source_iter(q!(vec![(1, 2), (1, 3), (2, 4)]))
+    ///     .into_keyed()
+    ///     .inspect(q!(|v| println!("{}", v)))
+    /// #   .interleave()
+    /// # }, |mut stream| async move {
+    /// # for w in vec![(1, 2), (1, 3), (2, 4)] {
+    /// #     assert_eq!(stream.next().await.unwrap(), w);
+    /// # }
+    /// # }));
+    /// ```
+    pub fn inspect_with_key<F>(
+        self,
+        f: impl IntoQuotedMut<'a, F, L>,
+    ) -> KeyedStream<K, V, L, B, O, R>
+    where
+        F: Fn(&(K, V)) + 'a,
+    {
+        KeyedStream {
+            underlying: self.underlying.inspect(f),
+            _phantom_order: Default::default(),
+        }
+    }
+}
+
+impl<'a, K, V, L, B> KeyedStream<K, V, L, B, TotalOrder, ExactlyOnce>
+where
+    K: Eq + Hash,
+    L: Location<'a>,
+{
+    /// A special case of [`Stream::scan`] for keyd streams. For each key group the values are transformed via the `f` combinator.
+    ///
+    /// Unlike [`Stream::fold_keyed`] which only returns the final accumulated value, `scan` produces a new stream
+    /// containing all intermediate accumulated values paired with the key. The scan operation can also terminate
+    /// early by returning `None`.
+    ///
+    /// The function takes a mutable reference to the accumulator and the current element, and returns
+    /// an `Option<U>`. If the function returns `Some(value)`, `value` is emitted to the output stream.
+    /// If the function returns `None`, the stream is terminated and no more elements are processed.
+    ///
+    /// # Example
+    /// ```rust
+    /// # use hydro_lang::*;
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// process
+    ///     .source_iter(q!(vec![(0, 1), (0, 2), (1, 3), (1, 4)]))
+    ///     .into_keyed()
+    ///     .scan(
+    ///         q!(|| 0),
+    ///         q!(|acc, x| {
+    ///             *acc += x;
+    ///             Some(*acc)
+    ///         }),
+    ///     )
+    /// #   .interleave()
+    /// # }, |mut stream| async move {
+    /// // Output: { 0: [1, 3], 1: [3, 7] }
+    /// # for w in vec![(0, 1), (0, 3), (1, 3), (1, 7)] {
+    /// #     assert_eq!(stream.next().await.unwrap(), w);
+    /// # }
+    /// # }));
+    /// ```
+    pub fn scan<A, U, I, F>(
+        self,
+        init: impl IntoQuotedMut<'a, I, L> + Copy,
+        f: impl IntoQuotedMut<'a, F, L> + Copy,
+    ) -> KeyedStream<K, U, L, B, TotalOrder, ExactlyOnce>
+    where
+        K: Clone,
+        I: Fn() -> A + 'a,
+        F: Fn(&mut A, V) -> Option<U> + 'a,
+    {
+        KeyedStream {
+            underlying: unsafe {
+                // SAFETY: keyed scan does not rely on order of keys
+                self.underlying
+                    .assume_ordering::<TotalOrder>()
+                    .scan_keyed(init, f)
+                    .into()
+            },
+            _phantom_order: Default::default(),
+        }
+    }
+
+    /// A variant of [`Stream::fold`], intended for keyed streams. The aggregation is executed in-order across the values
+    /// in each group. But the aggregation function returns a boolean, which when true indicates that the aggregated
+    /// result is complete and can be released to downstream computation. Unlike [`Stream::fold_keyed`], this means that
+    /// even if the input stream is [`crate::Unbounded`], the outputs of the fold can be processed like normal stream elements.
+    ///
+    /// # Example
+    /// ```rust
+    /// # use hydro_lang::*;
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// process
+    ///     .source_iter(q!(vec![(0, 2), (0, 3), (1, 3), (1, 6)]))
+    ///     .into_keyed()
+    ///     .fold_early_stop(
+    ///         q!(|| 0),
+    ///         q!(|acc, x| {
+    ///             *acc += x;
+    ///             x % 2 == 0
+    ///         }),
+    ///     )
+    /// #   .interleave()
+    /// # }, |mut stream| async move {
+    /// // Output: { 0: 2, 1: 9 }
+    /// # for w in vec![(0, 2), (1, 9)] {
+    /// #     assert_eq!(stream.next().await.unwrap(), w);
+    /// # }
+    /// # }));
+    /// ```
+    pub fn fold_early_stop<A, I, F>(
+        self,
+        init: impl IntoQuotedMut<'a, I, L> + Copy,
+        f: impl IntoQuotedMut<'a, F, L> + Copy,
+    ) -> KeyedStream<K, A, L, B, TotalOrder, ExactlyOnce>
+    where
+        K: Clone,
+        I: Fn() -> A + 'a,
+        F: Fn(&mut A, V) -> bool + 'a,
+    {
+        KeyedStream {
+            underlying: unsafe {
+                // SAFETY: keyed scan does not rely on order of keys
+                self.underlying
+                    .assume_ordering::<TotalOrder>()
+                    .fold_keyed_early_stop(init, f)
+                    .into()
+            },
+            _phantom_order: Default::default(),
+        }
+    }
+}

--- a/hydro_lang/src/lib.rs
+++ b/hydro_lang/src/lib.rs
@@ -33,6 +33,8 @@ pub use boundedness::{Bounded, Unbounded};
 pub mod stream;
 pub use stream::{NoOrder, Stream, TotalOrder};
 
+pub mod keyed_stream;
+
 pub mod singleton;
 pub use singleton::Singleton;
 

--- a/hydro_lang/src/location/mod.rs
+++ b/hydro_lang/src/location/mod.rs
@@ -14,6 +14,7 @@ use super::builder::FlowState;
 use crate::backtrace::get_backtrace;
 use crate::cycle::{CycleCollection, ForwardRef, ForwardRefMarker};
 use crate::ir::{DebugInstantiate, HydroIrMetadata, HydroLeaf, HydroNode, HydroSource};
+use crate::keyed_stream::KeyedStream;
 use crate::location::external_process::{
     ExternalBincodeBidi, ExternalBincodeSink, ExternalBytesPort, Many,
 };
@@ -286,14 +287,8 @@ pub trait Location<'a>: Clone {
         port_hint: NetworkHint,
     ) -> (
         ExternalBytesPort<Many>,
-        Stream<
-            Result<(u64, <Codec as Decoder>::Item), <Codec as Decoder>::Error>,
-            Self,
-            Unbounded,
-            NoOrder,
-            ExactlyOnce,
-        >,
-        ForwardRef<'a, Stream<(u64, T), Self, Unbounded, TotalOrder, ExactlyOnce>>,
+        KeyedStream<u64, <Codec as Decoder>::Item, Self, Unbounded, TotalOrder, ExactlyOnce>,
+        ForwardRef<'a, KeyedStream<u64, T, Self, Unbounded, TotalOrder, ExactlyOnce>>,
     )
     where
         Self: Sized + NoTick,
@@ -306,7 +301,7 @@ pub trait Location<'a>: Clone {
         };
 
         let (fwd_ref, to_sink) =
-            self.forward_ref::<Stream<(u64, T), Self, Unbounded, TotalOrder, ExactlyOnce>>();
+            self.forward_ref::<KeyedStream<u64, T, Self, Unbounded, TotalOrder, ExactlyOnce>>();
         let mut flow_state_borrow = self.flow_state().borrow_mut();
 
         let leaves = flow_state_borrow.leaves.as_mut().expect("Attempted to add a leaf to a flow that has already been finalized. No leaves can be added after the flow has been compiled()");
@@ -318,10 +313,35 @@ pub trait Location<'a>: Clone {
             serialize_fn: None,
             instantiate_fn: DebugInstantiate::Building,
             input: Box::new(HydroNode::Unpersist {
-                inner: Box::new(to_sink.ir_node.into_inner()),
+                inner: Box::new(to_sink.interleave().ir_node.into_inner()),
                 metadata: self.new_node_metadata::<(u64, T)>(),
             }),
         });
+
+        let raw_stream: Stream<
+            Result<(u64, <Codec as Decoder>::Item), <Codec as Decoder>::Error>,
+            Self,
+            Unbounded,
+            NoOrder,
+            ExactlyOnce,
+        > = Stream::new(
+            self.clone(),
+            HydroNode::Persist {
+                inner: Box::new(HydroNode::ExternalInput {
+                    from_external_id: from.id,
+                    from_key: next_external_port_id,
+                    from_many: true,
+                    codec_type: quote_type::<Codec>().into(),
+                    port_hint,
+                    instantiate_fn: DebugInstantiate::Building,
+                    deserialize_fn: None,
+                    metadata: self
+                        .new_node_metadata::<std::io::Result<(u64, <Codec as Decoder>::Item)>>(),
+                }),
+                metadata: self
+                    .new_node_metadata::<std::io::Result<(u64, <Codec as Decoder>::Item)>>(),
+            },
+        );
 
         (
             ExternalBytesPort {
@@ -329,25 +349,13 @@ pub trait Location<'a>: Clone {
                 port_id: next_external_port_id,
                 _phantom: PhantomData,
             },
-            Stream::new(
-                self.clone(),
-                HydroNode::Persist {
-                    inner: Box::new(HydroNode::ExternalInput {
-                        from_external_id: from.id,
-                        from_key: next_external_port_id,
-                        from_many: true,
-                        codec_type: quote_type::<Codec>().into(),
-                        port_hint,
-                        instantiate_fn: DebugInstantiate::Building,
-                        deserialize_fn: None,
-                        metadata: self
-                            .new_node_metadata::<std::io::Result<(u64, <Codec as Decoder>::Item)>>(
-                            ),
-                    }),
-                    metadata: self
-                        .new_node_metadata::<std::io::Result<(u64, <Codec as Decoder>::Item)>>(),
-                },
-            ),
+            unsafe {
+                // SAFETY: order of messages is deterministic within each key due to TCP
+                raw_stream
+                    .flatten_ordered() // TODO(shadaj): this silently drops framing errors, decide on right defaults
+                    .assume_ordering::<TotalOrder>()
+                    .into_keyed()
+            },
             fwd_ref,
         )
     }
@@ -358,8 +366,8 @@ pub trait Location<'a>: Clone {
         from: &External<L>,
     ) -> (
         ExternalBincodeBidi<InT, OutT, Many>,
-        Stream<(u64, InT), Self, Unbounded, NoOrder, ExactlyOnce>,
-        ForwardRef<'a, Stream<(u64, OutT), Self, Unbounded, TotalOrder, ExactlyOnce>>,
+        KeyedStream<u64, InT, Self, Unbounded, TotalOrder, ExactlyOnce>,
+        ForwardRef<'a, KeyedStream<u64, OutT, Self, Unbounded, TotalOrder, ExactlyOnce>>,
     )
     where
         Self: Sized + NoTick,
@@ -374,7 +382,7 @@ pub trait Location<'a>: Clone {
         let root = get_this_crate();
 
         let (fwd_ref, to_sink) =
-            self.forward_ref::<Stream<(u64, OutT), Self, Unbounded, TotalOrder, ExactlyOnce>>();
+            self.forward_ref::<KeyedStream<u64, OutT, Self, Unbounded, TotalOrder, ExactlyOnce>>();
         let mut flow_state_borrow = self.flow_state().borrow_mut();
 
         let leaves = flow_state_borrow.leaves.as_mut().expect("Attempted to add a leaf to a flow that has already been finalized. No leaves can be added after the flow has been compiled()");
@@ -393,7 +401,7 @@ pub trait Location<'a>: Clone {
             serialize_fn: Some(ser_fn.into()),
             instantiate_fn: DebugInstantiate::Building,
             input: Box::new(HydroNode::Unpersist {
-                inner: Box::new(to_sink.ir_node.into_inner()),
+                inner: Box::new(to_sink.interleave().ir_node.into_inner()),
                 metadata: self.new_node_metadata::<(u64, Bytes)>(),
             }),
         });
@@ -407,28 +415,33 @@ pub trait Location<'a>: Clone {
             }
         };
 
+        let raw_stream: Stream<(u64, InT), Self, Unbounded, NoOrder, ExactlyOnce> = Stream::new(
+            self.clone(),
+            HydroNode::Persist {
+                inner: Box::new(HydroNode::ExternalInput {
+                    from_external_id: from.id,
+                    from_key: next_external_port_id,
+                    from_many: true,
+                    codec_type: quote_type::<LengthDelimitedCodec>().into(),
+                    port_hint: NetworkHint::Auto,
+                    instantiate_fn: DebugInstantiate::Building,
+                    deserialize_fn: Some(deser_fn.into()),
+                    metadata: self.new_node_metadata::<(u64, InT)>(),
+                }),
+                metadata: self.new_node_metadata::<(u64, InT)>(),
+            },
+        );
+
         (
             ExternalBincodeBidi {
                 process_id: from.id,
                 port_id: next_external_port_id,
                 _phantom: PhantomData,
             },
-            Stream::new(
-                self.clone(),
-                HydroNode::Persist {
-                    inner: Box::new(HydroNode::ExternalInput {
-                        from_external_id: from.id,
-                        from_key: next_external_port_id,
-                        from_many: true,
-                        codec_type: quote_type::<LengthDelimitedCodec>().into(),
-                        port_hint: NetworkHint::Auto,
-                        instantiate_fn: DebugInstantiate::Building,
-                        deserialize_fn: Some(deser_fn.into()),
-                        metadata: self.new_node_metadata::<std::io::Result<(u64, BytesMut)>>(),
-                    }),
-                    metadata: self.new_node_metadata::<std::io::Result<(u64, BytesMut)>>(),
-                },
-            ),
+            unsafe {
+                // SAFETY: order of messages is deterministic within each key due to TCP
+                raw_stream.assume_ordering::<TotalOrder>().into_keyed()
+            },
             fwd_ref,
         )
     }
@@ -576,8 +589,8 @@ mod tests {
         let external = flow.external::<()>();
 
         let (in_port, input, complete_sink) = first_node.bidi_external_many_bincode(&external);
-        let out = input.send_bincode_external(&external);
-        complete_sink.complete(first_node.source_iter::<(u64, ()), _>(q!([])));
+        let out = input.interleave().send_bincode_external(&external);
+        complete_sink.complete(first_node.source_iter::<(u64, ()), _>(q!([])).into_keyed());
 
         let nodes = flow
             .with_process(&first_node, deployment.Localhost())
@@ -610,8 +623,8 @@ mod tests {
         let external = flow.external::<()>();
 
         let (in_port, input, complete_sink) = first_node.bidi_external_many_bincode(&external);
-        let out = input.send_bincode_external(&external);
-        complete_sink.complete(first_node.source_iter::<(u64, ()), _>(q!([])));
+        let out = input.interleave().send_bincode_external(&external);
+        complete_sink.complete(first_node.source_iter::<(u64, ()), _>(q!([])).into_keyed());
 
         let nodes = flow
             .with_process(&first_node, deployment.Localhost())
@@ -642,10 +655,8 @@ mod tests {
 
         let (in_port, input, complete_sink) = first_node
             .bidi_external_many_bytes::<_, _, LengthDelimitedCodec>(&external, NetworkHint::Auto);
-        let out = input
-            .map(q!(|r| r.unwrap()))
-            .send_bincode_external(&external);
-        complete_sink.complete(first_node.source_iter(q!([])));
+        let out = input.interleave().send_bincode_external(&external);
+        complete_sink.complete(first_node.source_iter(q!([])).into_keyed());
 
         let nodes = flow
             .with_process(&first_node, deployment.Localhost())
@@ -684,13 +695,8 @@ mod tests {
 
         let (port, input, complete_sink) = first_node
             .bidi_external_many_bytes::<_, _, LengthDelimitedCodec>(&external, NetworkHint::Auto);
-        complete_sink.complete(
-            unsafe { input.assume_ordering() }
-                .map(q!(|r| r.unwrap()))
-                .map(q!(|(id, bytes)| {
-                    (id, bytes.into_iter().map(|x| x + 1).collect())
-                })),
-        );
+        complete_sink
+            .complete(input.map(q!(|bytes| { bytes.into_iter().map(|x| x + 1).collect() })));
 
         let nodes = flow
             .with_process(&first_node, deployment.Localhost())
@@ -720,12 +726,7 @@ mod tests {
         let external = flow.external::<()>();
 
         let (port, input, complete_sink) = first_node.bidi_external_many_bincode(&external);
-        complete_sink.complete(unsafe { input.assume_ordering() }.map(q!(|(id, text): (
-            u64,
-            String
-        )| {
-            (id, text.to_uppercase())
-        })));
+        complete_sink.complete(input.map(q!(|text: String| { text.to_uppercase() })));
 
         let nodes = flow
             .with_process(&first_node, deployment.Localhost())

--- a/hydro_lang/src/stream.rs
+++ b/hydro_lang/src/stream.rs
@@ -16,6 +16,7 @@ use tokio::time::Instant;
 use crate::builder::FLOW_USED_MESSAGE;
 use crate::cycle::{CycleCollection, CycleComplete, DeferTick, ForwardRefMarker, TickCycleMarker};
 use crate::ir::{DebugInstantiate, HydroLeaf, HydroNode, TeeNode};
+use crate::keyed_stream::KeyedStream;
 use crate::location::external_process::{ExternalBincodeStream, ExternalBytesPort};
 use crate::location::tick::{Atomic, NoAtomic};
 use crate::location::{
@@ -289,7 +290,7 @@ impl<'a, T, L, B, O, R> Stream<T, L, B, O, R>
 where
     L: Location<'a>,
 {
-    /// Produces a stream based on invoking `f` on each element in order.
+    /// Produces a stream based on invoking `f` on each element.
     /// If you do not want to modify the stream and instead only want to view
     /// each item use [`Stream::inspect`] instead.
     ///
@@ -1684,6 +1685,15 @@ where
                 metadata: self.location.new_node_metadata::<(K, V1)>(),
             },
         )
+    }
+}
+
+impl<'a, K, V, L: Location<'a>, B, O, R> Stream<(K, V), L, B, O, R> {
+    pub fn into_keyed(self) -> KeyedStream<K, V, L, B, O, R> {
+        KeyedStream {
+            underlying: unsafe { self.assume_ordering::<NoOrder>() },
+            _phantom_order: Default::default(),
+        }
     }
 }
 

--- a/hydro_test/examples/echo.rs
+++ b/hydro_test/examples/echo.rs
@@ -4,7 +4,6 @@ use hydro_deploy::Deployment;
 use hydro_lang::deploy::TrybuildHost;
 use hydro_lang::graph_util::GraphConfig;
 use hydro_lang::{Location, NetworkHint};
-use stageleft::q;
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -24,10 +23,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (port, input, output_ref) =
         process.bidi_external_many_bytes::<_, _, LinesCodec>(&external, NetworkHint::Auto);
 
-    output_ref.complete(unsafe {
-        hydro_test::external_client::echo::echo_server(input.map(q!(|r| r.unwrap())))
-            .assume_ordering()
-    });
+    output_ref.complete(hydro_test::external_client::echo::echo_server(input));
 
     // Extract the IR BEFORE the builder is consumed by deployment methods
     let built = flow.finalize();

--- a/hydro_test/examples/http_hello.rs
+++ b/hydro_test/examples/http_hello.rs
@@ -5,7 +5,6 @@ use hydro_deploy::custom_service::ServerPort;
 use hydro_lang::deploy::TrybuildHost;
 use hydro_lang::graph_util::GraphConfig;
 use hydro_lang::{Location, NetworkHint};
-use stageleft::q;
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -26,7 +25,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .bidi_external_many_bytes::<_, _, LinesCodec>(&external, NetworkHint::TcpPort(Some(4000)));
 
     output_ref.complete(hydro_test::external_client::http_hello::http_hello_server(
-        unsafe { input.map(q!(|r| r.unwrap())).assume_ordering() },
+        input,
     ));
 
     // Extract the IR BEFORE the builder is consumed by deployment methods

--- a/hydro_test/src/external_client/echo.rs
+++ b/hydro_test/src/external_client/echo.rs
@@ -1,9 +1,10 @@
+use hydro_lang::keyed_stream::KeyedStream;
 use hydro_lang::*;
 
 pub fn echo_server<'a, P>(
-    in_stream: Stream<(u64, String), Process<'a, P>, Unbounded, NoOrder>,
-) -> Stream<(u64, String), Process<'a, P>, Unbounded, NoOrder> {
-    in_stream.inspect(q!(|(id, t)| println!(
+    in_stream: KeyedStream<u64, String, Process<'a, P>, Unbounded, TotalOrder>,
+) -> KeyedStream<u64, String, Process<'a, P>, Unbounded, TotalOrder> {
+    in_stream.inspect_with_key(q!(|(id, t)| println!(
         "...received request {} from client #{}, echoing back...",
         t, id
     )))


### PR DESCRIPTION

Previously, we would represent all key-value pairs as just a `Stream<(K, V)>`. When receiving data from multiple sources, such as external clients, this would result in interleaved `(ID, T)` pairs all smooshed into a single stream.

Because the interleaving is non-deterministic, the strongest type we could correctly give to this stream is `NoOrder`, which fails to capture that _within_ each key, the elements might be totally ordered. This introduces a new live collection type `KeyedStream`, where the stream markers apply only to elements within each key group, rather than across all elements (keys are assumed to have no order). This allows us to capture common request-response patterns with IDs without requiring any unsafe code.
