### PR TITLE
build: use `rust-lld` on `x86_64-unknown-linux-gnu `

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,6 +16,9 @@ linker = "rust-lld"
 [target.x86_64-apple-darwin]
 linker = "rust-lld"
 
+[target.x86_64-unknown-linux-gnu]
+linker = "rust-lld"
+
 [target.x86_64-unknown-linux-musl]
 linker = "rust-lld"
 


### PR DESCRIPTION

Improves compilation speed, and [will be default on Rust 1.90](https://blog.rust-lang.org/2025/09/01/rust-lld-on-1.90.0-stable), so good to be a bit ahead of the curve.
