### PR TITLE
refactor(hydro_lang): replace `internal_constants` with configurable parameters

### DIFF
--- a/hydro_lang/src/graph/render.rs
+++ b/hydro_lang/src/graph/render.rs
@@ -934,6 +934,7 @@ impl HydroNode {
 
             HydroNode::Counter {
                 tag: _,
+                prefix: _,
                 duration,
                 input,
                 metadata,

--- a/hydro_lang/src/ir.rs
+++ b/hydro_lang/src/ir.rs
@@ -1221,6 +1221,7 @@ pub enum HydroNode {
     Counter {
         tag: String,
         duration: DebugExpr,
+        prefix: String,
         input: Box<HydroNode>,
         metadata: HydroIrMetadata,
     },
@@ -1577,11 +1578,13 @@ impl HydroNode {
             HydroNode::Counter {
                 tag,
                 duration,
+                prefix,
                 input,
                 metadata,
             } => HydroNode::Counter {
                 tag: tag.clone(),
                 duration: duration.clone(),
+                prefix: prefix.clone(),
                 input: Box::new(input.deep_clone(seen_tees)),
                 metadata: metadata.clone(),
             },
@@ -2620,6 +2623,7 @@ impl HydroNode {
             HydroNode::Counter {
                 tag,
                 duration,
+                prefix,
                 input,
                 ..
             } => {
@@ -2634,7 +2638,7 @@ impl HydroNode {
                         let builder = graph_builders.entry(input_location_id).or_default();
                         builder.add_dfir(
                             parse_quote! {
-                                #counter_ident = #input_ident -> _counter(#tag, #duration);
+                                #counter_ident = #input_ident -> _counter(#tag, #duration, #prefix);
                             },
                             None,
                             Some(&next_stmt_id.to_string()),
@@ -3049,7 +3053,7 @@ mod test {
 
     #[test]
     fn hydro_node_size() {
-        assert_eq!(size_of::<HydroNode>(), 232);
+        assert_eq!(size_of::<HydroNode>(), 248);
     }
 
     #[test]

--- a/hydro_lang/src/lib.rs
+++ b/hydro_lang/src/lib.rs
@@ -22,13 +22,6 @@ pub mod runtime_support {
     pub mod resource_measurement;
 }
 
-#[doc(hidden)]
-pub mod internal_constants {
-    pub const CPU_USAGE_PREFIX: &str = "CPU:";
-    // Should remain consistent with dfir_lang/src/graph/ops/_counter.rs
-    pub const COUNTER_PREFIX: &str = "_counter";
-}
-
 pub mod prelude {
     // taken from `tokio`
     //! A "prelude" for users of the `hydro_lang` crate.

--- a/hydro_lang/src/runtime_support/resource_measurement.rs
+++ b/hydro_lang/src/runtime_support/resource_measurement.rs
@@ -47,7 +47,7 @@ pub async fn run(flow: Dfir<'_>) {
             system_time.num_milliseconds() as f32 / elapsed_time.num_milliseconds() as f32;
         println!(
             "{} Total {:.4}%, User {:.4}%, System {:.4}%",
-            crate::internal_constants::CPU_USAGE_PREFIX,
+            option_env!("HYDRO_RUNTIME_MEASURE_CPU_PREFIX").unwrap_or("CPU:"),
             percent_cpu_use,
             user_cpu_use,
             system_cpu_use
@@ -67,7 +67,7 @@ pub async fn run(flow: Dfir<'_>) {
 
         println!(
             "{} Total {:.4}%, User {:.4}%, System {:.4}%",
-            crate::internal_constants::CPU_USAGE_PREFIX,
+            option_env!("HYDRO_RUNTIME_MEASURE_CPU_PREFIX").unwrap_or("CPU:"),
             user_cpu_use,
             user_cpu_use,
             0.0

--- a/hydro_optimize/src/deploy.rs
+++ b/hydro_optimize/src/deploy.rs
@@ -53,6 +53,10 @@ impl ReusableHosts {
         };
         TrybuildHost::new(self.lazy_create_host(deployment, display_name.clone()))
             .additional_hydro_features(vec!["runtime_measure".to_string()])
+            .build_env(
+                "HYDRO_RUNTIME_MEASURE_CPU_PREFIX",
+                super::deploy_and_analyze::CPU_USAGE_PREFIX,
+            )
             .rustflags(rustflags)
             .tracing(
                 TracingOptions::builder()

--- a/hydro_optimize/src/deploy_and_analyze.rs
+++ b/hydro_optimize/src/deploy_and_analyze.rs
@@ -6,7 +6,6 @@ use hydro_lang::builder::deploy::DeployResult;
 use hydro_lang::builder::{FlowBuilder, RewriteIrFlowBuilder};
 use hydro_lang::deploy::HydroDeploy;
 use hydro_lang::deploy::deploy_graph::DeployCrateWrapper;
-use hydro_lang::internal_constants::{COUNTER_PREFIX, CPU_USAGE_PREFIX};
 use hydro_lang::ir::{HydroNode, HydroRoot, deep_clone, traverse_dfir};
 use hydro_lang::location::LocationId;
 use hydro_lang::rewrites::persist_pullup::persist_pullup;
@@ -17,6 +16,9 @@ use crate::decoupler::Decoupler;
 use crate::deploy::ReusableHosts;
 use crate::parse_results::{analyze_cluster_results, analyze_send_recv_overheads};
 use crate::repair::{cycle_source_to_sink_input, inject_id, remove_counter};
+
+const COUNTER_PREFIX: &str = "_optimize_counter";
+pub(crate) const CPU_USAGE_PREFIX: &str = "HYDRO_OPTIMIZE_CPU:";
 
 fn insert_counter_node(node: &mut HydroNode, next_stmt_id: &mut usize, duration: syn::Expr) {
     match node {
@@ -56,6 +58,7 @@ fn insert_counter_node(node: &mut HydroNode, next_stmt_id: &mut usize, duration:
             let counter = HydroNode::Counter {
                 tag: next_stmt_id.to_string(),
                 duration: duration.into(),
+                prefix: COUNTER_PREFIX.to_string(),
                 input: Box::new(node_content),
                 metadata: metadata.clone(),
             };


### PR DESCRIPTION

Instead of hardcoding certain prefixes for logging elements, we now allow them to be configured via DFIR parameters (for `_counter`) or build-time environment variables (for CPU information).
