### PR TITLE
refactor(hydro_lang)!: rename `graph_util` => `graph::config`

### DIFF
--- a/hydro_lang/src/builder/built.rs
+++ b/hydro_lang/src/builder/built.rs
@@ -330,7 +330,7 @@ impl<'a> BuiltFlow<'a> {
     #[cfg(feature = "viz")]
     pub fn generate_graph_with_config(
         &self,
-        config: &crate::graph_util::GraphConfig,
+        config: &crate::graph::config::GraphConfig,
         message_handler: Option<&dyn Fn(&str)>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         self.graph_api()
@@ -340,7 +340,7 @@ impl<'a> BuiltFlow<'a> {
     #[cfg(feature = "viz")]
     pub fn generate_all_files_with_config(
         &self,
-        config: &crate::graph_util::GraphConfig,
+        config: &crate::graph::config::GraphConfig,
         prefix: &str,
     ) -> Result<(), Box<dyn std::error::Error>> {
         self.graph_api()

--- a/hydro_lang/src/graph/api.rs
+++ b/hydro_lang/src/graph/api.rs
@@ -306,14 +306,14 @@ impl<'a> GraphApi<'a> {
     #[cfg(feature = "build")]
     pub fn generate_graph_with_config(
         &self,
-        config: &crate::graph_util::GraphConfig,
+        config: &crate::graph::config::GraphConfig,
         message_handler: Option<&dyn Fn(&str)>,
     ) -> Result<(), Box<dyn Error>> {
         if let Some(graph_type) = config.graph {
             let format = match graph_type {
-                crate::graph_util::GraphType::Mermaid => GraphFormat::Mermaid,
-                crate::graph_util::GraphType::Dot => GraphFormat::Dot,
-                crate::graph_util::GraphType::Reactflow => GraphFormat::ReactFlow,
+                crate::graph::config::GraphType::Mermaid => GraphFormat::Mermaid,
+                crate::graph::config::GraphType::Dot => GraphFormat::Dot,
+                crate::graph::config::GraphType::Reactflow => GraphFormat::ReactFlow,
             };
 
             self.open_browser(
@@ -332,7 +332,7 @@ impl<'a> GraphApi<'a> {
     #[cfg(feature = "build")]
     pub fn generate_all_files_with_config(
         &self,
-        config: &crate::graph_util::GraphConfig,
+        config: &crate::graph::config::GraphConfig,
         prefix: &str,
     ) -> Result<(), Box<dyn Error>> {
         self.generate_all_files(

--- a/hydro_lang/src/graph/config.rs
+++ b/hydro_lang/src/graph/config.rs
@@ -1,8 +1,6 @@
-#[cfg(feature = "viz")]
 use clap::{Parser, ValueEnum};
 
 /// Enum for choosing between mermaid, dot, and reactflow graph writing.
-#[cfg(feature = "viz")]
 #[derive(Copy, Clone, Debug, ValueEnum)]
 pub enum GraphType {
     /// Mermaid graphs.
@@ -13,7 +11,6 @@ pub enum GraphType {
     Reactflow,
 }
 
-#[cfg(feature = "viz")]
 impl std::fmt::Display for GraphType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self)
@@ -21,7 +18,6 @@ impl std::fmt::Display for GraphType {
 }
 
 /// Configuration for graph generation in examples.
-#[cfg(feature = "viz")]
 #[derive(Parser, Debug, Default)]
 pub struct GraphConfig {
     /// Graph format to generate and display

--- a/hydro_lang/src/graph/mod.rs
+++ b/hydro_lang/src/graph/mod.rs
@@ -1,6 +1,7 @@
 //! Graph visualization utilities for Hydro IR
 
 pub mod api;
+pub mod config;
 pub mod debug;
 pub mod graphviz;
 pub mod mermaid;

--- a/hydro_lang/src/lib.rs
+++ b/hydro_lang/src/lib.rs
@@ -94,11 +94,6 @@ pub mod ir;
 #[expect(missing_docs, reason = "TODO")]
 pub mod graph;
 
-#[cfg(feature = "viz")]
-#[cfg_attr(docsrs, doc(cfg(feature = "viz")))]
-#[expect(missing_docs, reason = "TODO")]
-pub mod graph_util;
-
 #[expect(missing_docs, reason = "TODO")]
 pub mod rewrites;
 

--- a/hydro_test/examples/benchmark_paxos.rs
+++ b/hydro_test/examples/benchmark_paxos.rs
@@ -18,7 +18,7 @@ async fn main() {
     #[command(author, version, about, long_about = None)]
     struct BenchmarkArgs {
         #[command(flatten)]
-        graph: hydro_lang::graph_util::GraphConfig,
+        graph: hydro_lang::graph::config::GraphConfig,
 
         /// Use GCP for deployment (provide project name)
         #[arg(long)]

--- a/hydro_test/examples/chat.rs
+++ b/hydro_test/examples/chat.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use dfir_rs::tokio_util::codec::LinesCodec;
 use hydro_deploy::Deployment;
 use hydro_lang::deploy::TrybuildHost;
-use hydro_lang::graph_util::GraphConfig;
+use hydro_lang::graph::config::GraphConfig;
 use hydro_lang::{Location, NetworkHint, nondet};
 
 #[derive(Parser, Debug)]

--- a/hydro_test/examples/compartmentalized_paxos.rs
+++ b/hydro_test/examples/compartmentalized_paxos.rs
@@ -15,7 +15,7 @@ struct Args {
 use hydro_deploy::gcp::GcpNetwork;
 use hydro_deploy::{Deployment, Host};
 use hydro_lang::deploy::TrybuildHost;
-use hydro_lang::graph_util::GraphConfig;
+use hydro_lang::graph::config::GraphConfig;
 use hydro_test::cluster::compartmentalized_paxos::{
     CompartmentalizedPaxosConfig, CoreCompartmentalizedPaxos,
 };

--- a/hydro_test/examples/compute_pi.rs
+++ b/hydro_test/examples/compute_pi.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use hydro_deploy::gcp::GcpNetwork;
 use hydro_deploy::{Deployment, Host};
 use hydro_lang::deploy::TrybuildHost;
-use hydro_lang::graph_util::GraphConfig;
+use hydro_lang::graph::config::GraphConfig;
 use tokio::sync::RwLock;
 
 type HostCreator = Box<dyn Fn(&mut Deployment) -> Arc<dyn Host>>;

--- a/hydro_test/examples/decouple_compute_pi.rs
+++ b/hydro_test/examples/decouple_compute_pi.rs
@@ -16,7 +16,7 @@ use hydro_deploy::gcp::GcpNetwork;
 use hydro_deploy::{Deployment, Host};
 use hydro_lang::Location;
 use hydro_lang::deploy::TrybuildHost;
-use hydro_lang::graph_util::GraphConfig;
+use hydro_lang::graph::config::GraphConfig;
 use hydro_lang::rewrites::persist_pullup;
 use hydro_optimize::debug;
 use hydro_optimize::decoupler::{self, Decoupler};

--- a/hydro_test/examples/echo.rs
+++ b/hydro_test/examples/echo.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use dfir_rs::tokio_util::codec::LinesCodec;
 use hydro_deploy::Deployment;
 use hydro_lang::deploy::TrybuildHost;
-use hydro_lang::graph_util::GraphConfig;
+use hydro_lang::graph::config::GraphConfig;
 use hydro_lang::{Location, NetworkHint};
 
 #[derive(Parser, Debug)]

--- a/hydro_test/examples/first_ten_distributed.rs
+++ b/hydro_test/examples/first_ten_distributed.rs
@@ -5,7 +5,7 @@ use futures::SinkExt;
 use hydro_deploy::gcp::GcpNetwork;
 use hydro_deploy::{Deployment, Host};
 use hydro_lang::deploy::TrybuildHost;
-use hydro_lang::graph_util::GraphConfig;
+use hydro_lang::graph::config::GraphConfig;
 use tokio::sync::RwLock;
 
 type HostCreator = Box<dyn Fn(&mut Deployment) -> Arc<dyn Host>>;

--- a/hydro_test/examples/http_counter.rs
+++ b/hydro_test/examples/http_counter.rs
@@ -3,7 +3,7 @@ use dfir_rs::tokio_util::codec::LinesCodec;
 use hydro_deploy::Deployment;
 use hydro_deploy::custom_service::ServerPort;
 use hydro_lang::deploy::TrybuildHost;
-use hydro_lang::graph_util::GraphConfig;
+use hydro_lang::graph::config::GraphConfig;
 use hydro_lang::{Location, NetworkHint};
 
 #[derive(Parser, Debug)]

--- a/hydro_test/examples/http_hello.rs
+++ b/hydro_test/examples/http_hello.rs
@@ -3,7 +3,7 @@ use dfir_rs::tokio_util::codec::LinesCodec;
 use hydro_deploy::Deployment;
 use hydro_deploy::custom_service::ServerPort;
 use hydro_lang::deploy::TrybuildHost;
-use hydro_lang::graph_util::GraphConfig;
+use hydro_lang::graph::config::GraphConfig;
 use hydro_lang::{Location, NetworkHint};
 
 #[derive(Parser, Debug)]

--- a/hydro_test/examples/map_reduce.rs
+++ b/hydro_test/examples/map_reduce.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use hydro_deploy::gcp::GcpNetwork;
 use hydro_deploy::{Deployment, Host};
 use hydro_lang::deploy::TrybuildHost;
-use hydro_lang::graph_util::GraphConfig;
+use hydro_lang::graph::config::GraphConfig;
 use tokio::sync::RwLock;
 
 type HostCreator = Box<dyn Fn(&mut Deployment) -> Arc<dyn Host>>;

--- a/hydro_test/examples/partition_simple_cluster.rs
+++ b/hydro_test/examples/partition_simple_cluster.rs
@@ -17,7 +17,7 @@ use hydro_deploy::gcp::GcpNetwork;
 use hydro_deploy::{Deployment, Host};
 use hydro_lang::Location;
 use hydro_lang::deploy::TrybuildHost;
-use hydro_lang::graph_util::GraphConfig;
+use hydro_lang::graph::config::GraphConfig;
 use hydro_lang::rewrites::persist_pullup;
 use hydro_optimize::partitioner::{self, Partitioner};
 use tokio::sync::RwLock;

--- a/hydro_test/examples/paxos.rs
+++ b/hydro_test/examples/paxos.rs
@@ -15,7 +15,7 @@ struct Args {
 use hydro_deploy::gcp::GcpNetwork;
 use hydro_deploy::{Deployment, Host};
 use hydro_lang::deploy::TrybuildHost;
-use hydro_lang::graph_util::GraphConfig;
+use hydro_lang::graph::config::GraphConfig;
 use hydro_test::cluster::paxos::{CorePaxos, PaxosConfig};
 use tokio::sync::RwLock;
 

--- a/hydro_test/examples/perf_compute_pi.rs
+++ b/hydro_test/examples/perf_compute_pi.rs
@@ -16,7 +16,7 @@ async fn main() {
     use hydro_deploy::Deployment;
     use hydro_deploy::gcp::GcpNetwork;
     use hydro_lang::Location;
-    use hydro_lang::graph_util::GraphConfig;
+    use hydro_lang::graph::config::GraphConfig;
     use hydro_optimize::deploy::ReusableHosts;
     use hydro_optimize::deploy_and_analyze::deploy_and_analyze;
     use hydro_test::cluster::compute_pi::{Leader, Worker, compute_pi};

--- a/hydro_test/examples/perf_paxos.rs
+++ b/hydro_test/examples/perf_paxos.rs
@@ -7,7 +7,7 @@ async fn main() {
     use hydro_deploy::Deployment;
     use hydro_deploy::gcp::GcpNetwork;
     use hydro_lang::Location;
-    use hydro_lang::graph_util::GraphConfig;
+    use hydro_lang::graph::config::GraphConfig;
     use hydro_optimize::decoupler;
     use hydro_optimize::deploy::ReusableHosts;
     use hydro_optimize::deploy_and_analyze::deploy_and_analyze;

--- a/hydro_test/examples/simple_cluster.rs
+++ b/hydro_test/examples/simple_cluster.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use hydro_deploy::gcp::GcpNetwork;
 use hydro_deploy::{Deployment, Host};
 use hydro_lang::deploy::TrybuildHost;
-use hydro_lang::graph_util::GraphConfig;
+use hydro_lang::graph::config::GraphConfig;
 use tokio::sync::RwLock;
 
 type HostCreator = Box<dyn Fn(&mut Deployment) -> Arc<dyn Host>>;

--- a/hydro_test/examples/two_pc.rs
+++ b/hydro_test/examples/two_pc.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use hydro_deploy::gcp::GcpNetwork;
 use hydro_deploy::{Deployment, Host};
 use hydro_lang::deploy::TrybuildHost;
-use hydro_lang::graph_util::GraphConfig;
+use hydro_lang::graph::config::GraphConfig;
 use tokio::sync::RwLock;
 
 type HostCreator = Box<dyn Fn(&mut Deployment) -> Arc<dyn Host>>;


### PR DESCRIPTION

Clearer name, and all the declarations in it were for configuring graph generation anyways.
