### PR TITLE
refactor(hydro_lang)!: move `boundedness` module under `live_collections`

### DIFF
--- a/hydro_lang/src/lib.rs
+++ b/hydro_lang/src/lib.rs
@@ -36,8 +36,8 @@ pub mod prelude {
 
     pub use stageleft::q;
 
-    pub use crate::boundedness::{Bounded, Unbounded};
     pub use crate::builder::FlowBuilder;
+    pub use crate::live_collections::boundedness::{Bounded, Unbounded};
     pub use crate::live_collections::keyed_singleton::KeyedSingleton;
     pub use crate::live_collections::keyed_stream::KeyedStream;
     pub use crate::live_collections::optional::Optional;
@@ -53,9 +53,6 @@ pub mod prelude {
 pub mod runtime_context;
 
 pub mod nondet;
-
-#[expect(missing_docs, reason = "TODO")]
-pub mod boundedness;
 
 #[expect(missing_docs, reason = "TODO")]
 pub mod live_collections;

--- a/hydro_lang/src/live_collections/boundedness.rs
+++ b/hydro_lang/src/live_collections/boundedness.rs
@@ -1,6 +1,6 @@
 use sealed::sealed;
 
-use crate::live_collections::keyed_singleton::{BoundedValue, KeyedSingletonBound};
+use super::keyed_singleton::{BoundedValue, KeyedSingletonBound};
 
 /// A marker trait indicating whether a stream’s length is bounded (finite) or unbounded (potentially infinite).
 ///

--- a/hydro_lang/src/live_collections/keyed_singleton.rs
+++ b/hydro_lang/src/live_collections/keyed_singleton.rs
@@ -2,11 +2,11 @@ use std::hash::Hash;
 
 use stageleft::{IntoQuotedMut, QuotedWithContext, q};
 
+use super::boundedness::{Bounded, Boundedness, Unbounded};
 use super::keyed_stream::KeyedStream;
 use super::optional::Optional;
 use super::singleton::Singleton;
 use super::stream::{ExactlyOnce, NoOrder, Stream, TotalOrder};
-use crate::boundedness::{Bounded, Boundedness, Unbounded};
 use crate::cycle::{CycleCollection, CycleComplete, ForwardRefMarker};
 use crate::location::tick::NoAtomic;
 use crate::location::{Atomic, Location, LocationId, NoTick, Tick};

--- a/hydro_lang/src/live_collections/keyed_stream.rs
+++ b/hydro_lang/src/live_collections/keyed_stream.rs
@@ -3,10 +3,10 @@ use std::marker::PhantomData;
 
 use stageleft::{IntoQuotedMut, QuotedWithContext, q};
 
+use super::boundedness::{Bounded, Boundedness, Unbounded};
 use super::keyed_singleton::KeyedSingleton;
 use super::optional::Optional;
 use super::stream::{ExactlyOnce, MinOrder, MinRetries, NoOrder, Stream, TotalOrder};
-use crate::boundedness::{Bounded, Boundedness, Unbounded};
 use crate::builder::ir::HydroNode;
 use crate::cycle::{CycleCollection, CycleComplete, ForwardRefMarker};
 use crate::location::tick::NoAtomic;
@@ -568,7 +568,7 @@ where
     /// A variant of [`Stream::fold`], intended for keyed streams. The aggregation is executed in-order across the values
     /// in each group. But the aggregation function returns a boolean, which when true indicates that the aggregated
     /// result is complete and can be released to downstream computation. Unlike [`Stream::fold_keyed`], this means that
-    /// even if the input stream is [`crate::boundedness::Unbounded`], the outputs of the fold can be processed like normal stream elements.
+    /// even if the input stream is [`super::boundedness::Unbounded`], the outputs of the fold can be processed like normal stream elements.
     ///
     /// # Example
     /// ```rust

--- a/hydro_lang/src/live_collections/mod.rs
+++ b/hydro_lang/src/live_collections/mod.rs
@@ -1,3 +1,5 @@
+pub mod boundedness;
+
 pub mod keyed_singleton;
 pub mod keyed_stream;
 pub mod optional;

--- a/hydro_lang/src/live_collections/optional.rs
+++ b/hydro_lang/src/live_collections/optional.rs
@@ -6,9 +6,9 @@ use std::rc::Rc;
 use stageleft::{IntoQuotedMut, QuotedWithContext, q};
 use syn::parse_quote;
 
+use super::boundedness::{Bounded, Boundedness, Unbounded};
 use super::singleton::{Singleton, ZipResult};
 use super::stream::{AtLeastOnce, ExactlyOnce, NoOrder, Stream, TotalOrder};
-use crate::boundedness::{Bounded, Boundedness, Unbounded};
 use crate::builder::FLOW_USED_MESSAGE;
 use crate::builder::ir::{HydroIrOpMetadata, HydroNode, HydroRoot, HydroSource, TeeNode};
 use crate::cycle::{CycleCollection, CycleComplete, DeferTick, ForwardRefMarker, TickCycleMarker};

--- a/hydro_lang/src/live_collections/singleton.rs
+++ b/hydro_lang/src/live_collections/singleton.rs
@@ -5,9 +5,9 @@ use std::rc::Rc;
 
 use stageleft::{IntoQuotedMut, QuotedWithContext, q};
 
+use super::boundedness::{Bounded, Boundedness, Unbounded};
 use super::optional::Optional;
 use super::stream::{AtLeastOnce, ExactlyOnce, NoOrder, Stream, TotalOrder};
-use crate::boundedness::{Bounded, Boundedness, Unbounded};
 use crate::builder::FLOW_USED_MESSAGE;
 use crate::builder::ir::{HydroIrOpMetadata, HydroNode, HydroRoot, TeeNode};
 use crate::cycle::{

--- a/hydro_lang/src/live_collections/stream.rs
+++ b/hydro_lang/src/live_collections/stream.rs
@@ -10,10 +10,10 @@ use stageleft::{IntoQuotedMut, QuotedWithContext, q};
 use syn::parse_quote;
 use tokio::time::Instant;
 
+use super::boundedness::{Bounded, Boundedness, Unbounded};
 use super::keyed_stream::KeyedStream;
 use super::optional::Optional;
 use super::singleton::Singleton;
-use crate::boundedness::{Bounded, Boundedness, Unbounded};
 use crate::builder::FLOW_USED_MESSAGE;
 use crate::builder::ir::{HydroIrOpMetadata, HydroNode, HydroRoot, TeeNode};
 use crate::cycle::{CycleCollection, CycleComplete, DeferTick, ForwardRefMarker, TickCycleMarker};

--- a/hydro_lang/src/live_collections/stream/networking.rs
+++ b/hydro_lang/src/live_collections/stream/networking.rs
@@ -5,8 +5,8 @@ use serde::de::DeserializeOwned;
 use stageleft::{q, quote_type};
 use syn::parse_quote;
 
-use crate::boundedness::{Boundedness, Unbounded};
 use crate::builder::ir::{DebugInstantiate, HydroIrOpMetadata, HydroNode, HydroRoot};
+use crate::live_collections::boundedness::{Boundedness, Unbounded};
 use crate::live_collections::keyed_singleton::KeyedSingleton;
 use crate::live_collections::keyed_stream::KeyedStream;
 use crate::live_collections::stream::{ExactlyOnce, Stream, TotalOrder};

--- a/hydro_lang/src/location/mod.rs
+++ b/hydro_lang/src/location/mod.rs
@@ -12,12 +12,12 @@ use syn::parse_quote;
 use tokio_util::codec::{Decoder, Encoder, LengthDelimitedCodec};
 
 use super::builder::FlowState;
-use crate::boundedness::Unbounded;
 use crate::builder::ir::backtrace::Backtrace;
 use crate::builder::ir::{
     DebugInstantiate, HydroIrMetadata, HydroIrOpMetadata, HydroNode, HydroRoot, HydroSource,
 };
 use crate::cycle::{CycleCollection, ForwardRef, ForwardRefMarker};
+use crate::live_collections::boundedness::Unbounded;
 use crate::live_collections::keyed_stream::KeyedStream;
 use crate::live_collections::singleton::Singleton;
 use crate::live_collections::stream::{ExactlyOnce, NoOrder, Stream, TotalOrder};

--- a/hydro_lang/src/location/tick.rs
+++ b/hydro_lang/src/location/tick.rs
@@ -5,13 +5,13 @@ use sealed::sealed;
 use stageleft::{QuotedWithContext, q};
 
 use super::{Cluster, Location, LocationId, Process};
-use crate::boundedness::Bounded;
 use crate::builder::FlowState;
 use crate::builder::ir::{HydroNode, HydroSource};
 use crate::cycle::{
     CycleCollection, CycleCollectionWithInitial, DeferTick, ForwardRef, ForwardRefMarker,
     TickCycle, TickCycleMarker,
 };
+use crate::live_collections::boundedness::Bounded;
 use crate::live_collections::optional::Optional;
 use crate::live_collections::singleton::Singleton;
 use crate::live_collections::stream::{ExactlyOnce, Stream, TotalOrder};

--- a/hydro_lang/src/test_util.rs
+++ b/hydro_lang/src/test_util.rs
@@ -7,8 +7,8 @@ use std::pin::Pin;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
-use crate::boundedness::Unbounded;
 use crate::builder::FlowBuilder;
+use crate::live_collections::boundedness::Unbounded;
 use crate::live_collections::stream::Stream;
 use crate::location::Process;
 

--- a/hydro_std/src/compartmentalize.rs
+++ b/hydro_std/src/compartmentalize.rs
@@ -1,4 +1,4 @@
-use hydro_lang::boundedness::Boundedness;
+use hydro_lang::live_collections::boundedness::Boundedness;
 use hydro_lang::live_collections::stream::NoOrder;
 use hydro_lang::location::cluster::CLUSTER_SELF_ID;
 use hydro_lang::location::{Location, MemberId, NoTick};

--- a/hydro_std/src/membership.rs
+++ b/hydro_std/src/membership.rs
@@ -1,9 +1,7 @@
 use std::hash::Hash;
 
-use hydro_lang::boundedness::Unbounded;
-use hydro_lang::live_collections::keyed_singleton::KeyedSingleton;
-use hydro_lang::live_collections::keyed_stream::KeyedStream;
 use hydro_lang::location::{Location, MembershipEvent};
+use hydro_lang::prelude::*;
 use stageleft::q;
 
 pub fn track_membership<'a, K: Hash + Eq, L: Location<'a>>(


### PR DESCRIPTION

Type tags for boundedness are only used in the type parameters for live collections.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydro-project/hydro/pull/2073).
* #2081
* #2075
* #2074
* __->__ #2073