### PR TITLE
feat(hydro_lang)!: refine types when values of a `KeyedSingleton` are immutable

### DIFF
--- a/hydro_lang/src/boundedness.rs
+++ b/hydro_lang/src/boundedness.rs
@@ -1,10 +1,12 @@
 use sealed::sealed;
 
+use crate::keyed_singleton::{BoundedValue, KeyedSingletonBound};
+
 /// A marker trait indicating whether a stream’s length is bounded (finite) or unbounded (potentially infinite).
 ///
 /// Implementors of this trait use it to signal the boundedness property of a stream.
 #[sealed]
-pub trait Boundedness {}
+pub trait Boundedness: KeyedBoundFoldLike {}
 
 /// Marks the stream as being unbounded, which means that it is not
 /// guaranteed to be complete in finite time.
@@ -19,3 +21,24 @@ pub enum Bounded {}
 
 #[sealed]
 impl Boundedness for Bounded {}
+
+/// Helper trait that determines the boundedness for the result of keyed aggregations.
+#[sealed::sealed]
+pub trait KeyedBoundFoldLike {
+    /// The boundedness of the keyed singleton if the values for each key will asynchronously change.
+    type WhenValueUnbounded: KeyedSingletonBound<UnderlyingBound = Self>;
+    /// The boundedness of the keyed singleton if the value for each key is immutable.
+    type WhenValueBounded: KeyedSingletonBound<UnderlyingBound = Self>;
+}
+
+#[sealed::sealed]
+impl KeyedBoundFoldLike for Unbounded {
+    type WhenValueUnbounded = Unbounded;
+    type WhenValueBounded = BoundedValue;
+}
+
+#[sealed::sealed]
+impl KeyedBoundFoldLike for Bounded {
+    type WhenValueUnbounded = Bounded;
+    type WhenValueBounded = Bounded;
+}

--- a/hydro_lang/src/keyed_singleton.rs
+++ b/hydro_lang/src/keyed_singleton.rs
@@ -2,6 +2,7 @@ use std::hash::Hash;
 
 use stageleft::{IntoQuotedMut, QuotedWithContext, q};
 
+use crate::boundedness::Boundedness;
 use crate::cycle::{CycleCollection, CycleComplete, ForwardRefMarker};
 use crate::location::tick::NoAtomic;
 use crate::location::{LocationId, NoTick};
@@ -13,11 +14,38 @@ use crate::{
     Unbounded, nondet,
 };
 
