### PR TITLE
docs(hydro_lang)!: add docs for `for_each` / `dest_sink` restrict to strict streams

### DIFF
--- a/hydro_lang/src/compile/rewrites/properties.rs
+++ b/hydro_lang/src/compile/rewrites/properties.rs
@@ -108,6 +108,7 @@ mod tests {
             .fold(q!(|| 0), counter_func)
             .entries()
             .all_ticks()
+            .assume_ordering(nondet!(/** test */))
             .for_each(q!(|(string, count)| println!("{}: {}", string, count)));
 
         let built = flow

--- a/hydro_lang/src/live_collections/stream/tests/backtrace_chained_ops.rs
+++ b/hydro_lang/src/live_collections/stream/tests/backtrace_chained_ops.rs
@@ -1,0 +1,42 @@
+// separate file for stable line numbers
+
+#[cfg(unix)]
+#[test]
+fn backtrace_chained_ops() {
+    use stageleft::q;
+
+    use crate::compile::ir::HydroRoot;
+    use crate::location::Location;
+    use crate::prelude::FlowBuilder;
+
+    let flow = FlowBuilder::new();
+    let node = flow.process::<()>();
+
+    node.source_iter(q!([123])).for_each(q!(|_| {}));
+
+    let finalized: crate::compile::built::BuiltFlow<'_> = flow.finalize();
+
+    let source_meta = if let HydroRoot::ForEach { input, .. } = &finalized.ir()[0] {
+        use crate::compile::ir::HydroNode;
+
+        if let HydroNode::Unpersist { inner, .. } = input.as_ref() {
+            if let HydroNode::Persist { inner, .. } = inner.as_ref() {
+                if let HydroNode::Source { metadata, .. } = inner.as_ref() {
+                    &metadata.op
+                } else {
+                    panic!()
+                }
+            } else {
+                panic!()
+            }
+        } else {
+            panic!()
+        }
+    } else {
+        panic!()
+    };
+    let for_each_meta = finalized.ir()[0].op_metadata();
+
+    hydro_build_utils::assert_debug_snapshot!(source_meta.backtrace.elements());
+    hydro_build_utils::assert_debug_snapshot!(for_each_meta.backtrace.elements());
+}

--- a/hydro_lang/src/live_collections/stream/tests/snapshots/hydro_lang__live_collections__stream__tests__backtrace_chained_ops__backtrace_chained_ops-2.snap
+++ b/hydro_lang/src/live_collections/stream/tests/snapshots/hydro_lang__live_collections__stream__tests__backtrace_chained_ops__backtrace_chained_ops-2.snap
@@ -1,24 +1,24 @@
 ---
-source: hydro_lang/src/live_collections/stream/mod.rs
+source: hydro_lang/src/live_collections/stream/tests/backtrace_chained_ops.rs
 expression: for_each_meta.backtrace.elements()
 ---
 [
     BacktraceElement {
-        fn_name: "hydro_lang::live_collections::stream::tests::backtrace_chained_ops",
+        fn_name: "hydro_lang::live_collections::stream::tests::backtrace_chained_ops::backtrace_chained_ops",
         lineno: Some(
-            2589,
+            13,
         ),
         colno: Some(
-            37,
+            33,
         ),
     },
     BacktraceElement {
-        fn_name: "hydro_lang::live_collections::stream::tests::backtrace_chained_ops::{{closure}}",
+        fn_name: "hydro_lang::live_collections::stream::tests::backtrace_chained_ops::backtrace_chained_ops::{{closure}}",
         lineno: Some(
-            2583,
+            5,
         ),
         colno: Some(
-            31,
+            27,
         ),
     },
     BacktraceElement {

--- a/hydro_lang/src/live_collections/stream/tests/snapshots/hydro_lang__live_collections__stream__tests__backtrace_chained_ops__backtrace_chained_ops.snap
+++ b/hydro_lang/src/live_collections/stream/tests/snapshots/hydro_lang__live_collections__stream__tests__backtrace_chained_ops__backtrace_chained_ops.snap
@@ -1,24 +1,24 @@
 ---
-source: hydro_lang/src/live_collections/stream/mod.rs
+source: hydro_lang/src/live_collections/stream/tests/backtrace_chained_ops.rs
 expression: source_meta.backtrace.elements()
 ---
 [
     BacktraceElement {
-        fn_name: "hydro_lang::live_collections::stream::tests::backtrace_chained_ops",
+        fn_name: "hydro_lang::live_collections::stream::tests::backtrace_chained_ops::backtrace_chained_ops",
         lineno: Some(
-            2589,
+            13,
         ),
         colno: Some(
-            14,
+            10,
         ),
     },
     BacktraceElement {
-        fn_name: "hydro_lang::live_collections::stream::tests::backtrace_chained_ops::{{closure}}",
+        fn_name: "hydro_lang::live_collections::stream::tests::backtrace_chained_ops::backtrace_chained_ops::{{closure}}",
         lineno: Some(
-            2583,
+            5,
         ),
         colno: Some(
-            31,
+            27,
         ),
     },
     BacktraceElement {

--- a/hydro_std/src/bench_client/mod.rs
+++ b/hydro_std/src/bench_client/mod.rs
@@ -227,6 +227,7 @@ pub fn print_bench_results<'a, Client: 'a, Aggregator>(
         .clone()
         .all_ticks()
         .sample_every(q!(Duration::from_millis(1000)), nondet_sampling)
+        .assume_retries(nondet!(/** extra logs due to duplicate samples are okay */))
         .for_each(q!(|num_clients_not_responded| println!(
             "Awaiting {} clients",
             num_clients_not_responded
@@ -246,6 +247,7 @@ pub fn print_bench_results<'a, Client: 'a, Aggregator>(
         .cross_singleton(client_count.clone())
         .continue_unless(waiting_for_clients.clone())
         .all_ticks()
+        .assume_retries(nondet!(/** extra logs due to duplicate samples are okay */))
         .for_each(q!(move |(throughputs, num_client_machines)| {
             if throughputs.sample_count() >= 2 {
                 let mean = throughputs.sample_mean() * num_client_machines as f64;
@@ -289,6 +291,7 @@ pub fn print_bench_results<'a, Client: 'a, Aggregator>(
         .batch(&print_tick, nondet_client_count)
         .continue_unless(waiting_for_clients)
         .all_ticks()
+        .assume_retries(nondet!(/** extra logs due to duplicate samples are okay */))
         .for_each(q!(move |latencies| {
             println!(
                 "Latency p50: {:.3} | p99 {:.3} | p999 {:.3} ms ({:} samples)",

--- a/hydro_test/src/cluster/compute_pi.rs
+++ b/hydro_test/src/cluster/compute_pi.rs
@@ -42,6 +42,7 @@ pub fn compute_pi<'a>(
             q!(Duration::from_secs(1)),
             nondet!(/** intentional output */),
         )
+        .assume_retries(nondet!(/** extra logs due to duplicate samples are okay */))
         .for_each(q!(|(inside, total)| {
             println!(
                 "pi: {} ({} trials)",

--- a/hydro_test/src/cluster/many_to_many.rs
+++ b/hydro_test/src/cluster/many_to_many.rs
@@ -6,6 +6,7 @@ pub fn many_to_many<'a>(flow: &FlowBuilder<'a>) -> Cluster<'a, ()> {
         .source_iter(q!(0..2))
         .broadcast_bincode(&cluster, nondet!(/** test */))
         .entries()
+        .assume_ordering(nondet!(/** intentionally unordered logs */))
         .for_each(q!(|n| println!("cluster received: {:?}", n)));
 
     cluster

--- a/hydro_test/src/cluster/map_reduce.rs
+++ b/hydro_test/src/cluster/map_reduce.rs
@@ -39,6 +39,7 @@ pub fn map_reduce<'a>(flow: &FlowBuilder<'a>) -> (Process<'a, Leader>, Cluster<'
         .snapshot(&process.tick(), nondet!(/** intentional output */))
         .entries()
         .all_ticks()
+        .assume_ordering(nondet!(/** unordered logs across keys are okay */))
         .for_each(q!(|(string, count)| println!("{}: {}", string, count)));
 
     (process, cluster)

--- a/hydro_test/src/cluster/simple_cluster.rs
+++ b/hydro_test/src/cluster/simple_cluster.rs
@@ -16,6 +16,7 @@ pub fn partition<'a, F: Fn((MemberId<()>, String)) -> (MemberId<()>, String) + '
             format!("Hello from {}", id.raw_id)
         )))
         .send_partitioned(&cluster2, dist_policy)
+        .assume_ordering(nondet!(/** testing, order does not matter */))
         .for_each(q!(move |message| println!(
             "My self id is {}, my message is {:?}",
             CLUSTER_SELF_ID.raw_id, message
@@ -70,6 +71,7 @@ pub fn simple_cluster<'a>(flow: &FlowBuilder<'a>) -> (Process<'a, ()>, Cluster<'
         )))
         .send_bincode(&process)
         .entries()
+        .assume_ordering(nondet!(/** testing, order does not matter */))
         .for_each(q!(|(id, d)| println!("node received: ({}, {:?})", id, d)));
 
     (process, cluster)

--- a/hydro_test/src/external_client/echo.rs
+++ b/hydro_test/src/external_client/echo.rs
@@ -14,6 +14,7 @@ pub fn echo_server<'a, P>(
     current_connections
         .key_count()
         .sample_every(q!(Duration::from_secs(1)), nondet!(/** logging */))
+        .assume_retries(nondet!(/** extra logs due to duplicate samples are okay */))
         .for_each(q!(|count| {
             println!("Current connections: {}", count);
         }));


### PR DESCRIPTION

Breaking Change: `for_each` / `dest_sink` now require a totally-ordered, retry-free stream since the downstream may not tolerate such non-determinism. This helps highlight cases where the developer needs to reason carefully about the safety of their side effects.
