### PR TITLE
refactor(hydro_lang)!: rename `Stream::union` to `Stream::interleave` and reduce local non-determinism

### DIFF
--- a/hydro_lang/src/keyed_stream.rs
+++ b/hydro_lang/src/keyed_stream.rs
@@ -1154,7 +1154,7 @@ mod tests {
 
         let sum = node
             .source_iter(q!([(0, 100), (1, 101), (2, 102), (2, 102)]))
-            .union(tick_triggered_input)
+            .interleave(tick_triggered_input)
             .into_keyed()
             .reduce_watermark_commutative(
                 watermark,

--- a/hydro_test/src/cluster/paxos.rs
+++ b/hydro_test/src/cluster/paxos.rs
@@ -265,8 +265,8 @@ pub fn leader_election<'a, L: Clone + Debug + Serialize + DeserializeOwned>(
     // c_to_proposers.clone().for_each(q!(|payload: ClientPayload| println!("Client sent proposer payload: {:?}", payload)));
 
     let p_received_max_ballot = p1b_fail
-        .union(p_received_p2b_ballots)
-        .union(p_to_proposers_i_am_leader_forward_ref)
+        .interleave(p_received_p2b_ballots)
+        .interleave(p_to_proposers_i_am_leader_forward_ref)
         .max()
         .unwrap_or(proposers.singleton(q!(Ballot {
             num: 0,


### PR DESCRIPTION

By using the `MinOrder` and `MinRetries` traits to cast to a weake guarantee, we can guarantee safety through the type system even when "casting" the marker.