-pub struct KeyedSingleton<K, V, Loc, Bound> {
-    pub(crate) underlying: Stream<(K, V), Loc, Bound, NoOrder, ExactlyOnce>,
+pub trait KeyedSingletonBound {
+    type UnderlyingBound: Boundedness;
+    type ValueBound: Boundedness;
 }
 
-impl<'a, K: Clone, V: Clone, Loc: Location<'a>, Bound> Clone for KeyedSingleton<K, V, Loc, Bound> {
+impl KeyedSingletonBound for Unbounded {
+    type UnderlyingBound = Unbounded;
+    type ValueBound = Unbounded;
+}
+
+impl KeyedSingletonBound for Bounded {
+    type UnderlyingBound = Bounded;
+    type ValueBound = Bounded;
+}
+
+/// A variation of boundedness specific to [`KeyedSingleton`], which indicates that once a key appears,
+/// its value is bounded and will never change. If the `KeyBound` is [`Bounded`], then the entire set of entries
+/// is bounded, but if it is [`Unbounded`], then new entries may appear asynchronously.
+pub struct BoundedValue;
+
+impl KeyedSingletonBound for BoundedValue {
+    type UnderlyingBound = Unbounded;
+    type ValueBound = Bounded;
+}
+
+pub struct KeyedSingleton<K, V, Loc, Bound: KeyedSingletonBound> {
+    pub(crate) underlying: Stream<(K, V), Loc, Bound::UnderlyingBound, NoOrder, ExactlyOnce>,
+}
+
+impl<'a, K: Clone, V: Clone, Loc: Location<'a>, Bound: KeyedSingletonBound> Clone
+    for KeyedSingleton<K, V, Loc, Bound>
+{
     fn clone(&self) -> Self {
         KeyedSingleton {
             underlying: self.underlying.clone(),
@@ -25,7 +53,8 @@ impl<'a, K: Clone, V: Clone, Loc: Location<'a>, Bound> Clone for KeyedSingleton<
     }
 }
 
-impl<'a, K, V, L, B> CycleCollection<'a, ForwardRefMarker> for KeyedSingleton<K, V, L, B>
+impl<'a, K, V, L, B: KeyedSingletonBound> CycleCollection<'a, ForwardRefMarker>
+    for KeyedSingleton<K, V, L, B>
 where
     L: Location<'a> + NoTick,
 {
@@ -38,7 +67,8 @@ where
     }
 }
 
-impl<'a, K, V, L, B> CycleComplete<'a, ForwardRefMarker> for KeyedSingleton<K, V, L, B>
+impl<'a, K, V, L, B: KeyedSingletonBound> CycleComplete<'a, ForwardRefMarker>
+    for KeyedSingleton<K, V, L, B>
 where
     L: Location<'a> + NoTick,
 {
@@ -47,21 +77,62 @@ where
     }
 }
 
-impl<'a, K, V, L: Location<'a>> KeyedSingleton<K, V, Tick<L>, Bounded> {
-    pub fn entries(self) -> Stream<(K, V), Tick<L>, Bounded, NoOrder, ExactlyOnce> {
+impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound<ValueBound = Bounded>>
+    KeyedSingleton<K, V, L, B>
+{
+    pub fn entries(self) -> Stream<(K, V), L, B::UnderlyingBound, NoOrder, ExactlyOnce> {
         self.underlying
     }
 
-    pub fn values(self) -> Stream<V, Tick<L>, Bounded, NoOrder, ExactlyOnce> {
-        self.underlying.map(q!(|(_, v)| v))
+    pub fn values(self) -> Stream<V, L, B::UnderlyingBound, NoOrder, ExactlyOnce> {
+        self.entries().map(q!(|(_, v)| v))
     }
 
-    pub fn keys(self) -> Stream<K, Tick<L>, Bounded, NoOrder, ExactlyOnce> {
-        self.underlying.map(q!(|(k, _)| k))
+    pub fn keys(self) -> Stream<K, L, B::UnderlyingBound, NoOrder, ExactlyOnce> {
+        self.entries().map(q!(|(k, _)| k))
+    }
+
+    pub fn filter_key_not_in<O2, R2>(self, other: Stream<K, L, Bounded, O2, R2>) -> Self
+    where
+        K: Hash + Eq,
+    {
+        KeyedSingleton {
+            underlying: self.entries().anti_join(other),
+        }
+    }
+
+    pub fn inspect<F>(self, f: impl IntoQuotedMut<'a, F, L> + Copy) -> KeyedSingleton<K, V, L, B>
+    where
+        F: Fn(&V) + 'a,
+    {
+        let f: ManualExpr<F, _> = ManualExpr::new(move |ctx: &L| f.splice_fn1_borrow_ctx(ctx));
+        KeyedSingleton {
+            underlying: self.underlying.inspect(q!({
+                let orig = f;
+                move |(_k, v)| orig(v)
+            })),
+        }
+    }
+
+    pub fn inspect_with_key<F>(self, f: impl IntoQuotedMut<'a, F, L>) -> KeyedSingleton<K, V, L, B>
+    where
+        F: Fn(&(K, V)) + 'a,
+    {
+        KeyedSingleton {
+            underlying: self.underlying.inspect(f),
+        }
+    }
+
+    pub fn into_keyed_stream(
+        self,
+    ) -> KeyedStream<K, V, L, B::UnderlyingBound, TotalOrder, ExactlyOnce> {
+        self.underlying
+            .into_keyed()
+            .assume_ordering(nondet!(/** only one element per key */))
     }
 }
 
-impl<'a, K, V, L: Location<'a>, B> KeyedSingleton<K, V, L, B> {
+impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound> KeyedSingleton<K, V, L, B> {
     pub fn map<U, F>(self, f: impl IntoQuotedMut<'a, F, L> + Copy) -> KeyedSingleton<K, U, L, B>
     where
         F: Fn(V) -> U + 'a,
@@ -71,6 +142,26 @@ impl<'a, K, V, L: Location<'a>, B> KeyedSingleton<K, V, L, B> {
             underlying: self.underlying.map(q!({
                 let orig = f;
                 move |(k, v)| (k, orig(v))
+            })),
+        }
+    }
+
+    pub fn map_with_key<U, F>(
+        self,
+        f: impl IntoQuotedMut<'a, F, L> + Copy,
+    ) -> KeyedSingleton<K, U, L, B>
+    where
+        F: Fn((K, V)) -> U + 'a,
+        K: Clone,
+    {
+        let f: ManualExpr<F, _> = ManualExpr::new(move |ctx: &L| f.splice_fn1_ctx(ctx));
+        KeyedSingleton {
+            underlying: self.underlying.map(q!({
+                let orig = f;
+                move |(k, v)| {
+                    let out = orig((k.clone(), v));
+                    (k, out)
+                }
             })),
         }
     }
@@ -104,7 +195,7 @@ impl<'a, K, V, L: Location<'a>, B> KeyedSingleton<K, V, L, B> {
         }
     }
 
-    pub fn key_count(self) -> Singleton<usize, L, B> {
+    pub fn key_count(self) -> Singleton<usize, L, B::UnderlyingBound> {
         self.underlying.count()
     }
 
@@ -117,6 +208,18 @@ impl<'a, K, V, L: Location<'a>, B> KeyedSingleton<K, V, L, B> {
             metadata.tag = Some(name.to_string());
         }
         self
+    }
+}
+
+impl<'a, K, V, L: Location<'a>> KeyedSingleton<K, V, Tick<L>, Bounded> {
+    pub fn latest(self) -> KeyedSingleton<K, V, L, Unbounded> {
+        KeyedSingleton {
+            underlying: Stream::new(
+                self.underlying.location.outer().clone(),
+                // no need to persist due to top-level replay
+                self.underlying.ir_node.into_inner(),
+            ),
+        }
     }
 }
 
@@ -152,7 +255,7 @@ impl<'a, K: Hash + Eq, V, L: Location<'a>> KeyedSingleton<K, V, Tick<L>, Bounded
     /// Given a keyed stream of lookup requests, where the key is the lookup and the value
     /// is some additional metadata, emits a keyed stream of lookup results where the key
     /// is the same as before, but the value is a tuple of the lookup result and the metadata
-    /// of the request.
+    /// of the request. If the key is not found, no output will be produced.
     ///
     /// # Example
     /// ```rust
@@ -169,7 +272,7 @@ impl<'a, K: Hash + Eq, V, L: Location<'a>> KeyedSingleton<K, V, Tick<L>, Bounded
     ///     .source_iter(q!(vec![(1, 100), (2, 200), (1, 101)]))
     ///     .into_keyed()
     ///     .batch(&tick, nondet!(/** test */));
-    /// keyed_data.get_many(other_data).entries().all_ticks()
+    /// keyed_data.get_many_if_present(other_data).entries().all_ticks()
     /// # }, |mut stream| async move {
     /// // { 1: [(10, 100), (10, 101)], 2: [(20, 200)] } in any order
     /// # let mut results = vec![];
@@ -180,28 +283,38 @@ impl<'a, K: Hash + Eq, V, L: Location<'a>> KeyedSingleton<K, V, Tick<L>, Bounded
     /// # assert_eq!(results, vec![(1, (10, 100)), (1, (10, 101)), (2, (20, 200))]);
     /// # }));
     /// ```
-    pub fn get_many<O2, R2, V2>(
+    pub fn get_many_if_present<O2, R2, V2>(
         self,
-        with: KeyedStream<K, V2, Tick<L>, Bounded, O2, R2>,
+        requests: KeyedStream<K, V2, Tick<L>, Bounded, O2, R2>,
     ) -> KeyedStream<K, (V, V2), Tick<L>, Bounded, NoOrder, R2> {
         self.entries()
             .weaker_retries()
-            .join(with.entries())
+            .join(requests.entries())
             .into_keyed()
     }
 
-    pub fn latest(self) -> KeyedSingleton<K, V, L, Unbounded> {
+    pub fn get_from<V2: Clone>(
+        self,
+        from: KeyedSingleton<V, V2, Tick<L>, Bounded>,
+    ) -> KeyedSingleton<K, (V, Option<V2>), Tick<L>, Bounded>
+    where
+        K: Clone,
+        V: Hash + Eq + Clone,
+    {
+        let to_lookup = self.entries().map(q!(|(k, v)| (v, k))).into_keyed();
+        let lookup_result = from.get_many_if_present(to_lookup.clone());
+        let missing_values =
+            to_lookup.filter_key_not_in(lookup_result.clone().entries().map(q!(|t| t.0)));
         KeyedSingleton {
-            underlying: Stream::new(
-                self.underlying.location.outer().clone(),
-                // no need to persist due to top-level replay
-                self.underlying.ir_node.into_inner(),
-            ),
+            underlying: lookup_result
+                .entries()
+                .map(q!(|(v, (v2, k))| (k, (v, Some(v2)))))
+                .chain(missing_values.entries().map(q!(|(v, k)| (k, (v, None))))),
         }
     }
 }
 
-impl<'a, K, V, L, B> KeyedSingleton<K, V, L, B>
+impl<'a, K, V, L, B: KeyedSingletonBound> KeyedSingleton<K, V, L, B>
 where
     L: Location<'a> + NoTick + NoAtomic,
 {
@@ -227,7 +340,22 @@ where
     }
 }
 
-impl<'a, K, V, L, B> KeyedSingleton<K, V, Atomic<L>, B>
+impl<'a, K, V, L, B: KeyedSingletonBound<ValueBound = Bounded>> KeyedSingleton<K, V, L, B>
+where
+    L: Location<'a> + NoTick + NoAtomic,
+{
+    /// Returns a keyed singleton with entries consisting of _new_ key-value pairs that have
+    /// arrived since the previous batch was released.
+    ///
+    /// # Non-Determinism
+    /// Because this picks a batch of asynchronously added entries, each output keyed singleton
+    /// has a non-deterministic set of key-value pairs.
+    pub fn batch(self, tick: &Tick<L>, nondet: NonDet) -> KeyedSingleton<K, V, Tick<L>, Bounded> {
+        self.atomic(tick).batch(nondet)
+    }
+}
+
+impl<'a, K, V, L, B: KeyedSingletonBound> KeyedSingleton<K, V, Atomic<L>, B>
 where
     L: Location<'a> + NoTick + NoAtomic,
 {
@@ -245,6 +373,29 @@ where
                 // no need to unpersist due to top-level replay
                 self.underlying.ir_node.into_inner(),
             ),
+        }
+    }
+
+    pub fn end_atomic(self) -> KeyedSingleton<K, V, L, B> {
+        KeyedSingleton {
+            underlying: self.underlying.end_atomic(),
+        }
+    }
+}
+
+impl<'a, K, V, L, B: KeyedSingletonBound<ValueBound = Bounded>> KeyedSingleton<K, V, Atomic<L>, B>
+where
+    L: Location<'a> + NoTick + NoAtomic,
+{
+    /// Returns a keyed singleton with entries consisting of _new_ key-value pairs that have
+    /// arrived since the previous batch was released.
+    ///
+    /// # Non-Determinism
+    /// Because this picks a batch of asynchronously added entries, each output keyed singleton
+    /// has a non-deterministic set of key-value pairs.
+    pub fn batch(self, nondet: NonDet) -> KeyedSingleton<K, V, Tick<L>, Bounded> {
+        KeyedSingleton {
+            underlying: self.underlying.batch(nondet),
         }
     }
 }

--- a/hydro_lang/src/optional.rs
+++ b/hydro_lang/src/optional.rs
@@ -6,6 +6,7 @@ use std::rc::Rc;
 use stageleft::{IntoQuotedMut, QuotedWithContext, q};
 use syn::parse_quote;
 
+use crate::boundedness::Boundedness;
 use crate::builder::FLOW_USED_MESSAGE;
 use crate::cycle::{CycleCollection, CycleComplete, DeferTick, ForwardRefMarker, TickCycleMarker};
 use crate::ir::{HydroLeaf, HydroNode, HydroSource, TeeNode};
@@ -16,7 +17,7 @@ use crate::stream::{AtLeastOnce, ExactlyOnce, NoOrder};
 use crate::unsafety::NonDet;
 use crate::{Bounded, Location, Singleton, Stream, Tick, TotalOrder, Unbounded};
 
-pub struct Optional<Type, Loc, Bound> {
+pub struct Optional<Type, Loc, Bound: Boundedness> {
     pub(crate) location: Loc,
     pub(crate) ir_node: RefCell<HydroNode>,
 
@@ -114,7 +115,7 @@ where
     }
 }
 
-impl<'a, T, L, B> CycleCollection<'a, ForwardRefMarker> for Optional<T, L, B>
+impl<'a, T, L, B: Boundedness> CycleCollection<'a, ForwardRefMarker> for Optional<T, L, B>
 where
     L: Location<'a> + NoTick,
 {
@@ -134,7 +135,7 @@ where
     }
 }
 
-impl<'a, T, L, B> CycleComplete<'a, ForwardRefMarker> for Optional<T, L, B>
+impl<'a, T, L, B: Boundedness> CycleComplete<'a, ForwardRefMarker> for Optional<T, L, B>
 where
     L: Location<'a> + NoTick,
 {
@@ -171,7 +172,7 @@ where
     }
 }
 
-impl<'a, T, L, B> From<Singleton<T, L, B>> for Optional<T, L, B>
+impl<'a, T, L, B: Boundedness> From<Singleton<T, L, B>> for Optional<T, L, B>
 where
     L: Location<'a>,
 {
@@ -180,7 +181,7 @@ where
     }
 }
 
-impl<'a, T, L, B> Clone for Optional<T, L, B>
+impl<'a, T, L, B: Boundedness> Clone for Optional<T, L, B>
 where
     T: Clone,
     L: Location<'a>,
@@ -210,7 +211,7 @@ where
     }
 }
 
