### PR TITLE
ci: set hydro-project-bot bot to be the author of generated PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,7 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           commit-message: "chore: update nightly snapshots"
+          author: hydro-project-bot[bot] <132423234+hydro-project-bot[bot]@users.noreply.github.com>
           title: "chore: update nightly snapshots"
           body: |
             [ci-full]


### PR DESCRIPTION

Otherwise it defaults to the user who triggered the workflow, which for reasons I don't understand is @MingweiSamuel?
