### PR TITLE
ci: avoid mutual-cancellation

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,8 +27,6 @@ jobs:
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v5.3.1
-        with:
-          cancel_others: ${{ github.event_name == 'pull_request' }}
 
   benches:
     name: Benchmarks

--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -19,8 +19,6 @@ jobs:
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v5.3.1
-        with:
-          cancel_others: ${{ github.event_name == 'pull_request' }}
 
   build-website:
     name: Build Website

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,6 @@ jobs:
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v5.3.1
-        with:
-          cancel_others: ${{ github.event_name == 'pull_request' }}
 
   test:
     name: All tests, lints, and checks

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v5.3.1
-        with:
-          cancel_others: ${{ github.event_name == 'pull_request' }}
 
   docs:
     name: Docs (rustdoc)

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -17,8 +17,6 @@ jobs:
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v5.3.1
-        with:
-          cancel_others: ${{ github.event_name == 'pull_request' }}
 
   test_dfir:
     name: Test dfir


### PR DESCRIPTION

Now that we use native support in GHA for cancelling duplicate workflows, no need to do that an action (that causes pairs of workflows to cancel each other).