-impl<'a, T, L, B> Optional<T, L, B>
+impl<'a, T, L, B: Boundedness> Optional<T, L, B>
 where
     L: Location<'a>,
 {
@@ -517,7 +518,7 @@ where
     }
 }
 
-impl<'a, T, L, B> Optional<T, Atomic<L>, B>
+impl<'a, T, L, B: Boundedness> Optional<T, Atomic<L>, B>
 where
     L: Location<'a> + NoTick,
 {
@@ -544,7 +545,7 @@ where
     }
 }
 
-impl<'a, T, L, B> Optional<T, L, B>
+impl<'a, T, L, B: Boundedness> Optional<T, L, B>
 where
     L: Location<'a> + NoTick + NoAtomic,
 {

--- a/hydro_lang/src/singleton.rs
+++ b/hydro_lang/src/singleton.rs
@@ -5,6 +5,7 @@ use std::rc::Rc;
 
 use stageleft::{IntoQuotedMut, QuotedWithContext, q};
 
+use crate::boundedness::Boundedness;
 use crate::builder::FLOW_USED_MESSAGE;
 use crate::cycle::{
     CycleCollection, CycleCollectionWithInitial, CycleComplete, DeferTick, ForwardRefMarker,
@@ -17,7 +18,7 @@ use crate::stream::{AtLeastOnce, ExactlyOnce};
 use crate::unsafety::NonDet;
 use crate::{Bounded, NoOrder, Optional, Stream, TotalOrder, Unbounded};
 
-pub struct Singleton<Type, Loc, Bound> {
+pub struct Singleton<Type, Loc, Bound: Boundedness> {
     pub(crate) location: Loc,
     pub(crate) ir_node: RefCell<HydroNode>,
 
@@ -132,7 +133,7 @@ where
     }
 }
 
-impl<'a, T, L, B> CycleCollection<'a, ForwardRefMarker> for Singleton<T, L, B>
+impl<'a, T, L, B: Boundedness> CycleCollection<'a, ForwardRefMarker> for Singleton<T, L, B>
 where
     L: Location<'a> + NoTick,
 {
@@ -152,7 +153,7 @@ where
     }
 }
 
-impl<'a, T, L, B> CycleComplete<'a, ForwardRefMarker> for Singleton<T, L, B>
+impl<'a, T, L, B: Boundedness> CycleComplete<'a, ForwardRefMarker> for Singleton<T, L, B>
 where
     L: Location<'a> + NoTick,
 {
@@ -180,7 +181,7 @@ where
     }
 }
 
