### PR TITLE
docs(hydro_lang): avoid rustfmt thrashing

### DIFF
--- a/hydro_lang/src/live_collections/stream/networking.rs
+++ b/hydro_lang/src/live_collections/stream/networking.rs
@@ -415,19 +415,21 @@ impl<'a, T, L, B: Boundedness, O, R> Stream<T, Cluster<'a, L>, B, O, R> {
     /// to get just the data:
     /// ```rust
     /// # use hydro_lang::prelude::*;
+    /// # use hydro_lang::live_collections::stream::NoOrder;
     /// # use futures::StreamExt;
     /// # tokio_test::block_on(hydro_lang::test_util::multi_location_test(|flow, process| {
     /// # let workers: Cluster<()> = flow.cluster::<()>();
     /// # let numbers: Stream<_, Cluster<_>, _> = workers.source_iter(q!(vec![1]));
-    /// numbers.send_bincode(&process).values() // Stream<i32, ..., NoOrder>
+    /// let values: Stream<i32, _, _, NoOrder> = numbers.send_bincode(&process).values();
+    /// # values
     /// # }, |mut stream| async move {
-    /// // if there are 4 members in the cluster, we should receive 4 elements
-    /// // 1, 1, 1, 1
     /// # let mut results = Vec::new();
     /// # for w in 0..4 {
     /// #     results.push(format!("{:?}", stream.next().await.unwrap()));
     /// # }
     /// # results.sort();
+    /// // if there are 4 members in the cluster, we should receive 4 elements
+    /// // 1, 1, 1, 1
     /// # assert_eq!(results, vec!["1", "1", "1", "1"]);
     /// # }));
     /// ```


### PR DESCRIPTION

For some reason, rustfmt didn't like the structure of the previous code block and would try to introduce an empty `//` line. This changes the structure to work around it.
