### PR TITLE
refactor(hydro_lang)!: set up prelude, move collections under `live_collections` module

### DIFF
--- a/docs/docs/hydro/live-collections/bounded-unbounded.md
+++ b/docs/docs/hydro/live-collections/bounded-unbounded.md
@@ -11,7 +11,7 @@ In Hydro, certain APIs are restricted to only work on collections that are **gua
 In some cases, you may need to convert between bounded and unbounded collections. Converting from a bounded collection **to an unbounded collection** is always allowed and safe, since it relaxes the guarantees on the collection. This can be done by calling `.into()` on the collection.
 
 ```rust,no_run
-# use hydro_lang::*;
+# use hydro_lang::prelude::*;
 # use futures::StreamExt;
 # let flow = FlowBuilder::new();
 # let process = flow.process::<()>();
@@ -23,7 +23,7 @@ let unbounded: Stream<_, _, Unbounded> = input.into();
 ```
 
 ```rust,no_run
-# use hydro_lang::*;
+# use hydro_lang::prelude::*;
 # use futures::StreamExt;
 # let flow = FlowBuilder::new();
 # let process = flow.process::<()>();
@@ -35,7 +35,7 @@ let unbounded: Singleton<_, _, Unbounded> = input.into();
 Converting from an unbounded collection **to a bounded collection**, however is more complex. This requires cutting off the unbounded collection at a specific point in time, which may not be possible to do deterministically. For example, the most common way to convert an unbounded `Stream` to a bounded one is to batch its elements non-deterministically using `.batch()`. Because this is non-deterministic, this API requires a [non-determinism guard](./determinism.md#unsafe-operations-in-hydro).
 
 ```rust,no_run
-# use hydro_lang::*;
+# use hydro_lang::prelude::*;
 # use futures::StreamExt;
 # let flow = FlowBuilder::new();
 # let process = flow.process::<()>();

--- a/docs/docs/hydro/live-collections/determinism.md
+++ b/docs/docs/hydro/live-collections/determinism.md
@@ -25,7 +25,7 @@ All **safe** APIs in Hydro (the ones you can call regularly in Rust) guarantee d
 These non-deterministic APIs take additional paramters called **non-determinism guards**. These values, with type `NonDep`, help you reason about how non-determinism affects your application. To pass a non-determinism guard, you must invoke `nondet!()` with an explanation for how the non-determinism affects the application. If the non-determinism is never exposed outside the function, or if it appears at the root of your application (and thus is documented in the service guarantees), you should use `nondet!()` with only a single parameter containing the explanation.
 
 ```rust,no_run
-# use hydro_lang::*;
+# use hydro_lang::prelude::*;
 use std::time::Duration;
 
 fn singleton_with_delay<T, L>(
@@ -42,7 +42,7 @@ When writing a function with Hydro that involves non-deterministic APIs, it is i
 If the outputs of your code are non-deterministic, you should take non-determinism guards and document this behavior in the Rustdoc. Then, when invoking APIs whose non-determinism propagates to the outputs of your code, you should use `nondet!` passing in an explanation as well the relevant guard parameter.
 
 ```rust
-# use hydro_lang::*;
+# use hydro_lang::prelude::*;
 use std::fmt::Debug;
 use std::time::Duration;
 

--- a/docs/docs/hydro/live-collections/keyed-streams.mdx
+++ b/docs/docs/hydro/live-collections/keyed-streams.mdx
@@ -15,9 +15,9 @@ Think of a keyed stream as a collection of independent sub-streams, each identif
 Any stream of tuples `(K, V)` can be converted into a keyed stream using the `into_keyed()` method:
 
 ```rust
-# use hydro_lang::*;
+# use hydro_lang::prelude::*;
 # use futures::StreamExt;
-# tokio_test::block_on(test_util::stream_transform_test(|process| {
+# tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
 let data = process.source_iter(q!(vec![
     ("user1", "login"),
     ("user2", "click"), 
@@ -50,9 +50,9 @@ Keyed streams are different from regular streams in that they capture a _partial
 Keyed streams support familiar transformation operations like `map` and `filter` ([full API](pathname:///rustdoc/hydro_lang/keyed_stream/struct.KeyedStream)) that operate on the values within each group, and thus preserve any ordering guarantees. Each key maintains its own independent processing pipeline - `user1` events are transformed and filtered separately from `user2` events:
 
 ```rust
-# use hydro_lang::*;
+# use hydro_lang::prelude::*;
 # use futures::StreamExt;