-impl<'a, T, L, B> Clone for Singleton<T, L, B>
+impl<'a, T, L, B: Boundedness> Clone for Singleton<T, L, B>
 where
     T: Clone,
     L: Location<'a>,
@@ -210,7 +211,7 @@ where
     }
 }
 
-impl<'a, T, L, B> Singleton<T, L, B>
+impl<'a, T, L, B: Boundedness> Singleton<T, L, B>
 where
     L: Location<'a>,
 {
@@ -402,7 +403,7 @@ where
     }
 }
 
-impl<'a, T, L, B> Singleton<T, Atomic<L>, B>
+impl<'a, T, L, B: Boundedness> Singleton<T, Atomic<L>, B>
 where
     L: Location<'a> + NoTick,
 {
@@ -429,7 +430,7 @@ where
     }
 }
 
-impl<'a, T, L, B> Singleton<T, L, B>
+impl<'a, T, L, B: Boundedness> Singleton<T, L, B>
 where
     L: Location<'a> + NoTick + NoAtomic,
 {
@@ -582,7 +583,8 @@ pub trait ZipResult<'a, Other> {
     fn make(location: Self::Location, ir_node: HydroNode) -> Self::Out;
 }
 
-impl<'a, T, U, L, B> ZipResult<'a, Singleton<U, Tick<L>, B>> for Singleton<T, Tick<L>, B>
+impl<'a, T, U, L, B: Boundedness> ZipResult<'a, Singleton<U, Tick<L>, B>>
+    for Singleton<T, Tick<L>, B>
 where
     U: Clone,
     L: Location<'a>,
