### PR TITLE
chore(hydro_lang): move backtrace test to separate module for stable line numbers

### DIFF
--- a/hydro_lang/src/live_collections/stream/tests/backtrace_chained_ops.rs
+++ b/hydro_lang/src/live_collections/stream/tests/backtrace_chained_ops.rs
@@ -1,0 +1,42 @@
+// separate file for stable line numbers
+
+#[cfg(unix)]
+#[test]
+fn backtrace_chained_ops() {
+    use stageleft::q;
+
+    use crate::compile::ir::HydroRoot;
+    use crate::location::Location;
+    use crate::prelude::FlowBuilder;
+
+    let flow = FlowBuilder::new();
+    let node = flow.process::<()>();
+
+    node.source_iter(q!([123])).for_each(q!(|_| {}));
+
+    let finalized: crate::compile::built::BuiltFlow<'_> = flow.finalize();
+
+    let source_meta = if let HydroRoot::ForEach { input, .. } = &finalized.ir()[0] {
+        use crate::compile::ir::HydroNode;
+
+        if let HydroNode::Unpersist { inner, .. } = input.as_ref() {
+            if let HydroNode::Persist { inner, .. } = inner.as_ref() {
+                if let HydroNode::Source { metadata, .. } = inner.as_ref() {
+                    &metadata.op
+                } else {
+                    panic!()
+                }
+            } else {
+                panic!()
+            }
+        } else {
+            panic!()
+        }
+    } else {
+        panic!()
+    };
+    let for_each_meta = finalized.ir()[0].op_metadata();
+
+    hydro_build_utils::assert_debug_snapshot!(source_meta.backtrace.elements());
+    hydro_build_utils::assert_debug_snapshot!(for_each_meta.backtrace.elements());
+}

--- a/hydro_lang/src/live_collections/stream/tests/snapshots/hydro_lang__live_collections__stream__tests__backtrace_chained_ops__backtrace_chained_ops-2.snap
+++ b/hydro_lang/src/live_collections/stream/tests/snapshots/hydro_lang__live_collections__stream__tests__backtrace_chained_ops__backtrace_chained_ops-2.snap
@@ -1,24 +1,24 @@
 ---
-source: hydro_lang/src/live_collections/stream/mod.rs
+source: hydro_lang/src/live_collections/stream/tests/backtrace_chained_ops.rs
 expression: for_each_meta.backtrace.elements()
 ---
 [
     BacktraceElement {
-        fn_name: "hydro_lang::live_collections::stream::tests::backtrace_chained_ops",
+        fn_name: "hydro_lang::live_collections::stream::tests::backtrace_chained_ops::backtrace_chained_ops",
         lineno: Some(
-            2589,
+            13,
         ),
         colno: Some(
-            37,
+            33,
         ),
     },
     BacktraceElement {
-        fn_name: "hydro_lang::live_collections::stream::tests::backtrace_chained_ops::{{closure}}",
+        fn_name: "hydro_lang::live_collections::stream::tests::backtrace_chained_ops::backtrace_chained_ops::{{closure}}",
         lineno: Some(
-            2583,
+            5,
         ),
         colno: Some(
-            31,
+            27,
         ),
     },
     BacktraceElement {

--- a/hydro_lang/src/live_collections/stream/tests/snapshots/hydro_lang__live_collections__stream__tests__backtrace_chained_ops__backtrace_chained_ops.snap
+++ b/hydro_lang/src/live_collections/stream/tests/snapshots/hydro_lang__live_collections__stream__tests__backtrace_chained_ops__backtrace_chained_ops.snap
@@ -1,24 +1,24 @@
 ---
-source: hydro_lang/src/live_collections/stream/mod.rs
+source: hydro_lang/src/live_collections/stream/tests/backtrace_chained_ops.rs
 expression: source_meta.backtrace.elements()
 ---
 [
     BacktraceElement {
-        fn_name: "hydro_lang::live_collections::stream::tests::backtrace_chained_ops",
+        fn_name: "hydro_lang::live_collections::stream::tests::backtrace_chained_ops::backtrace_chained_ops",
         lineno: Some(
-            2589,
+            13,
         ),
         colno: Some(
-            14,
+            10,
         ),
     },
     BacktraceElement {
-        fn_name: "hydro_lang::live_collections::stream::tests::backtrace_chained_ops::{{closure}}",
+        fn_name: "hydro_lang::live_collections::stream::tests::backtrace_chained_ops::backtrace_chained_ops::{{closure}}",
         lineno: Some(
-            2583,
+            5,
         ),
         colno: Some(
-            31,
+            27,
         ),
     },
     BacktraceElement {


### PR DESCRIPTION

Will reduce diff noise whenever modifying `Stream`.
