### PR TITLE
docs(hydro_lang)!: more stream network APIs, privatize internals

### DIFF
--- a/hydro_lang/src/live_collections/stream/networking.rs
+++ b/hydro_lang/src/live_collections/stream/networking.rs
@@ -37,8 +37,7 @@ fn track_membership<'a, C, L: Location<'a> + NoTick + NoAtomic>(
         .filter_map(q!(|v| if v { Some(()) } else { None }))
 }
 
-#[expect(missing_docs, reason = "TODO")]
-pub fn serialize_bincode_with_type(is_demux: bool, t_type: &syn::Type) -> syn::Expr {
+fn serialize_bincode_with_type(is_demux: bool, t_type: &syn::Type) -> syn::Expr {
     let root = get_this_crate();
 
     if is_demux {
@@ -60,13 +59,11 @@ pub fn serialize_bincode_with_type(is_demux: bool, t_type: &syn::Type) -> syn::E
     }
 }
 
-#[expect(missing_docs, reason = "TODO")]
-pub fn serialize_bincode<T: Serialize>(is_demux: bool) -> syn::Expr {
+pub(crate) fn serialize_bincode<T: Serialize>(is_demux: bool) -> syn::Expr {
     serialize_bincode_with_type(is_demux, &quote_type::<T>())
 }
 
-#[expect(missing_docs, reason = "TODO")]
-pub fn deserialize_bincode_with_type(tagged: Option<&syn::Type>, t_type: &syn::Type) -> syn::Expr {
+fn deserialize_bincode_with_type(tagged: Option<&syn::Type>, t_type: &syn::Type) -> syn::Expr {
     let root = get_this_crate();
 
     if let Some(c_type) = tagged {
@@ -91,12 +88,13 @@ pub(crate) fn deserialize_bincode<T: DeserializeOwned>(tagged: Option<&syn::Type
 
 impl<'a, T, L, B: Boundedness, O, R> Stream<T, Process<'a, L>, B, O, R> {
     /// "Moves" elements of this stream to a new distributed location by sending them over the network,
-    /// using [`bincode`] to serialize/deserialize messages. The returned stream captures the elements
-    /// received at the destination, where values will asynchronously arrive over the network.
+    /// using [`bincode`] to serialize/deserialize messages.
     ///
-    /// Sending from a [`Process`] to another [`Process`] preserves ordering and retries guarantees by
-    /// using a single TCP channel to send the values. The recipient is guaranteed to receive a _prefix_
-    /// or the sent messages; if the TCP connection is dropped no further messages will be sent.
+    /// The returned stream captures the elements received at the destination, where values will
+    /// asynchronously arrive over the network. Sending from a [`Process`] to another [`Process`]
+    /// preserves ordering and retries guarantees by using a single TCP channel to send the values. The
+    /// recipient is guaranteed to receive a _prefix_ or the sent messages; if the TCP connection is
+    /// dropped no further messages will be sent.
     ///
     /// # Example
     /// ```rust
@@ -138,18 +136,18 @@ impl<'a, T, L, B: Boundedness, O, R> Stream<T, Process<'a, L>, B, O, R> {
     }
 
     /// Broadcasts elements of this stream to all members of a cluster by sending them over the network,
-    /// using [`bincode`] to serialize/deserialize messages. Each element in the stream will be sent to
-    /// **every** member of the cluster based on the latest membership information.
+    /// using [`bincode`] to serialize/deserialize messages.
     ///
-    /// This is a common pattern in distributed systems for broadcasting data to all nodes in a cluster.
-    /// Unlike [`Stream::demux_bincode`], which requires `(MemberId, T)` tuples to target specific members,
-    /// `broadcast_bincode` takes a stream of **only data elements** and sends each element to all cluster members.
+    /// Each element in the stream will be sent to **every** member of the cluster based on the latest
+    /// membership information. This is a common pattern in distributed systems for broadcasting data to
+    /// all nodes in a cluster. Unlike [`Stream::demux_bincode`], which requires `(MemberId, T)` tuples to
+    /// target specific members, `broadcast_bincode` takes a stream of **only data elements** and sends
+    /// each element to all cluster members.
     ///
     /// # Non-Determinism
     /// The set of cluster members may asynchronously change over time. Each element is only broadcast
     /// to the current cluster members _at that point in time_. Depending on when we are notified of
-    /// membership changes, we will broadcast each element to different members, so each member may receive
-    /// different elements.
+    /// membership changes, we will broadcast each element to different members.
     ///
     /// # Example
     /// ```rust
@@ -160,10 +158,12 @@ impl<'a, T, L, B: Boundedness, O, R> Stream<T, Process<'a, L>, B, O, R> {
     /// let workers: Cluster<()> = flow.cluster::<()>();
     /// let numbers: Stream<_, Process<_>, _> = p1.source_iter(q!(vec![123]));
     /// let on_worker: Stream<_, Cluster<_>, _> = numbers.broadcast_bincode(&workers, nondet!(/** assuming stable membership */));
-    /// on_worker.send_bincode(&p2)
-    /// # .entries()
-    /// // if there are 4 members in the cluster, we should receive 4 elements
-    /// // { MemberId::<()>(0): [123], MemberId::<()>(1): [123], MemberId::<()>(2): [123], MemberId::<()>(3): [123] }
+    /// # on_worker.send_bincode(&p2).entries()
+    /// // if there are 4 members in the cluster, each receives one element
+    /// // - MemberId::<()>(0): [123]
+    /// // - MemberId::<()>(1): [123]
+    /// // - MemberId::<()>(2): [123]
+    /// // - MemberId::<()>(3): [123]
     /// # }, |mut stream| async move {
     /// # let mut results = Vec::new();
     /// # for w in 0..4 {
@@ -234,8 +234,41 @@ impl<'a, T, L, B: Boundedness, O, R> Stream<T, Process<'a, L>, B, O, R> {
     }
 }
 
-#[expect(missing_docs, reason = "TODO")]
 impl<'a, T, L, L2, B: Boundedness, O, R> Stream<(MemberId<L2>, T), Process<'a, L>, B, O, R> {
+    /// Sends elements of this stream to specific members of a cluster, identified by a [`MemberId`],
+    /// using [`bincode`] to serialize/deserialize messages.
+    ///
+    /// Each element in the stream must be a tuple `(MemberId<L2>, T)` where the first element
+    /// specifies which cluster member should receive the data. Unlike [`Stream::broadcast_bincode`],
+    /// this API allows precise targeting of specific cluster members rather than broadcasting to
+    /// all members.
+    ///
+    /// # Example
+    /// ```rust
+    /// # use hydro_lang::prelude::*;
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(hydro_lang::test_util::multi_location_test(|flow, p2| {
+    /// let p1 = flow.process::<()>();
+    /// let workers: Cluster<()> = flow.cluster::<()>();
+    /// let numbers: Stream<_, Process<_>, _> = p1.source_iter(q!(vec![0, 1, 2, 3]));
+    /// let on_worker: Stream<_, Cluster<_>, _> = numbers
+    ///     .map(q!(|x| (hydro_lang::location::MemberId::from_raw(x), x)))
+    ///     .demux_bincode(&workers);
+    /// # on_worker.send_bincode(&p2).entries()
+    /// // if there are 4 members in the cluster, each receives one element
+    /// // - MemberId::<()>(0): [0]
+    /// // - MemberId::<()>(1): [1]
+    /// // - MemberId::<()>(2): [2]
+    /// // - MemberId::<()>(3): [3]
+    /// # }, |mut stream| async move {
+    /// # let mut results = Vec::new();
+    /// # for w in 0..4 {
+    /// #     results.push(format!("{:?}", stream.next().await.unwrap()));
+    /// # }
+    /// # results.sort();
+    /// # assert_eq!(results, vec!["(MemberId::<()>(0), 0)", "(MemberId::<()>(1), 1)", "(MemberId::<()>(2), 2)", "(MemberId::<()>(3), 3)"]);
+    /// # }));
+    /// ```
     pub fn demux_bincode(
         self,
         other: &Cluster<'a, L2>,
@@ -247,8 +280,50 @@ impl<'a, T, L, L2, B: Boundedness, O, R> Stream<(MemberId<L2>, T), Process<'a, L
     }
 }
 
-#[expect(missing_docs, reason = "TODO")]
 impl<'a, T, L, B: Boundedness> Stream<T, Process<'a, L>, B, TotalOrder, ExactlyOnce> {
+    /// Distributes elements of this stream to cluster members in a round-robin fashion, using
+    /// [`bincode`] to serialize/deserialize messages.
+    ///
+    /// This provides load balancing by evenly distributing work across cluster members. The
+    /// distribution is deterministic based on element order - the first element goes to member 0,
+    /// the second to member 1, and so on, wrapping around when reaching the end of the member list.
+    ///
+    /// # Non-Determinism
+    /// The set of cluster members may asynchronously change over time. Each element is distributed
+    /// based on the current cluster membership _at that point in time_. Depending on when cluster
+    /// members join and leave, the round-robin pattern will change. Furthermore, even when the
+    /// membership is stable, the order of members in the round-robin pattern may change across runs.
+    ///
+    /// # Ordering Requirements
+    /// This method is only available on streams with [`TotalOrder`] and [`ExactlyOnce`], since the
+    /// order of messages and retries affects the round-robin pattern.
+    ///
+    /// # Example
+    /// ```rust
+    /// # use hydro_lang::prelude::*;
+    /// # use hydro_lang::live_collections::stream::{TotalOrder, ExactlyOnce};
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(hydro_lang::test_util::multi_location_test(|flow, p2| {
+    /// let p1 = flow.process::<()>();
+    /// let workers: Cluster<()> = flow.cluster::<()>();
+    /// let numbers: Stream<_, Process<_>, _, TotalOrder, ExactlyOnce> = p1.source_iter(q!(vec![1, 2, 3, 4]));
+    /// let on_worker: Stream<_, Cluster<_>, _> = numbers.round_robin_bincode(&workers, nondet!(/** assuming stable membership */));
+    /// on_worker.send_bincode(&p2)
+    /// # .first().values() // we use first to assert that each member gets one element
+    /// // with 4 cluster members, elements are distributed (with a non-deterministic round-robin order):
+    /// // - MemberId::<()>(?): [1]
+    /// // - MemberId::<()>(?): [2]
+    /// // - MemberId::<()>(?): [3]
+    /// // - MemberId::<()>(?): [4]
+    /// # }, |mut stream| async move {
+    /// # let mut results = Vec::new();
+    /// # for w in 0..4 {
+    /// #     results.push(stream.next().await.unwrap());
+    /// # }
+    /// # results.sort();
+    /// # assert_eq!(results, vec![1, 2, 3, 4]);
+    /// # }));
+    /// ```
     pub fn round_robin_bincode<L2: 'a>(
         self,
         other: &Cluster<'a, L2>,
@@ -262,9 +337,7 @@ impl<'a, T, L, B: Boundedness> Stream<T, Process<'a, L>, B, TotalOrder, ExactlyO
         let current_members = ids
             .snapshot(&join_tick, nondet_membership)
             .keys()
-            .assume_ordering(
-                nondet!(/** safe to assume ordering because each output is independent */),
-            )
+            .assume_ordering(nondet_membership)
             .collect_vec();
 
         self.enumerate()
@@ -279,8 +352,55 @@ impl<'a, T, L, B: Boundedness> Stream<T, Process<'a, L>, B, TotalOrder, ExactlyO
     }
 }
 
-#[expect(missing_docs, reason = "TODO")]
 impl<'a, T, L, B: Boundedness, O, R> Stream<T, Cluster<'a, L>, B, O, R> {
+    /// "Moves" elements of this stream from a cluster to a process by sending them over the network,
+    /// using [`bincode`] to serialize/deserialize messages.
+    ///
+    /// Each cluster member sends its local stream elements, and they are collected at the destination
+    /// as a [`KeyedStream`] where keys identify which cluster member sent each element.
+    ///
+    /// # Example
+    /// ```rust
+    /// # use hydro_lang::prelude::*;
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(hydro_lang::test_util::multi_location_test(|flow, process| {
+    /// let workers: Cluster<()> = flow.cluster::<()>();
+    /// let numbers: Stream<_, Cluster<_>, _> = workers.source_iter(q!(vec![1]));
+    /// let all_received = numbers.send_bincode(&process); // KeyedStream<MemberId<()>, i32, ...>
+    /// # all_received.entries()
+    /// # }, |mut stream| async move {
+    /// // if there are 4 members in the cluster, we should receive 4 elements
+    /// // { MemberId::<()>(0): [1], MemberId::<()>(1): [1], MemberId::<()>(2): [1], MemberId::<()>(3): [1] }
+    /// # let mut results = Vec::new();
+    /// # for w in 0..4 {
+    /// #     results.push(format!("{:?}", stream.next().await.unwrap()));
+    /// # }
+    /// # results.sort();
+    /// # assert_eq!(results, vec!["(MemberId::<()>(0), 1)", "(MemberId::<()>(1), 1)", "(MemberId::<()>(2), 1)", "(MemberId::<()>(3), 1)"]);
+    /// # }));
+    /// ```
+    ///
+    /// If you don't need to know which cluster member sent each element, you can use `.values()`
+    /// to get just the data:
+    /// ```rust
+    /// # use hydro_lang::prelude::*;
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(hydro_lang::test_util::multi_location_test(|flow, process| {
+    /// # let workers: Cluster<()> = flow.cluster::<()>();
+    /// # let numbers: Stream<_, Cluster<_>, _> = workers.source_iter(q!(vec![1]));
+    /// numbers.send_bincode(&process).values() // Stream<i32, ..., NoOrder>
+    /// //
+    /// # }, |mut stream| async move {
+    /// // if there are 4 members in the cluster, we should receive 4 elements
+    /// // 1, 1, 1, 1
+    /// # let mut results = Vec::new();
+    /// # for w in 0..4 {
+    /// #     results.push(format!("{:?}", stream.next().await.unwrap()));
+    /// # }
+    /// # results.sort();
+    /// # assert_eq!(results, vec!["1", "1", "1", "1"]);
+    /// # }));
+    /// ```
     pub fn send_bincode<L2>(
         self,
         other: &Process<'a, L2>,
@@ -306,6 +426,51 @@ impl<'a, T, L, B: Boundedness, O, R> Stream<T, Cluster<'a, L>, B, O, R> {
         raw_stream.into_keyed()
     }
 
+    /// Broadcasts elements of this stream at each source member to all members of a destination
+    /// cluster, using [`bincode`] to serialize/deserialize messages.
+    ///
+    /// Each source member sends each of its stream elements to **every** member of the cluster
+    /// based on its latest membership information. Unlike [`Stream::demux_bincode`], which requires
+    /// `(MemberId, T)` tuples to target specific members, `broadcast_bincode` takes a stream of
+    /// **only data elements** and sends each element to all cluster members.
+    ///
+    /// # Non-Determinism
+    /// The set of cluster members may asynchronously change over time. Each element is only broadcast
+    /// to the current cluster members known _at that point in time_ at the source member. Depending
+    /// on when each source member is notified of membership changes, it will broadcast each element
+    /// to different members.
+    ///
+    /// # Example
+    /// ```rust
+    /// # use hydro_lang::prelude::*;
+    /// # use hydro_lang::location::MemberId;
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(hydro_lang::test_util::multi_location_test(|flow, p2| {
+    /// # type Source = ();
+    /// # type Destination = ();
+    /// let source: Cluster<Source> = flow.cluster::<Source>();
+    /// let numbers: Stream<_, Cluster<Source>, _> = source.source_iter(q!(vec![123]));
+    /// let destination: Cluster<Destination> = flow.cluster::<Destination>();
+    /// let on_destination: KeyedStream<MemberId<Source>, _, Cluster<Destination>, _> = numbers.broadcast_bincode(&destination, nondet!(/** assuming stable membership */));
+    /// # on_destination.entries().send_bincode(&p2).entries()
+    /// // if there are 4 members in the desination, each receives one element from each source member
+    /// // - Destination(0): { Source(0): [123], Source(1): [123], ... }
+    /// // - Destination(1): { Source(0): [123], Source(1): [123], ... }
+    /// // - ...
+    /// # }, |mut stream| async move {
+    /// # let mut results = Vec::new();
+    /// # for w in 0..16 {
+    /// #     results.push(format!("{:?}", stream.next().await.unwrap()));
+    /// # }
+    /// # results.sort();
+    /// # assert_eq!(results, vec![
+    /// #   "(MemberId::<()>(0), (MemberId::<()>(0), 123))", "(MemberId::<()>(0), (MemberId::<()>(1), 123))", "(MemberId::<()>(0), (MemberId::<()>(2), 123))", "(MemberId::<()>(0), (MemberId::<()>(3), 123))",
+    /// #   "(MemberId::<()>(1), (MemberId::<()>(0), 123))", "(MemberId::<()>(1), (MemberId::<()>(1), 123))", "(MemberId::<()>(1), (MemberId::<()>(2), 123))", "(MemberId::<()>(1), (MemberId::<()>(3), 123))",
+    /// #   "(MemberId::<()>(2), (MemberId::<()>(0), 123))", "(MemberId::<()>(2), (MemberId::<()>(1), 123))", "(MemberId::<()>(2), (MemberId::<()>(2), 123))", "(MemberId::<()>(2), (MemberId::<()>(3), 123))",
+    /// #   "(MemberId::<()>(3), (MemberId::<()>(0), 123))", "(MemberId::<()>(3), (MemberId::<()>(1), 123))", "(MemberId::<()>(3), (MemberId::<()>(2), 123))", "(MemberId::<()>(3), (MemberId::<()>(3), 123))"
+    /// # ]);
+    /// # }));
+    /// ```
     pub fn broadcast_bincode<L2: 'a>(
         self,
         other: &Cluster<'a, L2>,
@@ -335,8 +500,51 @@ impl<'a, T, L, B: Boundedness, O, R> Stream<T, Cluster<'a, L>, B, O, R> {
     }
 }
 
-#[expect(missing_docs, reason = "TODO")]
 impl<'a, T, L, L2, B: Boundedness, O, R> Stream<(MemberId<L2>, T), Cluster<'a, L>, B, O, R> {
+    /// Sends elements of this stream at each source member to specific members of a destination
+    /// cluster, identified by a [`MemberId`], using [`bincode`] to serialize/deserialize messages.
+    ///
+    /// Each element in the stream must be a tuple `(MemberId<L2>, T)` where the first element
+    /// specifies which cluster member should receive the data. Unlike [`Stream::broadcast_bincode`],
+    /// this API allows precise targeting of specific cluster members rather than broadcasting to
+    /// all members.
+    ///
+    /// Each cluster member sends its local stream elements, and they are collected at each
+    /// destination member as a [`KeyedStream`] where keys identify which cluster member sent each
+    /// element.
+    ///
+    /// # Example
+    /// ```rust
+    /// # use hydro_lang::prelude::*;
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(hydro_lang::test_util::multi_location_test(|flow, p2| {
+    /// # type Source = ();
+    /// # type Destination = ();
+    /// let source: Cluster<Source> = flow.cluster::<Source>();
+    /// let numbers: Stream<_, Cluster<_>, _> = source
+    ///     .source_iter(q!(vec![0, 1, 2, 3]))
+    ///     .map(q!(|x| (hydro_lang::location::MemberId::from_raw(x), x)));
+    /// let destination: Cluster<Destination> = flow.cluster::<Destination>();
+    /// let all_received = numbers.demux_bincode(&destination); // KeyedStream<MemberId<Source>, i32, ...>
+    /// # all_received.entries().send_bincode(&p2).entries()
+    /// # }, |mut stream| async move {
+    /// // if there are 4 members in the destination cluster, each receives one message from each source member
+    /// // - Destination(0): { Source(0): [0], Source(1): [0], ... }
+    /// // - Destination(1): { Source(0): [1], Source(1): [1], ... }
+    /// // - ...
+    /// # let mut results = Vec::new();
+    /// # for w in 0..16 {
+    /// #     results.push(format!("{:?}", stream.next().await.unwrap()));
+    /// # }
+    /// # results.sort();
+    /// # assert_eq!(results, vec![
+    /// #   "(MemberId::<()>(0), (MemberId::<()>(0), 0))", "(MemberId::<()>(0), (MemberId::<()>(1), 0))", "(MemberId::<()>(0), (MemberId::<()>(2), 0))", "(MemberId::<()>(0), (MemberId::<()>(3), 0))",
+    /// #   "(MemberId::<()>(1), (MemberId::<()>(0), 1))", "(MemberId::<()>(1), (MemberId::<()>(1), 1))", "(MemberId::<()>(1), (MemberId::<()>(2), 1))", "(MemberId::<()>(1), (MemberId::<()>(3), 1))",
+    /// #   "(MemberId::<()>(2), (MemberId::<()>(0), 2))", "(MemberId::<()>(2), (MemberId::<()>(1), 2))", "(MemberId::<()>(2), (MemberId::<()>(2), 2))", "(MemberId::<()>(2), (MemberId::<()>(3), 2))",
+    /// #   "(MemberId::<()>(3), (MemberId::<()>(0), 3))", "(MemberId::<()>(3), (MemberId::<()>(1), 3))", "(MemberId::<()>(3), (MemberId::<()>(2), 3))", "(MemberId::<()>(3), (MemberId::<()>(3), 3))"
+    /// # ]);
+    /// # }));
+    /// ```
     pub fn demux_bincode(
         self,
         other: &Cluster<'a, L2>,


### PR DESCRIPTION

Breaking Change: internal APIs for generating serialization code are now private