-# tokio_test::block_on(test_util::stream_transform_test(|process| {
+# tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
 let events = process.source_iter(q!(vec![
     ("user1", "login"),
     ("user2", "click"), 
@@ -88,9 +88,9 @@ Keyed streams are most commonly used when dealing with network requests originat
 Keyed streams provide two methods to convert back to regular streams. The `.entries()` method returns a stream of `(K, V)` tuples, while `.values()` returns a stream of just the values, discarding keys. Note that both of these APIs return a stream with `NoOrder` ordering, because they interleave elements across key groups in non-deterministic order. This means that downstream logic must tolerate this unknown interleaving of elements appropriately.
 
 ```rust
-# use hydro_lang::*;
+# use hydro_lang::prelude::*;
 # use futures::StreamExt;
-# tokio_test::block_on(test_util::stream_transform_test(|process| {
+# tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
 let keyed = process
     .source_iter(q!(vec![("A", 1), ("B", 2), ("A", 3)]))
     .into_keyed();
@@ -113,9 +113,9 @@ let values = keyed.values(); // Stream<V, _, _, NoOrder>
 One of the most powerful features of keyed streams is the ability to perform aggregations within each key group. The `fold` operation accumulates values for each key independently, maintaining separate state for each key while preserving ordering guarantees within each group:
 
 ```rust
-# use hydro_lang::*;
+# use hydro_lang::prelude::*;
 # use futures::StreamExt;
-# tokio_test::block_on(test_util::stream_transform_test(|process| {
+# tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
 let purchases = process.source_iter(q!(vec![
     ("alice", 10),
     ("bob", 5),
@@ -145,9 +145,9 @@ purchases.fold(q!(|| 0), q!(|acc, amount| *acc += amount))
 Keyed streams support different fold variants based on ordering and retry guarantees. The basic `fold` requires `TotalOrder` within groups for order-dependent aggregation, while `fold_commutative` works with `NoOrder` and requires commutative operations. For handling potential duplicates, `fold_idempotent` requires idempotent operations, and `fold_commutative_idempotent` is the most flexible, handling both unordered and duplicate messages:
 
 ```rust
-# use hydro_lang::*;
+# use hydro_lang::prelude::*;
 # use futures::StreamExt;
-# tokio_test::block_on(test_util::stream_transform_test(|process| {
+# tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
 let tick = process.tick();
 
 let health_checks = process.source_iter(q!(vec![

--- a/docs/docs/hydro/live-collections/streams.md
+++ b/docs/docs/hydro/live-collections/streams.md
@@ -16,7 +16,7 @@ Streams have several type parameters:
 The simplest way to create a stream is to use [`Location::source_iter`](https://hydro.run/rustdoc/hydro_lang/location/trait.Location#method.source_iter), which creates a stream from any Rust type that can be converted into an [`Iterator`](https://doc.rust-lang.org/beta/std/iter/trait.Iterator.html) (via [`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html)). For example, we can create a stream of integers on a [process](../locations/processes) and transform it:
 
 ```rust
-# use hydro_lang::*;
+# use hydro_lang::prelude::*;
 # use futures::StreamExt;
 # tokio_test::block_on(test_util::multi_location_test(|flow, p_out| {
 let process = flow.process::<()>();
@@ -35,7 +35,7 @@ let numbers: Stream<_, Process<_>, Unbounded> = process
 Streams also can be sent over the network to participate in distributed programs. Under the hood, sending a stream sets up an RPC handler at the target location that will receive the stream elements. For example, we can send a stream of integers from one process to another with [bincode](https://docs.rs/bincode/latest/bincode/) serialization:
 
 ```rust
-# use hydro_lang::*;
+# use hydro_lang::prelude::*;
 # use futures::StreamExt;
 # tokio_test::block_on(test_util::multi_location_test(|flow, p_out| {
 let p1 = flow.process::<()>();
@@ -59,7 +59,7 @@ To track this behavior, stream have an `Order` type parameter that indicates whe
 If we send a stream from a cluster to a process and flatten the values across senders (with `.values()`), the return type will be a stream with `NoOrder`:
 
 ```rust,no_run
-# use hydro_lang::*;
+# use hydro_lang::prelude::*;
 # let flow = FlowBuilder::new();
 let workers: Cluster<()> = flow.cluster::<()>();
 let numbers: Stream<_, Cluster<_>, Unbounded, TotalOrder> =
@@ -74,7 +74,7 @@ The ordering of a stream determines which APIs are available on it. For example,
 A particularly common API that faces this restriction is [`fold`](pathname:///rustdoc/hydro_lang/stream/struct.Stream#method.fold) (and [`reduce`](pathname:///rustdoc/hydro_lang/stream/struct.Stream#method.reduce)). These APIs require the stream to have a deterministic order, since the result may depend on the order of elements. For example, the following code will not compile because `fold` is not available on `NoOrder` streams (note that the error is a bit misleading due to the Rust compiler attempting to apply `Iterator` methods):
 
 ```compile_fail
-# use hydro_lang::*;
+# use hydro_lang::prelude::*;
 # let flow = FlowBuilder::new();
 let workers: Cluster<()> = flow.cluster::<()>();
 let process: Process<()> = flow.process::<()>();
@@ -100,7 +100,7 @@ Running an aggregation (`fold`, `reduce`) converts a `Stream` into a `Singleton`
 To perform an aggregation with an unordered stream, you must use [`fold_commutative`](pathname:///rustdoc/hydro_lang/stream/struct.Stream#method.fold_commutative), which requires the provided closure to be commutative (and therefore immune to non-deterministic ordering):
 
 ```rust,no_run
-# use hydro_lang::*;
+# use hydro_lang::prelude::*;
 # use futures::StreamExt;
 # let flow = FlowBuilder::new();
 # let workers = flow.cluster::<()>();

--- a/docs/docs/hydro/locations/clusters.md
+++ b/docs/docs/hydro/locations/clusters.md
@@ -8,7 +8,7 @@ When building scalable distributed systems in Hydro, you'll often need to use **
 Like when creating a process, you can pass in a type parameter to a cluster to distinguish it from other clusters. For example, you can create a cluster with a marker of `Worker` to represent a pool of workers in a distributed system:
 
 ```rust,no_run
-# use hydro_lang::*;
+# use hydro_lang::prelude::*;
 struct Worker {}
 
 let flow = FlowBuilder::new();
@@ -18,7 +18,7 @@ let workers: Cluster<Worker> = flow.cluster::<Worker>();
 You can then instantiate a live collection on the cluster using the same APIs as for processes. For example, you can create a stream of integers on the worker cluster. If you launch this program, **each** member of the cluster will create a stream containing the elements 1, 2, 3, and 4:
 
 ```rust,no_run
-# use hydro_lang::*;
+# use hydro_lang::prelude::*;
 # struct Worker {}
 # let flow = FlowBuilder::new();
 # let workers: Cluster<Worker> = flow.cluster::<Worker>();
@@ -29,7 +29,7 @@ let numbers = workers.source_iter(q!(vec![1, 2, 3, 4]));
 When sending a live collection from a cluster to another location, **each** member of the cluster will send its local collection. On the receiver side, these collections will be joined together into a **keyed stream** of with `ID` keys and groups of  `Data` values where the ID uniquely identifies which member of the cluster the data came from. For example, you can send a stream from the worker cluster to another process using the `send_bincode` method:
 
 ```rust
-# use hydro_lang::*;
+# use hydro_lang::prelude::*;
 # use futures::StreamExt;
 # tokio_test::block_on(test_util::multi_location_test(|flow, process| {
 # let workers: Cluster<()> = flow.cluster::<()>();
@@ -53,7 +53,7 @@ numbers.send_bincode(&process) // KeyedStream<MemberId<()>, i32, ...>
 If you do not need to know _which_ member of the cluster the data came from, you can use the `values()` method on the keyed stream, which will drop the IDs at the receiver:
 
 ```rust
-# use hydro_lang::*;
+# use hydro_lang::prelude::*;
 # use futures::StreamExt;
 # tokio_test::block_on(test_util::multi_location_test(|flow, process| {
 # let workers: Cluster<()> = flow.cluster::<()>();
@@ -76,7 +76,7 @@ numbers.send_bincode(&process).values()
 In the reverse direction, when sending a stream _to_ a cluster, the sender must prepare `(ID, Data)` tuples, where the ID uniquely identifies which member of the cluster the data is intended for. Then, we can send a stream from a process to the worker cluster using the `demux_bincode` method:
 
 ```rust
-# use hydro_lang::*;
+# use hydro_lang::prelude::*;
 # use futures::StreamExt;
 # tokio_test::block_on(test_util::multi_location_test(|flow, p2| {
 # let p1 = flow.process::<()>();
@@ -103,7 +103,7 @@ on_worker.send_bincode(&p2)
 A common pattern in distributed systems is to broadcast data to all members of a cluster. In Hydro, this can be achieved using `broadcast_bincode`, which takes in a stream of **only data elements** and broadcasts them to all members of the cluster. For example, we can broadcast a stream of integers to the worker cluster:
 
 ```rust
-# use hydro_lang::*;
+# use hydro_lang::prelude::*;
 # use futures::StreamExt;
 # tokio_test::block_on(test_util::multi_location_test(|flow, p2| {
 # let p1 = flow.process::<()>();
@@ -127,7 +127,7 @@ on_worker.send_bincode(&p2)
 This API requires a [non-determinism guard](../live-collections/determinism.md#unsafe-operations-in-hydro), because the set of cluster members may asynchronously change over time. Depending on when we are notified of membership changes, we will broadcast to different members. Under the hood, the `broadcast_bincode` API uses a list of members of the cluster provided by the deployment system. To manually access this list, you can use the `source_cluster_members` method to get a stream of membership events (cluster members joining or leaving):
 
 ```rust
-# use hydro_lang::*;
+# use hydro_lang::prelude::*;
 # use futures::StreamExt;
 # tokio_test::block_on(test_util::multi_location_test(|flow, p2| {
 let p1 = flow.process::<()>();
@@ -152,7 +152,7 @@ let cluster_members = p1.source_cluster_members(&workers);
 In some programs, it may be necessary for cluster members to know their own ID (for example, to construct a ballot in Paxos). In Hydro, this can be achieved by using the `CLUSTER_SELF_ID` constant, which can be used inside `q!(...)` blocks to get the current cluster member's ID:
 
 ```rust
-# use hydro_lang::*;
+# use hydro_lang::prelude::*;
 # use futures::StreamExt;
 # tokio_test::block_on(test_util::multi_location_test(|flow, process| {
 use hydro_lang::location::cluster::CLUSTER_SELF_ID;
@@ -181,7 +181,7 @@ self_id_stream
 You can only use `CLUSTER_SELF_ID` in code that will run on a `Cluster<_>`, such as when calling `Stream::map` when that stream is on a cluster. If you try to use it in code that will run on a `Process<_>`, you'll get a compile-time error:
 
 ```compile_fail
-# use hydro_lang::*;
+# use hydro_lang::prelude::*;
 # let flow = FlowBuilder::new();
 let process: Process<()> = flow.process::<()>();
 process.source_iter(q!([CLUSTER_SELF_ID]));

--- a/docs/docs/hydro/locations/index.md
+++ b/docs/docs/hydro/locations/index.md
@@ -15,7 +15,7 @@ Locations can be created by calling the appropriate method on the global `FlowBu
 It is possible to create **different** locations that still have the same type, for example:
 
 ```rust
-# use hydro_lang::*;
+# use hydro_lang::prelude::*;
 let flow = FlowBuilder::new();
 let process1: Process<()> = flow.process::<()>();
 let process2: Process<()> = flow.process::<()>();
@@ -27,7 +27,7 @@ assert_ne!(process1, process2);
 These locations will not be unified and may be deployed to separate machines. When deploying a Hydro program, additional runtime checks will be performed to ensure that input locations match.
 
 ```rust
-# use hydro_lang::*;
+# use hydro_lang::prelude::*;
 let flow = FlowBuilder::new();
 let process1: Process<()> = flow.process::<()>();
 let process2: Process<()> = flow.process::<()>();

--- a/docs/docs/hydro/locations/processes.md
+++ b/docs/docs/hydro/locations/processes.md
@@ -6,7 +6,7 @@ sidebar_position: 0
 The simplest type of location in Hydro is a **process**. A process represents a **single thread** running a piece of a Hydro program (with no internal concurrency). When creating a process, you can pass in a type parameter that will be used as a marker to distinguish that process from others (and will also be used to mark logs originating at that process). For example, you can create a process with a marker of `Leader` to represent a leader in a distributed system:
 
 ```rust,no_run
-# use hydro_lang::*;
+# use hydro_lang::prelude::*;
 struct Leader {}
 
 let flow = FlowBuilder::new();
@@ -22,7 +22,7 @@ Currently, each Hydro process is deployed as a **separate** operating system pro
 Once we have a process, we can create live collections on that process (see [Live Collections](../live-collections/) for more details). For example, we can create a stream of integers on the leader process:
 
 ```rust,no_run
-# use hydro_lang::*;
+# use hydro_lang::prelude::*;
 # struct Leader {}
 # let flow = FlowBuilder::new();
 # let leader: Process<Leader> = flow.process::<Leader>();
@@ -33,7 +33,7 @@ let numbers = leader.source_iter(q!(vec![1, 2, 3, 4]));
 Because a process represents a single machine, it is straightforward to send data to and from a process. For example, we can send a stream of integers from the leader process to another process using the `send_bincode` method (which uses [bincode](https://docs.rs/bincode/latest/bincode/) as a serialization format). This automatically sets up network senders and receivers on the two processes.
 
 ```rust,no_run
-# use hydro_lang::*;
+# use hydro_lang::prelude::*;
 # struct Leader {}
 # let flow = FlowBuilder::new();
 # let leader: Process<Leader> = flow.process::<Leader>();

--- a/docs/docs/hydro/optimizations/partitioning.mdx
+++ b/docs/docs/hydro/optimizations/partitioning.mdx
@@ -158,7 +158,7 @@ If each parent of `Chain` has different dependencies on the same input, what are
 
 Imagine `Chain` then joins with another stream, as in the following program.
 ```rust
-# use hydro_lang::*;
+# use hydro_lang::prelude::*;
 fn chain_parents_same_input<'a, L>(
     flow: FlowBuilder<'a>,
     input1: Stream<(usize, usize), Process<'a, L>, Unbounded>,
@@ -194,7 +194,7 @@ The two tuples of `input1` both need to join with the single tuple of `input2`, 
 
 Imagine `Chain` then joins with another stream, as in the following program.
 ```rust
-# use hydro_lang::*;
+# use hydro_lang::prelude::*;
 fn chain_parents_different_inputs<'a, L>(
     flow: FlowBuilder<'a>,
     input1: Stream<(usize, usize), Process<'a, L>, Unbounded>,

--- a/hydro_lang/src/boundedness.rs
+++ b/hydro_lang/src/boundedness.rs
@@ -1,6 +1,6 @@
 use sealed::sealed;
 
-use crate::keyed_singleton::{BoundedValue, KeyedSingletonBound};
+use crate::live_collections::keyed_singleton::{BoundedValue, KeyedSingletonBound};
 
 /// A marker trait indicating whether a stream’s length is bounded (finite) or unbounded (potentially infinite).
 ///

--- a/hydro_lang/src/builder/compiled.rs
+++ b/hydro_lang/src/builder/compiled.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use dfir_lang::graph::DfirGraph;
 
-use crate::Location;
+use crate::location::Location;
 use crate::staging_util::Invariant;
 
 pub struct CompiledFlow<'a, ID> {

--- a/hydro_lang/src/deploy/trybuild.rs
+++ b/hydro_lang/src/deploy/trybuild.rs
@@ -153,7 +153,7 @@ pub fn compile_graph_trybuild(
 
     let source_ast: syn::File = syn::parse_quote! {
         #![allow(unused_imports, unused_crate_dependencies, missing_docs, non_snake_case)]
-        use hydro_lang::*;
+        use hydro_lang::prelude::*;
         use hydro_lang::runtime_support::dfir_rs as __root_dfir_rs;
 
         #[allow(unused)]

--- a/hydro_lang/src/lib.rs
+++ b/hydro_lang/src/lib.rs
@@ -14,8 +14,6 @@
 
 stageleft::stageleft_no_entry_crate!();
 
-pub use stageleft::q;
-
 #[cfg(feature = "runtime_support")]
 #[cfg_attr(docsrs, doc(cfg(feature = "runtime_support")))]
 #[doc(hidden)]
@@ -31,6 +29,31 @@ pub mod internal_constants {
     pub const COUNTER_PREFIX: &str = "_counter";
 }
 
+pub mod prelude {
+    // taken from `tokio`
+    //! A "prelude" for users of the `hydro_lang` crate.
+    //!
+    //! This prelude is similar to the standard library's prelude in that you'll almost always want to import its entire contents, but unlike the standard library's prelude you'll have to do so manually:
+    //! ```
+    //! # #![allow(warnings)]
+    //! use hydro_lang::prelude::*;
+    //! ```
+    //!
+    //! The prelude may grow over time as additional items see ubiquitous use.
+
+    pub use stageleft::q;
+
+    pub use crate::boundedness::{Bounded, Unbounded};
+    pub use crate::builder::FlowBuilder;
+    pub use crate::live_collections::keyed_singleton::KeyedSingleton;
+    pub use crate::live_collections::keyed_stream::KeyedStream;
+    pub use crate::live_collections::optional::Optional;
+    pub use crate::live_collections::singleton::Singleton;
+    pub use crate::live_collections::stream::Stream;
+    pub use crate::location::{Cluster, External, Location as _, Process, Tick};
+    pub use crate::unsafety::{NonDet, nondet};
+}
+
 #[cfg(feature = "dfir_context")]
 #[cfg_attr(docsrs, doc(cfg(feature = "dfir_context")))]
 #[expect(missing_docs, reason = "TODO")]
@@ -38,33 +61,15 @@ pub mod runtime_context;
 
 #[expect(missing_docs, reason = "TODO")]
 pub mod unsafety;
-pub use unsafety::*;
 
 #[expect(missing_docs, reason = "TODO")]
 pub mod boundedness;
-pub use boundedness::{Bounded, Unbounded};
 
 #[expect(missing_docs, reason = "TODO")]
-pub mod stream;
-pub use stream::{NoOrder, Stream, TotalOrder};
-
-#[expect(missing_docs, reason = "TODO")]
-pub mod keyed_singleton;
-#[expect(missing_docs, reason = "TODO")]
-pub mod keyed_stream;
-pub use keyed_stream::KeyedStream;
-
-#[expect(missing_docs, reason = "TODO")]
-pub mod singleton;
-pub use singleton::Singleton;
-
-#[expect(missing_docs, reason = "TODO")]
-pub mod optional;
-pub use optional::Optional;
+pub mod live_collections;
 
 #[expect(missing_docs, reason = "TODO")]
 pub mod location;
-pub use location::{Cluster, External, Location, Process, Tick};
 
 #[expect(missing_docs, reason = "TODO")]
 #[cfg(any(
@@ -79,7 +84,6 @@ pub mod cycle;
 
 #[expect(missing_docs, reason = "TODO")]
 pub mod builder;
-pub use builder::FlowBuilder;
 
 mod manual_expr;
 

--- a/hydro_lang/src/live_collections/keyed_singleton.rs
+++ b/hydro_lang/src/live_collections/keyed_singleton.rs
@@ -2,17 +2,16 @@ use std::hash::Hash;
 
 use stageleft::{IntoQuotedMut, QuotedWithContext, q};
 
-use crate::boundedness::Boundedness;
+use super::keyed_stream::KeyedStream;
+use super::optional::Optional;
+use super::singleton::Singleton;
+use super::stream::{ExactlyOnce, NoOrder, Stream, TotalOrder};
+use crate::boundedness::{Bounded, Boundedness, Unbounded};
 use crate::cycle::{CycleCollection, CycleComplete, ForwardRefMarker};
 use crate::location::tick::NoAtomic;
-use crate::location::{Atomic, LocationId, NoTick};
+use crate::location::{Atomic, Location, LocationId, NoTick, Tick};
 use crate::manual_expr::ManualExpr;
-use crate::stream::ExactlyOnce;
-use crate::unsafety::NonDet;
-use crate::{
-    Bounded, KeyedStream, Location, NoOrder, Optional, Singleton, Stream, Tick, TotalOrder,
-    Unbounded, nondet,
-};
+use crate::unsafety::{NonDet, nondet};
 
 pub trait KeyedSingletonBound {
     type UnderlyingBound: Boundedness;
@@ -228,9 +227,9 @@ impl<'a, K: Hash + Eq, V, L: Location<'a>> KeyedSingleton<K, V, Tick<L>, Bounded
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let keyed_data = process
     ///     .source_iter(q!(vec![(1, 2), (2, 3)]))
@@ -259,9 +258,9 @@ impl<'a, K: Hash + Eq, V, L: Location<'a>> KeyedSingleton<K, V, Tick<L>, Bounded
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let keyed_data = process
     ///     .source_iter(q!(vec![(1, 10), (2, 20)]))

--- a/hydro_lang/src/live_collections/keyed_stream.rs
+++ b/hydro_lang/src/live_collections/keyed_stream.rs
@@ -3,16 +3,16 @@ use std::marker::PhantomData;
 
 use stageleft::{IntoQuotedMut, QuotedWithContext, q};
 
-use crate::boundedness::Boundedness;
+use super::keyed_singleton::KeyedSingleton;
+use super::optional::Optional;
+use super::stream::{ExactlyOnce, MinOrder, MinRetries, NoOrder, Stream, TotalOrder};
+use crate::boundedness::{Bounded, Boundedness, Unbounded};
 use crate::cycle::{CycleCollection, CycleComplete, ForwardRefMarker};
 use crate::ir::HydroNode;
-use crate::keyed_singleton::KeyedSingleton;
 use crate::location::tick::NoAtomic;
-use crate::location::{Atomic, LocationId, NoTick, check_matching_location};
+use crate::location::{Atomic, Location, LocationId, NoTick, Tick, check_matching_location};
 use crate::manual_expr::ManualExpr;
-use crate::stream::{ExactlyOnce, MinOrder, MinRetries};
-use crate::unsafety::NonDet;
-use crate::*;
+use crate::unsafety::{NonDet, nondet};
 
 /// Keyed Streams capture streaming elements of type `V` grouped by a key of type `K`,
 /// where the order of keys is non-deterministic but the order *within* each group may
@@ -114,9 +114,9 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O, R> KeyedStream<K, V, L, B, O,
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// process
     ///     .source_iter(q!(vec![(1, 2), (1, 3), (2, 4)]))
     ///     .into_keyed()
@@ -137,9 +137,9 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O, R> KeyedStream<K, V, L, B, O,
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// process
     ///     .source_iter(q!(vec![(1, 2), (1, 3), (2, 4)]))
     ///     .into_keyed()
@@ -163,9 +163,9 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O, R> KeyedStream<K, V, L, B, O,
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// process
     ///     .source_iter(q!(vec![(1, 2), (1, 3), (2, 4)]))
     ///     .into_keyed()
@@ -200,9 +200,9 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O, R> KeyedStream<K, V, L, B, O,
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// process
     ///     .source_iter(q!(vec![(1, 2), (1, 3), (2, 4)]))
     ///     .into_keyed()
@@ -245,9 +245,9 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O, R> KeyedStream<K, V, L, B, O,
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// process
     ///     .source_iter(q!(vec![(1, 2), (1, 3), (2, 4)]))
     ///     .into_keyed()
@@ -283,9 +283,9 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O, R> KeyedStream<K, V, L, B, O,
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// process
     ///     .source_iter(q!(vec![(1, 2), (1, 3), (2, 4)]))
     ///     .into_keyed()
@@ -317,9 +317,9 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O, R> KeyedStream<K, V, L, B, O,
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// process
     ///     .source_iter(q!(vec![(1, "2"), (1, "hello"), (2, "4")]))
     ///     .into_keyed()
@@ -355,9 +355,9 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O, R> KeyedStream<K, V, L, B, O,
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// process
     ///     .source_iter(q!(vec![(1, "2"), (1, "hello"), (2, "2")]))
     ///     .into_keyed()
@@ -397,9 +397,9 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O, R> KeyedStream<K, V, L, B, O,
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// process
     ///     .source_iter(q!(vec![(1, 2), (1, 3), (2, 4)]))
     ///     .into_keyed()
@@ -431,9 +431,9 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O, R> KeyedStream<K, V, L, B, O,
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// process
     ///     .source_iter(q!(vec![(1, 2), (1, 3), (2, 4)]))
     ///     .into_keyed()
@@ -480,9 +480,9 @@ impl<'a, K, V, L: Location<'a> + NoTick + NoAtomic, O, R> KeyedStream<K, V, L, U
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let numbers1 = process.source_iter(q!(vec![(1, 2), (3, 4)])).into_keyed();
     /// let numbers2 = process.source_iter(q!(vec![(1, 3), (3, 5)])).into_keyed();
     /// numbers1.interleave(numbers2)
@@ -522,9 +522,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// process
     ///     .source_iter(q!(vec![(0, 1), (0, 2), (1, 3), (1, 4)]))
     ///     .into_keyed()
@@ -572,9 +572,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// process
     ///     .source_iter(q!(vec![(0, 2), (0, 3), (1, 3), (1, 6)]))
     ///     .into_keyed()
@@ -625,9 +625,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let numbers = process
     ///     .source_iter(q!(vec![(1, 2), (2, 3), (1, 3), (2, 4)]))
@@ -674,9 +674,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let numbers = process
     ///     .source_iter(q!(vec![(1, 2), (2, 3), (1, 3), (2, 4)]))
@@ -715,9 +715,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let watermark = tick.singleton(q!(1));
     /// let numbers = process
@@ -776,9 +776,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let numbers = process
     ///     .source_iter(q!(vec![(1, 2), (2, 3), (1, 3), (2, 4)]))
@@ -811,9 +811,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let numbers = process
     ///     .source_iter(q!(vec![(1, 2), (2, 3), (1, 3), (2, 4)]))
@@ -843,9 +843,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let watermark = tick.singleton(q!(1));
     /// let numbers = process
@@ -889,9 +889,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let numbers = process
     ///     .source_iter(q!(vec![(1, false), (2, true), (1, false), (2, false)]))
@@ -924,9 +924,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let numbers = process
     ///     .source_iter(q!(vec![(1, false), (2, true), (1, false), (2, false)]))
@@ -956,9 +956,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let watermark = tick.singleton(q!(1));
     /// let numbers = process
@@ -1003,9 +1003,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let numbers = process
     ///     .source_iter(q!(vec![(1, false), (2, true), (1, false), (2, false)]))
@@ -1040,9 +1040,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let numbers = process
     ///     .source_iter(q!(vec![(1, false), (2, true), (1, false), (2, false)]))
@@ -1074,9 +1074,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let watermark = tick.singleton(q!(1));
     /// let numbers = process
@@ -1111,9 +1111,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let keyed_stream = process
     ///     .source_iter(q!(vec![ (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd') ]))
@@ -1218,8 +1218,9 @@ mod tests {
     use hydro_deploy::Deployment;
     use stageleft::q;
 
+    use crate::builder::FlowBuilder;
     use crate::location::Location;
-    use crate::{FlowBuilder, nondet};
+    use crate::unsafety::nondet;
 
     #[tokio::test]
     async fn reduce_watermark_filter() {

--- a/hydro_lang/src/live_collections/mod.rs
+++ b/hydro_lang/src/live_collections/mod.rs
@@ -1,0 +1,5 @@
+pub mod keyed_singleton;
+pub mod keyed_stream;
+pub mod optional;
+pub mod singleton;
+pub mod stream;

--- a/hydro_lang/src/live_collections/optional.rs
+++ b/hydro_lang/src/live_collections/optional.rs
@@ -6,16 +6,15 @@ use std::rc::Rc;
 use stageleft::{IntoQuotedMut, QuotedWithContext, q};
 use syn::parse_quote;
 
-use crate::boundedness::Boundedness;
+use super::singleton::{Singleton, ZipResult};
+use super::stream::{AtLeastOnce, ExactlyOnce, NoOrder, Stream, TotalOrder};
+use crate::boundedness::{Bounded, Boundedness, Unbounded};
 use crate::builder::FLOW_USED_MESSAGE;
 use crate::cycle::{CycleCollection, CycleComplete, DeferTick, ForwardRefMarker, TickCycleMarker};
 use crate::ir::{HydroIrOpMetadata, HydroNode, HydroRoot, HydroSource, TeeNode};
 use crate::location::tick::{Atomic, NoAtomic};
-use crate::location::{LocationId, NoTick, check_matching_location};
-use crate::singleton::ZipResult;
-use crate::stream::{AtLeastOnce, ExactlyOnce, NoOrder};
+use crate::location::{Location, LocationId, NoTick, Tick, check_matching_location};
 use crate::unsafety::NonDet;
-use crate::{Bounded, Location, Singleton, Stream, Tick, TotalOrder, Unbounded};
 
 pub struct Optional<Type, Loc, Bound: Boundedness> {
     pub(crate) location: Loc,
@@ -237,9 +236,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let optional = tick.optional_first_tick(q!(1));
     /// optional.map(q!(|v| v + 1)).all_ticks()

--- a/hydro_lang/src/live_collections/singleton.rs
+++ b/hydro_lang/src/live_collections/singleton.rs
@@ -5,7 +5,9 @@ use std::rc::Rc;
 
 use stageleft::{IntoQuotedMut, QuotedWithContext, q};
 
-use crate::boundedness::Boundedness;
+use super::optional::Optional;
+use super::stream::{AtLeastOnce, ExactlyOnce, NoOrder, Stream, TotalOrder};
+use crate::boundedness::{Bounded, Boundedness, Unbounded};
 use crate::builder::FLOW_USED_MESSAGE;
 use crate::cycle::{
     CycleCollection, CycleCollectionWithInitial, CycleComplete, DeferTick, ForwardRefMarker,
@@ -14,9 +16,7 @@ use crate::cycle::{
 use crate::ir::{HydroIrOpMetadata, HydroNode, HydroRoot, TeeNode};
 use crate::location::tick::{Atomic, NoAtomic};
 use crate::location::{Location, LocationId, NoTick, Tick, check_matching_location};
-use crate::stream::{AtLeastOnce, ExactlyOnce};
 use crate::unsafety::NonDet;
-use crate::{Bounded, NoOrder, Optional, Stream, TotalOrder, Unbounded};
 
 pub struct Singleton<Type, Loc, Bound: Boundedness> {
     pub(crate) location: Loc,
@@ -638,7 +638,9 @@ mod tests {
     use hydro_deploy::Deployment;
     use stageleft::q;
 
-    use crate::*;
+    use crate::builder::FlowBuilder;
+    use crate::location::Location;
+    use crate::unsafety::nondet;
 
     #[tokio::test]
     async fn tick_cycle_cardinality() {

--- a/hydro_lang/src/live_collections/snapshots/hydro_lang__live_collections__stream__tests__backtrace_chained_ops-2.snap
+++ b/hydro_lang/src/live_collections/snapshots/hydro_lang__live_collections__stream__tests__backtrace_chained_ops-2.snap
@@ -1,21 +1,21 @@
 ---
-source: hydro_lang/src/stream.rs
-expression: source_meta.backtrace.elements()
+source: hydro_lang/src/live_collections/stream.rs
+expression: for_each_meta.backtrace.elements()
 ---
 [
     BacktraceElement {
-        fn_name: "hydro_lang::stream::tests::backtrace_chained_ops",
+        fn_name: "hydro_lang::live_collections::stream::tests::backtrace_chained_ops",
         lineno: Some(
-            2588,
+            2589,
         ),
         colno: Some(
-            14,
+            37,
         ),
     },
     BacktraceElement {
-        fn_name: "hydro_lang::stream::tests::backtrace_chained_ops::{{closure}}",
+        fn_name: "hydro_lang::live_collections::stream::tests::backtrace_chained_ops::{{closure}}",
         lineno: Some(
-            2582,
+            2583,
         ),
         colno: Some(
             31,

--- a/hydro_lang/src/live_collections/snapshots/hydro_lang__live_collections__stream__tests__backtrace_chained_ops.snap
+++ b/hydro_lang/src/live_collections/snapshots/hydro_lang__live_collections__stream__tests__backtrace_chained_ops.snap
@@ -1,21 +1,21 @@
 ---
-source: hydro_lang/src/stream.rs
-expression: for_each_meta.backtrace.elements()
+source: hydro_lang/src/live_collections/stream.rs
+expression: source_meta.backtrace.elements()
 ---
 [
     BacktraceElement {
-        fn_name: "hydro_lang::stream::tests::backtrace_chained_ops",
+        fn_name: "hydro_lang::live_collections::stream::tests::backtrace_chained_ops",
         lineno: Some(
-            2588,
+            2589,
         ),
         colno: Some(
-            37,
+            14,
         ),
     },
     BacktraceElement {
-        fn_name: "hydro_lang::stream::tests::backtrace_chained_ops::{{closure}}",
+        fn_name: "hydro_lang::live_collections::stream::tests::backtrace_chained_ops::{{closure}}",
         lineno: Some(
-            2582,
+            2583,
         ),
         colno: Some(
             31,

--- a/hydro_lang/src/live_collections/stream.rs
+++ b/hydro_lang/src/live_collections/stream.rs
@@ -10,16 +10,17 @@ use stageleft::{IntoQuotedMut, QuotedWithContext, q};
 use syn::parse_quote;
 use tokio::time::Instant;
 
-use crate::boundedness::Boundedness;
+use super::keyed_stream::KeyedStream;
+use super::optional::Optional;
+use super::singleton::Singleton;
+use crate::boundedness::{Bounded, Boundedness, Unbounded};
 use crate::builder::FLOW_USED_MESSAGE;
 use crate::cycle::{CycleCollection, CycleComplete, DeferTick, ForwardRefMarker, TickCycleMarker};
 use crate::ir::{HydroIrOpMetadata, HydroNode, HydroRoot, TeeNode};
-use crate::keyed_stream::KeyedStream;
 use crate::location::tick::{Atomic, NoAtomic};
 use crate::location::{Location, LocationId, NoTick, Tick, check_matching_location};
 use crate::manual_expr::ManualExpr;
-use crate::unsafety::NonDet;
-use crate::*;
+use crate::unsafety::{NonDet, nondet};
 
 pub mod networking;
 
@@ -292,9 +293,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let words = process.source_iter(q!(vec!["hello", "world"]));
     /// words.map(q!(|x| x.to_uppercase()))
     /// # }, |mut stream| async move {
@@ -327,9 +328,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// process
     ///     .source_iter(q!(vec![vec![1, 2], vec![3, 4]]))
     ///     .flat_map_ordered(q!(|x| x))
@@ -361,9 +362,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::{*, stream::ExactlyOnce};
+    /// # use hydro_lang::{prelude::*, live_collections::stream::{NoOrder, ExactlyOnce}};
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test::<_, _, NoOrder, ExactlyOnce>(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test::<_, _, NoOrder, ExactlyOnce>(|process| {
     /// process
     ///     .source_iter(q!(vec![
     ///         std::collections::HashSet::<i32>::from_iter(vec![1, 2]),
@@ -406,9 +407,9 @@ where
     /// not deterministic, use [`Stream::flatten_unordered`] instead.
     ///
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// process
     ///     .source_iter(q!(vec![vec![1, 2], vec![3, 4]]))
     ///     .flatten_ordered()
@@ -431,9 +432,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::{*, stream::ExactlyOnce};
+    /// # use hydro_lang::{prelude::*, live_collections::stream::{NoOrder, ExactlyOnce}};
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test::<_, _, NoOrder, ExactlyOnce>(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test::<_, _, NoOrder, ExactlyOnce>(|process| {
     /// process
     ///     .source_iter(q!(vec![
     ///         std::collections::HashSet::<i32>::from_iter(vec![1, 2]),
@@ -465,9 +466,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// process
     ///     .source_iter(q!(vec![1, 2, 3, 4]))
     ///     .filter(q!(|&x| x > 2))
@@ -497,9 +498,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// process
     ///     .source_iter(q!(vec!["1", "hello", "world", "2"]))
     ///     .filter_map(q!(|s| s.parse::<usize>().ok()))
@@ -529,9 +530,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let batch = process
     ///   .source_iter(q!(vec![1, 2, 3, 4]))
@@ -580,10 +581,10 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use std::collections::HashSet;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let stream1 = process.source_iter(q!(vec!['a', 'b', 'c']));
     /// let stream2 = process.source_iter(q!(vec![1, 2, 3]));
@@ -617,9 +618,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     ///     process.source_iter(q!(vec![1, 2, 3, 2, 1, 4])).unique()
     /// # }, |mut stream| async move {
@@ -646,9 +647,9 @@ where
     /// all its elements are available before producing any output.
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let stream = process
     ///   .source_iter(q!(vec![ 1, 2, 3, 4 ]))
@@ -687,9 +688,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let nums = process.source_iter(q!(vec![1, 2]));
     /// // prints "1 * 10 = 10" and "2 * 10 = 20"
     /// nums.inspect(q!(|x| println!("{} * 10 = {}", x, x * 10)))
@@ -814,9 +815,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// process.source_iter(q!(&[1, 2, 3])).cloned()
     /// # }, |mut stream| async move {
     /// // 1, 2, 3
@@ -846,9 +847,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let bools = process.source_iter(q!(vec![false, true, false]));
     /// let batch = bools.batch(&tick, nondet!(/** test */));
@@ -885,9 +886,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let bools = process.source_iter(q!(vec![false, true, false]));
     /// let batch = bools.batch(&tick, nondet!(/** test */));
@@ -917,9 +918,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let numbers = process.source_iter(q!(vec![1, 2, 3, 4]));
     /// let batch = numbers.batch(&tick, nondet!(/** test */));
@@ -946,9 +947,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let numbers = process.source_iter(q!(vec![1, 2, 3, 4]));
     /// let batch = numbers.batch(&tick, nondet!(/** test */));
@@ -995,9 +996,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let numbers = process.source_iter(q!(vec![1, 2, 3, 4]));
     /// let batch = numbers.batch(&tick, nondet!(/** test */));
@@ -1031,9 +1032,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let numbers = process.source_iter(q!(vec![1, 2, 3, 4]));
     /// let batch = numbers.batch(&tick, nondet!(/** test */));
@@ -1067,9 +1068,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let numbers = process.source_iter(q!(vec![1, 2, 3, 4]));
     /// let batch = numbers.batch(&tick, nondet!(/** test */));
@@ -1093,9 +1094,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let numbers = process.source_iter(q!(vec![1, 2, 3, 4]));
     /// let batch = numbers.batch(&tick, nondet!(/** test */));
@@ -1122,9 +1123,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let bools = process.source_iter(q!(vec![false, true, false]));
     /// let batch = bools.batch(&tick, nondet!(/** test */));
@@ -1158,9 +1159,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let bools = process.source_iter(q!(vec![false, true, false]));
     /// let batch = bools.batch(&tick, nondet!(/** test */));
@@ -1186,9 +1187,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let numbers = process.source_iter(q!(vec![1, 2, 3, 4]));
     /// let batch = numbers.batch(&tick, nondet!(/** test */));
@@ -1210,9 +1211,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let numbers = process.source_iter(q!(vec![1, 2, 3, 4]));
     /// let batch = numbers.batch(&tick, nondet!(/** test */));
@@ -1235,9 +1236,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::{*, stream::ExactlyOnce};
+    /// # use hydro_lang::{prelude::*, live_collections::stream::{TotalOrder, ExactlyOnce}};
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test::<_, _, TotalOrder, ExactlyOnce>(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test::<_, _, TotalOrder, ExactlyOnce>(|process| {
     /// let tick = process.tick();
     /// let numbers = process.source_iter(q!(vec![1, 2, 3, 4]));
     /// numbers.enumerate()
@@ -1285,9 +1286,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let words = process.source_iter(q!(vec!["HELLO", "WORLD"]));
     /// let batch = words.batch(&tick, nondet!(/** test */));
@@ -1351,9 +1352,9 @@ where
     ///
     /// Basic usage - running sum:
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// process.source_iter(q!(vec![1, 2, 3, 4])).scan(
     ///     q!(|| 0),
     ///     q!(|acc, x| {
@@ -1371,9 +1372,9 @@ where
     ///
     /// Early termination example:
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// process.source_iter(q!(vec![1, 2, 3, 4])).scan(
     ///     q!(|| 1),
     ///     q!(|state, x| {
@@ -1442,9 +1443,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let words = process.source_iter(q!(vec!["HELLO", "WORLD"]));
     /// let batch = words.batch(&tick, nondet!(/** test */));
@@ -1488,9 +1489,9 @@ impl<'a, T, L: Location<'a> + NoTick + NoAtomic, O, R> Stream<T, L, Unbounded, O
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let numbers = process.source_iter(q!(vec![1, 2, 3, 4]));
     /// numbers.clone().map(q!(|x| x + 1)).interleave(numbers)
     /// # }, |mut stream| async move {
@@ -1536,9 +1537,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let numbers = process.source_iter(q!(vec![4, 2, 3, 1]));
     /// let batch = numbers.batch(&tick, nondet!(/** test */));
@@ -1574,9 +1575,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let numbers = process.source_iter(q!(vec![1, 2, 3, 4]));
     /// let batch = numbers.batch(&tick, nondet!(/** test */));
@@ -1638,10 +1639,10 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use std::collections::HashSet;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let stream1 = process.source_iter(q!(vec![(1, 'a'), (2, 'b')]));
     /// let stream2 = process.source_iter(q!(vec![(1, 'x'), (2, 'y')]));
@@ -1677,9 +1678,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let stream = process
     ///   .source_iter(q!(vec![ (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd') ]))
@@ -1738,9 +1739,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// process
     ///     .source_iter(q!(vec![(0, 1), (0, 2), (1, 3), (1, 4)]))
     ///     .scan_keyed(
@@ -1791,9 +1792,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// process
     ///     .source_iter(q!(vec![(0, 2), (0, 3), (1, 3), (1, 6)]))
     ///     .fold_keyed_early_stop(
@@ -1856,9 +1857,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let numbers = process.source_iter(q!(vec![(1, 2), (2, 3), (1, 3), (2, 4)]));
     /// let batch = numbers.batch(&tick, nondet!(/** test */));
@@ -1895,9 +1896,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let numbers = process.source_iter(q!(vec![(1, 2), (2, 3), (1, 3), (2, 4)]));
     /// let batch = numbers.batch(&tick, nondet!(/** test */));
@@ -1946,9 +1947,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let numbers = process.source_iter(q!(vec![(1, false), (2, true), (1, false), (2, false)]));
     /// let batch = numbers.batch(&tick, nondet!(/** test */));
@@ -1978,9 +1979,9 @@ where
     /// Given a stream of pairs `(K, V)`, produces a new stream of unique keys `K`.
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let numbers = process.source_iter(q!(vec![(1, 2), (2, 3), (1, 3), (2, 4)]));
     /// let batch = numbers.batch(&tick, nondet!(/** test */));
@@ -2009,9 +2010,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let numbers = process.source_iter(q!(vec![(1, false), (2, true), (1, false), (2, false)]));
     /// let batch = numbers.batch(&tick, nondet!(/** test */));
@@ -2054,9 +2055,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let numbers = process.source_iter(q!(vec![(1, 2), (2, 3), (1, 3), (2, 4)]));
     /// let batch = numbers.batch(&tick, nondet!(/** test */));
@@ -2092,9 +2093,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let numbers = process.source_iter(q!(vec![(1, 2), (2, 3), (1, 3), (2, 4)]));
     /// let batch = numbers.batch(&tick, nondet!(/** test */));
@@ -2135,9 +2136,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let numbers = process.source_iter(q!(vec![(1, false), (2, true), (1, false), (2, false)]));
     /// let batch = numbers.batch(&tick, nondet!(/** test */));
@@ -2173,9 +2174,9 @@ where
     ///
     /// # Example
     /// ```rust
-    /// # use hydro_lang::*;
+    /// # use hydro_lang::prelude::*;
     /// # use futures::StreamExt;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let tick = process.tick();
     /// let numbers = process.source_iter(q!(vec![(1, false), (2, true), (1, false), (2, false)]));
     /// let batch = numbers.batch(&tick, nondet!(/** test */));
@@ -2243,8 +2244,8 @@ where
     /// ```rust
     /// # use std::collections::HashSet;
     /// # use futures::StreamExt;
-    /// # use hydro_lang::*;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # use hydro_lang::prelude::*;
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// process.source_iter(q!([2, 3, 1, 9, 6, 5, 4, 7, 8]))
     ///     .map(q!(|x| async move {
     ///         tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
@@ -2361,8 +2362,8 @@ where
     /// ```rust
     /// # use std::collections::HashSet;
     /// # use futures::StreamExt;
-    /// # use hydro_lang::*;
-    /// # tokio_test::block_on(test_util::stream_transform_test(|process| {
+    /// # use hydro_lang::prelude::*;
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// process.source_iter(q!([2, 3, 1, 9, 6, 5, 4, 7, 8]))
     ///     .map(q!(|x| async move {
     ///         tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
@@ -2501,7 +2502,7 @@ mod tests {
     use serde::{Deserialize, Serialize};
     use stageleft::q;
 
-    use crate::FlowBuilder;
+    use crate::builder::FlowBuilder;
     use crate::location::Location;
 
     struct P1 {}

--- a/hydro_lang/src/live_collections/stream/networking.rs
+++ b/hydro_lang/src/live_collections/stream/networking.rs
@@ -5,16 +5,16 @@ use serde::de::DeserializeOwned;
 use stageleft::{q, quote_type};
 use syn::parse_quote;
 
-use crate::boundedness::Boundedness;
+use crate::boundedness::{Boundedness, Unbounded};
 use crate::ir::{DebugInstantiate, HydroIrOpMetadata, HydroNode, HydroRoot};
-use crate::keyed_singleton::KeyedSingleton;
-use crate::keyed_stream::KeyedStream;
+use crate::live_collections::keyed_singleton::KeyedSingleton;
+use crate::live_collections::keyed_stream::KeyedStream;
+use crate::live_collections::stream::{ExactlyOnce, Stream, TotalOrder};
 use crate::location::external_process::ExternalBincodeStream;
 use crate::location::tick::NoAtomic;
-use crate::location::{MemberId, MembershipEvent, NoTick};
+use crate::location::{Cluster, External, Location, MemberId, MembershipEvent, NoTick, Process};
 use crate::staging_util::get_this_crate;
-use crate::stream::ExactlyOnce;
-use crate::{Cluster, External, Location, NonDet, Process, Stream, TotalOrder, Unbounded, nondet};
+use crate::unsafety::{NonDet, nondet};
 
 // same as the one in `hydro_std`, but internal use only
 fn track_membership<'a, C, L: Location<'a> + NoTick + NoAtomic>(

--- a/hydro_lang/src/location/mod.rs
+++ b/hydro_lang/src/location/mod.rs
@@ -13,19 +13,20 @@ use tokio_util::codec::{Decoder, Encoder, LengthDelimitedCodec};
 
 use super::builder::FlowState;
 use crate::backtrace::Backtrace;
+use crate::boundedness::Unbounded;
 use crate::cycle::{CycleCollection, ForwardRef, ForwardRefMarker};
 use crate::ir::{
     DebugInstantiate, HydroIrMetadata, HydroIrOpMetadata, HydroNode, HydroRoot, HydroSource,
 };
-use crate::keyed_stream::KeyedStream;
+use crate::live_collections::keyed_stream::KeyedStream;
+use crate::live_collections::singleton::Singleton;
+use crate::live_collections::stream::{ExactlyOnce, NoOrder, Stream, TotalOrder};
 use crate::location::cluster::ClusterIds;
 use crate::location::external_process::{
     ExternalBincodeBidi, ExternalBincodeSink, ExternalBytesPort, Many,
 };
 use crate::staging_util::get_this_crate;
-use crate::stream::ExactlyOnce;
-use crate::unsafety::NonDet;
-use crate::{NoOrder, Singleton, Stream, TotalOrder, Unbounded, nondet};
+use crate::unsafety::{NonDet, nondet};
 
 pub mod external_process;
 pub use external_process::External;
@@ -303,7 +304,10 @@ pub trait Location<'a>: Clone {
                         port_hint: NetworkHint::Auto,
                         instantiate_fn: DebugInstantiate::Building,
                         deserialize_fn: Some(
-                            crate::stream::networking::deserialize_bincode::<T>(None).into(),
+                            crate::live_collections::stream::networking::deserialize_bincode::<T>(
+                                None,
+                            )
+                            .into(),
                         ),
                         metadata: self.new_node_metadata::<T>(),
                     }),
@@ -649,8 +653,8 @@ mod tests {
     use stageleft::q;
     use tokio_util::codec::LengthDelimitedCodec;
 
-    use crate::location::NetworkHint;
-    use crate::{FlowBuilder, Location};
+    use crate::builder::FlowBuilder;
+    use crate::location::{Location, NetworkHint};
 
     #[tokio::test]
     async fn external_bytes() {

--- a/hydro_lang/src/location/tick.rs
+++ b/hydro_lang/src/location/tick.rs
@@ -5,14 +5,17 @@ use sealed::sealed;
 use stageleft::{QuotedWithContext, q};
 
 use super::{Cluster, Location, LocationId, Process};
+use crate::boundedness::Bounded;
 use crate::builder::FlowState;
 use crate::cycle::{
     CycleCollection, CycleCollectionWithInitial, DeferTick, ForwardRef, ForwardRefMarker,
     TickCycle, TickCycleMarker,
 };
 use crate::ir::{HydroNode, HydroSource};
-use crate::stream::ExactlyOnce;
-use crate::{Bounded, Optional, Singleton, Stream, TotalOrder, nondet};
+use crate::live_collections::optional::Optional;
+use crate::live_collections::singleton::Singleton;
+use crate::live_collections::stream::{ExactlyOnce, Stream, TotalOrder};
+use crate::unsafety::nondet;
 
 #[sealed]
 pub trait NoTick {}

--- a/hydro_lang/src/rewrites/persist_pullup.rs
+++ b/hydro_lang/src/rewrites/persist_pullup.rs
@@ -209,7 +209,7 @@ mod tests {
 
     use crate::deploy::HydroDeploy;
     use crate::location::Location;
-    use crate::nondet;
+    use crate::unsafety::nondet;
 
     #[test]
     fn persist_pullup_through_map() {

--- a/hydro_lang/src/rewrites/properties.rs
+++ b/hydro_lang/src/rewrites/properties.rs
@@ -69,9 +69,10 @@ pub fn properties_optimize(ir: &mut [HydroRoot], db: &mut PropertyDatabase) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::builder::FlowBuilder;
     use crate::deploy::HydroDeploy;
     use crate::location::Location;
-    use crate::{FlowBuilder, nondet};
+    use crate::unsafety::nondet;
 
     #[test]
     fn test_property_database() {

--- a/hydro_lang/src/runtime_context.rs
+++ b/hydro_lang/src/runtime_context.rs
@@ -2,7 +2,7 @@ use dfir_rs::scheduled::context::Context;
 use quote::quote;
 use stageleft::runtime_support::{FreeVariableWithContext, QuoteTokens};
 
-use crate::Location;
+use crate::location::Location;
 
 pub static RUNTIME_CONTEXT: RuntimeContext = RuntimeContext { _private: &() };
 
@@ -29,9 +29,11 @@ where
 mod tests {
     use futures::StreamExt;
     use hydro_deploy::Deployment;
+    use stageleft::q;
 
     use super::RUNTIME_CONTEXT;
-    use crate::*;
+    use crate::builder::FlowBuilder;
+    use crate::location::Location;
 
     struct P1 {}
 

--- a/hydro_lang/src/test_util.rs
+++ b/hydro_lang/src/test_util.rs
@@ -7,7 +7,10 @@ use std::pin::Pin;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
-use crate::{FlowBuilder, Process, Stream, Unbounded};
+use crate::boundedness::Unbounded;
+use crate::builder::FlowBuilder;
+use crate::live_collections::stream::Stream;
+use crate::location::Process;
 
 /// Sets up a test with multiple processes / clusters declared in the test logic (`thunk`). The test logic must return
 /// a single streaming output, which can then be read in `check` (an async closure) to perform assertions.

--- a/hydro_lang/src/unsafety.rs
+++ b/hydro_lang/src/unsafety.rs
@@ -1,6 +1,9 @@
 #[derive(Copy, Clone)]
 pub struct NonDet;
 
+#[doc(inline)]
+pub use crate::nondet as nondet;
+
 #[macro_export]
 /// Fulfills a non-determinism guard parameter by declaring a reason why the
 /// non-determinism is tolerated or providing other non-determinism guards

--- a/hydro_lang/tests/compile-fail/send_bincode_lifetime.rs
+++ b/hydro_lang/tests/compile-fail/send_bincode_lifetime.rs
@@ -1,4 +1,4 @@
-use hydro_lang::*;
+use hydro_lang::prelude::*;
 
 struct P1 {}
 struct P2 {}

--- a/hydro_lang/tests/compile-fail/send_bincode_lifetime.stderr
+++ b/hydro_lang/tests/compile-fail/send_bincode_lifetime.stderr
@@ -9,8 +9,8 @@ error: lifetime may not live long enough
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
   |
   = help: consider adding the following bound: `'b: 'a`
-  = note: requirement occurs because of the type `hydro_lang::Process<'_, P1>`, which makes the generic argument `'_` invariant
-  = note: the struct `hydro_lang::Process<'a, ProcessTag>` is invariant over the parameter `'a`
+  = note: requirement occurs because of the type `hydro_lang::prelude::Process<'_, P1>`, which makes the generic argument `'_` invariant
+  = note: the struct `hydro_lang::prelude::Process<'a, ProcessTag>` is invariant over the parameter `'a`
   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
@@ -24,8 +24,8 @@ error: lifetime may not live long enough
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'a` must outlive `'b`
   |
   = help: consider adding the following bound: `'a: 'b`
-  = note: requirement occurs because of the type `hydro_lang::Process<'_, P2>`, which makes the generic argument `'_` invariant
-  = note: the struct `hydro_lang::Process<'a, ProcessTag>` is invariant over the parameter `'a`
+  = note: requirement occurs because of the type `hydro_lang::prelude::Process<'_, P2>`, which makes the generic argument `'_` invariant
+  = note: the struct `hydro_lang::prelude::Process<'a, ProcessTag>` is invariant over the parameter `'a`
   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 help: `'a` and `'b` must be the same: replace one with the other

--- a/hydro_optimize/src/decoupler.rs
+++ b/hydro_optimize/src/decoupler.rs
@@ -6,8 +6,10 @@ use hydro_lang::ir::{
     DebugInstantiate, DebugType, HydroIrMetadata, HydroIrOpMetadata, HydroNode, HydroRoot, TeeNode,
     transform_bottom_up, traverse_dfir,
 };
+use hydro_lang::live_collections::stream::networking::{
+    deserialize_bincode_with_type, serialize_bincode_with_type,
+};
 use hydro_lang::location::{LocationId, MemberId};
-use hydro_lang::stream::networking::{deserialize_bincode_with_type, serialize_bincode_with_type};
 use proc_macro2::Span;
 use serde::{Deserialize, Serialize};
 use stageleft::quote_type;
@@ -272,8 +274,11 @@ mod tests {
     use std::collections::HashSet;
 
     use hydro_deploy::Deployment;
+    use hydro_lang::builder::FlowBuilder;
+    use hydro_lang::ir;
+    use hydro_lang::location::Location;
     use hydro_lang::rewrites::persist_pullup::persist_pullup;
-    use hydro_lang::{FlowBuilder, Location, ir, nondet};
+    use hydro_lang::unsafety::nondet;
     use stageleft::q;
 
     use crate::debug::name_to_id_map;
@@ -285,9 +290,9 @@ mod tests {
         output_to_original_machine_after: Vec<(&str, i32)>,
         place_on_decoupled_machine: Vec<(&str, i32)>,
     ) -> (
-        hydro_lang::Cluster<'a, ()>,
-        hydro_lang::Cluster<'a, ()>,
-        hydro_lang::Cluster<'a, ()>,
+        hydro_lang::location::Cluster<'a, ()>,
+        hydro_lang::location::Cluster<'a, ()>,
+        hydro_lang::location::Cluster<'a, ()>,
         hydro_lang::builder::built::BuiltFlow<'a>,
     ) {
         let builder = FlowBuilder::new();

--- a/hydro_optimize/src/deploy_and_analyze.rs
+++ b/hydro_optimize/src/deploy_and_analyze.rs
@@ -2,9 +2,8 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use hydro_deploy::Deployment;
-use hydro_lang::FlowBuilder;
-use hydro_lang::builder::RewriteIrFlowBuilder;
 use hydro_lang::builder::deploy::DeployResult;
+use hydro_lang::builder::{FlowBuilder, RewriteIrFlowBuilder};
 use hydro_lang::deploy::HydroDeploy;
 use hydro_lang::deploy::deploy_graph::DeployCrateWrapper;
 use hydro_lang::internal_constants::{COUNTER_PREFIX, CPU_USAGE_PREFIX};

--- a/hydro_optimize/src/partition_node_analysis.rs
+++ b/hydro_optimize/src/partition_node_analysis.rs
@@ -744,9 +744,10 @@ mod tests {
 
     use hydro_lang::deploy::HydroDeploy;
     use hydro_lang::ir::deep_clone;
+    use hydro_lang::live_collections::stream::NoOrder;
     use hydro_lang::location::LocationId;
+    use hydro_lang::prelude::*;
     use hydro_lang::rewrites::persist_pullup::persist_pullup;
-    use hydro_lang::{Bounded, FlowBuilder, Location, NoOrder, Stream, nondet};
     use stageleft::q;
 
     use crate::debug::name_to_id_map;

--- a/hydro_optimize/src/partition_syn_analysis.rs
+++ b/hydro_optimize/src/partition_syn_analysis.rs
@@ -778,9 +778,10 @@ mod tests {
     use std::cell::RefCell;
     use std::collections::BTreeMap;
 
+    use hydro_lang::builder::FlowBuilder;
     use hydro_lang::deploy::HydroDeploy;
     use hydro_lang::ir::{HydroNode, HydroRoot, deep_clone, traverse_dfir};
-    use hydro_lang::{FlowBuilder, Location};
+    use hydro_lang::location::Location;
     use stageleft::q;
     use syn::visit::Visit;
 

--- a/hydro_optimize/src/partitioner.rs
+++ b/hydro_optimize/src/partitioner.rs
@@ -2,8 +2,10 @@ use core::panic;
 use std::collections::HashMap;
 
 use hydro_lang::ir::{HydroNode, HydroRoot, traverse_dfir};
+use hydro_lang::live_collections::stream::networking::{
+    deserialize_bincode_with_type, serialize_bincode_with_type,
+};
 use hydro_lang::location::LocationId;
-use hydro_lang::stream::networking::{deserialize_bincode_with_type, serialize_bincode_with_type};
 use serde::{Deserialize, Serialize};
 use syn::visit_mut::{self, VisitMut};
 

--- a/hydro_optimize/src/rewrites.rs
+++ b/hydro_optimize/src/rewrites.rs
@@ -1,7 +1,6 @@
-use hydro_lang::builder::RewriteIrFlowBuilder;
+use hydro_lang::builder::{FlowBuilder, RewriteIrFlowBuilder};
 use hydro_lang::ir::{HydroIrMetadata, HydroNode, HydroRoot, deep_clone};
-use hydro_lang::location::LocationId;
-use hydro_lang::{Cluster, FlowBuilder, Location};
+use hydro_lang::location::{Cluster, Location, LocationId};
 use serde::{Deserialize, Serialize};
 use syn::visit_mut::{self, VisitMut};
 

--- a/hydro_std/src/bench_client/mod.rs
+++ b/hydro_std/src/bench_client/mod.rs
@@ -4,7 +4,8 @@ use std::time::{Duration, Instant};
 
 use hdrhistogram::Histogram;
 use hdrhistogram::serialization::{Deserializer, Serializer, V2Serializer};
-use hydro_lang::*;
+use hydro_lang::live_collections::stream::{NoOrder, TotalOrder};
+use hydro_lang::prelude::*;
 use serde::{Deserialize, Serialize};
 
 pub mod rolling_average;

--- a/hydro_std/src/compartmentalize.rs
+++ b/hydro_std/src/compartmentalize.rs
@@ -1,8 +1,8 @@
 use hydro_lang::boundedness::Boundedness;
-use hydro_lang::location::MemberId;
+use hydro_lang::live_collections::stream::NoOrder;
 use hydro_lang::location::cluster::CLUSTER_SELF_ID;
-use hydro_lang::*;
-use location::NoTick;
+use hydro_lang::location::{Location, MemberId, NoTick};
+use hydro_lang::prelude::*;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use stageleft::IntoQuotedMut;

--- a/hydro_std/src/membership.rs
+++ b/hydro_std/src/membership.rs
@@ -1,9 +1,9 @@
 use std::hash::Hash;
 
-use hydro_lang::keyed_singleton::KeyedSingleton;
-use hydro_lang::keyed_stream::KeyedStream;
-use hydro_lang::location::MembershipEvent;
-use hydro_lang::{Location, Unbounded};
+use hydro_lang::boundedness::Unbounded;
+use hydro_lang::live_collections::keyed_singleton::KeyedSingleton;
+use hydro_lang::live_collections::keyed_stream::KeyedStream;
+use hydro_lang::location::{Location, MembershipEvent};
 use stageleft::q;
 
 pub fn track_membership<'a, K: Hash + Eq, L: Location<'a>>(

--- a/hydro_std/src/quorum.rs
+++ b/hydro_std/src/quorum.rs
@@ -1,8 +1,8 @@
 use std::hash::Hash;
 
-use hydro_lang::location::Atomic;
-use hydro_lang::*;
-use location::NoTick;
+use hydro_lang::live_collections::stream::NoOrder;
+use hydro_lang::location::{Atomic, Location, NoTick};
+use hydro_lang::prelude::*;
 
 #[expect(clippy::type_complexity, reason = "stream types with ordering")]
 pub fn collect_quorum_with_response<

--- a/hydro_std/src/request_response.rs
+++ b/hydro_std/src/request_response.rs
@@ -1,8 +1,8 @@
 use std::hash::Hash;
 
-use hydro_lang::location::Atomic;
-use hydro_lang::*;
-use location::NoTick;
+use hydro_lang::live_collections::stream::NoOrder;
+use hydro_lang::location::{Atomic, Location, NoTick};
+use hydro_lang::prelude::*;
 
 type JoinResponses<K, M, V, L> = Stream<(K, (M, V)), Atomic<L>, Unbounded, NoOrder>;
 

--- a/hydro_test/examples/benchmark_paxos.rs
+++ b/hydro_test/examples/benchmark_paxos.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use clap::Parser;
 use hydro_deploy::Deployment;
 use hydro_deploy::gcp::GcpNetwork;
-use hydro_lang::Location;
+use hydro_lang::location::Location;
 use hydro_optimize::deploy::ReusableHosts;
 use hydro_optimize::deploy_and_analyze::deploy_and_analyze;
 use hydro_test::cluster::kv_replica::Replica;
@@ -67,7 +67,7 @@ async fn main() {
                 num_clients, num_clients_per_node, run_seconds
             );
 
-            let builder = hydro_lang::FlowBuilder::new();
+            let builder = hydro_lang::builder::FlowBuilder::new();
             let proposers = builder.cluster();
             let acceptors = builder.cluster();
             let clients = builder.cluster();

--- a/hydro_test/examples/chat.rs
+++ b/hydro_test/examples/chat.rs
@@ -3,8 +3,8 @@ use dfir_rs::tokio_util::codec::LinesCodec;
 use hydro_deploy::Deployment;
 use hydro_lang::deploy::TrybuildHost;
 use hydro_lang::graph::config::GraphConfig;
-use hydro_lang::location::NetworkHint;
-use hydro_lang::{Location, nondet};
+use hydro_lang::location::{Location, NetworkHint};
+use hydro_lang::unsafety::nondet;
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -16,7 +16,7 @@ struct Args {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
     let mut deployment = Deployment::new();
-    let flow = hydro_lang::FlowBuilder::new();
+    let flow = hydro_lang::builder::FlowBuilder::new();
 
     let process = flow.process::<()>();
     let external = flow.external::<()>();

--- a/hydro_test/examples/compartmentalized_paxos.rs
+++ b/hydro_test/examples/compartmentalized_paxos.rs
@@ -48,7 +48,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Box::new(move |_| -> Arc<dyn Host> { localhost.clone() })
     };
 
-    let builder = hydro_lang::FlowBuilder::new();
+    let builder = hydro_lang::builder::FlowBuilder::new();
     let f = 1;
     let num_clients = 1;
     let num_clients_per_node = 100; // Change based on experiment between 1, 50, 100.

--- a/hydro_test/examples/compute_pi.rs
+++ b/hydro_test/examples/compute_pi.rs
@@ -49,7 +49,7 @@ async fn main() {
         )
     };
 
-    let builder = hydro_lang::FlowBuilder::new();
+    let builder = hydro_lang::builder::FlowBuilder::new();
     let (cluster, leader) = hydro_test::cluster::compute_pi::compute_pi(&builder, 8192);
 
     // Extract the IR for graph visualization

--- a/hydro_test/examples/decouple_compute_pi.rs
+++ b/hydro_test/examples/decouple_compute_pi.rs
@@ -14,9 +14,9 @@ struct Args {
 }
 use hydro_deploy::gcp::GcpNetwork;
 use hydro_deploy::{Deployment, Host};
-use hydro_lang::Location;
 use hydro_lang::deploy::TrybuildHost;
 use hydro_lang::graph::config::GraphConfig;
+use hydro_lang::location::Location;
 use hydro_lang::rewrites::persist_pullup;
 use hydro_optimize::debug;
 use hydro_optimize::decoupler::{self, Decoupler};
@@ -57,7 +57,7 @@ async fn main() {
         )
     };
 
-    let builder = hydro_lang::FlowBuilder::new();
+    let builder = hydro_lang::builder::FlowBuilder::new();
     let (cluster, leader) = hydro_test::cluster::compute_pi::compute_pi(&builder, 8192);
 
     let decoupled_cluster = builder.cluster::<DecoupledCluster>();

--- a/hydro_test/examples/echo.rs
+++ b/hydro_test/examples/echo.rs
@@ -1,10 +1,9 @@
 use clap::Parser;
 use dfir_rs::tokio_util::codec::LinesCodec;
 use hydro_deploy::Deployment;
-use hydro_lang::Location;
 use hydro_lang::deploy::TrybuildHost;
 use hydro_lang::graph::config::GraphConfig;
-use hydro_lang::location::NetworkHint;
+use hydro_lang::location::{Location, NetworkHint};
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -16,7 +15,7 @@ struct Args {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
     let mut deployment = Deployment::new();
-    let flow = hydro_lang::FlowBuilder::new();
+    let flow = hydro_lang::builder::FlowBuilder::new();
 
     let process = flow.process::<()>();
     let external = flow.external::<()>();

--- a/hydro_test/examples/first_ten_distributed.rs
+++ b/hydro_test/examples/first_ten_distributed.rs
@@ -50,7 +50,7 @@ async fn main() {
         )
     };
 
-    let builder = hydro_lang::FlowBuilder::new();
+    let builder = hydro_lang::builder::FlowBuilder::new();
     let external = builder.external();
     let p1 = builder.process();
     let p2 = builder.process();

--- a/hydro_test/examples/http_counter.rs
+++ b/hydro_test/examples/http_counter.rs
@@ -2,10 +2,9 @@ use clap::Parser;
 use dfir_rs::tokio_util::codec::LinesCodec;
 use hydro_deploy::Deployment;
 use hydro_deploy::custom_service::ServerPort;
-use hydro_lang::Location;
 use hydro_lang::deploy::TrybuildHost;
 use hydro_lang::graph::config::GraphConfig;
-use hydro_lang::location::NetworkHint;
+use hydro_lang::location::{Location, NetworkHint};
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -17,7 +16,7 @@ struct Args {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
     let mut deployment = Deployment::new();
-    let flow = hydro_lang::FlowBuilder::new();
+    let flow = hydro_lang::builder::FlowBuilder::new();
 
     let process = flow.process::<()>();
     let external = flow.external::<()>();

--- a/hydro_test/examples/http_hello.rs
+++ b/hydro_test/examples/http_hello.rs
@@ -2,10 +2,9 @@ use clap::Parser;
 use dfir_rs::tokio_util::codec::LinesCodec;
 use hydro_deploy::Deployment;
 use hydro_deploy::custom_service::ServerPort;
-use hydro_lang::Location;
 use hydro_lang::deploy::TrybuildHost;
 use hydro_lang::graph::config::GraphConfig;
-use hydro_lang::location::NetworkHint;
+use hydro_lang::location::{Location, NetworkHint};
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -17,7 +16,7 @@ struct Args {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
     let mut deployment = Deployment::new();
-    let flow = hydro_lang::FlowBuilder::new();
+    let flow = hydro_lang::builder::FlowBuilder::new();
 
     let process = flow.process::<()>();
     let external = flow.external::<()>();

--- a/hydro_test/examples/map_reduce.rs
+++ b/hydro_test/examples/map_reduce.rs
@@ -49,7 +49,7 @@ async fn main() {
         )
     };
 
-    let builder = hydro_lang::FlowBuilder::new();
+    let builder = hydro_lang::builder::FlowBuilder::new();
     let (leader, cluster) = hydro_test::cluster::map_reduce::map_reduce(&builder);
 
     // Extract the IR for graph visualization

--- a/hydro_test/examples/partition_simple_cluster.rs
+++ b/hydro_test/examples/partition_simple_cluster.rs
@@ -15,9 +15,9 @@ struct Args {
 }
 use hydro_deploy::gcp::GcpNetwork;
 use hydro_deploy::{Deployment, Host};
-use hydro_lang::Location;
 use hydro_lang::deploy::TrybuildHost;
 use hydro_lang::graph::config::GraphConfig;
+use hydro_lang::location::Location;
 use hydro_lang::rewrites::persist_pullup;
 use hydro_optimize::partitioner::{self, Partitioner};
 use tokio::sync::RwLock;
@@ -55,7 +55,7 @@ async fn main() {
         )
     };
 
-    let builder = hydro_lang::FlowBuilder::new();
+    let builder = hydro_lang::builder::FlowBuilder::new();
     let (process, cluster) = hydro_test::cluster::simple_cluster::simple_cluster(&builder);
 
     let num_original_nodes = 2;

--- a/hydro_test/examples/partition_two_pc.rs
+++ b/hydro_test/examples/partition_two_pc.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 
 use hydro_deploy::gcp::GcpNetwork;
 use hydro_deploy::{Deployment, Host};
-use hydro_lang::Location;
 use hydro_lang::deploy::TrybuildHost;
+use hydro_lang::location::Location;
 use hydro_lang::rewrites::persist_pullup::persist_pullup;
 use hydro_optimize::partition_node_analysis::{nodes_to_partition, partitioning_analysis};
 use hydro_optimize::partitioner::{Partitioner, partition};
@@ -37,7 +37,7 @@ async fn main() {
         Box::new(move |_| -> Arc<dyn Host> { localhost.clone() })
     };
 
-    let builder = hydro_lang::FlowBuilder::new();
+    let builder = hydro_lang::builder::FlowBuilder::new();
     let num_participants = 3;
     let num_partitions = 3;
     let num_clients = 3;

--- a/hydro_test/examples/paxos.rs
+++ b/hydro_test/examples/paxos.rs
@@ -45,7 +45,7 @@ async fn main() {
         Box::new(move |_| -> Arc<dyn Host> { localhost.clone() })
     };
 
-    let builder = hydro_lang::FlowBuilder::new();
+    let builder = hydro_lang::builder::FlowBuilder::new();
     let f = 1;
     let num_clients = 3;
     let num_clients_per_node = 100; // Change based on experiment between 1, 50, 100.

--- a/hydro_test/examples/perf_compute_pi.rs
+++ b/hydro_test/examples/perf_compute_pi.rs
@@ -15,8 +15,8 @@ async fn main() {
     use clap::Parser;
     use hydro_deploy::Deployment;
     use hydro_deploy::gcp::GcpNetwork;
-    use hydro_lang::Location;
     use hydro_lang::graph::config::GraphConfig;
+    use hydro_lang::location::Location;
     use hydro_optimize::deploy::ReusableHosts;
     use hydro_optimize::deploy_and_analyze::deploy_and_analyze;
     use hydro_test::cluster::compute_pi::{Leader, Worker, compute_pi};
@@ -50,7 +50,7 @@ async fn main() {
         network: network.clone(),
     };
 
-    let builder = hydro_lang::FlowBuilder::new();
+    let builder = hydro_lang::builder::FlowBuilder::new();
     let (cluster, leader) = compute_pi(&builder, 8192);
 
     let clusters = vec![(

--- a/hydro_test/examples/perf_paxos.rs
+++ b/hydro_test/examples/perf_paxos.rs
@@ -6,8 +6,8 @@ async fn main() {
     use clap::Parser;
     use hydro_deploy::Deployment;
     use hydro_deploy::gcp::GcpNetwork;
-    use hydro_lang::Location;
     use hydro_lang::graph::config::GraphConfig;
+    use hydro_lang::location::Location;
     use hydro_optimize::decoupler;
     use hydro_optimize::deploy::ReusableHosts;
     use hydro_optimize::deploy_and_analyze::deploy_and_analyze;
@@ -37,7 +37,7 @@ async fn main() {
     };
     let network = Arc::new(RwLock::new(GcpNetwork::new(&project, None)));
 
-    let mut builder = hydro_lang::FlowBuilder::new();
+    let mut builder = hydro_lang::builder::FlowBuilder::new();
     let f = 1;
     let num_clients = 3;
     let num_clients_per_node = 500; // Change based on experiment between 1, 50, 100.

--- a/hydro_test/examples/simple_cluster.rs
+++ b/hydro_test/examples/simple_cluster.rs
@@ -49,7 +49,7 @@ async fn main() {
         )
     };
 
-    let builder = hydro_lang::FlowBuilder::new();
+    let builder = hydro_lang::builder::FlowBuilder::new();
     let (process, cluster) = hydro_test::cluster::simple_cluster::simple_cluster(&builder);
 
     // Extract the IR for graph visualization

--- a/hydro_test/examples/two_pc.rs
+++ b/hydro_test/examples/two_pc.rs
@@ -42,7 +42,7 @@ async fn main() {
         Box::new(move |_| -> Arc<dyn Host> { localhost.clone() })
     };
 
-    let builder = hydro_lang::FlowBuilder::new();
+    let builder = hydro_lang::builder::FlowBuilder::new();
     let num_participants = 3;
     let num_clients = 3;
     let num_clients_per_node = 100; // Change based on experiment between 1, 50, 100.

--- a/hydro_test/src/cluster/compartmentalized_paxos.rs
+++ b/hydro_test/src/cluster/compartmentalized_paxos.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 
-use hydro_lang::location::{Atomic, MemberId};
-use hydro_lang::*;
+use hydro_lang::live_collections::stream::NoOrder;
+use hydro_lang::location::{Atomic, Location, MemberId};
+use hydro_lang::prelude::*;
 use hydro_std::quorum::collect_quorum;
 use hydro_std::request_response::join_responses;
 use serde::{Deserialize, Serialize};

--- a/hydro_test/src/cluster/compute_pi.rs
+++ b/hydro_test/src/cluster/compute_pi.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use hydro_lang::*;
+use hydro_lang::prelude::*;
 
 pub struct Worker {}
 pub struct Leader {}
@@ -55,8 +55,8 @@ pub fn compute_pi<'a>(
 
 #[cfg(test)]
 mod tests {
-    use hydro_lang::Location;
     use hydro_lang::deploy::HydroDeploy;
+    use hydro_lang::location::Location;
     use hydro_lang::rewrites::persist_pullup;
     use hydro_optimize::decoupler;
 
@@ -64,7 +64,7 @@ mod tests {
 
     #[test]
     fn compute_pi_ir() {
-        let builder = hydro_lang::FlowBuilder::new();
+        let builder = hydro_lang::builder::FlowBuilder::new();
         let _ = super::compute_pi(&builder, 8192);
         let built = builder.with_default_optimize::<HydroDeploy>();
 
@@ -81,7 +81,7 @@ mod tests {
 
     #[test]
     fn decoupled_compute_pi_ir() {
-        let builder = hydro_lang::FlowBuilder::new();
+        let builder = hydro_lang::builder::FlowBuilder::new();
         let (cluster, _) = super::compute_pi(&builder, 8192);
         let decoupled_cluster = builder.cluster::<DecoupledCluster>();
         let decoupler = decoupler::Decoupler {

--- a/hydro_test/src/cluster/kv_replica.rs
+++ b/hydro_test/src/cluster/kv_replica.rs
@@ -2,7 +2,8 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::hash::Hash;
 
-use hydro_lang::*;
+use hydro_lang::live_collections::stream::NoOrder;
+use hydro_lang::prelude::*;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 

--- a/hydro_test/src/cluster/many_to_many.rs
+++ b/hydro_test/src/cluster/many_to_many.rs
@@ -1,4 +1,4 @@
-use hydro_lang::*;
+use hydro_lang::prelude::*;
 
 pub fn many_to_many<'a>(flow: &FlowBuilder<'a>) -> Cluster<'a, ()> {
     let cluster = flow.cluster();
@@ -18,7 +18,7 @@ mod tests {
 
     #[test]
     fn many_to_many_ir() {
-        let builder = hydro_lang::FlowBuilder::new();
+        let builder = hydro_lang::builder::FlowBuilder::new();
         let _ = super::many_to_many(&builder);
         let built = builder.finalize();
 
@@ -29,7 +29,7 @@ mod tests {
     async fn many_to_many() {
         let mut deployment = Deployment::new();
 
-        let builder = hydro_lang::FlowBuilder::new();
+        let builder = hydro_lang::builder::FlowBuilder::new();
         let cluster = super::many_to_many(&builder);
 
         let nodes = builder

--- a/hydro_test/src/cluster/map_reduce.rs
+++ b/hydro_test/src/cluster/map_reduce.rs
@@ -1,4 +1,4 @@
-use hydro_lang::*;
+use hydro_lang::prelude::*;
 
 pub struct Leader {}
 pub struct Worker {}
@@ -50,7 +50,7 @@ mod tests {
 
     #[test]
     fn map_reduce_ir() {
-        let builder = hydro_lang::FlowBuilder::new();
+        let builder = hydro_lang::builder::FlowBuilder::new();
         let _ = super::map_reduce(&builder);
         let built = builder.with_default_optimize::<HydroDeploy>();
 

--- a/hydro_test/src/cluster/paxos.rs
+++ b/hydro_test/src/cluster/paxos.rs
@@ -3,10 +3,10 @@ use std::fmt::Debug;
 use std::hash::Hash;
 use std::time::Duration;
 
+use hydro_lang::live_collections::stream::{AtLeastOnce, NoOrder, TotalOrder};
 use hydro_lang::location::cluster::CLUSTER_SELF_ID;
-use hydro_lang::location::{Atomic, MemberId};
-use hydro_lang::stream::AtLeastOnce;
-use hydro_lang::*;
+use hydro_lang::location::{Atomic, Location, MemberId};
+use hydro_lang::prelude::*;
 use hydro_std::quorum::{collect_quorum, collect_quorum_with_response};
 use hydro_std::request_response::join_responses;
 use serde::de::DeserializeOwned;

--- a/hydro_test/src/cluster/paxos_bench.rs
+++ b/hydro_test/src/cluster/paxos_bench.rs
@@ -1,5 +1,6 @@
+use hydro_lang::live_collections::stream::NoOrder;
 use hydro_lang::location::cluster::CLUSTER_SELF_ID;
-use hydro_lang::*;
+use hydro_lang::prelude::*;
 use hydro_std::bench_client::{bench_client, print_bench_results};
 use hydro_std::quorum::collect_quorum;
 
@@ -148,11 +149,11 @@ mod tests {
 
     #[cfg(stageleft_runtime)]
     fn create_paxos<'a>(
-        proposers: &hydro_lang::Cluster<'a, crate::cluster::paxos::Proposer>,
-        acceptors: &hydro_lang::Cluster<'a, crate::cluster::paxos::Acceptor>,
-        clients: &hydro_lang::Cluster<'a, super::Client>,
-        client_aggregator: &hydro_lang::Process<'a, super::Aggregator>,
-        replicas: &hydro_lang::Cluster<'a, crate::cluster::kv_replica::Replica>,
+        proposers: &hydro_lang::location::Cluster<'a, crate::cluster::paxos::Proposer>,
+        acceptors: &hydro_lang::location::Cluster<'a, crate::cluster::paxos::Acceptor>,
+        clients: &hydro_lang::location::Cluster<'a, super::Client>,
+        client_aggregator: &hydro_lang::location::Process<'a, super::Aggregator>,
+        replicas: &hydro_lang::location::Cluster<'a, crate::cluster::kv_replica::Replica>,
     ) {
         super::paxos_bench(
             100,
@@ -177,7 +178,7 @@ mod tests {
 
     #[test]
     fn paxos_ir() {
-        let builder = hydro_lang::FlowBuilder::new();
+        let builder = hydro_lang::builder::FlowBuilder::new();
         let proposers = builder.cluster();
         let acceptors = builder.cluster();
         let clients = builder.cluster();
@@ -228,7 +229,7 @@ mod tests {
 
     #[tokio::test]
     async fn paxos_some_throughput() {
-        let builder = hydro_lang::FlowBuilder::new();
+        let builder = hydro_lang::builder::FlowBuilder::new();
         let proposers = builder.cluster();
         let acceptors = builder.cluster();
         let clients = builder.cluster();

--- a/hydro_test/src/cluster/paxos_with_client.rs
+++ b/hydro_test/src/cluster/paxos_with_client.rs
@@ -1,7 +1,8 @@
 use std::fmt::Debug;
 
-use hydro_lang::location::MemberId;
-use hydro_lang::*;
+use hydro_lang::live_collections::stream::{NoOrder, TotalOrder};
+use hydro_lang::location::{Location, MemberId};
+use hydro_lang::prelude::*;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 

--- a/hydro_test/src/cluster/simple_cluster.rs
+++ b/hydro_test/src/cluster/simple_cluster.rs
@@ -1,6 +1,6 @@
 use hydro_lang::location::cluster::CLUSTER_SELF_ID;
 use hydro_lang::location::{MemberId, MembershipEvent};
-use hydro_lang::*;
+use hydro_lang::prelude::*;
 use hydro_std::compartmentalize::{DecoupleClusterStream, DecoupleProcessStream, PartitionStream};
 use stageleft::IntoQuotedMut;
 
@@ -80,16 +80,15 @@ mod tests {
     use std::collections::HashMap;
 
     use hydro_deploy::Deployment;
-    use hydro_lang::Location;
     use hydro_lang::deploy::{DeployCrateWrapper, HydroDeploy};
-    use hydro_lang::location::MemberId;
+    use hydro_lang::location::{Location, MemberId};
     use hydro_lang::rewrites::persist_pullup;
     use hydro_optimize::partitioner::{self, Partitioner};
     use stageleft::q;
 
     #[test]
     fn simple_cluster_ir() {
-        let builder = hydro_lang::FlowBuilder::new();
+        let builder = hydro_lang::builder::FlowBuilder::new();
         let _ = super::simple_cluster(&builder);
         let built = builder.finalize();
 
@@ -100,7 +99,7 @@ mod tests {
     async fn simple_cluster() {
         let mut deployment = Deployment::new();
 
-        let builder = hydro_lang::FlowBuilder::new();
+        let builder = hydro_lang::builder::FlowBuilder::new();
         let (node, cluster) = super::simple_cluster(&builder);
 
         let nodes = builder
@@ -158,7 +157,7 @@ mod tests {
     async fn decouple_process() {
         let mut deployment = Deployment::new();
 
-        let builder = hydro_lang::FlowBuilder::new();
+        let builder = hydro_lang::builder::FlowBuilder::new();
         let (process1, process2) = super::decouple_process(&builder);
         let built = builder.with_default_optimize();
 
@@ -180,7 +179,7 @@ mod tests {
     async fn decouple_cluster() {
         let mut deployment = Deployment::new();
 
-        let builder = hydro_lang::FlowBuilder::new();
+        let builder = hydro_lang::builder::FlowBuilder::new();
         let (cluster1, cluster2) = super::decouple_cluster(&builder);
         let built = builder.with_default_optimize();
 
@@ -219,7 +218,7 @@ mod tests {
 
         let num_nodes = 3;
         let num_partitions = 2;
-        let builder = hydro_lang::FlowBuilder::new();
+        let builder = hydro_lang::builder::FlowBuilder::new();
         let (cluster1, cluster2) = super::partition(
             builder.cluster::<()>(),
             builder.cluster::<()>(),
@@ -265,7 +264,7 @@ mod tests {
 
     #[test]
     fn partitioned_simple_cluster_ir() {
-        let builder = hydro_lang::FlowBuilder::new();
+        let builder = hydro_lang::builder::FlowBuilder::new();
         let (_, cluster) = super::simple_cluster(&builder);
         let partitioner = Partitioner {
             nodes_to_partition: HashMap::from([(5, vec!["1".to_string()])]),

--- a/hydro_test/src/cluster/two_pc.rs
+++ b/hydro_test/src/cluster/two_pc.rs
@@ -1,7 +1,8 @@
 use std::fmt::Debug;
 use std::hash::Hash;
 
-use hydro_lang::*;
+use hydro_lang::live_collections::stream::NoOrder;
+use hydro_lang::prelude::*;
 use hydro_std::quorum::collect_quorum;
 use serde::Serialize;
 use serde::de::DeserializeOwned;

--- a/hydro_test/src/cluster/two_pc_bench.rs
+++ b/hydro_test/src/cluster/two_pc_bench.rs
@@ -1,4 +1,4 @@
-use hydro_lang::*;
+use hydro_lang::prelude::*;
 use hydro_std::bench_client::{bench_client, print_bench_results};
 
 use super::two_pc::{Coordinator, Participant};
@@ -42,12 +42,12 @@ mod tests {
 
     use dfir_lang::graph::WriteConfig;
     use hydro_deploy::Deployment;
-    use hydro_lang::Location;
     use hydro_lang::deploy::{DeployCrateWrapper, HydroDeploy, TrybuildHost};
     use hydro_lang::ir::deep_clone;
-    use hydro_lang::rewrites::persist_pullup::persist_pullup;
+    use hydro_lang::location::Location;
     #[cfg(stageleft_runtime)]
-    use hydro_lang::{Cluster, Process};
+    use hydro_lang::location::{Cluster, Process};
+    use hydro_lang::rewrites::persist_pullup::persist_pullup;
     use hydro_optimize::debug::name_to_id_map;
     use hydro_optimize::partition_node_analysis::{nodes_to_partition, partitioning_analysis};
     use hydro_optimize::partitioner::{Partitioner, partition};
@@ -80,7 +80,7 @@ mod tests {
 
     #[test]
     fn two_pc_ir() {
-        let builder = hydro_lang::FlowBuilder::new();
+        let builder = hydro_lang::builder::FlowBuilder::new();
         let coordinator = builder.process();
         let participants = builder.cluster();
         let clients = builder.cluster();
@@ -126,7 +126,7 @@ mod tests {
 
     #[tokio::test]
     async fn two_pc_some_throughput() {
-        let builder = hydro_lang::FlowBuilder::new();
+        let builder = hydro_lang::builder::FlowBuilder::new();
         let coordinator = builder.process();
         let participants = builder.cluster();
         let clients = builder.cluster();
@@ -178,7 +178,7 @@ mod tests {
 
     #[test]
     fn two_pc_partition_coordinator() {
-        let builder = hydro_lang::FlowBuilder::new();
+        let builder = hydro_lang::builder::FlowBuilder::new();
         let coordinator = builder.process();
         let partitioned_coordinator = builder.cluster::<()>();
         let participants = builder.cluster();
@@ -236,7 +236,7 @@ mod tests {
 
     #[test]
     fn two_pc_partition_participant() {
-        let builder = hydro_lang::FlowBuilder::new();
+        let builder = hydro_lang::builder::FlowBuilder::new();
         let coordinator = builder.process();
         let participants = builder.cluster();
         let clients = builder.cluster();

--- a/hydro_test/src/distributed/first_ten.rs
+++ b/hydro_test/src/distributed/first_ten.rs
@@ -1,5 +1,5 @@
-use hydro_lang::*;
-use location::external_process::ExternalBincodeSink;
+use hydro_lang::location::external_process::ExternalBincodeSink;
+use hydro_lang::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
@@ -35,7 +35,7 @@ mod tests {
 
     #[test]
     fn first_ten_distributed_ir() {
-        let builder = hydro_lang::FlowBuilder::new();
+        let builder = hydro_lang::builder::FlowBuilder::new();
         let external = builder.external();
         let p1 = builder.process();
         let p2 = builder.process();
@@ -48,7 +48,7 @@ mod tests {
     async fn first_ten_distributed() {
         let mut deployment = Deployment::new();
 
-        let builder = hydro_lang::FlowBuilder::new();
+        let builder = hydro_lang::builder::FlowBuilder::new();
         let external = builder.external();
         let p1 = builder.process();
         let p2 = builder.process();

--- a/hydro_test/src/external_client/chat.rs
+++ b/hydro_test/src/external_client/chat.rs
@@ -1,10 +1,10 @@
 use std::hash::{DefaultHasher, Hash, Hasher};
 
 use colored::{Color, Colorize};
-use hydro_lang::keyed_stream::KeyedStream;
+use hydro_lang::live_collections::stream::NoOrder;
 use hydro_lang::location::MembershipEvent;
+use hydro_lang::prelude::*;
 use hydro_lang::unsafety::NonDet;
-use hydro_lang::*;
 use hydro_std::membership::track_membership;
 use palette::{FromColor, Hsv, Srgb};
 

--- a/hydro_test/src/external_client/echo.rs
+++ b/hydro_test/src/external_client/echo.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
-use hydro_lang::keyed_stream::KeyedStream;
+use hydro_lang::live_collections::stream::TotalOrder;
 use hydro_lang::location::MembershipEvent;
-use hydro_lang::*;
+use hydro_lang::prelude::*;
 use hydro_std::membership::track_membership;
 
 pub fn echo_server<'a, P>(

--- a/hydro_test/src/external_client/http_counter.rs
+++ b/hydro_test/src/external_client/http_counter.rs
@@ -1,5 +1,5 @@
-use hydro_lang::keyed_stream::KeyedStream;
-use hydro_lang::*;
+use hydro_lang::live_collections::stream::{NoOrder, TotalOrder};
+use hydro_lang::prelude::*;
 
 #[derive(Debug, Clone)]
 pub enum RequestType {

--- a/hydro_test/src/external_client/http_hello.rs
+++ b/hydro_test/src/external_client/http_hello.rs
@@ -1,6 +1,6 @@
-use hydro_lang::keyed_singleton::{BoundedValue, KeyedSingleton};
-use hydro_lang::keyed_stream::KeyedStream;
-use hydro_lang::*;
+use hydro_lang::live_collections::keyed_singleton::{BoundedValue, KeyedSingleton};
+use hydro_lang::live_collections::stream::TotalOrder;
+use hydro_lang::prelude::*;
 
 pub fn http_hello_server<'a, P>(
     in_stream: KeyedStream<u64, String, Process<'a, P>, Unbounded, TotalOrder>,

--- a/hydro_test/src/local/chat_app.rs
+++ b/hydro_test/src/local/chat_app.rs
@@ -1,5 +1,6 @@
+use hydro_lang::live_collections::stream::NoOrder;
+use hydro_lang::prelude::*;
 use hydro_lang::unsafety::NonDet;
-use hydro_lang::*;
 
 pub fn chat_app<'a>(
     process: &Process<'a>,
@@ -38,7 +39,8 @@ pub fn chat_app<'a>(
 mod tests {
     use futures::{SinkExt, Stream, StreamExt};
     use hydro_deploy::Deployment;
-    use hydro_lang::{Location, nondet};
+    use hydro_lang::location::Location;
+    use hydro_lang::unsafety::nondet;
 
     async fn take_next_n<T>(stream: &mut (impl Stream<Item = T> + Unpin), n: usize) -> Vec<T> {
         let mut out = Vec::with_capacity(n);
@@ -56,7 +58,7 @@ mod tests {
     async fn test_chat_app_no_replay() {
         let mut deployment = Deployment::new();
 
-        let builder = hydro_lang::FlowBuilder::new();
+        let builder = hydro_lang::builder::FlowBuilder::new();
         let external = builder.external::<()>();
         let p1 = builder.process();
 
@@ -121,7 +123,7 @@ mod tests {
     async fn test_chat_app_replay() {
         let mut deployment = Deployment::new();
 
-        let builder = hydro_lang::FlowBuilder::new();
+        let builder = hydro_lang::builder::FlowBuilder::new();
         let external = builder.external::<()>();
         let p1 = builder.process();
 

--- a/hydro_test/src/local/count_elems.rs
+++ b/hydro_test/src/local/count_elems.rs
@@ -1,4 +1,4 @@
-use hydro_lang::*;
+use hydro_lang::prelude::*;
 
 pub fn count_elems<'a, T: 'a>(
     process: &Process<'a>,
@@ -19,13 +19,13 @@ pub fn count_elems<'a, T: 'a>(
 mod tests {
     use futures::{SinkExt, StreamExt};
     use hydro_deploy::Deployment;
-    use hydro_lang::Location;
+    use hydro_lang::location::Location;
 
     #[tokio::test]
     async fn test_count() {
         let mut deployment = Deployment::new();
 
-        let builder = hydro_lang::FlowBuilder::new();
+        let builder = hydro_lang::builder::FlowBuilder::new();
         let external = builder.external::<()>();
         let p1 = builder.process();
 

--- a/hydro_test/src/local/futures.rs
+++ b/hydro_test/src/local/futures.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
-use hydro_lang::*;
+use hydro_lang::live_collections::stream::NoOrder;
+use hydro_lang::prelude::*;
 use stageleft::q;
 
 pub fn unordered<'a>(process: &Process<'a>) -> Stream<u32, Process<'a>, Unbounded, NoOrder> {
@@ -34,7 +35,7 @@ mod tests {
     async fn test_unordered() {
         let mut deployment = Deployment::new();
 
-        let builder = hydro_lang::FlowBuilder::new();
+        let builder = hydro_lang::builder::FlowBuilder::new();
         let external = builder.external::<()>();
         let p1 = builder.process();
 
@@ -66,7 +67,7 @@ mod tests {
     async fn test_ordered() {
         let mut deployment = Deployment::new();
 
-        let builder = hydro_lang::FlowBuilder::new();
+        let builder = hydro_lang::builder::FlowBuilder::new();
         let external = builder.external::<()>();
         let p1 = builder.process();
 

--- a/hydro_test/src/local/graph_reachability.rs
+++ b/hydro_test/src/local/graph_reachability.rs
@@ -1,4 +1,5 @@
-use hydro_lang::*;
+use hydro_lang::live_collections::stream::NoOrder;
+use hydro_lang::prelude::*;
 
 pub fn graph_reachability<'a>(
     process: &Process<'a>,
@@ -35,14 +36,14 @@ pub fn graph_reachability<'a>(
 mod tests {
     use futures::{SinkExt, StreamExt};
     use hydro_deploy::Deployment;
-    use hydro_lang::Location;
+    use hydro_lang::location::Location;
 
     #[tokio::test]
     #[ignore = "broken because ticks in Hydro are only triggered by external input"]
     async fn test_reachability() {
         let mut deployment = Deployment::new();
 
-        let builder = hydro_lang::FlowBuilder::new();
+        let builder = hydro_lang::builder::FlowBuilder::new();
         let external = builder.external::<()>();
         let p1 = builder.process();
 

--- a/hydro_test/src/local/negation.rs
+++ b/hydro_test/src/local/negation.rs
@@ -1,4 +1,4 @@
-use hydro_lang::*;
+use hydro_lang::prelude::*;
 
 pub fn test_difference<'a>(
     process: &Process<'a>,
@@ -86,7 +86,7 @@ pub fn test_anti_join<'a>(
 mod tests {
     use futures::{SinkExt, Stream, StreamExt};
     use hydro_deploy::Deployment;
-    use hydro_lang::Location;
+    use hydro_lang::location::Location;
 
     async fn take_next_n<T>(stream: &mut (impl Stream<Item = T> + Unpin), n: usize) -> Vec<T> {
         let mut out = Vec::with_capacity(n);
@@ -104,7 +104,7 @@ mod tests {
     async fn test_difference_tick_tick() {
         let mut deployment = Deployment::new();
 
-        let builder = hydro_lang::FlowBuilder::new();
+        let builder = hydro_lang::builder::FlowBuilder::new();
         let external = builder.external::<()>();
         let p1 = builder.process();
 
@@ -135,7 +135,7 @@ mod tests {
     async fn test_difference_tick_static() {
         let mut deployment = Deployment::new();
 
-        let builder = hydro_lang::FlowBuilder::new();
+        let builder = hydro_lang::builder::FlowBuilder::new();
         let external = builder.external::<()>();
         let p1 = builder.process();
 
@@ -166,7 +166,7 @@ mod tests {
     async fn test_difference_static_tick() {
         let mut deployment = Deployment::new();
 
-        let builder = hydro_lang::FlowBuilder::new();
+        let builder = hydro_lang::builder::FlowBuilder::new();
         let external = builder.external::<()>();
         let p1 = builder.process();
 
@@ -201,7 +201,7 @@ mod tests {
     async fn test_difference_static_static() {
         let mut deployment = Deployment::new();
 
-        let builder = hydro_lang::FlowBuilder::new();
+        let builder = hydro_lang::builder::FlowBuilder::new();
         let external = builder.external::<()>();
         let p1 = builder.process();
 
@@ -236,7 +236,7 @@ mod tests {
     async fn test_anti_join_tick_tick() {
         let mut deployment = Deployment::new();
 
-        let builder = hydro_lang::FlowBuilder::new();
+        let builder = hydro_lang::builder::FlowBuilder::new();
         let external = builder.external::<()>();
         let p1 = builder.process();
 
@@ -267,7 +267,7 @@ mod tests {
     async fn test_anti_join_tick_static() {
         let mut deployment = Deployment::new();
 
-        let builder = hydro_lang::FlowBuilder::new();
+        let builder = hydro_lang::builder::FlowBuilder::new();
         let external = builder.external::<()>();
         let p1 = builder.process();
 
@@ -298,7 +298,7 @@ mod tests {
     async fn test_anti_join_static_tick() {
         let mut deployment = Deployment::new();
 
-        let builder = hydro_lang::FlowBuilder::new();
+        let builder = hydro_lang::builder::FlowBuilder::new();
         let external = builder.external::<()>();
         let p1 = builder.process();
 
@@ -333,7 +333,7 @@ mod tests {
     async fn test_anti_join_static_static() {
         let mut deployment = Deployment::new();
 
-        let builder = hydro_lang::FlowBuilder::new();
+        let builder = hydro_lang::builder::FlowBuilder::new();
         let external = builder.external::<()>();
         let p1 = builder.process();
 

--- a/template/hydro/examples/first_ten.rs
+++ b/template/hydro/examples/first_ten.rs
@@ -4,7 +4,7 @@ use hydro_deploy::Deployment;
 async fn main() {
     let mut deployment = Deployment::new();
 
-    let flow = hydro_lang::FlowBuilder::new();
+    let flow = hydro_lang::builder::FlowBuilder::new();
     let process = flow.process();
     hydro_template::first_ten::first_ten(&process);
 

--- a/template/hydro/examples/first_ten_cluster.rs
+++ b/template/hydro/examples/first_ten_cluster.rs
@@ -4,7 +4,7 @@ use hydro_deploy::Deployment;
 async fn main() {
     let mut deployment = Deployment::new();
 
-    let flow = hydro_lang::FlowBuilder::new();
+    let flow = hydro_lang::builder::FlowBuilder::new();
     let leader = flow.process();
     let workers = flow.cluster();
     hydro_template::first_ten_cluster::first_ten_cluster(&leader, &workers);

--- a/template/hydro/examples/first_ten_cluster_gcp.rs
+++ b/template/hydro/examples/first_ten_cluster_gcp.rs
@@ -17,7 +17,7 @@ async fn main() {
     let mut deployment = Deployment::new();
     let vpc = Arc::new(RwLock::new(GcpNetwork::new(&gcp_project, None)));
 
-    let flow = hydro_lang::FlowBuilder::new();
+    let flow = hydro_lang::builder::FlowBuilder::new();
     let leader = flow.process();
     let workers = flow.cluster();
     hydro_template::first_ten_cluster::first_ten_cluster(&leader, &workers);

--- a/template/hydro/examples/first_ten_distributed.rs
+++ b/template/hydro/examples/first_ten_distributed.rs
@@ -4,7 +4,7 @@ use hydro_deploy::Deployment;
 async fn main() {
     let mut deployment = Deployment::new();
 
-    let flow = hydro_lang::FlowBuilder::new();
+    let flow = hydro_lang::builder::FlowBuilder::new();
     let p1 = flow.process();
     let p2 = flow.process();
     hydro_template::first_ten_distributed::first_ten_distributed(&p1, &p2);

--- a/template/hydro/examples/first_ten_distributed_gcp.rs
+++ b/template/hydro/examples/first_ten_distributed_gcp.rs
@@ -17,7 +17,7 @@ async fn main() {
     let mut deployment = Deployment::new();
     let vpc = Arc::new(RwLock::new(GcpNetwork::new(&gcp_project, None)));
 
-    let flow = hydro_lang::FlowBuilder::new();
+    let flow = hydro_lang::builder::FlowBuilder::new();
     let p1 = flow.process();
     let p2 = flow.process();
     hydro_template::first_ten_distributed::first_ten_distributed(&p1, &p2);

--- a/template/hydro/src/first_ten.rs
+++ b/template/hydro/src/first_ten.rs
@@ -1,4 +1,4 @@
-use hydro_lang::*;
+use hydro_lang::prelude::*;
 
 pub fn first_ten(process: &Process) {
     process

--- a/template/hydro/src/first_ten_cluster.rs
+++ b/template/hydro/src/first_ten_cluster.rs
@@ -1,4 +1,4 @@
-use hydro_lang::*;
+use hydro_lang::prelude::*;
 
 pub struct Leader {}
 pub struct Worker {}
@@ -29,7 +29,7 @@ mod tests {
         let mut deployment = Deployment::new();
         let localhost = deployment.Localhost();
 
-        let flow = hydro_lang::FlowBuilder::new();
+        let flow = hydro_lang::builder::FlowBuilder::new();
         let leader = flow.process();
         let workers = flow.cluster();
         super::first_ten_cluster(&leader, &workers);

--- a/template/hydro/src/first_ten_distributed.rs
+++ b/template/hydro/src/first_ten_distributed.rs
@@ -1,4 +1,4 @@
-use hydro_lang::*;
+use hydro_lang::prelude::*;
 
 pub struct P1 {}
 pub struct P2 {}
@@ -21,7 +21,7 @@ mod tests {
         let mut deployment = Deployment::new();
         let localhost = deployment.Localhost();
 
-        let flow = hydro_lang::FlowBuilder::new();
+        let flow = hydro_lang::builder::FlowBuilder::new();
         let p1 = flow.process();
         let p2 = flow.process();
         super::first_ten_distributed(&p1, &p2);


### PR DESCRIPTION

Bigger refactor to clean up the top-level namespace for `hydro_lang`. First, we move all the definitions for different live collections into the `live_collections` module.

Then, instead of having a bunch of types exported directly from `hydro_lang`, we instead create a `prelude` module that exports them. This reduces the pollution of the namespace when importing from `hydro_lang`.
