### PR TITLE
ci: add collector jobs to handle required status checks for skipped matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,6 @@ jobs:
 
   test:
     name: All tests, lints, and checks
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.event_name != 'pull_request' }}
     timeout-minutes: 45
     needs: pre_job
     runs-on: ${{ matrix.os }}
@@ -216,6 +215,20 @@ jobs:
               console.log(`Closed existing issue #${existingIssue.number} - tests now passing`);
             }
 
+  test-all:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: Test Suite Result (Full Matrix)
+    needs: [test]
+    steps:
+      - run: |
+          result="${{ needs.build.result }}"
+          if [[ $result == "success" || $result == "skipped" ]]; then
+            exit 0
+          else
+            exit 1
+          fi
+
   test-wasm:
     name: Test Suite (WebAssembly)
     if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.event_name != 'pull_request' }}
@@ -260,3 +273,17 @@ jobs:
         run: cargo test -p dfir_rs --target wasm32-unknown-unknown --tests --no-fail-fast
 
       - run: cargo check -p dfir_rs --target wasm32-unknown-unknown
+  
+  test-wasm-all:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: Test Suite Result (WebAssembly Full Matrix)
+    needs: [test-wasm]
+    steps:
+      - run: |
+          result="${{ needs.build.result }}"
+          if [[ $result == "success" || $result == "skipped" ]]; then
+            exit 0
+          else
+            exit 1
+          fi


### PR DESCRIPTION

Actions does not expand the matrix is the task is skipped, which causes the required status checks to be stuck in a pending state. This workaround adds "collector" jobs which aggregate the result of the matrix so that we can require that check instead.