@@ -604,7 +606,8 @@ where
     }
 }
 
-impl<'a, T, U, L, B> ZipResult<'a, Optional<U, Tick<L>, B>> for Singleton<T, Tick<L>, B>
+impl<'a, T, U, L, B: Boundedness> ZipResult<'a, Optional<U, Tick<L>, B>>
+    for Singleton<T, Tick<L>, B>
 where
     U: Clone,
     L: Location<'a>,

--- a/hydro_lang/src/stream/networking.rs
+++ b/hydro_lang/src/stream/networking.rs
@@ -5,6 +5,7 @@ use serde::de::DeserializeOwned;
 use stageleft::{q, quote_type};
 use syn::parse_quote;
 
+use crate::boundedness::Boundedness;
 use crate::ir::{DebugInstantiate, HydroLeaf, HydroNode};
 use crate::keyed_singleton::KeyedSingleton;
 use crate::keyed_stream::KeyedStream;
@@ -83,7 +84,7 @@ pub(crate) fn deserialize_bincode<T: DeserializeOwned>(tagged: Option<&syn::Type
     deserialize_bincode_with_type(tagged, &quote_type::<T>())
 }
 
-impl<'a, T, L, B, O, R> Stream<T, Cluster<'a, L>, B, O, R> {
+impl<'a, T, L, B: Boundedness, O, R> Stream<T, Cluster<'a, L>, B, O, R> {
     pub fn send_bincode<L2>(
         self,
         other: &Process<'a, L2>,
@@ -138,7 +139,7 @@ impl<'a, T, L, B, O, R> Stream<T, Cluster<'a, L>, B, O, R> {
     }
 }
 
-impl<'a, T, L, L2, B, O, R> Stream<(MemberId<L2>, T), Process<'a, L>, B, O, R> {
+impl<'a, T, L, L2, B: Boundedness, O, R> Stream<(MemberId<L2>, T), Process<'a, L>, B, O, R> {
     pub fn demux_bincode(
         self,
         other: &Cluster<'a, L2>,
@@ -150,7 +151,7 @@ impl<'a, T, L, L2, B, O, R> Stream<(MemberId<L2>, T), Process<'a, L>, B, O, R> {
     }
 }
 
-impl<'a, T, L, L2, B, O, R> KeyedStream<MemberId<L2>, T, Process<'a, L>, B, O, R> {
+impl<'a, T, L, L2, B: Boundedness, O, R> KeyedStream<MemberId<L2>, T, Process<'a, L>, B, O, R> {
     pub fn demux_bincode(
         self,
         other: &Cluster<'a, L2>,
@@ -175,7 +176,7 @@ impl<'a, T, L, L2, B, O, R> KeyedStream<MemberId<L2>, T, Process<'a, L>, B, O, R
     }
 }
 
-impl<'a, T, L, B> Stream<T, Process<'a, L>, B, TotalOrder, ExactlyOnce> {
+impl<'a, T, L, B: Boundedness> Stream<T, Process<'a, L>, B, TotalOrder, ExactlyOnce> {
     pub fn round_robin_bincode<L2: 'a>(
         self,
         other: &Cluster<'a, L2>,
@@ -206,7 +207,7 @@ impl<'a, T, L, B> Stream<T, Process<'a, L>, B, TotalOrder, ExactlyOnce> {
     }
 }
 
-impl<'a, T, L, L2, B, O, R> Stream<(MemberId<L2>, T), Cluster<'a, L>, B, O, R> {
+impl<'a, T, L, L2, B: Boundedness, O, R> Stream<(MemberId<L2>, T), Cluster<'a, L>, B, O, R> {
     pub fn demux_bincode(
         self,
         other: &Cluster<'a, L2>,
@@ -218,7 +219,7 @@ impl<'a, T, L, L2, B, O, R> Stream<(MemberId<L2>, T), Cluster<'a, L>, B, O, R> {
     }
 }
 
-impl<'a, T, L, L2, B, O, R> KeyedStream<MemberId<L2>, T, Cluster<'a, L>, B, O, R> {
+impl<'a, T, L, L2, B: Boundedness, O, R> KeyedStream<MemberId<L2>, T, Cluster<'a, L>, B, O, R> {
     pub fn demux_bincode(
         self,
         other: &Cluster<'a, L2>,
@@ -245,7 +246,7 @@ impl<'a, T, L, L2, B, O, R> KeyedStream<MemberId<L2>, T, Cluster<'a, L>, B, O, R
     }
 }
 
-impl<'a, T, L, B, O, R> Stream<T, Process<'a, L>, B, O, R> {
+impl<'a, T, L, B: Boundedness, O, R> Stream<T, Process<'a, L>, B, O, R> {
     pub fn send_bincode<L2>(
         self,
         other: &Process<'a, L2>,

--- a/hydro_std/src/compartmentalize.rs
+++ b/hydro_std/src/compartmentalize.rs
@@ -1,3 +1,4 @@
+use hydro_lang::boundedness::Boundedness;
 use hydro_lang::*;
 use location::NoTick;
 use serde::Serialize;
@@ -38,7 +39,7 @@ pub trait DecoupleClusterStream<'a, T, C1, B, Order> {
         T: Clone + Serialize + DeserializeOwned;
 }
 
-impl<'a, T, C1, B, Order> DecoupleClusterStream<'a, T, C1, B, Order>
+impl<'a, T, C1, B: Boundedness, Order> DecoupleClusterStream<'a, T, C1, B, Order>
     for Stream<T, Cluster<'a, C1>, B, Order>
 {
     fn decouple_cluster<C2: 'a>(
@@ -71,7 +72,7 @@ pub trait DecoupleProcessStream<'a, T, L: Location<'a> + NoTick, B, Order> {
         T: Clone + Serialize + DeserializeOwned;
 }
 
-impl<'a, T, L, B, Order> DecoupleProcessStream<'a, T, Process<'a, L>, B, Order>
+impl<'a, T, L, B: Boundedness, Order> DecoupleProcessStream<'a, T, Process<'a, L>, B, Order>
     for Stream<T, Process<'a, L>, B, Order>
 {
     fn decouple_process<P2>(

--- a/hydro_test/examples/http_hello.rs
+++ b/hydro_test/examples/http_hello.rs
@@ -24,9 +24,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (port, input, _membership, output_ref) = process
         .bidi_external_many_bytes::<_, _, LinesCodec>(&external, NetworkHint::TcpPort(Some(4000)));
 
-    output_ref.complete(hydro_test::external_client::http_hello::http_hello_server(
-        input,
-    ));
+    output_ref.complete(
+        hydro_test::external_client::http_hello::http_hello_server(input).into_keyed_stream(),
+    );
 
     // Extract the IR BEFORE the builder is consumed by deployment methods
     let built = flow.finalize();

--- a/hydro_test/src/external_client/http_hello.rs
+++ b/hydro_test/src/external_client/http_hello.rs
@@ -1,9 +1,10 @@
+use hydro_lang::keyed_singleton::{BoundedValue, KeyedSingleton};
 use hydro_lang::keyed_stream::KeyedStream;
 use hydro_lang::*;
 
 pub fn http_hello_server<'a, P>(
     in_stream: KeyedStream<u64, String, Process<'a, P>, Unbounded, TotalOrder>,
-) -> KeyedStream<u64, String, Process<'a, P>, Unbounded, TotalOrder> {
+) -> KeyedSingleton<u64, String, Process<'a, P>, BoundedValue> {
     in_stream
         .inspect_with_key(q!(|(id, line)| println!(
             "Received line from client #{}: '{}'",


### PR DESCRIPTION

There are many cases where once a value is released into a `KeyedSingleton`, it will never be changes. In such cases, we can permit APIs like `.entries` even if the set of entries is growing.

We use this type to improve the API surface for looking up values for a request. Now, a `KeyedSingleton` of requests can look up values from another `KeyedSingleton`.
