### PR TITLE
docs(hydro_lang): docs for `backtrace` module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
-  CARGO_PROFILE_DEV_STRIP: "debuginfo"
-  CARGO_PROFILE_TEST_STRIP: "debuginfo"
-  CARGO_PROFILE_RELEASE_STRIP: "debuginfo"
+  RUSTFLAGS: "-C debuginfo=line-tables-only"
 
 defaults:
   run:

--- a/hydro_lang/src/ir.rs
+++ b/hydro_lang/src/ir.rs
@@ -24,7 +24,6 @@ use syn::visit_mut::VisitMut;
 use crate::NetworkHint;
 #[cfg(stageleft_runtime)]
 use crate::backtrace::Backtrace;
-use crate::backtrace::get_backtrace;
 #[cfg(feature = "build")]
 use crate::deploy::{Deploy, RegisterPort};
 use crate::location::LocationId;
@@ -1020,7 +1019,7 @@ impl HydroIrOpMetadata {
     #[inline(never)]
     fn new_with_skip(skip_count: usize) -> HydroIrOpMetadata {
         HydroIrOpMetadata {
-            backtrace: get_backtrace(2 + skip_count),
+            backtrace: Backtrace::get_backtrace(2 + skip_count),
             cpu_usage: None,
             network_recv_cpu_usage: None,
             id: None,

--- a/hydro_lang/src/lib.rs
+++ b/hydro_lang/src/lib.rs
@@ -104,7 +104,6 @@ pub mod rewrites;
 
 mod staging_util;
 
-#[expect(missing_docs, reason = "TODO")]
 pub mod backtrace;
 
 #[cfg(feature = "deploy")]

--- a/hydro_lang/src/location/mod.rs
+++ b/hydro_lang/src/location/mod.rs
@@ -12,7 +12,7 @@ use syn::parse_quote;
 use tokio_util::codec::{Decoder, Encoder, LengthDelimitedCodec};
 
 use super::builder::FlowState;
-use crate::backtrace::get_backtrace;
+use crate::backtrace::Backtrace;
 use crate::cycle::{CycleCollection, ForwardRef, ForwardRefMarker};
 use crate::ir::{
     DebugInstantiate, HydroIrMetadata, HydroIrOpMetadata, HydroNode, HydroRoot, HydroSource,
@@ -139,7 +139,7 @@ pub trait Location<'a>: Clone {
             cardinality: None,
             tag: None,
             op: HydroIrOpMetadata {
-                backtrace: get_backtrace(2),
+                backtrace: Backtrace::get_backtrace(2),
                 cpu_usage: None,
                 network_recv_cpu_usage: None,
                 id: None,

--- a/hydro_lang/src/snapshots/hydro_lang__stream__tests__backtrace_chained_ops-2.snap
+++ b/hydro_lang/src/snapshots/hydro_lang__stream__tests__backtrace_chained_ops-2.snap
@@ -1,24 +1,24 @@
 ---
-source: hydro_lang/src/backtrace.rs
-expression: elements
+source: hydro_lang/src/stream.rs
+expression: for_each_meta.backtrace.elements()
 ---
 [
     BacktraceElement {
-        fn_name: "hydro_lang::backtrace::tests::test_backtrace",
+        fn_name: "hydro_lang::stream::tests::backtrace_chained_ops",
         lineno: Some(
-            129,
+            2588,
         ),
         colno: Some(
-            25,
+            37,
         ),
     },
     BacktraceElement {
-        fn_name: "hydro_lang::backtrace::tests::test_backtrace::{{closure}}",
+        fn_name: "hydro_lang::stream::tests::backtrace_chained_ops::{{closure}}",
         lineno: Some(
-            128,
+            2582,
         ),
         colno: Some(
-            24,
+            31,
         ),
     },
     BacktraceElement {

--- a/hydro_lang/src/snapshots/hydro_lang__stream__tests__backtrace_chained_ops.snap
+++ b/hydro_lang/src/snapshots/hydro_lang__stream__tests__backtrace_chained_ops.snap
@@ -1,24 +1,24 @@
 ---
-source: hydro_lang/src/backtrace.rs
-expression: elements
+source: hydro_lang/src/stream.rs
+expression: source_meta.backtrace.elements()
 ---
 [
     BacktraceElement {
-        fn_name: "hydro_lang::backtrace::tests::test_backtrace",
+        fn_name: "hydro_lang::stream::tests::backtrace_chained_ops",
         lineno: Some(
-            129,
+            2588,
         ),
         colno: Some(
-            25,
+            14,
         ),
     },
     BacktraceElement {
-        fn_name: "hydro_lang::backtrace::tests::test_backtrace::{{closure}}",
+        fn_name: "hydro_lang::stream::tests::backtrace_chained_ops::{{closure}}",
         lineno: Some(
-            128,
+            2582,
         ),
         colno: Some(
-            24,
+            31,
         ),
     },
     BacktraceElement {

--- a/hydro_lang/src/stream.rs
+++ b/hydro_lang/src/stream.rs
@@ -2576,4 +2576,41 @@ mod tests {
 
         assert_eq!(external_out.next().await.unwrap(), 1);
     }
+
+    #[cfg(unix)]
+    #[test]
+    fn backtrace_chained_ops() {
+        use crate::ir::HydroRoot;
+
+        let flow = FlowBuilder::new();
+        let node = flow.process::<()>();
+
+        node.source_iter(q!([123])).for_each(q!(|_| {}));
+
+        let finalized: crate::builder::built::BuiltFlow<'_> = flow.finalize();
+
+        let source_meta = if let HydroRoot::ForEach { input, .. } = &finalized.ir()[0] {
+            use crate::ir::HydroNode;
+
+            if let HydroNode::Unpersist { inner, .. } = input.as_ref() {
+                if let HydroNode::Persist { inner, .. } = inner.as_ref() {
+                    if let HydroNode::Source { metadata, .. } = inner.as_ref() {
+                        &metadata.op
+                    } else {
+                        panic!()
+                    }
+                } else {
+                    panic!()
+                }
+            } else {
+                panic!()
+            }
+        } else {
+            panic!()
+        };
+        let for_each_meta = finalized.ir()[0].op_metadata();
+
+        hydro_build_utils::assert_debug_snapshot!(source_meta.backtrace.elements());
+        hydro_build_utils::assert_debug_snapshot!(for_each_meta.backtrace.elements());
+    }
 }


### PR DESCRIPTION

Also cleans up the API interface, adds the `colno` field, and a unit test showing that we can precisely identify each element of chained operators.
