### PR TITLE
docs: consistently refer to Hydro as a framework

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -47,8 +47,8 @@ authors:
 repository-code: 'https://github.com/hydro-project/hydro/'
 url: 'https://hydro.run/'
 abstract: >-
-  Hydro is a language stack for programming distributed systems,
-  buil on top of DFIR, a lattice-aware dataflow system.
+  Hydro is a framework for programming distributed systems,
+  built on top of DFIR, a lattice-aware dataflow system.
 keywords:
   - dataflow
   - distributed systems

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Hydro integrates naturally with standard Rust constructs and IDEs, providing typ
 <b>Get started today at <a href="https://hydro.run">hydro.run</a>!</b>
 
 # Learn More
-- **Docs**: There are docs for the [high-level Hydro language](https://hydro.run/docs/hydro/) and the low-level dataflow IR, [DFIR](https://hydro.run/docs/dfir), as well as the [Hydro Deploy](https://hydro.run/docs/deploy) framework for launching Hydro programs.
+- **Docs**: There are docs for the [high-level Hydro framework](https://hydro.run/docs/hydro/) and the low-level dataflow IR, [DFIR](https://hydro.run/docs/dfir), as well as the [Hydro Deploy](https://hydro.run/docs/deploy) framework for launching Hydro programs.
 
 - **Research Papers**: Our [research publications](https://hydro.run/research) are available on the project website. Some notable selections:
     - The original Hydro vision paper from CIDR 2021: [New Directions in Cloud Programming](https://hydro.run/papers/new-directions.pdf)

--- a/dfir_rs/README.md
+++ b/dfir_rs/README.md
@@ -2,7 +2,7 @@
 
 DFIR (Dataflow Intermediate Representation) is a small language and compiler for low-latency
 dataflow programs, written in Rust. DFIR serves as dataflow representation and runtime execution library for the
-[Hydro framework](https://hydro.run/docs/dfir/ecosystem), which is under development
+[Hydro framework](https://hydro.run/docs/hydro/), which is under development
 as a complete framework for distributed programming.
 
 DFIR is designed with two use cases in mind:

--- a/dfir_rs/README.md
+++ b/dfir_rs/README.md
@@ -2,8 +2,8 @@
 
 DFIR (Dataflow Intermediate Representation) is a small language and compiler for low-latency
 dataflow programs, written in Rust. DFIR serves as dataflow representation and runtime execution library for the
-[Hydro language stack](https://hydro.run/docs/dfir/ecosystem), which is under development
-as a complete compiler stack for distributed programming languages.
+[Hydro framework](https://hydro.run/docs/dfir/ecosystem), which is under development
+as a complete framework for distributed programming.
 
 DFIR is designed with two use cases in mind:
   - Expert developers can program directly in the DFIR language to build individual components that can interoperate in a distributed program or service.

--- a/docs/docs/dfir/concepts/index.md
+++ b/docs/docs/dfir/concepts/index.md
@@ -35,7 +35,7 @@ which send and receive flows of data to each other.
 > DFIR itself does not generate distributed code. It is a library for specifying the processes (individual nodes) that
 > participate in a distributed system.
 >
-> In the [Hydro Project](https://hydro.run), higher-level framework are being built on top of DFIR to generate
+> In the [Hydro Project](https://hydro.run), higher-level frameworks are being built on top of DFIR to generate
 > distributed code in the form of multiple processes.
 > Meanwhile, you can use DFIR to write your own distributed code, by writing individual processes that work together,
 > and deploying them manually or with a tool like [Hydroplane](https://github.com/hydro-project/hydroplane). See the [Hydro Ecosystem](../ecosystem) for more on this.

--- a/docs/docs/dfir/concepts/index.md
+++ b/docs/docs/dfir/concepts/index.md
@@ -35,7 +35,7 @@ which send and receive flows of data to each other.
 > DFIR itself does not generate distributed code. It is a library for specifying the processes (individual nodes) that
 > participate in a distributed system.
 >
-> In the [Hydro Project](https://hydro.run), higher-level languages are being built on top of DFIR to generate
+> In the [Hydro Project](https://hydro.run), higher-level framework are being built on top of DFIR to generate
 > distributed code in the form of multiple processes.
 > Meanwhile, you can use DFIR to write your own distributed code, by writing individual processes that work together,
 > and deploying them manually or with a tool like [Hydroplane](https://github.com/hydro-project/hydroplane). See the [Hydro Ecosystem](../ecosystem) for more on this.

--- a/docs/docs/dfir/ecosystem.md
+++ b/docs/docs/dfir/ecosystem.md
@@ -10,7 +10,7 @@ A rough picture of the Hydro stack is below:
 
 Working down from the top:
 
-- [*Hydro*](../hydro) is an end-user-facing high-level [choreographic](https://en.wikipedia.org/wiki/Choreographic_programming) [dataflow](https://en.wikipedia.org/wiki/Dataflow_programming) framework. Hydro is a *global* framework for programming a fleet of processes. Programmers author dataflow pipelines that start with streams of events and data, and span boundaries across multiple `process` and (scalable) `cluster` specifications. [Hydro Deploy](../hydro/deploy) is a service for launching Hydro programs on a variety of platforms.
+- [*Hydro*](../hydro) is an end-user-facing high-level [location-oriented](https://en.wikipedia.org/wiki/Choreographic_programming) [dataflow](https://en.wikipedia.org/wiki/Dataflow_programming) framework. Hydro is a *global* framework for programming a fleet of processes. Programmers author dataflow pipelines that start with streams of events and data, and span boundaries across multiple `process` and (scalable) `cluster` specifications. [Hydro Deploy](../hydro/deploy) is a service for launching Hydro programs on a variety of platforms.
 
 - *Hydrolysis* is a compiler that translates a global Hydro spec to multiple single-threaded DFIR programs, which collectively implement the global spec.
 This compilation phase is currently a part of the Hydro codebase, but will evolve into a standalone optimizing compiler inspired by database query optimizers and [e-graphs](https://en.wikipedia.org/wiki/E-graph).

--- a/docs/docs/dfir/ecosystem.md
+++ b/docs/docs/dfir/ecosystem.md
@@ -10,13 +10,13 @@ A rough picture of the Hydro stack is below:
 
 Working down from the top:
 
-- [*Hydro*](../hydro) is an end-user-facing high-level [choreographic](https://en.wikipedia.org/wiki/Choreographic_programming) [dataflow](https://en.wikipedia.org/wiki/Dataflow_programming) language. Hydro is a *global* language for programming a fleet of processes. Programmers author dataflow pipelines that start with streams of events and data, and span boundaries across multiple `process` and (scalable) `cluster` specifications. [Hydro Deploy](../hydro/deploy) is a service for launching Hydro programs on a variety of platforms.
+- [*Hydro*](../hydro) is an end-user-facing high-level [choreographic](https://en.wikipedia.org/wiki/Choreographic_programming) [dataflow](https://en.wikipedia.org/wiki/Dataflow_programming) framework. Hydro is a *global* framework for programming a fleet of processes. Programmers author dataflow pipelines that start with streams of events and data, and span boundaries across multiple `process` and (scalable) `cluster` specifications. [Hydro Deploy](../hydro/deploy) is a service for launching Hydro programs on a variety of platforms.
 
 - *Hydrolysis* is a compiler that translates a global Hydro spec to multiple single-threaded DFIR programs, which collectively implement the global spec.
 This compilation phase is currently a part of the Hydro codebase, but will evolve into a standalone optimizing compiler inspired by database query optimizers and [e-graphs](https://en.wikipedia.org/wiki/E-graph).
 
 - [DFIR and its compiler/runtime](https://github.com/hydro-project/hydro/tree/main/dfir_rs) are the subject of this book.
-Where Hydro is a *global* language for programming a fleet of processes, DFIR is a *local* language for programming a single process that participates in a distributed system. More specifically, DFIR is an internal representation (IR) language and runtime library that generates the low-level Rust code for an individual process. As a low-level IR, DFIR is not intended for the general-purpose programmer. For most users it is intended as a readable compiler target from Hydro; advanced developers can also use it to manually program individual processes.
+Where Hydro is a *global* framework for programming a fleet of processes, DFIR is a *local* language for programming a single process that participates in a distributed system. More specifically, DFIR is an internal representation (IR) language and runtime library that generates the low-level Rust code for an individual process. As a low-level IR, DFIR is not intended for the general-purpose programmer. For most users it is intended as a readable compiler target from Hydro; advanced developers can also use it to manually program individual processes.
 
 - Hydro also supports *Deterministic Simulation Testing* to aid in debugging distributed programs. Documentation on this feature is forthcoming.
 


### PR DESCRIPTION
Fixes: #1883 