### PR TITLE
fix(hydro_lang)!: introduce `generator` API and ensure that `fold_early_stop` actually terminates

### DIFF
--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -1,7 +1,6 @@
 //! Definitions and core APIs for the [`Stream`] live collection.
 
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::future::Future;
 use std::hash::Hash;
 use std::marker::PhantomData;
@@ -24,7 +23,6 @@ use crate::forward_handle::{ForwardRef, TickCycle};
 use crate::location::dynamic::{DynLocation, LocationId};
 use crate::location::tick::{Atomic, DeferTick, NoAtomic};
 use crate::location::{Location, NoTick, Tick, check_matching_location};
-use crate::manual_expr::ManualExpr;
 use crate::nondet::{NonDet, nondet};
 
 pub mod networking;
@@ -1718,125 +1716,6 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O, R> Stream<(K, V), L, B, O, R>
             underlying: self.weakest_ordering(),
             _phantom_order: Default::default(),
         }
-    }
-}
-
-impl<'a, K, V, L, B: Boundedness> Stream<(K, V), L, B, TotalOrder, ExactlyOnce>
-where
-    K: Eq + Hash,
-    L: Location<'a>,
-{
-    /// A special case of [`Stream::scan`], in the spirit of SQL's GROUP BY and aggregation constructs. The input
-    /// tuples are partitioned into groups by the first element ("keys"), and for each group the values
-    /// in the second element are transformed via the `f` combinator.
-    ///
-    /// Unlike [`Stream::fold_keyed`] which only returns the final accumulated value, `scan` produces a new stream
-    /// containing all intermediate accumulated values paired with the key. The scan operation can also terminate
-    /// early by returning `None`.
-    ///
-    /// The function takes a mutable reference to the accumulator and the current element, and returns
-    /// an `Option<U>`. If the function returns `Some(value)`, `value` is emitted to the output stream.
-    /// If the function returns `None`, the stream is terminated and no more elements are processed.
-    ///
-    /// # Example
-    /// ```rust
-    /// # use hydro_lang::prelude::*;
-    /// # use futures::StreamExt;
-    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
-    /// process
-    ///     .source_iter(q!(vec![(0, 1), (0, 2), (1, 3), (1, 4)]))
-    ///     .scan_keyed(
-    ///         q!(|| 0),
-    ///         q!(|acc, x| {
-    ///             *acc += x;
-    ///             Some(*acc)
-    ///         }),
-    ///     )
-    /// # }, |mut stream| async move {
-    /// // Output: (0, 1), (0, 3), (1, 3), (1, 7)
-    /// # for w in vec![(0, 1), (0, 3), (1, 3), (1, 7)] {
-    /// #     assert_eq!(stream.next().await.unwrap(), w);
-    /// # }
-    /// # }));
-    /// ```
-    pub fn scan_keyed<A, U, I, F>(
-        self,
-        init: impl IntoQuotedMut<'a, I, L> + Copy,
-        f: impl IntoQuotedMut<'a, F, L> + Copy,
-    ) -> Stream<(K, U), L, B, TotalOrder, ExactlyOnce>
-    where
-        K: Clone,
-        I: Fn() -> A + 'a,
-        F: Fn(&mut A, V) -> Option<U> + 'a,
-    {
-        let init: ManualExpr<I, _> = ManualExpr::new(move |ctx: &L| init.splice_fn0_ctx(ctx));
-        let f: ManualExpr<F, _> = ManualExpr::new(move |ctx: &L| f.splice_fn2_borrow_mut_ctx(ctx));
-        self.scan(
-            q!(|| HashMap::new()),
-            q!(move |acc, (k, v)| {
-                let existing_state = acc.entry(k.clone()).or_insert_with(&init);
-                if let Some(out) = f(existing_state, v) {
-                    Some(Some((k, out)))
-                } else {
-                    acc.remove(&k);
-                    Some(None)
-                }
-            }),
-        )
-        .flatten_ordered()
-    }
-
-    /// Like [`Stream::fold_keyed`], in the spirit of SQL's GROUP BY and aggregation constructs. But the aggregation
-    /// function returns a boolean, which when true indicates that the aggregated result is complete and can be
-    /// released to downstream computation. Unlike [`Stream::fold_keyed`], this means that even if the input stream
-    /// is [`Unbounded`], the outputs of the fold can be processed like normal stream elements.
-    ///
-    /// # Example
-    /// ```rust
-    /// # use hydro_lang::prelude::*;
-    /// # use futures::StreamExt;
-    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
-    /// process
-    ///     .source_iter(q!(vec![(0, 2), (0, 3), (1, 3), (1, 6)]))
-    ///     .fold_keyed_early_stop(
-    ///         q!(|| 0),
-    ///         q!(|acc, x| {
-    ///             *acc += x;
-    ///             x % 2 == 0
-    ///         }),
-    ///     )
-    /// # }, |mut stream| async move {
-    /// // Output: (0, 2), (1, 9)
-    /// # for w in vec![(0, 2), (1, 9)] {
-    /// #     assert_eq!(stream.next().await.unwrap(), w);
-    /// # }
-    /// # }));
-    /// ```
-    pub fn fold_keyed_early_stop<A, I, F>(
-        self,
-        init: impl IntoQuotedMut<'a, I, L> + Copy,
-        f: impl IntoQuotedMut<'a, F, L> + Copy,
-    ) -> Stream<(K, A), L, B, TotalOrder, ExactlyOnce>
-    where
-        K: Clone,
-        I: Fn() -> A + 'a,
-        F: Fn(&mut A, V) -> bool + 'a,
-    {
-        let init: ManualExpr<I, _> = ManualExpr::new(move |ctx: &L| init.splice_fn0_ctx(ctx));
-        let f: ManualExpr<F, _> = ManualExpr::new(move |ctx: &L| f.splice_fn2_borrow_mut_ctx(ctx));
-        self.scan(
-            q!(|| HashMap::new()),
-            q!(move |acc, (k, v)| {
-                let existing_state = acc.entry(k.clone()).or_insert_with(&init);
-                if f(existing_state, v) {
-                    let out = acc.remove(&k).unwrap();
-                    Some(Some((k, out)))
-                } else {
-                    Some(None)
-                }
-            }),
-        )
-        .flatten_ordered()
     }
 }
 


### PR DESCRIPTION

Previously, `fold_early_stop` would _reset_ its state instead of terminating and ignoring future elements, which broke downstream users such as `first`.

Now, we introduce a new `generate` API that offers a more flexible API (versus scan) for iterative processing that yields elements, and use it to implement `fold_early_stop`, which fixes the bugs. We also remove the old `scan_keyed` API in favor of `KeyedStream::scan`.

There is still an issue that the `None` value for each group's generator state will be kept around indefninitely. We will need to pass around termination markers for each group to garbage collect these.
