### PR TITLE
refactor(hydro_lang)!: remove `::delta` operators from collections

### DIFF
--- a/hydro_lang/src/live_collections/keyed_singleton.rs
+++ b/hydro_lang/src/live_collections/keyed_singleton.rs
@@ -84,22 +84,25 @@ where
     }
 }
 
-#[expect(missing_docs, reason = "TODO")]
 impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound<ValueBound = Bounded>>
     KeyedSingleton<K, V, L, B>
 {
+    #[expect(missing_docs, reason = "TODO")]
     pub fn entries(self) -> Stream<(K, V), L, B::UnderlyingBound, NoOrder, ExactlyOnce> {
         self.underlying
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn values(self) -> Stream<V, L, B::UnderlyingBound, NoOrder, ExactlyOnce> {
         self.entries().map(q!(|(_, v)| v))
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn keys(self) -> Stream<K, L, B::UnderlyingBound, NoOrder, ExactlyOnce> {
         self.entries().map(q!(|(k, _)| k))
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn filter_key_not_in<O2: Ordering, R2: Retries>(
         self,
         other: Stream<K, L, Bounded, O2, R2>,
@@ -112,6 +115,7 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound<ValueBound = Bounded>>
         }
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn inspect<F>(self, f: impl IntoQuotedMut<'a, F, L> + Copy) -> KeyedSingleton<K, V, L, B>
     where
         F: Fn(&V) + 'a,
@@ -125,6 +129,7 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound<ValueBound = Bounded>>
         }
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn inspect_with_key<F>(self, f: impl IntoQuotedMut<'a, F, L>) -> KeyedSingleton<K, V, L, B>
     where
         F: Fn(&(K, V)) + 'a,
@@ -134,6 +139,7 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound<ValueBound = Bounded>>
         }
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn into_keyed_stream(
         self,
     ) -> KeyedStream<K, V, L, B::UnderlyingBound, TotalOrder, ExactlyOnce> {
@@ -340,19 +346,6 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound> KeyedSingleton<K, V, L, 
     }
 }
 
-#[expect(missing_docs, reason = "TODO")]
-impl<'a, K, V, L: Location<'a>> KeyedSingleton<K, V, Tick<L>, Bounded> {
-    pub fn latest(self) -> KeyedSingleton<K, V, L, Unbounded> {
-        KeyedSingleton {
-            underlying: Stream::new(
-                self.underlying.location.outer().clone(),
-                // no need to persist due to top-level replay
-                self.underlying.ir_node.into_inner(),
-            ),
-        }
-    }
-}
-
 impl<'a, K: Hash + Eq, V, L: Location<'a>> KeyedSingleton<K, V, Tick<L>, Bounded> {
     /// Gets the value associated with a specific key from the keyed singleton.
     ///
@@ -449,20 +442,26 @@ impl<'a, K, V, L, B: KeyedSingletonBound> KeyedSingleton<K, V, L, B>
 where
     L: Location<'a> + NoTick + NoAtomic,
 {
-    #[expect(missing_docs, reason = "TODO")]
+    /// Shifts this keyed singleton into an atomic context, which guarantees that any downstream logic
+    /// will all be executed synchronously before any outputs are yielded (in [`KeyedSingleton::end_atomic`]).
+    ///
+    /// This is useful to enforce local consistency constraints, such as ensuring that a write is
+    /// processed before an acknowledgement is emitted. Entering an atomic section requires a [`Tick`]
+    /// argument that declares where the keyed singleton will be atomically processed. Batching a
+    /// keyed singleton into the _same_ [`Tick`] will preserve the synchronous execution, while
+    /// batching into a different [`Tick`] will introduce asynchrony.
     pub fn atomic(self, tick: &Tick<L>) -> KeyedSingleton<K, V, Atomic<L>, B> {
         KeyedSingleton {
             underlying: self.underlying.atomic(tick),
         }
     }
 
-    /// Given a tick, returns a keyed singleton with a entries consisting of keys with
-    /// snapshots of the value singleton.
+    /// Returns a keyed singleton with a snapshot of each key-value entry at a non-deterministic
+    /// point in time.
     ///
     /// # Non-Determinism
-    /// Because this picks a snapshot of each singleton whose value is continuously changing,
-    /// the output singleton has a non-deterministic value since each snapshot can be at an
-    /// arbitrary point in time.
+    /// Because this picks a snapshot of each entry, which is continuously changing, each output has a
+    /// non-deterministic set of entries since each snapshot can be at an arbitrary point in time.
     pub fn snapshot(
         self,
         tick: &Tick<L>,
@@ -472,32 +471,16 @@ where
     }
 }
 
-impl<'a, K, V, L, B: KeyedSingletonBound<ValueBound = Bounded>> KeyedSingleton<K, V, L, B>
-where
-    L: Location<'a> + NoTick + NoAtomic,
-{
-    /// Returns a keyed singleton with entries consisting of _new_ key-value pairs that have
-    /// arrived since the previous batch was released.
-    ///
-    /// # Non-Determinism
-    /// Because this picks a batch of asynchronously added entries, each output keyed singleton
-    /// has a non-deterministic set of key-value pairs.
-    pub fn batch(self, tick: &Tick<L>, nondet: NonDet) -> KeyedSingleton<K, V, Tick<L>, Bounded> {
-        self.atomic(tick).batch(nondet)
-    }
-}
-
 impl<'a, K, V, L, B: KeyedSingletonBound> KeyedSingleton<K, V, Atomic<L>, B>
 where
     L: Location<'a> + NoTick + NoAtomic,
 {
-    /// Returns a keyed singleton with a entries consisting of keys with snapshots of the value
-    /// singleton being atomically processed.
+    /// Returns a keyed singleton with a snapshot of each key-value entry, consistent with the
+    /// state of the keyed singleton being atomically processed.
     ///
     /// # Non-Determinism
-    /// Because this picks a snapshot of each singleton whose value is continuously changing,
-    /// each output singleton has a non-deterministic value since each snapshot can be at an
-    /// arbitrary point in time.
+    /// Because this picks a snapshot of each entry, which is continuously changing, each output has a
+    /// non-deterministic set of entries since each snapshot can be at an arbitrary point in time.
     pub fn snapshot(self, _nondet: NonDet) -> KeyedSingleton<K, V, Tick<L>, Bounded> {
         KeyedSingleton {
             underlying: Stream::new(
@@ -508,7 +491,8 @@ where
         }
     }
 
-    #[expect(missing_docs, reason = "TODO")]
+    /// Yields the elements of this keyed singleton back into a top-level, asynchronous execution context.
+    /// See [`KeyedSingleton::atomic`] for more details.
     pub fn end_atomic(self) -> KeyedSingleton<K, V, L, B> {
         KeyedSingleton {
             underlying: self.underlying.end_atomic(),
@@ -516,12 +500,111 @@ where
     }
 }
 
-impl<'a, K, V, L, B: KeyedSingletonBound<ValueBound = Bounded>> KeyedSingleton<K, V, Atomic<L>, B>
+impl<'a, K, V, L: Location<'a>> KeyedSingleton<K, V, Tick<L>, Bounded> {
+    /// Asynchronously yields this keyed singleton outside the tick, which will
+    /// be asynchronously updated with the latest set of entries inside the tick.
+    ///
+    /// This converts a bounded value _inside_ a tick into an asynchronous value outside the
+    /// tick that tracks the inner value. This is useful for getting the value as of the
+    /// "most recent" tick, but note that updates are propagated asynchronously outside the tick.
+    ///
+    /// The entire set of entries are propagated on each tick, which means that if a tick
+    /// does not have a key "XYZ" that was present in the previous tick, the entry for "XYZ" will
+    /// also be removed from the output.
+    ///
+    /// # Example
+    /// ```rust
+    /// # use hydro_lang::prelude::*;
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
+    /// let tick = process.tick();
+    /// # // ticks are lazy by default, forces the second tick to run
+    /// # tick.spin_batch(q!(1)).all_ticks().for_each(q!(|_| {}));
+    /// # let batch_first_tick = process
+    /// #   .source_iter(q!(vec![(1, 2), (2, 3)]))
+    /// #   .batch(&tick, nondet!(/** test */))
+    /// #   .into_keyed();
+    /// # let batch_second_tick = process
+    /// #   .source_iter(q!(vec![(2, 4), (3, 5)]))
+    /// #   .batch(&tick, nondet!(/** test */))
+    /// #   .into_keyed()
+    /// #   .defer_tick(); // appears on the second tick
+    /// # let input_batch = batch_first_tick.chain(batch_second_tick).first();
+    /// input_batch // first tick: { 1: 2, 2: 3 }, second tick: { 2: 4, 3: 5 }
+    ///     .latest()
+    /// # .snapshot(&tick, nondet!(/** test */))
+    /// # .entries()
+    /// # .all_ticks()
+    /// # }, |mut stream| async move {
+    /// // asynchronously changes from { 1: 2, 2: 3 } ~> { 2: 4, 3: 5 }
+    /// # for w in vec![(1, 2), (2, 3), (2, 4), (3, 5)] {
+    /// #     assert_eq!(stream.next().await.unwrap(), w);
+    /// # }
+    /// # }));
+    /// ```
+    pub fn latest(self) -> KeyedSingleton<K, V, L, Unbounded> {
+        KeyedSingleton {
+            underlying: Stream::new(
+                self.underlying.location.outer().clone(),
+                // no need to persist due to top-level replay
+                self.underlying.ir_node.into_inner(),
+            ),
+        }
+    }
+
+    /// Synchronously yields this keyed singleton outside the tick as an unbounded keyed singleton,
+    /// which will be updated with the latest set of entries inside the tick.
+    ///
+    /// Unlike [`KeyedSingleton::latest`], this preserves synchronous execution, as the output
+    /// keyed singleton is emitted in an [`Atomic`] context that will process elements synchronously
+    /// with the input keyed singleton's [`Tick`] context.
+    pub fn latest_atomic(self) -> KeyedSingleton<K, V, Atomic<L>, Unbounded> {
+        KeyedSingleton {
+            underlying: Stream::new(
+                Atomic {
+                    tick: self.underlying.location,
+                },
+                // no need to persist due to top-level replay
+                self.underlying.ir_node.into_inner(),
+            ),
+        }
+    }
+
+    #[expect(missing_docs, reason = "TODO")]
+    pub fn defer_tick(self) -> KeyedSingleton<K, V, Tick<L>, Bounded> {
+        KeyedSingleton {
+            underlying: self.underlying.defer_tick(),
+        }
+    }
+}
+
+impl<'a, K, V, L, B: KeyedSingletonBound<ValueBound = Bounded>> KeyedSingleton<K, V, L, B>
 where
     L: Location<'a> + NoTick + NoAtomic,
 {
     /// Returns a keyed singleton with entries consisting of _new_ key-value pairs that have
     /// arrived since the previous batch was released.
+    ///
+    /// Currently, there is no `all_ticks` dual on [`KeyedSingleton`], instead you may want to use
+    /// [`KeyedSingleton::into_keyed_stream`] then yield with [`KeyedStream::all_ticks`].
+    ///
+    /// # Non-Determinism
+    /// Because this picks a batch of asynchronously added entries, each output keyed singleton
+    /// has a non-deterministic set of key-value pairs.
+    pub fn batch(self, tick: &Tick<L>, nondet: NonDet) -> KeyedSingleton<K, V, Tick<L>, Bounded> {
+        self.atomic(tick).batch(nondet)
+    }
+}
+
+impl<'a, K, V, L, B: KeyedSingletonBound<ValueBound = Bounded>> KeyedSingleton<K, V, Atomic<L>, B>
+where
+    L: Location<'a> + NoTick + NoAtomic,
+{
+    /// Returns a keyed singleton with entries consisting of _new_ key-value pairs that are being
+    /// atomically processed.
+    ///
+    /// Currently, there is no dual to asynchronously yield back outside the tick, instead you
+    /// should use [`KeyedSingleton::into_keyed_stream`] and yield a [`KeyedStream`].
     ///
     /// # Non-Determinism
     /// Because this picks a batch of asynchronously added entries, each output keyed singleton

--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -1524,7 +1524,7 @@ mod tests {
         let tick_triggered_input = node
             .source_iter(q!([(3, 103)]))
             .batch(&node_tick, nondet!(/** test */))
-            .continue_if(
+            .filter_if_some(
                 tick_trigger
                     .clone()
                     .batch(&node_tick, nondet!(/** test */))

--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -1455,6 +1455,14 @@ where
             _phantom_order: Default::default(),
         }
     }
+
+    #[expect(missing_docs, reason = "TODO")]
+    pub fn defer_tick(self) -> KeyedStream<K, V, Tick<L>, Bounded, O, R> {
+        KeyedStream {
+            underlying: self.underlying.defer_tick(),
+            _phantom_order: Default::default(),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/hydro_lang/src/live_collections/optional.rs
+++ b/hydro_lang/src/live_collections/optional.rs
@@ -499,7 +499,30 @@ where
         )
     }
 
-    #[expect(missing_docs, reason = "TODO")]
+    /// Combines this singleton with another [`Singleton`] or [`Optional`] by tupling their values.
+    ///
+    /// If the other value is a [`Optional`], the output will be non-null only if the argument is
+    /// non-null. This is useful for combining several pieces of state together.
+    ///
+    /// # Example
+    /// ```rust
+    /// # use hydro_lang::prelude::*;
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
+    /// let tick = process.tick();
+    /// let numbers = process
+    ///   .source_iter(q!(vec![123, 456, 789]))
+    ///   .batch(&tick, nondet!(/** test */));
+    /// let min = numbers.clone().min(); // Optional
+    /// let max = numbers.max(); // Optional
+    /// min.zip(max).all_ticks()
+    /// # }, |mut stream| async move {
+    /// // [(123, 789)]
+    /// # for w in vec![(123, 789)] {
+    /// #     assert_eq!(stream.next().await.unwrap(), w);
+    /// # }
+    /// # }));
+    /// ```
     pub fn zip<O>(self, other: impl Into<Optional<O, L, B>>) -> Optional<(T, O), L, B>
     where
         O: Clone,

--- a/hydro_lang/src/live_collections/optional.rs
+++ b/hydro_lang/src/live_collections/optional.rs
@@ -980,7 +980,38 @@ where
         )
     }
 
-    #[expect(missing_docs, reason = "TODO")]
+    /// Converts this optional into a [`Stream`] containing a single element, the value, if it is
+    /// non-null. Otherwise, the stream is empty.
+    ///
+    /// # Example
+    /// ```rust
+    /// # use hydro_lang::prelude::*;
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
+    /// # let tick = process.tick();
+    /// # // ticks are lazy by default, forces the second tick to run
+    /// # tick.spin_batch(q!(1)).all_ticks().for_each(q!(|_| {}));
+    /// # let batch_first_tick = process
+    /// #   .source_iter(q!(vec![]))
+    /// #   .batch(&tick, nondet!(/** test */));
+    /// # let batch_second_tick = process
+    /// #   .source_iter(q!(vec![123, 456]))
+    /// #   .batch(&tick, nondet!(/** test */))
+    /// #   .defer_tick(); // appears on the second tick
+    /// # let input_batch = batch_first_tick.chain(batch_second_tick);
+    /// input_batch // first tick: [], second tick: [123, 456]
+    ///     .clone()
+    ///     .max()
+    ///     .into_stream()
+    ///     .chain(input_batch)
+    ///     .all_ticks()
+    /// # }, |mut stream| async move {
+    /// // [456, 123, 456]
+    /// # for w in vec![456, 123, 456] {
+    /// #     assert_eq!(stream.next().await.unwrap(), w);
+    /// # }
+    /// # }));
+    /// ```
     pub fn into_stream(self) -> Stream<T, Tick<L>, Bounded, TotalOrder, ExactlyOnce> {
         Stream::new(self.location, self.ir_node.into_inner())
     }

--- a/hydro_lang/src/live_collections/optional.rs
+++ b/hydro_lang/src/live_collections/optional.rs
@@ -969,17 +969,6 @@ where
         )
     }
 
-    #[expect(missing_docs, reason = "TODO")]
-    pub fn delta(self) -> Optional<T, Tick<L>, Bounded> {
-        Optional::new(
-            self.location.clone(),
-            HydroNode::Delta {
-                inner: Box::new(self.ir_node.into_inner()),
-                metadata: self.location.new_node_metadata::<T>(),
-            },
-        )
-    }
-
     /// Converts this optional into a [`Stream`] containing a single element, the value, if it is
     /// non-null. Otherwise, the stream is empty.
     ///

--- a/hydro_lang/src/live_collections/singleton.rs
+++ b/hydro_lang/src/live_collections/singleton.rs
@@ -487,7 +487,31 @@ where
         )
     }
 
-    #[expect(missing_docs, reason = "TODO")]
+    /// Combines this singleton with another [`Singleton`] or [`Optional`] by tupling their values.
+    ///
+    /// If the other value is a [`Singleton`], the output will be a [`Singleton`], but if it is an
+    /// [`Optional`], the output will be an [`Optional`] that is non-null only if the argument is
+    /// non-null. This is useful for combining several pieces of state together.
+    ///
+    /// # Example
+    /// ```rust
+    /// # use hydro_lang::prelude::*;
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
+    /// let tick = process.tick();
+    /// let numbers = process
+    ///   .source_iter(q!(vec![123, 456]))
+    ///   .batch(&tick, nondet!(/** test */));
+    /// let count = numbers.clone().count(); // Singleton
+    /// let max = numbers.max(); // Optional
+    /// count.zip(max).all_ticks()
+    /// # }, |mut stream| async move {
+    /// // [(2, 456)]
+    /// # for w in vec![(2, 456)] {
+    /// #     assert_eq!(stream.next().await.unwrap(), w);
+    /// # }
+    /// # }));
+    /// ```
     pub fn zip<O>(self, other: O) -> <Self as ZipResult<'a, O>>::Out
     where
         Self: ZipResult<'a, O, Location = L>,

--- a/hydro_lang/src/live_collections/singleton.rs
+++ b/hydro_lang/src/live_collections/singleton.rs
@@ -888,17 +888,6 @@ where
         )
     }
 
-    #[expect(missing_docs, reason = "TODO")]
-    pub fn delta(self) -> Optional<T, Tick<L>, Bounded> {
-        Optional::new(
-            self.location.clone(),
-            HydroNode::Delta {
-                inner: Box::new(self.ir_node.into_inner()),
-                metadata: self.location.new_node_metadata::<T>(),
-            },
-        )
-    }
-
     /// Converts this singleton into a [`Stream`] containing a single element, the value.
     ///
     /// # Example

--- a/hydro_lang/src/live_collections/singleton.rs
+++ b/hydro_lang/src/live_collections/singleton.rs
@@ -899,7 +899,27 @@ where
         )
     }
 
-    #[expect(missing_docs, reason = "TODO")]
+    /// Converts this singleton into a [`Stream`] containing a single element, the value.
+    ///
+    /// # Example
+    /// ```rust
+    /// # use hydro_lang::prelude::*;
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
+    /// let tick = process.tick();
+    /// let batch_input = process
+    ///   .source_iter(q!(vec![123, 456]))
+    ///   .batch(&tick, nondet!(/** test */));
+    /// batch_input.clone().chain(
+    ///   batch_input.count().into_stream()
+    /// ).all_ticks()
+    /// # }, |mut stream| async move {
+    /// // [123, 456, 2]
+    /// # for w in vec![123, 456, 2] {
+    /// #     assert_eq!(stream.next().await.unwrap(), w);
+    /// # }
+    /// # }));
+    /// ```
     pub fn into_stream(self) -> Stream<T, Tick<L>, Bounded, TotalOrder, ExactlyOnce> {
         Stream::new(self.location, self.ir_node.into_inner())
     }

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -2580,17 +2580,6 @@ where
             },
         )
     }
-
-    #[expect(missing_docs, reason = "TODO")]
-    pub fn delta(self) -> Stream<T, Tick<L>, Bounded, O, R> {
-        Stream::new(
-            self.location.clone(),
-            HydroNode::Delta {
-                inner: Box::new(self.ir_node.into_inner()),
-                metadata: self.location.new_node_metadata::<T>(),
-            },
-        )
-    }
 }
 
 #[cfg(test)]

--- a/hydro_std/src/bench_client/mod.rs
+++ b/hydro_std/src/bench_client/mod.rs
@@ -150,7 +150,7 @@ where
 
     let c_throughput_new_batch = c_received_quorum_payloads
         .count()
-        .continue_unless(c_stats_output_timer.clone())
+        .filter_if_none(c_stats_output_timer.clone())
         .map(q!(|batch_size| (batch_size, false)));
 
     let c_throughput_reset = c_stats_output_timer.map(q!(|_| (0, true))).defer_tick();
@@ -246,7 +246,7 @@ pub fn print_bench_results<'a, Client: 'a, Aggregator>(
         .sample_every(q!(Duration::from_millis(1000)), nondet_sampling)
         .batch(&print_tick, nondet_client_count)
         .cross_singleton(client_count.clone())
-        .continue_unless(waiting_for_clients.clone())
+        .filter_if_none(waiting_for_clients.clone())
         .all_ticks()
         .assume_retries(nondet!(/** extra logs due to duplicate samples are okay */))
         .for_each(q!(move |(throughputs, num_client_machines)| {
@@ -290,7 +290,7 @@ pub fn print_bench_results<'a, Client: 'a, Aggregator>(
     combined_latencies
         .sample_every(q!(Duration::from_millis(1000)), nondet_sampling)
         .batch(&print_tick, nondet_client_count)
-        .continue_unless(waiting_for_clients)
+        .filter_if_none(waiting_for_clients)
         .all_ticks()
         .assume_retries(nondet!(/** extra logs due to duplicate samples are okay */))
         .for_each(q!(move |latencies| {

--- a/hydro_test/src/cluster/compartmentalized_paxos.rs
+++ b/hydro_test/src/cluster/compartmentalized_paxos.rs
@@ -163,7 +163,7 @@ pub fn compartmentalized_paxos_core<'a, P: PaxosPayload>(
 
     let just_became_leader = p_is_leader
         .clone()
-        .continue_unless(p_is_leader.clone().defer_tick());
+        .filter_if_none(p_is_leader.clone().defer_tick());
 
     let c_to_proposers = c_to_proposers(
         just_became_leader
@@ -263,7 +263,7 @@ fn sequence_payload<'a, P: PaxosPayload>(
                     nondet_commit_leader_change
                 ),
             )
-            .continue_if(p_is_leader.clone()),
+            .filter_if_some(p_is_leader.clone()),
     );
 
     let num_proxy_leaders = config.num_proxy_leaders;

--- a/hydro_test/src/cluster/kv_replica.rs
+++ b/hydro_test/src/cluster/kv_replica.rs
@@ -118,7 +118,11 @@ pub fn kv_replica<'a, K: KvKey, V: KvValue>(
     // Send checkpoints to the acceptors when we've processed enough payloads
     let (r_checkpointed_seqs_complete_cycle, r_checkpointed_seqs) =
         replica_tick.cycle::<Optional<usize, _, _>>();
-    let r_max_checkpointed_seq = r_checkpointed_seqs.persist().max().into_singleton();
+    let r_max_checkpointed_seq = r_checkpointed_seqs
+        .into_stream()
+        .persist()
+        .max()
+        .into_singleton();
     let r_checkpoint_seq_new = r_max_checkpointed_seq
         .zip(r_next_slot)
         .filter_map(q!(

--- a/hydro_test/src/cluster/paxos_bench.rs
+++ b/hydro_test/src/cluster/paxos_bench.rs
@@ -85,7 +85,7 @@ pub fn paxos_bench<'a>(
             // Find the smallest checkpoint seq that everyone agrees to
             a_checkpoint_largest_seqs
                 .entries()
-                .continue_if(a_checkpoints_quorum_reached)
+                .filter_if_some(a_checkpoints_quorum_reached)
                 .map(q!(|(_sender, seq)| seq))
                 .min()
                 .latest()

--- a/hydro_test/src/cluster/paxos_with_client.rs
+++ b/hydro_test/src/cluster/paxos_with_client.rs
@@ -89,7 +89,7 @@ pub trait PaxosLike<'a>: Sized {
                     let all_payloads = unsent_payloads.chain(payload_batch);
 
                     unsent_payloads_complete.complete_next_tick(
-                        all_payloads.clone().continue_unless(latest_leader.clone()),
+                        all_payloads.clone().filter_if_none(latest_leader.clone()),
                     );
 
                     all_payloads.cross_singleton(latest_leader).all_ticks()

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir.snap
@@ -818,14 +818,40 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                 },
                                                                                                                 right: Map {
-                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _u | () }),
+                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _u | () }),
                                                                                                                     input: Filter {
-                                                                                                                        f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < usize , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | c | * c == 0 }),
-                                                                                                                        input: Fold {
-                                                                                                                            init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | | 0usize }),
-                                                                                                                            acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | count , _ | * count += 1 }),
-                                                                                                                            input: Tee {
-                                                                                                                                inner: <tee 4>,
+                                                                                                                        f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_none () }),
+                                                                                                                        input: ChainFirst {
+                                                                                                                            first: Map {
+                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
+                                                                                                                                input: Map {
+                                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                                                                                                    input: Tee {
+                                                                                                                                        inner: <tee 4>,
+                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                            location_kind: Tick(
+                                                                                                                                                1,
+                                                                                                                                                Cluster(
+                                                                                                                                                    0,
+                                                                                                                                                ),
+                                                                                                                                            ),
+                                                                                                                                            output_type: Some(
+                                                                                                                                                (),
+                                                                                                                                            ),
+                                                                                                                                        },
+                                                                                                                                    },
+                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                        location_kind: Tick(
+                                                                                                                                            1,
+                                                                                                                                            Cluster(
+                                                                                                                                                0,
+                                                                                                                                            ),
+                                                                                                                                        ),
+                                                                                                                                        output_type: Some(
+                                                                                                                                            (),
+                                                                                                                                        ),
+                                                                                                                                    },
+                                                                                                                                },
                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                     location_kind: Tick(
                                                                                                                                         1,
@@ -834,7 +860,33 @@ expression: built.ir()
                                                                                                                                         ),
                                                                                                                                     ),
                                                                                                                                     output_type: Some(
-                                                                                                                                        (),
+                                                                                                                                        core :: option :: Option < () >,
+                                                                                                                                    ),
+                                                                                                                                },
+                                                                                                                            },
+                                                                                                                            second: Persist {
+                                                                                                                                inner: Source {
+                                                                                                                                    source: Iter(
+                                                                                                                                        [:: std :: option :: Option :: None],
+                                                                                                                                    ),
+                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                        location_kind: Cluster(
+                                                                                                                                            0,
+                                                                                                                                        ),
+                                                                                                                                        output_type: Some(
+                                                                                                                                            core :: option :: Option < () >,
+                                                                                                                                        ),
+                                                                                                                                    },
+                                                                                                                                },
+                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                    location_kind: Tick(
+                                                                                                                                        1,
+                                                                                                                                        Cluster(
+                                                                                                                                            0,
+                                                                                                                                        ),
+                                                                                                                                    ),
+                                                                                                                                    output_type: Some(
+                                                                                                                                        core :: option :: Option < () >,
                                                                                                                                     ),
                                                                                                                                 },
                                                                                                                             },
@@ -846,7 +898,7 @@ expression: built.ir()
                                                                                                                                     ),
                                                                                                                                 ),
                                                                                                                                 output_type: Some(
-                                                                                                                                    usize,
+                                                                                                                                    core :: option :: Option < () >,
                                                                                                                                 ),
                                                                                                                             },
                                                                                                                         },
@@ -858,7 +910,7 @@ expression: built.ir()
                                                                                                                                 ),
                                                                                                                             ),
                                                                                                                             output_type: Some(
-                                                                                                                                usize,
+                                                                                                                                core :: option :: Option < () >,
                                                                                                                             ),
                                                                                                                         },
                                                                                                                     },
@@ -1963,51 +2015,71 @@ expression: built.ir()
                     },
                 },
                 right: Map {
-                    f: stageleft :: runtime_support :: fn1_type_hint :: < usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _u | () }),
+                    f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _u | () }),
                     input: Filter {
-                        f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < usize , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | c | * c == 0 }),
-                        input: Fold {
-                            init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | | 0usize }),
-                            acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | count , _ | * count += 1 }),
-                            input: Tee {
-                                inner: <tee 15>: Map {
-                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | ballot | ballot . proposer_id }),
-                                    input: Reduce {
-                                        f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | curr , new | { if new > * curr { * curr = new ; } } }),
-                                        input: Persist {
-                                            inner: Inspect {
-                                                f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_with_client :: * ; | ballot | println ! ("Client notified that leader was elected: {:?}" , ballot) }),
-                                                input: Map {
-                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                                    input: Network {
-                                                        serialize_fn: Some(
-                                                            :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: location :: MemberId < _ > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
-                                                        ),
-                                                        instantiate_fn: <network instantiate>,
-                                                        deserialize_fn: Some(
-                                                            | res | { let (id , b) = res . unwrap () ; (hydro_lang :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_raw (id) , hydro_lang :: runtime_support :: bincode :: deserialize :: < hydro_test :: __staged :: cluster :: paxos :: Ballot > (& b) . unwrap ()) },
-                                                        ),
-                                                        input: CrossProduct {
-                                                            left: Map {
-                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , ()) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                                input: FilterMap {
-                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , bool) , core :: option :: Option < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , ()) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < bool , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | v | if v { Some (()) } else { None } }) ; { let orig = f__free ; move | (k , v) | orig (v) . map (| v | (k , v)) } }),
-                                                                    input: FoldKeyed {
-                                                                        init: stageleft :: runtime_support :: fn0_type_hint :: < bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | | false }),
-                                                                        acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < bool , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | present , event | { match event { MembershipEvent :: Joined => * present = true , MembershipEvent :: Left => * present = false , } } }),
-                                                                        input: Persist {
-                                                                            inner: Map {
-                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < & hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | id | (* id , MembershipEvent :: Joined) }),
-                                                                                input: Source {
-                                                                                    source: Iter(
-                                                                                        { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let underlying_memberids__free = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: location :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >] > (__hydro_lang_cluster_ids_2) } ; underlying_memberids__free },
-                                                                                    ),
+                        f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | o | o . is_none () }),
+                        input: ChainFirst {
+                            first: Map {
+                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
+                                input: Map {
+                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ | () }),
+                                    input: Tee {
+                                        inner: <tee 15>: Map {
+                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | ballot | ballot . proposer_id }),
+                                            input: Reduce {
+                                                f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | curr , new | { if new > * curr { * curr = new ; } } }),
+                                                input: Persist {
+                                                    inner: Inspect {
+                                                        f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_with_client :: * ; | ballot | println ! ("Client notified that leader was elected: {:?}" , ballot) }),
+                                                        input: Map {
+                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
+                                                            input: Network {
+                                                                serialize_fn: Some(
+                                                                    :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: location :: MemberId < _ > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
+                                                                ),
+                                                                instantiate_fn: <network instantiate>,
+                                                                deserialize_fn: Some(
+                                                                    | res | { let (id , b) = res . unwrap () ; (hydro_lang :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_raw (id) , hydro_lang :: runtime_support :: bincode :: deserialize :: < hydro_test :: __staged :: cluster :: paxos :: Ballot > (& b) . unwrap ()) },
+                                                                ),
+                                                                input: CrossProduct {
+                                                                    left: Map {
+                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , ()) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
+                                                                        input: FilterMap {
+                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , bool) , core :: option :: Option < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , ()) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < bool , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | v | if v { Some (()) } else { None } }) ; { let orig = f__free ; move | (k , v) | orig (v) . map (| v | (k , v)) } }),
+                                                                            input: FoldKeyed {
+                                                                                init: stageleft :: runtime_support :: fn0_type_hint :: < bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | | false }),
+                                                                                acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < bool , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | present , event | { match event { MembershipEvent :: Joined => * present = true , MembershipEvent :: Left => * present = false , } } }),
+                                                                                input: Persist {
+                                                                                    inner: Map {
+                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < & hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | id | (* id , MembershipEvent :: Joined) }),
+                                                                                        input: Source {
+                                                                                            source: Iter(
+                                                                                                { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let underlying_memberids__free = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: location :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >] > (__hydro_lang_cluster_ids_2) } ; underlying_memberids__free },
+                                                                                            ),
+                                                                                            metadata: HydroIrMetadata {
+                                                                                                location_kind: Cluster(
+                                                                                                    0,
+                                                                                                ),
+                                                                                                output_type: Some(
+                                                                                                    & hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >,
+                                                                                                ),
+                                                                                            },
+                                                                                        },
+                                                                                        metadata: HydroIrMetadata {
+                                                                                            location_kind: Cluster(
+                                                                                                0,
+                                                                                            ),
+                                                                                            output_type: Some(
+                                                                                                (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
+                                                                                            ),
+                                                                                        },
+                                                                                    },
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_kind: Cluster(
                                                                                             0,
                                                                                         ),
                                                                                         output_type: Some(
-                                                                                            & hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >,
+                                                                                            (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
                                                                                         ),
                                                                                     },
                                                                                 },
@@ -2016,7 +2088,7 @@ expression: built.ir()
                                                                                         0,
                                                                                     ),
                                                                                     output_type: Some(
-                                                                                        (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
+                                                                                        (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , bool),
                                                                                     ),
                                                                                 },
                                                                             },
@@ -2025,87 +2097,145 @@ expression: built.ir()
                                                                                     0,
                                                                                 ),
                                                                                 output_type: Some(
-                                                                                    (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
+                                                                                    (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , ()),
                                                                                 ),
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_kind: Cluster(
-                                                                                0,
-                                                                            ),
-                                                                            output_type: Some(
-                                                                                (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , bool),
-                                                                            ),
-                                                                        },
-                                                                    },
-                                                                    metadata: HydroIrMetadata {
-                                                                        location_kind: Cluster(
-                                                                            0,
-                                                                        ),
-                                                                        output_type: Some(
-                                                                            (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , ()),
-                                                                        ),
-                                                                    },
-                                                                },
-                                                                metadata: HydroIrMetadata {
-                                                                    location_kind: Tick(
-                                                                        9,
-                                                                        Cluster(
-                                                                            0,
-                                                                        ),
-                                                                    ),
-                                                                    output_type: Some(
-                                                                        hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >,
-                                                                    ),
-                                                                },
-                                                            },
-                                                            right: Map {
-                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , ()) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _signal) | d }),
-                                                                input: CrossSingleton {
-                                                                    left: Tee {
-                                                                        inner: <tee 3>,
-                                                                        metadata: HydroIrMetadata {
                                                                             location_kind: Tick(
-                                                                                1,
+                                                                                9,
                                                                                 Cluster(
                                                                                     0,
                                                                                 ),
                                                                             ),
                                                                             output_type: Some(
-                                                                                hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >,
                                                                             ),
                                                                         },
                                                                     },
                                                                     right: Map {
-                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _u | () }),
-                                                                        input: Tee {
-                                                                            inner: <tee 16>: Map {
-                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (() , ()) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | (d , _signal) | d }),
-                                                                                input: CrossSingleton {
-                                                                                    left: Tee {
-                                                                                        inner: <tee 11>,
-                                                                                        metadata: HydroIrMetadata {
-                                                                                            location_kind: Tick(
-                                                                                                1,
-                                                                                                Cluster(
-                                                                                                    0,
-                                                                                                ),
-                                                                                            ),
-                                                                                            output_type: Some(
-                                                                                                (),
-                                                                                            ),
-                                                                                        },
-                                                                                    },
-                                                                                    right: Map {
-                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _u | () }),
-                                                                                        input: Filter {
-                                                                                            f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < usize , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | c | * c == 0 }),
-                                                                                            input: Fold {
-                                                                                                init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | | 0usize }),
-                                                                                                acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | count , _ | * count += 1 }),
-                                                                                                input: DeferTick {
-                                                                                                    input: Tee {
-                                                                                                        inner: <tee 11>,
+                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , ()) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _signal) | d }),
+                                                                        input: CrossSingleton {
+                                                                            left: Tee {
+                                                                                inner: <tee 3>,
+                                                                                metadata: HydroIrMetadata {
+                                                                                    location_kind: Tick(
+                                                                                        1,
+                                                                                        Cluster(
+                                                                                            0,
+                                                                                        ),
+                                                                                    ),
+                                                                                    output_type: Some(
+                                                                                        hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                    ),
+                                                                                },
+                                                                            },
+                                                                            right: Map {
+                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _u | () }),
+                                                                                input: Tee {
+                                                                                    inner: <tee 16>: Map {
+                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (() , ()) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | (d , _signal) | d }),
+                                                                                        input: CrossSingleton {
+                                                                                            left: Tee {
+                                                                                                inner: <tee 11>,
+                                                                                                metadata: HydroIrMetadata {
+                                                                                                    location_kind: Tick(
+                                                                                                        1,
+                                                                                                        Cluster(
+                                                                                                            0,
+                                                                                                        ),
+                                                                                                    ),
+                                                                                                    output_type: Some(
+                                                                                                        (),
+                                                                                                    ),
+                                                                                                },
+                                                                                            },
+                                                                                            right: Map {
+                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _u | () }),
+                                                                                                input: Filter {
+                                                                                                    f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_none () }),
+                                                                                                    input: ChainFirst {
+                                                                                                        first: Map {
+                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
+                                                                                                            input: Map {
+                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                                                                                input: DeferTick {
+                                                                                                                    input: Tee {
+                                                                                                                        inner: <tee 11>,
+                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                            location_kind: Tick(
+                                                                                                                                1,
+                                                                                                                                Cluster(
+                                                                                                                                    0,
+                                                                                                                                ),
+                                                                                                                            ),
+                                                                                                                            output_type: Some(
+                                                                                                                                (),
+                                                                                                                            ),
+                                                                                                                        },
+                                                                                                                    },
+                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                        location_kind: Tick(
+                                                                                                                            1,
+                                                                                                                            Cluster(
+                                                                                                                                0,
+                                                                                                                            ),
+                                                                                                                        ),
+                                                                                                                        output_type: Some(
+                                                                                                                            (),
+                                                                                                                        ),
+                                                                                                                    },
+                                                                                                                },
+                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                    location_kind: Tick(
+                                                                                                                        1,
+                                                                                                                        Cluster(
+                                                                                                                            0,
+                                                                                                                        ),
+                                                                                                                    ),
+                                                                                                                    output_type: Some(
+                                                                                                                        (),
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                            },
+                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                location_kind: Tick(
+                                                                                                                    1,
+                                                                                                                    Cluster(
+                                                                                                                        0,
+                                                                                                                    ),
+                                                                                                                ),
+                                                                                                                output_type: Some(
+                                                                                                                    core :: option :: Option < () >,
+                                                                                                                ),
+                                                                                                            },
+                                                                                                        },
+                                                                                                        second: Persist {
+                                                                                                            inner: Source {
+                                                                                                                source: Iter(
+                                                                                                                    [:: std :: option :: Option :: None],
+                                                                                                                ),
+                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                    location_kind: Cluster(
+                                                                                                                        0,
+                                                                                                                    ),
+                                                                                                                    output_type: Some(
+                                                                                                                        core :: option :: Option < () >,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                            },
+                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                location_kind: Tick(
+                                                                                                                    1,
+                                                                                                                    Cluster(
+                                                                                                                        0,
+                                                                                                                    ),
+                                                                                                                ),
+                                                                                                                output_type: Some(
+                                                                                                                    core :: option :: Option < () >,
+                                                                                                                ),
+                                                                                                            },
+                                                                                                        },
                                                                                                         metadata: HydroIrMetadata {
                                                                                                             location_kind: Tick(
                                                                                                                 1,
@@ -2114,7 +2244,7 @@ expression: built.ir()
                                                                                                                 ),
                                                                                                             ),
                                                                                                             output_type: Some(
-                                                                                                                (),
+                                                                                                                core :: option :: Option < () >,
                                                                                                             ),
                                                                                                         },
                                                                                                     },
@@ -2126,7 +2256,7 @@ expression: built.ir()
                                                                                                             ),
                                                                                                         ),
                                                                                                         output_type: Some(
-                                                                                                            (),
+                                                                                                            core :: option :: Option < () >,
                                                                                                         ),
                                                                                                     },
                                                                                                 },
@@ -2138,7 +2268,7 @@ expression: built.ir()
                                                                                                         ),
                                                                                                     ),
                                                                                                     output_type: Some(
-                                                                                                        usize,
+                                                                                                        (),
                                                                                                     ),
                                                                                                 },
                                                                                             },
@@ -2150,7 +2280,7 @@ expression: built.ir()
                                                                                                     ),
                                                                                                 ),
                                                                                                 output_type: Some(
-                                                                                                    usize,
+                                                                                                    (() , ()),
                                                                                                 ),
                                                                                             },
                                                                                         },
@@ -2174,7 +2304,7 @@ expression: built.ir()
                                                                                             ),
                                                                                         ),
                                                                                         output_type: Some(
-                                                                                            (() , ()),
+                                                                                            (),
                                                                                         ),
                                                                                     },
                                                                                 },
@@ -2198,7 +2328,7 @@ expression: built.ir()
                                                                                     ),
                                                                                 ),
                                                                                 output_type: Some(
-                                                                                    (),
+                                                                                    (hydro_test :: __staged :: cluster :: paxos :: Ballot , ()),
                                                                                 ),
                                                                             },
                                                                         },
@@ -2210,43 +2340,37 @@ expression: built.ir()
                                                                                 ),
                                                                             ),
                                                                             output_type: Some(
-                                                                                (),
+                                                                                hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                             ),
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
                                                                         location_kind: Tick(
-                                                                            1,
+                                                                            9,
                                                                             Cluster(
                                                                                 0,
                                                                             ),
                                                                         ),
                                                                         output_type: Some(
-                                                                            (hydro_test :: __staged :: cluster :: paxos :: Ballot , ()),
+                                                                            (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
                                                                         ),
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_kind: Tick(
-                                                                        1,
-                                                                        Cluster(
-                                                                            0,
-                                                                        ),
+                                                                    location_kind: Cluster(
+                                                                        2,
                                                                     ),
                                                                     output_type: Some(
-                                                                        hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                        (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
                                                                     ),
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_kind: Tick(
-                                                                    9,
-                                                                    Cluster(
-                                                                        0,
-                                                                    ),
+                                                                location_kind: Cluster(
+                                                                    2,
                                                                 ),
                                                                 output_type: Some(
-                                                                    (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                    hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                 ),
                                                             },
                                                         },
@@ -2255,7 +2379,7 @@ expression: built.ir()
                                                                 2,
                                                             ),
                                                             output_type: Some(
-                                                                (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                             ),
                                                         },
                                                     },
@@ -2282,25 +2406,31 @@ expression: built.ir()
                                                     2,
                                                 ),
                                                 output_type: Some(
-                                                    hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                    hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                                 ),
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_kind: Cluster(
-                                                2,
+                                            location_kind: Tick(
+                                                10,
+                                                Cluster(
+                                                    2,
+                                                ),
                                             ),
                                             output_type: Some(
-                                                hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                             ),
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_kind: Cluster(
-                                            2,
+                                        location_kind: Tick(
+                                            10,
+                                            Cluster(
+                                                2,
+                                            ),
                                         ),
                                         output_type: Some(
-                                            hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
+                                            (),
                                         ),
                                     },
                                 },
@@ -2312,7 +2442,33 @@ expression: built.ir()
                                         ),
                                     ),
                                     output_type: Some(
-                                        hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
+                                        core :: option :: Option < () >,
+                                    ),
+                                },
+                            },
+                            second: Persist {
+                                inner: Source {
+                                    source: Iter(
+                                        [:: std :: option :: Option :: None],
+                                    ),
+                                    metadata: HydroIrMetadata {
+                                        location_kind: Cluster(
+                                            2,
+                                        ),
+                                        output_type: Some(
+                                            core :: option :: Option < () >,
+                                        ),
+                                    },
+                                },
+                                metadata: HydroIrMetadata {
+                                    location_kind: Tick(
+                                        10,
+                                        Cluster(
+                                            2,
+                                        ),
+                                    ),
+                                    output_type: Some(
+                                        core :: option :: Option < () >,
                                     ),
                                 },
                             },
@@ -2324,7 +2480,7 @@ expression: built.ir()
                                     ),
                                 ),
                                 output_type: Some(
-                                    usize,
+                                    core :: option :: Option < () >,
                                 ),
                             },
                         },
@@ -2336,7 +2492,7 @@ expression: built.ir()
                                 ),
                             ),
                             output_type: Some(
-                                usize,
+                                core :: option :: Option < () >,
                             ),
                         },
                     },
@@ -5988,22 +6144,48 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         right: Map {
-                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _u | () }),
+                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _u | () }),
                                                                                             input: Filter {
-                                                                                                f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < usize , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | c | * c == 0 }),
-                                                                                                input: Fold {
-                                                                                                    init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | | 0usize }),
-                                                                                                    acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | count , _ | * count += 1 }),
-                                                                                                    input: Tee {
-                                                                                                        inner: <tee 51>: Reduce {
-                                                                                                            f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
-                                                                                                            input: Source {
-                                                                                                                source: Stream(
-                                                                                                                    { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let interval__free = { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; Duration :: from_secs (1) } ; tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval (interval__free)) },
-                                                                                                                ),
+                                                                                                f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | o | o . is_none () }),
+                                                                                                input: ChainFirst {
+                                                                                                    first: Map {
+                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
+                                                                                                        input: Map {
+                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _ | () }),
+                                                                                                            input: Tee {
+                                                                                                                inner: <tee 51>: Reduce {
+                                                                                                                    f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
+                                                                                                                    input: Source {
+                                                                                                                        source: Stream(
+                                                                                                                            { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let interval__free = { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; Duration :: from_secs (1) } ; tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval (interval__free)) },
+                                                                                                                        ),
+                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                            location_kind: Cluster(
+                                                                                                                                2,
+                                                                                                                            ),
+                                                                                                                            output_type: Some(
+                                                                                                                                hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
+                                                                                                                            ),
+                                                                                                                        },
+                                                                                                                    },
+                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                        location_kind: Tick(
+                                                                                                                            0,
+                                                                                                                            Cluster(
+                                                                                                                                2,
+                                                                                                                            ),
+                                                                                                                        ),
+                                                                                                                        output_type: Some(
+                                                                                                                            hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
+                                                                                                                        ),
+                                                                                                                    },
+                                                                                                                },
                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                    location_kind: Cluster(
-                                                                                                                        2,
+                                                                                                                    location_kind: Tick(
+                                                                                                                        0,
+                                                                                                                        Cluster(
+                                                                                                                            2,
+                                                                                                                        ),
                                                                                                                     ),
                                                                                                                     output_type: Some(
                                                                                                                         hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
@@ -6018,7 +6200,7 @@ expression: built.ir()
                                                                                                                     ),
                                                                                                                 ),
                                                                                                                 output_type: Some(
-                                                                                                                    hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
+                                                                                                                    (),
                                                                                                                 ),
                                                                                                             },
                                                                                                         },
@@ -6030,7 +6212,33 @@ expression: built.ir()
                                                                                                                 ),
                                                                                                             ),
                                                                                                             output_type: Some(
-                                                                                                                hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
+                                                                                                                core :: option :: Option < () >,
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    },
+                                                                                                    second: Persist {
+                                                                                                        inner: Source {
+                                                                                                            source: Iter(
+                                                                                                                [:: std :: option :: Option :: None],
+                                                                                                            ),
+                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                location_kind: Cluster(
+                                                                                                                    2,
+                                                                                                                ),
+                                                                                                                output_type: Some(
+                                                                                                                    core :: option :: Option < () >,
+                                                                                                                ),
+                                                                                                            },
+                                                                                                        },
+                                                                                                        metadata: HydroIrMetadata {
+                                                                                                            location_kind: Tick(
+                                                                                                                0,
+                                                                                                                Cluster(
+                                                                                                                    2,
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                            output_type: Some(
+                                                                                                                core :: option :: Option < () >,
                                                                                                             ),
                                                                                                         },
                                                                                                     },
@@ -6042,7 +6250,7 @@ expression: built.ir()
                                                                                                             ),
                                                                                                         ),
                                                                                                         output_type: Some(
-                                                                                                            usize,
+                                                                                                            core :: option :: Option < () >,
                                                                                                         ),
                                                                                                     },
                                                                                                 },
@@ -6054,7 +6262,7 @@ expression: built.ir()
                                                                                                         ),
                                                                                                     ),
                                                                                                     output_type: Some(
-                                                                                                        usize,
+                                                                                                        core :: option :: Option < () >,
                                                                                                     ),
                                                                                                 },
                                                                                             },
@@ -6551,14 +6759,40 @@ expression: built.ir()
                     },
                 },
                 right: Map {
-                    f: stageleft :: runtime_support :: fn1_type_hint :: < usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _u | () }),
+                    f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _u | () }),
                     input: Filter {
-                        f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < usize , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | c | * c == 0 }),
-                        input: Fold {
-                            init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | | 0usize }),
-                            acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | count , _ | * count += 1 }),
-                            input: Tee {
-                                inner: <tee 48>,
+                        f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | o | o . is_none () }),
+                        input: ChainFirst {
+                            first: Map {
+                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
+                                input: Map {
+                                    f: stageleft :: runtime_support :: fn1_type_hint :: < usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ | () }),
+                                    input: Tee {
+                                        inner: <tee 48>,
+                                        metadata: HydroIrMetadata {
+                                            location_kind: Tick(
+                                                17,
+                                                Process(
+                                                    3,
+                                                ),
+                                            ),
+                                            output_type: Some(
+                                                usize,
+                                            ),
+                                        },
+                                    },
+                                    metadata: HydroIrMetadata {
+                                        location_kind: Tick(
+                                            17,
+                                            Process(
+                                                3,
+                                            ),
+                                        ),
+                                        output_type: Some(
+                                            (),
+                                        ),
+                                    },
+                                },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
                                         17,
@@ -6567,7 +6801,33 @@ expression: built.ir()
                                         ),
                                     ),
                                     output_type: Some(
-                                        usize,
+                                        core :: option :: Option < () >,
+                                    ),
+                                },
+                            },
+                            second: Persist {
+                                inner: Source {
+                                    source: Iter(
+                                        [:: std :: option :: Option :: None],
+                                    ),
+                                    metadata: HydroIrMetadata {
+                                        location_kind: Process(
+                                            3,
+                                        ),
+                                        output_type: Some(
+                                            core :: option :: Option < () >,
+                                        ),
+                                    },
+                                },
+                                metadata: HydroIrMetadata {
+                                    location_kind: Tick(
+                                        17,
+                                        Process(
+                                            3,
+                                        ),
+                                    ),
+                                    output_type: Some(
+                                        core :: option :: Option < () >,
                                     ),
                                 },
                             },
@@ -6579,7 +6839,7 @@ expression: built.ir()
                                     ),
                                 ),
                                 output_type: Some(
-                                    usize,
+                                    core :: option :: Option < () >,
                                 ),
                             },
                         },
@@ -6591,7 +6851,7 @@ expression: built.ir()
                                 ),
                             ),
                             output_type: Some(
-                                usize,
+                                core :: option :: Option < () >,
                             ),
                         },
                     },
@@ -6943,14 +7203,40 @@ expression: built.ir()
                     },
                 },
                 right: Map {
-                    f: stageleft :: runtime_support :: fn1_type_hint :: < usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _u | () }),
+                    f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _u | () }),
                     input: Filter {
-                        f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < usize , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | c | * c == 0 }),
-                        input: Fold {
-                            init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | | 0usize }),
-                            acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | count , _ | * count += 1 }),
-                            input: Tee {
-                                inner: <tee 48>,
+                        f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | o | o . is_none () }),
+                        input: ChainFirst {
+                            first: Map {
+                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
+                                input: Map {
+                                    f: stageleft :: runtime_support :: fn1_type_hint :: < usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ | () }),
+                                    input: Tee {
+                                        inner: <tee 48>,
+                                        metadata: HydroIrMetadata {
+                                            location_kind: Tick(
+                                                17,
+                                                Process(
+                                                    3,
+                                                ),
+                                            ),
+                                            output_type: Some(
+                                                usize,
+                                            ),
+                                        },
+                                    },
+                                    metadata: HydroIrMetadata {
+                                        location_kind: Tick(
+                                            17,
+                                            Process(
+                                                3,
+                                            ),
+                                        ),
+                                        output_type: Some(
+                                            (),
+                                        ),
+                                    },
+                                },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
                                         17,
@@ -6959,7 +7245,33 @@ expression: built.ir()
                                         ),
                                     ),
                                     output_type: Some(
-                                        usize,
+                                        core :: option :: Option < () >,
+                                    ),
+                                },
+                            },
+                            second: Persist {
+                                inner: Source {
+                                    source: Iter(
+                                        [:: std :: option :: Option :: None],
+                                    ),
+                                    metadata: HydroIrMetadata {
+                                        location_kind: Process(
+                                            3,
+                                        ),
+                                        output_type: Some(
+                                            core :: option :: Option < () >,
+                                        ),
+                                    },
+                                },
+                                metadata: HydroIrMetadata {
+                                    location_kind: Tick(
+                                        17,
+                                        Process(
+                                            3,
+                                        ),
+                                    ),
+                                    output_type: Some(
+                                        core :: option :: Option < () >,
                                     ),
                                 },
                             },
@@ -6971,7 +7283,7 @@ expression: built.ir()
                                     ),
                                 ),
                                 output_type: Some(
-                                    usize,
+                                    core :: option :: Option < () >,
                                 ),
                             },
                         },
@@ -6983,7 +7295,7 @@ expression: built.ir()
                                 ),
                             ),
                             output_type: Some(
-                                usize,
+                                core :: option :: Option < () >,
                             ),
                         },
                     },

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir@acceptor_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir@acceptor_mermaid.snap
@@ -118,163 +118,163 @@ linkStyle default stroke:#aaa
 25v1
 35v1
 34v1
-subgraph var_reduce_keyed_watermark_chain_296 ["var <tt>reduce_keyed_watermark_chain_296</tt>"]
-    style var_reduce_keyed_watermark_chain_296 fill:transparent
+subgraph var_reduce_keyed_watermark_chain_308 ["var <tt>reduce_keyed_watermark_chain_308</tt>"]
+    style var_reduce_keyed_watermark_chain_308 fill:transparent
     33v1
 end
 subgraph var_stream_2 ["var <tt>stream_2</tt>"]
     style var_stream_2 fill:transparent
     1v1
 end
-subgraph var_stream_249 ["var <tt>stream_249</tt>"]
-    style var_stream_249 fill:transparent
+subgraph var_stream_261 ["var <tt>stream_261</tt>"]
+    style var_stream_261 fill:transparent
     18v1
     19v1
 end
-subgraph var_stream_250 ["var <tt>stream_250</tt>"]
-    style var_stream_250 fill:transparent
+subgraph var_stream_262 ["var <tt>stream_262</tt>"]
+    style var_stream_262 fill:transparent
     20v1
 end
-subgraph var_stream_251 ["var <tt>stream_251</tt>"]
-    style var_stream_251 fill:transparent
+subgraph var_stream_263 ["var <tt>stream_263</tt>"]
+    style var_stream_263 fill:transparent
     21v1
 end
-subgraph var_stream_253 ["var <tt>stream_253</tt>"]
-    style var_stream_253 fill:transparent
+subgraph var_stream_265 ["var <tt>stream_265</tt>"]
+    style var_stream_265 fill:transparent
     22v1
 end
-subgraph var_stream_254 ["var <tt>stream_254</tt>"]
-    style var_stream_254 fill:transparent
+subgraph var_stream_266 ["var <tt>stream_266</tt>"]
+    style var_stream_266 fill:transparent
     23v1
-end
-subgraph var_stream_286 ["var <tt>stream_286</tt>"]
-    style var_stream_286 fill:transparent
-    26v1
-end
-subgraph var_stream_287 ["var <tt>stream_287</tt>"]
-    style var_stream_287 fill:transparent
-    27v1
-end
-subgraph var_stream_288 ["var <tt>stream_288</tt>"]
-    style var_stream_288 fill:transparent
-    28v1
-end
-subgraph var_stream_289 ["var <tt>stream_289</tt>"]
-    style var_stream_289 fill:transparent
-    29v1
-end
-subgraph var_stream_290 ["var <tt>stream_290</tt>"]
-    style var_stream_290 fill:transparent
-    30v1
-end
-subgraph var_stream_293 ["var <tt>stream_293</tt>"]
-    style var_stream_293 fill:transparent
-    31v1
-end
-subgraph var_stream_294 ["var <tt>stream_294</tt>"]
-    style var_stream_294 fill:transparent
-    32v1
-end
-subgraph var_stream_296 ["var <tt>stream_296</tt>"]
-    style var_stream_296 fill:transparent
-    36v1
-    37v1
-end
-subgraph var_stream_297 ["var <tt>stream_297</tt>"]
-    style var_stream_297 fill:transparent
-    38v1
 end
 subgraph var_stream_298 ["var <tt>stream_298</tt>"]
     style var_stream_298 fill:transparent
+    26v1
+end
+subgraph var_stream_299 ["var <tt>stream_299</tt>"]
+    style var_stream_299 fill:transparent
+    27v1
+end
+subgraph var_stream_300 ["var <tt>stream_300</tt>"]
+    style var_stream_300 fill:transparent
+    28v1
+end
+subgraph var_stream_301 ["var <tt>stream_301</tt>"]
+    style var_stream_301 fill:transparent
+    29v1
+end
+subgraph var_stream_302 ["var <tt>stream_302</tt>"]
+    style var_stream_302 fill:transparent
+    30v1
+end
+subgraph var_stream_305 ["var <tt>stream_305</tt>"]
+    style var_stream_305 fill:transparent
+    31v1
+end
+subgraph var_stream_306 ["var <tt>stream_306</tt>"]
+    style var_stream_306 fill:transparent
+    32v1
+end
+subgraph var_stream_308 ["var <tt>stream_308</tt>"]
+    style var_stream_308 fill:transparent
+    36v1
+    37v1
+end
+subgraph var_stream_309 ["var <tt>stream_309</tt>"]
+    style var_stream_309 fill:transparent
+    38v1
+end
+subgraph var_stream_310 ["var <tt>stream_310</tt>"]
+    style var_stream_310 fill:transparent
     39v1
 end
-subgraph var_stream_360 ["var <tt>stream_360</tt>"]
-    style var_stream_360 fill:transparent
+subgraph var_stream_372 ["var <tt>stream_372</tt>"]
+    style var_stream_372 fill:transparent
     40v1
     41v1
 end
-subgraph var_stream_361 ["var <tt>stream_361</tt>"]
-    style var_stream_361 fill:transparent
+subgraph var_stream_373 ["var <tt>stream_373</tt>"]
+    style var_stream_373 fill:transparent
     42v1
 end
-subgraph var_stream_362 ["var <tt>stream_362</tt>"]
-    style var_stream_362 fill:transparent
+subgraph var_stream_374 ["var <tt>stream_374</tt>"]
+    style var_stream_374 fill:transparent
     43v1
 end
-subgraph var_stream_364 ["var <tt>stream_364</tt>"]
-    style var_stream_364 fill:transparent
+subgraph var_stream_376 ["var <tt>stream_376</tt>"]
+    style var_stream_376 fill:transparent
     44v1
 end
-subgraph var_stream_365 ["var <tt>stream_365</tt>"]
-    style var_stream_365 fill:transparent
+subgraph var_stream_377 ["var <tt>stream_377</tt>"]
+    style var_stream_377 fill:transparent
     45v1
 end
-subgraph var_stream_366 ["var <tt>stream_366</tt>"]
-    style var_stream_366 fill:transparent
+subgraph var_stream_378 ["var <tt>stream_378</tt>"]
+    style var_stream_378 fill:transparent
     46v1
 end
-subgraph var_stream_367 ["var <tt>stream_367</tt>"]
-    style var_stream_367 fill:transparent
+subgraph var_stream_379 ["var <tt>stream_379</tt>"]
+    style var_stream_379 fill:transparent
     47v1
 end
-subgraph var_stream_368 ["var <tt>stream_368</tt>"]
-    style var_stream_368 fill:transparent
+subgraph var_stream_380 ["var <tt>stream_380</tt>"]
+    style var_stream_380 fill:transparent
     48v1
 end
-subgraph var_stream_369 ["var <tt>stream_369</tt>"]
-    style var_stream_369 fill:transparent
+subgraph var_stream_381 ["var <tt>stream_381</tt>"]
+    style var_stream_381 fill:transparent
     49v1
 end
-subgraph var_stream_370 ["var <tt>stream_370</tt>"]
-    style var_stream_370 fill:transparent
+subgraph var_stream_382 ["var <tt>stream_382</tt>"]
+    style var_stream_382 fill:transparent
     50v1
-end
-subgraph var_stream_71 ["var <tt>stream_71</tt>"]
-    style var_stream_71 fill:transparent
-    3v1
-    4v1
-end
-subgraph var_stream_72 ["var <tt>stream_72</tt>"]
-    style var_stream_72 fill:transparent
-    5v1
-end
-subgraph var_stream_73 ["var <tt>stream_73</tt>"]
-    style var_stream_73 fill:transparent
-    6v1
 end
 subgraph var_stream_75 ["var <tt>stream_75</tt>"]
     style var_stream_75 fill:transparent
-    7v1
+    3v1
+    4v1
 end
 subgraph var_stream_76 ["var <tt>stream_76</tt>"]
     style var_stream_76 fill:transparent
-    8v1
+    5v1
 end
 subgraph var_stream_77 ["var <tt>stream_77</tt>"]
     style var_stream_77 fill:transparent
-    9v1
-end
-subgraph var_stream_78 ["var <tt>stream_78</tt>"]
-    style var_stream_78 fill:transparent
-    10v1
+    6v1
 end
 subgraph var_stream_79 ["var <tt>stream_79</tt>"]
     style var_stream_79 fill:transparent
-    11v1
+    7v1
 end
 subgraph var_stream_80 ["var <tt>stream_80</tt>"]
     style var_stream_80 fill:transparent
-    12v1
+    8v1
 end
 subgraph var_stream_81 ["var <tt>stream_81</tt>"]
     style var_stream_81 fill:transparent
-    13v1
+    9v1
+end
+subgraph var_stream_82 ["var <tt>stream_82</tt>"]
+    style var_stream_82 fill:transparent
+    10v1
 end
 subgraph var_stream_83 ["var <tt>stream_83</tt>"]
     style var_stream_83 fill:transparent
-    14v1
+    11v1
 end
 subgraph var_stream_84 ["var <tt>stream_84</tt>"]
     style var_stream_84 fill:transparent
+    12v1
+end
+subgraph var_stream_85 ["var <tt>stream_85</tt>"]
+    style var_stream_85 fill:transparent
+    13v1
+end
+subgraph var_stream_87 ["var <tt>stream_87</tt>"]
+    style var_stream_87 fill:transparent
+    14v1
+end
+subgraph var_stream_88 ["var <tt>stream_88</tt>"]
+    style var_stream_88 fill:transparent
     15v1
 end

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir@proposer_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir@proposer_mermaid.snap
@@ -55,189 +55,197 @@ linkStyle default stroke:#aaa
 45v1["<div style=text-align:center>(45v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
 46v1["<div style=text-align:center>(46v1)</div> <code><br>fold::&lt;<br>    'static,<br>&gt;(<br>    {<br>        || None<br>    },<br>    {<br>        |latest, _| {<br>            *latest = Some(Instant::now());<br>        }<br>    },<br>)</code>"]:::otherClass
 47v1["<div style=text-align:center>(47v1)</div> <code><br>filter_map({<br>    let duration__free = {<br>        let i_am_leader_check_timeout__free = 10u64;<br>        Duration::from_secs(i_am_leader_check_timeout__free)<br>    };<br>    move |latest_received| {<br>        if let Some(latest_received) = latest_received {<br>            if Instant::now().duration_since(latest_received) &gt; duration__free {<br>                Some(())<br>            } else {<br>                None<br>            }<br>        } else {<br>            Some(())<br>        }<br>    }<br>})</code>"]:::otherClass
-48v1["<div style=text-align:center>(48v1)</div> <code><br>fold::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        || 0usize<br>    },<br>    {<br>        |count, _| *count += 1<br>    },<br>)</code>"]:::otherClass
-49v1["<div style=text-align:center>(49v1)</div> <code><br>filter({<br>    |c| *c == 0<br>})</code>"]:::otherClass
-50v1["<div style=text-align:center>(50v1)</div> <code><br>map({<br>    |_u| ()<br>})</code>"]:::otherClass
-51v1["<div style=text-align:center>(51v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-52v1["<div style=text-align:center>(52v1)</div> <code><br>map({<br>    |(d, _signal)| d<br>})</code>"]:::otherClass
-53v1["<div style=text-align:center>(53v1)</div> <code><br>source_stream({<br>    let delay__free = {<br>        let CLUSTER_SELF_ID__free = hydro_lang::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Proposer,<br>        &gt;::from_raw(__hydro_lang_cluster_self_id_0);<br>        let i_am_leader_check_timeout_delay_multiplier__free = 15usize;<br>        Duration::from_secs(<br>            (CLUSTER_SELF_ID__free.raw_id<br>                * i_am_leader_check_timeout_delay_multiplier__free as u32)<br>                .into(),<br>        )<br>    };<br>    let interval__free = {<br>        let i_am_leader_check_timeout__free = 10u64;<br>        Duration::from_secs(i_am_leader_check_timeout__free)<br>    };<br>    tokio_stream::wrappers::IntervalStream::new(<br>        tokio::time::interval_at(<br>            tokio::time::Instant::now() + delay__free,<br>            interval__free,<br>        ),<br>    )<br>})</code>"]:::otherClass
-54v1["<div style=text-align:center>(54v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    |_, _| {}<br>})</code>"]:::otherClass
-55v1["<div style=text-align:center>(55v1)</div> <code><br>map({<br>    |_u| ()<br>})</code>"]:::otherClass
-56v1["<div style=text-align:center>(56v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-57v1["<div style=text-align:center>(57v1)</div> <code><br>map({<br>    |(d, _signal)| d<br>})</code>"]:::otherClass
-58v1["<div style=text-align:center>(58v1)</div> <code><br>map({<br>    |_u| ()<br>})</code>"]:::otherClass
-59v1["<div style=text-align:center>(59v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-60v1["<div style=text-align:center>(60v1)</div> <code><br>map({<br>    |(d, _signal)| d<br>})</code>"]:::otherClass
-61v1["<div style=text-align:center>(61v1)</div> <code><br>inspect({<br>    |_| println!(&quot;Proposer leader expired, sending P1a&quot;)<br>})</code>"]:::otherClass
-62v1["<div style=text-align:center>(62v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-63v1["<div style=text-align:center>(63v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.raw_id,<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
-64v1["<div style=text-align:center>(64v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-65v1["<div style=text-align:center>(65v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
-66v1["<div style=text-align:center>(66v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Acceptor,<br>        &gt;::from_raw(id),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            (<br>                hydro_test::__staged::cluster::paxos::Ballot,<br>                core::result::Result&lt;<br>                    (<br>                        core::option::Option&lt;usize&gt;,<br>                        std::collections::hash_map::HashMap&lt;<br>                            usize,<br>                            hydro_test::__staged::cluster::paxos::LogValue&lt;<br>                                hydro_test::__staged::cluster::kv_replica::KvPayload&lt;<br>                                    u32,<br>                                    (<br>                                        hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                                            hydro_test::__staged::cluster::paxos_bench::Client,<br>                                        &gt;,<br>                                        u32,<br>                                    ),<br>                                &gt;,<br>                            &gt;,<br>                        &gt;,<br>                    ),<br>                    hydro_test::__staged::cluster::paxos::Ballot,<br>                &gt;,<br>            ),<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
-67v1["<div style=text-align:center>(67v1)</div> <code><br>map({<br>    |(_, v)| v<br>})</code>"]:::otherClass
-68v1["<div style=text-align:center>(68v1)</div> <code><br>inspect({<br>    |p1b| println!(&quot;Proposer received P1b: {:?}&quot;, p1b)<br>})</code>"]:::otherClass
-69v1["<div style=text-align:center>(69v1)</div> <code><br>tee()</code>"]:::otherClass
-70v1["<div style=text-align:center>(70v1)</div> <code><br>chain()</code>"]:::otherClass
-71v1["<div style=text-align:center>(71v1)</div> <code><br>tee()</code>"]:::otherClass
-72v1["<div style=text-align:center>(72v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        move || (0, 0)<br>    },<br>    {<br>        move |accum, value| {<br>            if value.is_ok() {<br>                accum.0 += 1;<br>            } else {<br>                accum.1 += 1;<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
+48v1["<div style=text-align:center>(48v1)</div> <code><br>map({<br>    |_| ()<br>})</code>"]:::otherClass
+49v1["<div style=text-align:center>(49v1)</div> <code><br>map({<br>    |v| Some(v)<br>})</code>"]:::otherClass
+50v1["<div style=text-align:center>(50v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
+51v1["<div style=text-align:center>(51v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
+52v1["<div style=text-align:center>(52v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+53v1["<div style=text-align:center>(53v1)</div> <code><br>filter({<br>    |o| o.is_none()<br>})</code>"]:::otherClass
+54v1["<div style=text-align:center>(54v1)</div> <code><br>map({<br>    |_u| ()<br>})</code>"]:::otherClass
+55v1["<div style=text-align:center>(55v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+56v1["<div style=text-align:center>(56v1)</div> <code><br>map({<br>    |(d, _signal)| d<br>})</code>"]:::otherClass
+57v1["<div style=text-align:center>(57v1)</div> <code><br>source_stream({<br>    let delay__free = {<br>        let CLUSTER_SELF_ID__free = hydro_lang::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Proposer,<br>        &gt;::from_raw(__hydro_lang_cluster_self_id_0);<br>        let i_am_leader_check_timeout_delay_multiplier__free = 15usize;<br>        Duration::from_secs(<br>            (CLUSTER_SELF_ID__free.raw_id<br>                * i_am_leader_check_timeout_delay_multiplier__free as u32)<br>                .into(),<br>        )<br>    };<br>    let interval__free = {<br>        let i_am_leader_check_timeout__free = 10u64;<br>        Duration::from_secs(i_am_leader_check_timeout__free)<br>    };<br>    tokio_stream::wrappers::IntervalStream::new(<br>        tokio::time::interval_at(<br>            tokio::time::Instant::now() + delay__free,<br>            interval__free,<br>        ),<br>    )<br>})</code>"]:::otherClass
+58v1["<div style=text-align:center>(58v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    |_, _| {}<br>})</code>"]:::otherClass
+59v1["<div style=text-align:center>(59v1)</div> <code><br>map({<br>    |_u| ()<br>})</code>"]:::otherClass
+60v1["<div style=text-align:center>(60v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+61v1["<div style=text-align:center>(61v1)</div> <code><br>map({<br>    |(d, _signal)| d<br>})</code>"]:::otherClass
+62v1["<div style=text-align:center>(62v1)</div> <code><br>map({<br>    |_u| ()<br>})</code>"]:::otherClass
+63v1["<div style=text-align:center>(63v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+64v1["<div style=text-align:center>(64v1)</div> <code><br>map({<br>    |(d, _signal)| d<br>})</code>"]:::otherClass
+65v1["<div style=text-align:center>(65v1)</div> <code><br>inspect({<br>    |_| println!(&quot;Proposer leader expired, sending P1a&quot;)<br>})</code>"]:::otherClass
+66v1["<div style=text-align:center>(66v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+67v1["<div style=text-align:center>(67v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.raw_id,<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+68v1["<div style=text-align:center>(68v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+69v1["<div style=text-align:center>(69v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
+70v1["<div style=text-align:center>(70v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Acceptor,<br>        &gt;::from_raw(id),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            (<br>                hydro_test::__staged::cluster::paxos::Ballot,<br>                core::result::Result&lt;<br>                    (<br>                        core::option::Option&lt;usize&gt;,<br>                        std::collections::hash_map::HashMap&lt;<br>                            usize,<br>                            hydro_test::__staged::cluster::paxos::LogValue&lt;<br>                                hydro_test::__staged::cluster::kv_replica::KvPayload&lt;<br>                                    u32,<br>                                    (<br>                                        hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                                            hydro_test::__staged::cluster::paxos_bench::Client,<br>                                        &gt;,<br>                                        u32,<br>                                    ),<br>                                &gt;,<br>                            &gt;,<br>                        &gt;,<br>                    ),<br>                    hydro_test::__staged::cluster::paxos::Ballot,<br>                &gt;,<br>            ),<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
+71v1["<div style=text-align:center>(71v1)</div> <code><br>map({<br>    |(_, v)| v<br>})</code>"]:::otherClass
+72v1["<div style=text-align:center>(72v1)</div> <code><br>inspect({<br>    |p1b| println!(&quot;Proposer received P1b: {:?}&quot;, p1b)<br>})</code>"]:::otherClass
 73v1["<div style=text-align:center>(73v1)</div> <code><br>tee()</code>"]:::otherClass
-74v1["<div style=text-align:center>(74v1)</div> <code><br>filter({<br>    let f__free = {<br>        let min__free = 2usize;<br>        move |(success, _error)| success &gt;= &amp;min__free<br>    };<br>    {<br>        let orig = f__free;<br>        move |(_k, v)| orig(v)<br>    }<br>})</code>"]:::otherClass
-75v1["<div style=text-align:center>(75v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
-76v1["<div style=text-align:center>(76v1)</div> <code><br>filter({<br>    let f__free = {<br>        let max__free = 3usize;<br>        move |(success, error)| (success + error) &gt;= max__free<br>    };<br>    {<br>        let orig = f__free;<br>        move |(_k, v)| orig(v)<br>    }<br>})</code>"]:::otherClass
-77v1["<div style=text-align:center>(77v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
-78v1["<div style=text-align:center>(78v1)</div> <code><br>tee()</code>"]:::otherClass
-79v1["<div style=text-align:center>(79v1)</div> <code><br>difference_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-80v1["<div style=text-align:center>(80v1)</div> <code><br>anti_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-81v1["<div style=text-align:center>(81v1)</div> <code><br>filter({<br>    let f__free = {<br>        let min__free = 2usize;<br>        move |(success, _error)| success &lt; &amp;min__free<br>    };<br>    {<br>        let orig = f__free;<br>        move |(_k, v)| orig(v)<br>    }<br>})</code>"]:::otherClass
-82v1["<div style=text-align:center>(82v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
-83v1["<div style=text-align:center>(83v1)</div> <code><br>anti_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-84v1["<div style=text-align:center>(84v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-85v1["<div style=text-align:center>(85v1)</div> <code><br>anti_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-86v1["<div style=text-align:center>(86v1)</div> <code><br>filter_map({<br>    move |(key, res)| match res {<br>        Ok(v) =&gt; Some((key, v)),<br>        Err(_) =&gt; None,<br>    }<br>})</code>"]:::otherClass
-87v1["<div style=text-align:center>(87v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        || vec![]<br>    },<br>    {<br>        |logs, log| {<br>            logs.push(log);<br>        }<br>    },<br>)</code>"]:::otherClass
-88v1["<div style=text-align:center>(88v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    let key_fn = {<br>        |t| t.0<br>    };<br>    move |curr, new| {<br>        if key_fn(&amp;new) &gt; key_fn(&amp;*curr) {<br>            *curr = new;<br>        }<br>    }<br>})</code>"]:::otherClass
-89v1["<div style=text-align:center>(89v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-90v1["<div style=text-align:center>(90v1)</div> <code><br>filter_map({<br>    move |((quorum_ballot, quorum_accepted), my_ballot)| {<br>        if quorum_ballot == my_ballot { Some(quorum_accepted) } else { None }<br>    }<br>})</code>"]:::otherClass
-91v1["<div style=text-align:center>(91v1)</div> <code><br>tee()</code>"]:::otherClass
-92v1["<div style=text-align:center>(92v1)</div> <code><br>map({<br>    |_| ()<br>})</code>"]:::otherClass
+74v1["<div style=text-align:center>(74v1)</div> <code><br>chain()</code>"]:::otherClass
+75v1["<div style=text-align:center>(75v1)</div> <code><br>tee()</code>"]:::otherClass
+76v1["<div style=text-align:center>(76v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        move || (0, 0)<br>    },<br>    {<br>        move |accum, value| {<br>            if value.is_ok() {<br>                accum.0 += 1;<br>            } else {<br>                accum.1 += 1;<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
+77v1["<div style=text-align:center>(77v1)</div> <code><br>tee()</code>"]:::otherClass
+78v1["<div style=text-align:center>(78v1)</div> <code><br>filter({<br>    let f__free = {<br>        let min__free = 2usize;<br>        move |(success, _error)| success &gt;= &amp;min__free<br>    };<br>    {<br>        let orig = f__free;<br>        move |(_k, v)| orig(v)<br>    }<br>})</code>"]:::otherClass
+79v1["<div style=text-align:center>(79v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
+80v1["<div style=text-align:center>(80v1)</div> <code><br>filter({<br>    let f__free = {<br>        let max__free = 3usize;<br>        move |(success, error)| (success + error) &gt;= max__free<br>    };<br>    {<br>        let orig = f__free;<br>        move |(_k, v)| orig(v)<br>    }<br>})</code>"]:::otherClass
+81v1["<div style=text-align:center>(81v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
+82v1["<div style=text-align:center>(82v1)</div> <code><br>tee()</code>"]:::otherClass
+83v1["<div style=text-align:center>(83v1)</div> <code><br>difference_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+84v1["<div style=text-align:center>(84v1)</div> <code><br>anti_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+85v1["<div style=text-align:center>(85v1)</div> <code><br>filter({<br>    let f__free = {<br>        let min__free = 2usize;<br>        move |(success, _error)| success &lt; &amp;min__free<br>    };<br>    {<br>        let orig = f__free;<br>        move |(_k, v)| orig(v)<br>    }<br>})</code>"]:::otherClass
+86v1["<div style=text-align:center>(86v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
+87v1["<div style=text-align:center>(87v1)</div> <code><br>anti_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+88v1["<div style=text-align:center>(88v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+89v1["<div style=text-align:center>(89v1)</div> <code><br>anti_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+90v1["<div style=text-align:center>(90v1)</div> <code><br>filter_map({<br>    move |(key, res)| match res {<br>        Ok(v) =&gt; Some((key, v)),<br>        Err(_) =&gt; None,<br>    }<br>})</code>"]:::otherClass
+91v1["<div style=text-align:center>(91v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        || vec![]<br>    },<br>    {<br>        |logs, log| {<br>            logs.push(log);<br>        }<br>    },<br>)</code>"]:::otherClass
+92v1["<div style=text-align:center>(92v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    let key_fn = {<br>        |t| t.0<br>    };<br>    move |curr, new| {<br>        if key_fn(&amp;new) &gt; key_fn(&amp;*curr) {<br>            *curr = new;<br>        }<br>    }<br>})</code>"]:::otherClass
 93v1["<div style=text-align:center>(93v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-94v1["<div style=text-align:center>(94v1)</div> <code><br>filter({<br>    |(received_max_ballot, cur_ballot)| *received_max_ballot &lt;= *cur_ballot<br>})</code>"]:::otherClass
-95v1["<div style=text-align:center>(95v1)</div> <code><br>map({<br>    |_| ()<br>})</code>"]:::otherClass
-97v1["<div style=text-align:center>(97v1)</div> <code><br>map({<br>    |_u| ()<br>})</code>"]:::otherClass
-98v1["<div style=text-align:center>(98v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-99v1["<div style=text-align:center>(99v1)</div> <code><br>map({<br>    |(d, _signal)| d<br>})</code>"]:::otherClass
-100v1["<div style=text-align:center>(100v1)</div> <code><br>tee()</code>"]:::otherClass
-101v1["<div style=text-align:center>(101v1)</div> <code><br>filter_map({<br>    move |(key, res)| match res {<br>        Ok(_) =&gt; None,<br>        Err(e) =&gt; Some((key, e)),<br>    }<br>})</code>"]:::otherClass
-102v1["<div style=text-align:center>(102v1)</div> <code><br>map({<br>    |(_, ballot)| ballot<br>})</code>"]:::otherClass
-103v1["<div style=text-align:center>(103v1)</div> <code><br>source_iter({<br>    let underlying_memberids__free = unsafe {<br>        ::std::mem::transmute::&lt;<br>            _,<br>            &amp;[hydro_lang::location::MemberId&lt;<br>                hydro_test::__staged::cluster::paxos_bench::Client,<br>            &gt;],<br>        &gt;(__hydro_lang_cluster_ids_2)<br>    };<br>    underlying_memberids__free<br>})</code>"]:::otherClass
-104v1["<div style=text-align:center>(104v1)</div> <code><br>map({<br>    |id| (*id, MembershipEvent::Joined)<br>})</code>"]:::otherClass
-105v1["<div style=text-align:center>(105v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        || false<br>    },<br>    {<br>        |present, event| {<br>            match event {<br>                MembershipEvent::Joined =&gt; *present = true,<br>                MembershipEvent::Left =&gt; *present = false,<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
-106v1["<div style=text-align:center>(106v1)</div> <code><br>filter_map({<br>    let f__free = {<br>        |v| if v { Some(()) } else { None }<br>    };<br>    {<br>        let orig = f__free;<br>        move |(k, v)| orig(v).map(|v| (k, v))<br>    }<br>})</code>"]:::otherClass
-107v1["<div style=text-align:center>(107v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
-108v1["<div style=text-align:center>(108v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-109v1["<div style=text-align:center>(109v1)</div> <code><br>fold::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        || 0usize<br>    },<br>    {<br>        |count, _| *count += 1<br>    },<br>)</code>"]:::otherClass
-110v1["<div style=text-align:center>(110v1)</div> <code><br>filter({<br>    |c| *c == 0<br>})</code>"]:::otherClass
-111v1["<div style=text-align:center>(111v1)</div> <code><br>map({<br>    |_u| ()<br>})</code>"]:::otherClass
-112v1["<div style=text-align:center>(112v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-113v1["<div style=text-align:center>(113v1)</div> <code><br>map({<br>    |(d, _signal)| d<br>})</code>"]:::otherClass
-115v1["<div style=text-align:center>(115v1)</div> <code><br>map({<br>    |_u| ()<br>})</code>"]:::otherClass
-116v1["<div style=text-align:center>(116v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-117v1["<div style=text-align:center>(117v1)</div> <code><br>map({<br>    |(d, _signal)| d<br>})</code>"]:::otherClass
-118v1["<div style=text-align:center>(118v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-119v1["<div style=text-align:center>(119v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.raw_id,<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
-120v1["<div style=text-align:center>(120v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-121v1["<div style=text-align:center>(121v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
-122v1["<div style=text-align:center>(122v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos_bench::Client,<br>        &gt;::from_raw(id),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            hydro_test::__staged::cluster::kv_replica::KvPayload&lt;<br>                u32,<br>                (<br>                    hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                        hydro_test::__staged::cluster::paxos_bench::Client,<br>                    &gt;,<br>                    u32,<br>                ),<br>            &gt;,<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
-123v1["<div style=text-align:center>(123v1)</div> <code><br>map({<br>    |(_, v)| v<br>})</code>"]:::otherClass
-124v1["<div style=text-align:center>(124v1)</div> <code><br>map({<br>    |_u| ()<br>})</code>"]:::otherClass
-125v1["<div style=text-align:center>(125v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-126v1["<div style=text-align:center>(126v1)</div> <code><br>map({<br>    |(d, _signal)| d<br>})</code>"]:::otherClass
-127v1["<div style=text-align:center>(127v1)</div> <code><br>enumerate::&lt;'tick&gt;()</code>"]:::otherClass
-128v1["<div style=text-align:center>(128v1)</div> <code><br>flat_map({<br>    |v| v<br>})</code>"]:::otherClass
-129v1["<div style=text-align:center>(129v1)</div> <code><br>tee()</code>"]:::otherClass
-130v1["<div style=text-align:center>(130v1)</div> <code><br>map({<br>    |(_checkpoint, log)| log<br>})</code>"]:::otherClass
-131v1["<div style=text-align:center>(131v1)</div> <code><br>flat_map({<br>    |d| d<br>})</code>"]:::otherClass
-132v1["<div style=text-align:center>(132v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        || (0, None)<br>    },<br>    {<br>        |curr_entry, new_entry| {<br>            if let Some(curr_entry_payload) = &amp;mut curr_entry.1 {<br>                let same_values = new_entry.value == curr_entry_payload.value;<br>                let higher_ballot = new_entry.ballot &gt; curr_entry_payload.ballot;<br>                if same_values {<br>                    curr_entry.0 += 1;<br>                }<br>                if higher_ballot {<br>                    curr_entry_payload.ballot = new_entry.ballot;<br>                    if !same_values {<br>                        curr_entry.0 = 1;<br>                        curr_entry_payload.value = new_entry.value;<br>                    }<br>                }<br>            } else {<br>                *curr_entry = (1, Some(new_entry));<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
-133v1["<div style=text-align:center>(133v1)</div> <code><br>map({<br>    let f__free = {<br>        |(count, entry)| (count, entry.unwrap())<br>    };<br>    {<br>        let orig = f__free;<br>        move |(k, v)| (k, orig(v))<br>    }<br>})</code>"]:::otherClass
-134v1["<div style=text-align:center>(134v1)</div> <code><br>tee()</code>"]:::otherClass
-135v1["<div style=text-align:center>(135v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
-136v1["<div style=text-align:center>(136v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    |curr, new| {<br>        if new &gt; *curr {<br>            *curr = new;<br>        }<br>    }<br>})</code>"]:::otherClass
+94v1["<div style=text-align:center>(94v1)</div> <code><br>filter_map({<br>    move |((quorum_ballot, quorum_accepted), my_ballot)| {<br>        if quorum_ballot == my_ballot { Some(quorum_accepted) } else { None }<br>    }<br>})</code>"]:::otherClass
+95v1["<div style=text-align:center>(95v1)</div> <code><br>tee()</code>"]:::otherClass
+96v1["<div style=text-align:center>(96v1)</div> <code><br>map({<br>    |_| ()<br>})</code>"]:::otherClass
+97v1["<div style=text-align:center>(97v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+98v1["<div style=text-align:center>(98v1)</div> <code><br>filter({<br>    |(received_max_ballot, cur_ballot)| *received_max_ballot &lt;= *cur_ballot<br>})</code>"]:::otherClass
+99v1["<div style=text-align:center>(99v1)</div> <code><br>map({<br>    |_| ()<br>})</code>"]:::otherClass
+101v1["<div style=text-align:center>(101v1)</div> <code><br>map({<br>    |_u| ()<br>})</code>"]:::otherClass
+102v1["<div style=text-align:center>(102v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+103v1["<div style=text-align:center>(103v1)</div> <code><br>map({<br>    |(d, _signal)| d<br>})</code>"]:::otherClass
+104v1["<div style=text-align:center>(104v1)</div> <code><br>tee()</code>"]:::otherClass
+105v1["<div style=text-align:center>(105v1)</div> <code><br>filter_map({<br>    move |(key, res)| match res {<br>        Ok(_) =&gt; None,<br>        Err(e) =&gt; Some((key, e)),<br>    }<br>})</code>"]:::otherClass
+106v1["<div style=text-align:center>(106v1)</div> <code><br>map({<br>    |(_, ballot)| ballot<br>})</code>"]:::otherClass
+107v1["<div style=text-align:center>(107v1)</div> <code><br>source_iter({<br>    let underlying_memberids__free = unsafe {<br>        ::std::mem::transmute::&lt;<br>            _,<br>            &amp;[hydro_lang::location::MemberId&lt;<br>                hydro_test::__staged::cluster::paxos_bench::Client,<br>            &gt;],<br>        &gt;(__hydro_lang_cluster_ids_2)<br>    };<br>    underlying_memberids__free<br>})</code>"]:::otherClass
+108v1["<div style=text-align:center>(108v1)</div> <code><br>map({<br>    |id| (*id, MembershipEvent::Joined)<br>})</code>"]:::otherClass
+109v1["<div style=text-align:center>(109v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        || false<br>    },<br>    {<br>        |present, event| {<br>            match event {<br>                MembershipEvent::Joined =&gt; *present = true,<br>                MembershipEvent::Left =&gt; *present = false,<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
+110v1["<div style=text-align:center>(110v1)</div> <code><br>filter_map({<br>    let f__free = {<br>        |v| if v { Some(()) } else { None }<br>    };<br>    {<br>        let orig = f__free;<br>        move |(k, v)| orig(v).map(|v| (k, v))<br>    }<br>})</code>"]:::otherClass
+111v1["<div style=text-align:center>(111v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
+112v1["<div style=text-align:center>(112v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+113v1["<div style=text-align:center>(113v1)</div> <code><br>map({<br>    |_| ()<br>})</code>"]:::otherClass
+114v1["<div style=text-align:center>(114v1)</div> <code><br>map({<br>    |v| Some(v)<br>})</code>"]:::otherClass
+115v1["<div style=text-align:center>(115v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
+116v1["<div style=text-align:center>(116v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
+117v1["<div style=text-align:center>(117v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+118v1["<div style=text-align:center>(118v1)</div> <code><br>filter({<br>    |o| o.is_none()<br>})</code>"]:::otherClass
+119v1["<div style=text-align:center>(119v1)</div> <code><br>map({<br>    |_u| ()<br>})</code>"]:::otherClass
+120v1["<div style=text-align:center>(120v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+121v1["<div style=text-align:center>(121v1)</div> <code><br>map({<br>    |(d, _signal)| d<br>})</code>"]:::otherClass
+123v1["<div style=text-align:center>(123v1)</div> <code><br>map({<br>    |_u| ()<br>})</code>"]:::otherClass
+124v1["<div style=text-align:center>(124v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+125v1["<div style=text-align:center>(125v1)</div> <code><br>map({<br>    |(d, _signal)| d<br>})</code>"]:::otherClass
+126v1["<div style=text-align:center>(126v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+127v1["<div style=text-align:center>(127v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.raw_id,<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+128v1["<div style=text-align:center>(128v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+129v1["<div style=text-align:center>(129v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
+130v1["<div style=text-align:center>(130v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos_bench::Client,<br>        &gt;::from_raw(id),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            hydro_test::__staged::cluster::kv_replica::KvPayload&lt;<br>                u32,<br>                (<br>                    hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                        hydro_test::__staged::cluster::paxos_bench::Client,<br>                    &gt;,<br>                    u32,<br>                ),<br>            &gt;,<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
+131v1["<div style=text-align:center>(131v1)</div> <code><br>map({<br>    |(_, v)| v<br>})</code>"]:::otherClass
+132v1["<div style=text-align:center>(132v1)</div> <code><br>map({<br>    |_u| ()<br>})</code>"]:::otherClass
+133v1["<div style=text-align:center>(133v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+134v1["<div style=text-align:center>(134v1)</div> <code><br>map({<br>    |(d, _signal)| d<br>})</code>"]:::otherClass
+135v1["<div style=text-align:center>(135v1)</div> <code><br>enumerate::&lt;'tick&gt;()</code>"]:::otherClass
+136v1["<div style=text-align:center>(136v1)</div> <code><br>flat_map({<br>    |v| v<br>})</code>"]:::otherClass
 137v1["<div style=text-align:center>(137v1)</div> <code><br>tee()</code>"]:::otherClass
-138v1["<div style=text-align:center>(138v1)</div> <code><br>map({<br>    |max_slot| max_slot + 1<br>})</code>"]:::otherClass
-139v1["<div style=text-align:center>(139v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-140v1["<div style=text-align:center>(140v1)</div> <code><br>source_iter({<br>    let e__free = {<br>        0<br>    };<br>    [e__free]<br>})</code>"]:::otherClass
-141v1["<div style=text-align:center>(141v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
-142v1["<div style=text-align:center>(142v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-143v1["<div style=text-align:center>(143v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-144v1["<div style=text-align:center>(144v1)</div> <code><br>tee()</code>"]:::otherClass
-145v1["<div style=text-align:center>(145v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-146v1["<div style=text-align:center>(146v1)</div> <code><br>map({<br>    |((index, payload), base_slot)| (base_slot + index, payload)<br>})</code>"]:::otherClass
-147v1["<div style=text-align:center>(147v1)</div> <code><br>tee()</code>"]:::otherClass
-148v1["<div style=text-align:center>(148v1)</div> <code><br>fold::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        || 0usize<br>    },<br>    {<br>        |count, _| *count += 1<br>    },<br>)</code>"]:::otherClass
-150v1["<div style=text-align:center>(150v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-151v1["<div style=text-align:center>(151v1)</div> <code><br>map({<br>    |(num_payloads, base_slot)| base_slot + num_payloads<br>})</code>"]:::otherClass
-152v1["<div style=text-align:center>(152v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-153v1["<div style=text-align:center>(153v1)</div> <code><br>source_iter({<br>    let underlying_memberids__free = unsafe {<br>        ::std::mem::transmute::&lt;<br>            _,<br>            &amp;[hydro_lang::location::MemberId&lt;<br>                hydro_test::__staged::cluster::paxos::Acceptor,<br>            &gt;],<br>        &gt;(__hydro_lang_cluster_ids_1)<br>    };<br>    underlying_memberids__free<br>})</code>"]:::otherClass
-154v1["<div style=text-align:center>(154v1)</div> <code><br>map({<br>    |id| (*id, MembershipEvent::Joined)<br>})</code>"]:::otherClass
-155v1["<div style=text-align:center>(155v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        || false<br>    },<br>    {<br>        |present, event| {<br>            match event {<br>                MembershipEvent::Joined =&gt; *present = true,<br>                MembershipEvent::Left =&gt; *present = false,<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
-156v1["<div style=text-align:center>(156v1)</div> <code><br>filter_map({<br>    let f__free = {<br>        |v| if v { Some(()) } else { None }<br>    };<br>    {<br>        let orig = f__free;<br>        move |(k, v)| orig(v).map(|v| (k, v))<br>    }<br>})</code>"]:::otherClass
-157v1["<div style=text-align:center>(157v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
+138v1["<div style=text-align:center>(138v1)</div> <code><br>map({<br>    |(_checkpoint, log)| log<br>})</code>"]:::otherClass
+139v1["<div style=text-align:center>(139v1)</div> <code><br>flat_map({<br>    |d| d<br>})</code>"]:::otherClass
+140v1["<div style=text-align:center>(140v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        || (0, None)<br>    },<br>    {<br>        |curr_entry, new_entry| {<br>            if let Some(curr_entry_payload) = &amp;mut curr_entry.1 {<br>                let same_values = new_entry.value == curr_entry_payload.value;<br>                let higher_ballot = new_entry.ballot &gt; curr_entry_payload.ballot;<br>                if same_values {<br>                    curr_entry.0 += 1;<br>                }<br>                if higher_ballot {<br>                    curr_entry_payload.ballot = new_entry.ballot;<br>                    if !same_values {<br>                        curr_entry.0 = 1;<br>                        curr_entry_payload.value = new_entry.value;<br>                    }<br>                }<br>            } else {<br>                *curr_entry = (1, Some(new_entry));<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
+141v1["<div style=text-align:center>(141v1)</div> <code><br>map({<br>    let f__free = {<br>        |(count, entry)| (count, entry.unwrap())<br>    };<br>    {<br>        let orig = f__free;<br>        move |(k, v)| (k, orig(v))<br>    }<br>})</code>"]:::otherClass
+142v1["<div style=text-align:center>(142v1)</div> <code><br>tee()</code>"]:::otherClass
+143v1["<div style=text-align:center>(143v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
+144v1["<div style=text-align:center>(144v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    |curr, new| {<br>        if new &gt; *curr {<br>            *curr = new;<br>        }<br>    }<br>})</code>"]:::otherClass
+145v1["<div style=text-align:center>(145v1)</div> <code><br>tee()</code>"]:::otherClass
+146v1["<div style=text-align:center>(146v1)</div> <code><br>map({<br>    |max_slot| max_slot + 1<br>})</code>"]:::otherClass
+147v1["<div style=text-align:center>(147v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+148v1["<div style=text-align:center>(148v1)</div> <code><br>source_iter({<br>    let e__free = {<br>        0<br>    };<br>    [e__free]<br>})</code>"]:::otherClass
+149v1["<div style=text-align:center>(149v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
+150v1["<div style=text-align:center>(150v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+151v1["<div style=text-align:center>(151v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+152v1["<div style=text-align:center>(152v1)</div> <code><br>tee()</code>"]:::otherClass
+153v1["<div style=text-align:center>(153v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+154v1["<div style=text-align:center>(154v1)</div> <code><br>map({<br>    |((index, payload), base_slot)| (base_slot + index, payload)<br>})</code>"]:::otherClass
+155v1["<div style=text-align:center>(155v1)</div> <code><br>tee()</code>"]:::otherClass
+156v1["<div style=text-align:center>(156v1)</div> <code><br>fold::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        || 0usize<br>    },<br>    {<br>        |count, _| *count += 1<br>    },<br>)</code>"]:::otherClass
 158v1["<div style=text-align:center>(158v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-159v1["<div style=text-align:center>(159v1)</div> <code><br>map({<br>    |((slot, payload), ballot)| ((slot, ballot), Some(payload))<br>})</code>"]:::otherClass
-160v1["<div style=text-align:center>(160v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-161v1["<div style=text-align:center>(161v1)</div> <code><br>filter_map({<br>    |(checkpoint, _log)| checkpoint<br>})</code>"]:::otherClass
-162v1["<div style=text-align:center>(162v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    |curr, new| {<br>        if new &gt; *curr {<br>            *curr = new;<br>        }<br>    }<br>})</code>"]:::otherClass
-163v1["<div style=text-align:center>(163v1)</div> <code><br>map({<br>    |v| Some(v)<br>})</code>"]:::otherClass
-164v1["<div style=text-align:center>(164v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
-165v1["<div style=text-align:center>(165v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
-166v1["<div style=text-align:center>(166v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-167v1["<div style=text-align:center>(167v1)</div> <code><br>tee()</code>"]:::otherClass
+159v1["<div style=text-align:center>(159v1)</div> <code><br>map({<br>    |(num_payloads, base_slot)| base_slot + num_payloads<br>})</code>"]:::otherClass
+160v1["<div style=text-align:center>(160v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+161v1["<div style=text-align:center>(161v1)</div> <code><br>source_iter({<br>    let underlying_memberids__free = unsafe {<br>        ::std::mem::transmute::&lt;<br>            _,<br>            &amp;[hydro_lang::location::MemberId&lt;<br>                hydro_test::__staged::cluster::paxos::Acceptor,<br>            &gt;],<br>        &gt;(__hydro_lang_cluster_ids_1)<br>    };<br>    underlying_memberids__free<br>})</code>"]:::otherClass
+162v1["<div style=text-align:center>(162v1)</div> <code><br>map({<br>    |id| (*id, MembershipEvent::Joined)<br>})</code>"]:::otherClass
+163v1["<div style=text-align:center>(163v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        || false<br>    },<br>    {<br>        |present, event| {<br>            match event {<br>                MembershipEvent::Joined =&gt; *present = true,<br>                MembershipEvent::Left =&gt; *present = false,<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
+164v1["<div style=text-align:center>(164v1)</div> <code><br>filter_map({<br>    let f__free = {<br>        |v| if v { Some(()) } else { None }<br>    };<br>    {<br>        let orig = f__free;<br>        move |(k, v)| orig(v).map(|v| (k, v))<br>    }<br>})</code>"]:::otherClass
+165v1["<div style=text-align:center>(165v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
+166v1["<div style=text-align:center>(166v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+167v1["<div style=text-align:center>(167v1)</div> <code><br>map({<br>    |((slot, payload), ballot)| ((slot, ballot), Some(payload))<br>})</code>"]:::otherClass
 168v1["<div style=text-align:center>(168v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-169v1["<div style=text-align:center>(169v1)</div> <code><br>filter_map({<br>    let f__free = 1usize;<br>    move |(((slot, (count, entry)), ballot), checkpoint)| {<br>        if count &gt; f__free {<br>            return None;<br>        } else if let Some(checkpoint) = checkpoint &amp;&amp; slot &lt;= checkpoint {<br>            return None;<br>        }<br>        Some(((slot, ballot), entry.value))<br>    }<br>})</code>"]:::otherClass
-170v1["<div style=text-align:center>(170v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-171v1["<div style=text-align:center>(171v1)</div> <code><br>flat_map({<br>    |(max_slot, checkpoint)| {<br>        if let Some(checkpoint) = checkpoint {<br>            (checkpoint + 1)..max_slot<br>        } else {<br>            0..max_slot<br>        }<br>    }<br>})</code>"]:::otherClass
-172v1["<div style=text-align:center>(172v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
-173v1["<div style=text-align:center>(173v1)</div> <code><br>difference_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-174v1["<div style=text-align:center>(174v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-175v1["<div style=text-align:center>(175v1)</div> <code><br>map({<br>    move |(slot, ballot)| ((slot, ballot), None)<br>})</code>"]:::otherClass
-176v1["<div style=text-align:center>(176v1)</div> <code><br>chain()</code>"]:::otherClass
-177v1["<div style=text-align:center>(177v1)</div> <code><br>chain()</code>"]:::otherClass
-178v1["<div style=text-align:center>(178v1)</div> <code><br>map({<br>    |_u| ()<br>})</code>"]:::otherClass
-179v1["<div style=text-align:center>(179v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-180v1["<div style=text-align:center>(180v1)</div> <code><br>map({<br>    |(d, _signal)| d<br>})</code>"]:::otherClass
-181v1["<div style=text-align:center>(181v1)</div> <code><br>tee()</code>"]:::otherClass
-182v1["<div style=text-align:center>(182v1)</div> <code><br>map({<br>    let CLUSTER_SELF_ID__free = hydro_lang::location::MemberId::&lt;<br>        hydro_test::__staged::cluster::paxos::Proposer,<br>    &gt;::from_raw(__hydro_lang_cluster_self_id_0);<br>    move |((slot, ballot), value)| P2a {<br>        sender: CLUSTER_SELF_ID__free,<br>        ballot,<br>        slot,<br>        value,<br>    }<br>})</code>"]:::otherClass
-183v1["<div style=text-align:center>(183v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-184v1["<div style=text-align:center>(184v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.raw_id,<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
-185v1["<div style=text-align:center>(185v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-186v1["<div style=text-align:center>(186v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
-187v1["<div style=text-align:center>(187v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Acceptor,<br>        &gt;::from_raw(id),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            (<br>                (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>                core::result::Result&lt;<br>                    (),<br>                    hydro_test::__staged::cluster::paxos::Ballot,<br>                &gt;,<br>            ),<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
-188v1["<div style=text-align:center>(188v1)</div> <code><br>map({<br>    |(_, v)| v<br>})</code>"]:::otherClass
+169v1["<div style=text-align:center>(169v1)</div> <code><br>filter_map({<br>    |(checkpoint, _log)| checkpoint<br>})</code>"]:::otherClass
+170v1["<div style=text-align:center>(170v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    |curr, new| {<br>        if new &gt; *curr {<br>            *curr = new;<br>        }<br>    }<br>})</code>"]:::otherClass
+171v1["<div style=text-align:center>(171v1)</div> <code><br>map({<br>    |v| Some(v)<br>})</code>"]:::otherClass
+172v1["<div style=text-align:center>(172v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
+173v1["<div style=text-align:center>(173v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
+174v1["<div style=text-align:center>(174v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+175v1["<div style=text-align:center>(175v1)</div> <code><br>tee()</code>"]:::otherClass
+176v1["<div style=text-align:center>(176v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+177v1["<div style=text-align:center>(177v1)</div> <code><br>filter_map({<br>    let f__free = 1usize;<br>    move |(((slot, (count, entry)), ballot), checkpoint)| {<br>        if count &gt; f__free {<br>            return None;<br>        } else if let Some(checkpoint) = checkpoint &amp;&amp; slot &lt;= checkpoint {<br>            return None;<br>        }<br>        Some(((slot, ballot), entry.value))<br>    }<br>})</code>"]:::otherClass
+178v1["<div style=text-align:center>(178v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+179v1["<div style=text-align:center>(179v1)</div> <code><br>flat_map({<br>    |(max_slot, checkpoint)| {<br>        if let Some(checkpoint) = checkpoint {<br>            (checkpoint + 1)..max_slot<br>        } else {<br>            0..max_slot<br>        }<br>    }<br>})</code>"]:::otherClass
+180v1["<div style=text-align:center>(180v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
+181v1["<div style=text-align:center>(181v1)</div> <code><br>difference_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+182v1["<div style=text-align:center>(182v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+183v1["<div style=text-align:center>(183v1)</div> <code><br>map({<br>    move |(slot, ballot)| ((slot, ballot), None)<br>})</code>"]:::otherClass
+184v1["<div style=text-align:center>(184v1)</div> <code><br>chain()</code>"]:::otherClass
+185v1["<div style=text-align:center>(185v1)</div> <code><br>chain()</code>"]:::otherClass
+186v1["<div style=text-align:center>(186v1)</div> <code><br>map({<br>    |_u| ()<br>})</code>"]:::otherClass
+187v1["<div style=text-align:center>(187v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+188v1["<div style=text-align:center>(188v1)</div> <code><br>map({<br>    |(d, _signal)| d<br>})</code>"]:::otherClass
 189v1["<div style=text-align:center>(189v1)</div> <code><br>tee()</code>"]:::otherClass
-190v1["<div style=text-align:center>(190v1)</div> <code><br>chain()</code>"]:::otherClass
-191v1["<div style=text-align:center>(191v1)</div> <code><br>tee()</code>"]:::otherClass
-192v1["<div style=text-align:center>(192v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        move || (0, 0)<br>    },<br>    {<br>        move |accum, value| {<br>            if value.is_ok() {<br>                accum.0 += 1;<br>            } else {<br>                accum.1 += 1;<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
-193v1["<div style=text-align:center>(193v1)</div> <code><br>tee()</code>"]:::otherClass
-194v1["<div style=text-align:center>(194v1)</div> <code><br>filter_map({<br>    let min__free = 2usize;<br>    move |(key, (success, _error))| {<br>        if success &gt;= min__free { Some(key) } else { None }<br>    }<br>})</code>"]:::otherClass
-195v1["<div style=text-align:center>(195v1)</div> <code><br>tee()</code>"]:::otherClass
-196v1["<div style=text-align:center>(196v1)</div> <code><br>filter({<br>    let f__free = {<br>        let max__free = 3usize;<br>        move |(success, error)| (success + error) &gt;= max__free<br>    };<br>    {<br>        let orig = f__free;<br>        move |(_k, v)| orig(v)<br>    }<br>})</code>"]:::otherClass
-197v1["<div style=text-align:center>(197v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
-198v1["<div style=text-align:center>(198v1)</div> <code><br>tee()</code>"]:::otherClass
-199v1["<div style=text-align:center>(199v1)</div> <code><br>difference_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-200v1["<div style=text-align:center>(200v1)</div> <code><br>anti_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-201v1["<div style=text-align:center>(201v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-202v1["<div style=text-align:center>(202v1)</div> <code><br>chain()</code>"]:::otherClass
+190v1["<div style=text-align:center>(190v1)</div> <code><br>map({<br>    let CLUSTER_SELF_ID__free = hydro_lang::location::MemberId::&lt;<br>        hydro_test::__staged::cluster::paxos::Proposer,<br>    &gt;::from_raw(__hydro_lang_cluster_self_id_0);<br>    move |((slot, ballot), value)| P2a {<br>        sender: CLUSTER_SELF_ID__free,<br>        ballot,<br>        slot,<br>        value,<br>    }<br>})</code>"]:::otherClass
+191v1["<div style=text-align:center>(191v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+192v1["<div style=text-align:center>(192v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.raw_id,<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+193v1["<div style=text-align:center>(193v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+194v1["<div style=text-align:center>(194v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
+195v1["<div style=text-align:center>(195v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Acceptor,<br>        &gt;::from_raw(id),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            (<br>                (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>                core::result::Result&lt;<br>                    (),<br>                    hydro_test::__staged::cluster::paxos::Ballot,<br>                &gt;,<br>            ),<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
+196v1["<div style=text-align:center>(196v1)</div> <code><br>map({<br>    |(_, v)| v<br>})</code>"]:::otherClass
+197v1["<div style=text-align:center>(197v1)</div> <code><br>tee()</code>"]:::otherClass
+198v1["<div style=text-align:center>(198v1)</div> <code><br>chain()</code>"]:::otherClass
+199v1["<div style=text-align:center>(199v1)</div> <code><br>tee()</code>"]:::otherClass
+200v1["<div style=text-align:center>(200v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        move || (0, 0)<br>    },<br>    {<br>        move |accum, value| {<br>            if value.is_ok() {<br>                accum.0 += 1;<br>            } else {<br>                accum.1 += 1;<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
+201v1["<div style=text-align:center>(201v1)</div> <code><br>tee()</code>"]:::otherClass
+202v1["<div style=text-align:center>(202v1)</div> <code><br>filter_map({<br>    let min__free = 2usize;<br>    move |(key, (success, _error))| {<br>        if success &gt;= min__free { Some(key) } else { None }<br>    }<br>})</code>"]:::otherClass
 203v1["<div style=text-align:center>(203v1)</div> <code><br>tee()</code>"]:::otherClass
-204v1["<div style=text-align:center>(204v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-205v1["<div style=text-align:center>(205v1)</div> <code><br>difference_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-206v1["<div style=text-align:center>(206v1)</div> <code><br>map({<br>    |k| (k, ())<br>})</code>"]:::otherClass
-207v1["<div style=text-align:center>(207v1)</div> <code><br>tee()</code>"]:::otherClass
-208v1["<div style=text-align:center>(208v1)</div> <code><br>map({<br>    |(key, _)| key<br>})</code>"]:::otherClass
-209v1["<div style=text-align:center>(209v1)</div> <code><br>anti_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-210v1["<div style=text-align:center>(210v1)</div> <code><br>filter_map({<br>    move |(key, res)| match res {<br>        Ok(_) =&gt; None,<br>        Err(e) =&gt; Some((key, e)),<br>    }<br>})</code>"]:::otherClass
-211v1["<div style=text-align:center>(211v1)</div> <code><br>map({<br>    |(_, ballot)| ballot<br>})</code>"]:::otherClass
-212v1["<div style=text-align:center>(212v1)</div> <code><br>source_iter({<br>    let underlying_memberids__free = unsafe {<br>        ::std::mem::transmute::&lt;<br>            _,<br>            &amp;[hydro_lang::location::MemberId&lt;<br>                hydro_test::__staged::cluster::kv_replica::Replica,<br>            &gt;],<br>        &gt;(__hydro_lang_cluster_ids_4)<br>    };<br>    underlying_memberids__free<br>})</code>"]:::otherClass
-213v1["<div style=text-align:center>(213v1)</div> <code><br>map({<br>    |id| (*id, MembershipEvent::Joined)<br>})</code>"]:::otherClass
-214v1["<div style=text-align:center>(214v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        || false<br>    },<br>    {<br>        |present, event| {<br>            match event {<br>                MembershipEvent::Joined =&gt; *present = true,<br>                MembershipEvent::Left =&gt; *present = false,<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
-215v1["<div style=text-align:center>(215v1)</div> <code><br>filter_map({<br>    let f__free = {<br>        |v| if v { Some(()) } else { None }<br>    };<br>    {<br>        let orig = f__free;<br>        move |(k, v)| orig(v).map(|v| (k, v))<br>    }<br>})</code>"]:::otherClass
-216v1["<div style=text-align:center>(216v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
-217v1["<div style=text-align:center>(217v1)</div> <code><br>join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-218v1["<div style=text-align:center>(218v1)</div> <code><br>map({<br>    |(key, (meta, resp))| (key, (meta, resp))<br>})</code>"]:::otherClass
-219v1["<div style=text-align:center>(219v1)</div> <code><br>map({<br>    |((slot, _ballot), (value, _))| (slot, value)<br>})</code>"]:::otherClass
-220v1["<div style=text-align:center>(220v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-221v1["<div style=text-align:center>(221v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.raw_id,<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
-222v1["<div style=text-align:center>(222v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-320v1["<div style=text-align:center>(320v1)</div> <code><br>identity()</code>"]:::otherClass
-322v1["<div style=text-align:center>(322v1)</div> <code><br>identity()</code>"]:::otherClass
-324v1["<div style=text-align:center>(324v1)</div> <code><br>identity()</code>"]:::otherClass
+204v1["<div style=text-align:center>(204v1)</div> <code><br>filter({<br>    let f__free = {<br>        let max__free = 3usize;<br>        move |(success, error)| (success + error) &gt;= max__free<br>    };<br>    {<br>        let orig = f__free;<br>        move |(_k, v)| orig(v)<br>    }<br>})</code>"]:::otherClass
+205v1["<div style=text-align:center>(205v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
+206v1["<div style=text-align:center>(206v1)</div> <code><br>tee()</code>"]:::otherClass
+207v1["<div style=text-align:center>(207v1)</div> <code><br>difference_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+208v1["<div style=text-align:center>(208v1)</div> <code><br>anti_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+209v1["<div style=text-align:center>(209v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+210v1["<div style=text-align:center>(210v1)</div> <code><br>chain()</code>"]:::otherClass
+211v1["<div style=text-align:center>(211v1)</div> <code><br>tee()</code>"]:::otherClass
+212v1["<div style=text-align:center>(212v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+213v1["<div style=text-align:center>(213v1)</div> <code><br>difference_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+214v1["<div style=text-align:center>(214v1)</div> <code><br>map({<br>    |k| (k, ())<br>})</code>"]:::otherClass
+215v1["<div style=text-align:center>(215v1)</div> <code><br>tee()</code>"]:::otherClass
+216v1["<div style=text-align:center>(216v1)</div> <code><br>map({<br>    |(key, _)| key<br>})</code>"]:::otherClass
+217v1["<div style=text-align:center>(217v1)</div> <code><br>anti_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+218v1["<div style=text-align:center>(218v1)</div> <code><br>filter_map({<br>    move |(key, res)| match res {<br>        Ok(_) =&gt; None,<br>        Err(e) =&gt; Some((key, e)),<br>    }<br>})</code>"]:::otherClass
+219v1["<div style=text-align:center>(219v1)</div> <code><br>map({<br>    |(_, ballot)| ballot<br>})</code>"]:::otherClass
+220v1["<div style=text-align:center>(220v1)</div> <code><br>source_iter({<br>    let underlying_memberids__free = unsafe {<br>        ::std::mem::transmute::&lt;<br>            _,<br>            &amp;[hydro_lang::location::MemberId&lt;<br>                hydro_test::__staged::cluster::kv_replica::Replica,<br>            &gt;],<br>        &gt;(__hydro_lang_cluster_ids_4)<br>    };<br>    underlying_memberids__free<br>})</code>"]:::otherClass
+221v1["<div style=text-align:center>(221v1)</div> <code><br>map({<br>    |id| (*id, MembershipEvent::Joined)<br>})</code>"]:::otherClass
+222v1["<div style=text-align:center>(222v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        || false<br>    },<br>    {<br>        |present, event| {<br>            match event {<br>                MembershipEvent::Joined =&gt; *present = true,<br>                MembershipEvent::Left =&gt; *present = false,<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
+223v1["<div style=text-align:center>(223v1)</div> <code><br>filter_map({<br>    let f__free = {<br>        |v| if v { Some(()) } else { None }<br>    };<br>    {<br>        let orig = f__free;<br>        move |(k, v)| orig(v).map(|v| (k, v))<br>    }<br>})</code>"]:::otherClass
+224v1["<div style=text-align:center>(224v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
+225v1["<div style=text-align:center>(225v1)</div> <code><br>join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+226v1["<div style=text-align:center>(226v1)</div> <code><br>map({<br>    |(key, (meta, resp))| (key, (meta, resp))<br>})</code>"]:::otherClass
+227v1["<div style=text-align:center>(227v1)</div> <code><br>map({<br>    |((slot, _ballot), (value, _))| (slot, value)<br>})</code>"]:::otherClass
+228v1["<div style=text-align:center>(228v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+229v1["<div style=text-align:center>(229v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.raw_id,<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+230v1["<div style=text-align:center>(230v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
 326v1["<div style=text-align:center>(326v1)</div> <code><br>identity()</code>"]:::otherClass
 328v1["<div style=text-align:center>(328v1)</div> <code><br>identity()</code>"]:::otherClass
 330v1["<div style=text-align:center>(330v1)</div> <code><br>identity()</code>"]:::otherClass
 332v1["<div style=text-align:center>(332v1)</div> <code><br>identity()</code>"]:::otherClass
 334v1["<div style=text-align:center>(334v1)</div> <code><br>identity()</code>"]:::otherClass
+336v1["<div style=text-align:center>(336v1)</div> <code><br>identity()</code>"]:::otherClass
+338v1["<div style=text-align:center>(338v1)</div> <code><br>identity()</code>"]:::otherClass
+340v1["<div style=text-align:center>(340v1)</div> <code><br>identity()</code>"]:::otherClass
 1v1-->2v1
-102v1--x|0|3v1; linkStyle 1 stroke:red
-211v1-->|1|3v1
+106v1--x|0|3v1; linkStyle 1 stroke:red
+219v1-->|1|3v1
 3v1--x|0|4v1; linkStyle 3 stroke:red
 39v1-->|1|4v1
 4v1--x5v1; linkStyle 5 stroke:red
@@ -245,7 +253,7 @@ linkStyle default stroke:#aaa
 5v1--x|0|8v1; linkStyle 7 stroke:red
 7v1-->|1|8v1
 8v1-->9v1
-16v1-->320v1
+16v1-->326v1
 11v1-->12v1
 10v1--x|0|13v1; linkStyle 12 stroke:red
 12v1-->|1|13v1
@@ -259,7 +267,7 @@ linkStyle default stroke:#aaa
 20v1-->21v1
 14v1-->22v1
 22v1-->23v1
-100v1-->24v1
+104v1-->24v1
 24v1-->25v1
 23v1-->|input|26v1
 25v1--x|single|26v1; linkStyle 27 stroke:red
@@ -276,242 +284,250 @@ linkStyle default stroke:#aaa
 36v1-->37v1
 37v1-->38v1
 38v1-->39v1
-80v1-->322v1
+84v1-->328v1
 41v1-->42v1
 42v1--x43v1; linkStyle 43 stroke:red
 43v1-->44v1
 44v1-->45v1
 39v1--x46v1; linkStyle 46 stroke:red
 46v1-->47v1
-24v1--x48v1; linkStyle 48 stroke:red
+24v1-->48v1
 48v1-->49v1
-49v1-->50v1
-47v1-->|input|51v1
-50v1--x|single|51v1; linkStyle 52 stroke:red
-51v1-->52v1
-53v1--x54v1; linkStyle 54 stroke:red
-54v1-->55v1
-52v1-->|input|56v1
-55v1--x|single|56v1; linkStyle 57 stroke:red
-56v1-->57v1
-57v1-->58v1
-23v1-->|input|59v1
-58v1--x|single|59v1; linkStyle 61 stroke:red
-59v1-->60v1
+50v1-->51v1
+49v1--x|0|52v1; linkStyle 51 stroke:red
+51v1-->|1|52v1
+52v1-->53v1
+53v1-->54v1
+47v1-->|input|55v1
+54v1--x|single|55v1; linkStyle 56 stroke:red
+55v1-->56v1
+57v1--x58v1; linkStyle 58 stroke:red
+58v1-->59v1
+56v1-->|input|60v1
+59v1--x|single|60v1; linkStyle 61 stroke:red
 60v1-->61v1
-45v1-->|0|62v1
-61v1-->|1|62v1
+61v1-->62v1
+23v1-->|input|63v1
+62v1--x|single|63v1; linkStyle 65 stroke:red
 63v1-->64v1
-62v1-->63v1
-65v1-->66v1
-66v1-->67v1
+64v1-->65v1
+45v1-->|0|66v1
+65v1-->|1|66v1
 67v1-->68v1
-68v1-->69v1
-40v1--x|0|70v1; linkStyle 72 stroke:red
-69v1-->|1|70v1
+66v1-->67v1
+69v1-->70v1
 70v1-->71v1
-71v1--x72v1; linkStyle 75 stroke:red
+71v1-->72v1
 72v1-->73v1
-73v1-->74v1
+40v1--x|0|74v1; linkStyle 76 stroke:red
+73v1-->|1|74v1
 74v1-->75v1
-73v1-->76v1
+75v1--x76v1; linkStyle 79 stroke:red
 76v1-->77v1
 77v1-->78v1
-75v1-->|pos|79v1
-78v1--x|neg|79v1; linkStyle 83 stroke:red
-71v1-->|pos|80v1
-78v1--x|neg|80v1; linkStyle 85 stroke:red
-73v1-->81v1
+78v1-->79v1
+77v1-->80v1
+80v1-->81v1
 81v1-->82v1
-71v1-->|pos|83v1
-82v1--x|neg|83v1; linkStyle 89 stroke:red
-79v1-->324v1
-83v1-->|pos|85v1
-84v1--x|neg|85v1; linkStyle 92 stroke:red
+79v1-->|pos|83v1
+82v1--x|neg|83v1; linkStyle 87 stroke:red
+75v1-->|pos|84v1
+82v1--x|neg|84v1; linkStyle 89 stroke:red
+77v1-->85v1
 85v1-->86v1
-86v1--x87v1; linkStyle 94 stroke:red
-87v1--x88v1; linkStyle 95 stroke:red
-88v1-->|input|89v1
-23v1--x|single|89v1; linkStyle 97 stroke:red
+75v1-->|pos|87v1
+86v1--x|neg|87v1; linkStyle 93 stroke:red
+83v1-->330v1
+87v1-->|pos|89v1
+88v1--x|neg|89v1; linkStyle 96 stroke:red
 89v1-->90v1
-90v1-->91v1
-91v1-->92v1
-9v1-->|input|93v1
-23v1--x|single|93v1; linkStyle 102 stroke:red
+90v1--x91v1; linkStyle 98 stroke:red
+91v1--x92v1; linkStyle 99 stroke:red
+92v1-->|input|93v1
+23v1--x|single|93v1; linkStyle 101 stroke:red
 93v1-->94v1
 94v1-->95v1
-95v1-->97v1
-92v1-->|input|98v1
-97v1--x|single|98v1; linkStyle 107 stroke:red
+95v1-->96v1
+9v1-->|input|97v1
+23v1--x|single|97v1; linkStyle 106 stroke:red
+97v1-->98v1
 98v1-->99v1
-99v1-->100v1
-69v1-->101v1
-101v1-->102v1
+99v1-->101v1
+96v1-->|input|102v1
+101v1--x|single|102v1; linkStyle 111 stroke:red
+102v1-->103v1
 103v1-->104v1
-104v1--x105v1; linkStyle 113 stroke:red
+73v1-->105v1
 105v1-->106v1
-106v1-->107v1
-100v1-->326v1
+107v1-->108v1
 108v1--x109v1; linkStyle 117 stroke:red
 109v1-->110v1
 110v1-->111v1
-100v1-->|input|112v1
-111v1--x|single|112v1; linkStyle 121 stroke:red
+104v1-->332v1
 112v1-->113v1
-113v1-->115v1
-23v1-->|input|116v1
-115v1--x|single|116v1; linkStyle 125 stroke:red
-116v1-->117v1
-107v1-->|0|118v1
-117v1-->|1|118v1
-119v1-->120v1
+113v1-->114v1
+115v1-->116v1
+114v1--x|0|117v1; linkStyle 124 stroke:red
+116v1-->|1|117v1
+117v1-->118v1
 118v1-->119v1
-121v1-->122v1
-122v1-->123v1
-100v1-->124v1
-123v1-->|input|125v1
-124v1--x|single|125v1; linkStyle 135 stroke:red
-125v1-->126v1
+104v1-->|input|120v1
+119v1--x|single|120v1; linkStyle 129 stroke:red
+120v1-->121v1
+121v1-->123v1
+23v1-->|input|124v1
+123v1--x|single|124v1; linkStyle 133 stroke:red
+124v1-->125v1
+111v1-->|0|126v1
+125v1-->|1|126v1
+127v1-->128v1
 126v1-->127v1
-91v1-->128v1
-128v1-->129v1
 129v1-->130v1
 130v1-->131v1
-131v1--x132v1; linkStyle 142 stroke:red
-132v1-->133v1
+104v1-->132v1
+131v1-->|input|133v1
+132v1--x|single|133v1; linkStyle 143 stroke:red
 133v1-->134v1
 134v1-->135v1
-135v1--x136v1; linkStyle 146 stroke:red
+95v1-->136v1
 136v1-->137v1
 137v1-->138v1
-151v1-->328v1
+138v1-->139v1
+139v1--x140v1; linkStyle 150 stroke:red
 140v1-->141v1
-139v1--x|0|142v1; linkStyle 151 stroke:red
-141v1-->|1|142v1
-138v1--x|0|143v1; linkStyle 153 stroke:red
-142v1-->|1|143v1
-143v1-->144v1
-127v1-->|input|145v1
-144v1--x|single|145v1; linkStyle 157 stroke:red
+141v1-->142v1
+142v1-->143v1
+143v1--x144v1; linkStyle 154 stroke:red
+144v1-->145v1
 145v1-->146v1
-146v1-->147v1
-147v1--x148v1; linkStyle 160 stroke:red
-148v1-->|input|150v1
-144v1--x|single|150v1; linkStyle 162 stroke:red
-150v1-->151v1
-200v1-->330v1
+159v1-->334v1
+148v1-->149v1
+147v1--x|0|150v1; linkStyle 159 stroke:red
+149v1-->|1|150v1
+146v1--x|0|151v1; linkStyle 161 stroke:red
+150v1-->|1|151v1
+151v1-->152v1
+135v1-->|input|153v1
+152v1--x|single|153v1; linkStyle 165 stroke:red
 153v1-->154v1
-154v1--x155v1; linkStyle 166 stroke:red
-155v1-->156v1
-156v1-->157v1
-147v1-->|input|158v1
-23v1--x|single|158v1; linkStyle 170 stroke:red
+154v1-->155v1
+155v1--x156v1; linkStyle 168 stroke:red
+156v1-->|input|158v1
+152v1--x|single|158v1; linkStyle 170 stroke:red
 158v1-->159v1
-134v1-->|input|160v1
-23v1--x|single|160v1; linkStyle 173 stroke:red
-129v1-->161v1
-161v1--x162v1; linkStyle 175 stroke:red
-162v1-->163v1
+208v1-->336v1
+161v1-->162v1
+162v1--x163v1; linkStyle 174 stroke:red
+163v1-->164v1
 164v1-->165v1
-163v1--x|0|166v1; linkStyle 178 stroke:red
-165v1-->|1|166v1
+155v1-->|input|166v1
+23v1--x|single|166v1; linkStyle 178 stroke:red
 166v1-->167v1
-160v1-->|input|168v1
-167v1--x|single|168v1; linkStyle 182 stroke:red
-168v1-->169v1
-137v1-->|input|170v1
-167v1--x|single|170v1; linkStyle 185 stroke:red
+142v1-->|input|168v1
+23v1--x|single|168v1; linkStyle 181 stroke:red
+137v1-->169v1
+169v1--x170v1; linkStyle 183 stroke:red
 170v1-->171v1
-134v1-->172v1
-171v1-->|pos|173v1
-172v1--x|neg|173v1; linkStyle 189 stroke:red
-173v1-->|input|174v1
-23v1--x|single|174v1; linkStyle 191 stroke:red
+172v1-->173v1
+171v1--x|0|174v1; linkStyle 186 stroke:red
+173v1-->|1|174v1
 174v1-->175v1
-169v1--x|0|176v1; linkStyle 193 stroke:red
-175v1-->|1|176v1
-159v1--x|0|177v1; linkStyle 195 stroke:red
-176v1-->|1|177v1
-100v1-->178v1
-177v1-->|input|179v1
-178v1--x|single|179v1; linkStyle 199 stroke:red
-179v1-->180v1
-180v1-->181v1
-181v1-->182v1
-157v1-->|0|183v1
-182v1-->|1|183v1
-184v1-->185v1
-183v1-->184v1
-186v1-->187v1
+168v1-->|input|176v1
+175v1--x|single|176v1; linkStyle 190 stroke:red
+176v1-->177v1
+145v1-->|input|178v1
+175v1--x|single|178v1; linkStyle 193 stroke:red
+178v1-->179v1
+142v1-->180v1
+179v1-->|pos|181v1
+180v1--x|neg|181v1; linkStyle 197 stroke:red
+181v1-->|input|182v1
+23v1--x|single|182v1; linkStyle 199 stroke:red
+182v1-->183v1
+177v1--x|0|184v1; linkStyle 201 stroke:red
+183v1-->|1|184v1
+167v1--x|0|185v1; linkStyle 203 stroke:red
+184v1-->|1|185v1
+104v1-->186v1
+185v1-->|input|187v1
+186v1--x|single|187v1; linkStyle 207 stroke:red
 187v1-->188v1
 188v1-->189v1
-152v1--x|0|190v1; linkStyle 210 stroke:red
-189v1-->|1|190v1
-190v1-->191v1
-191v1--x192v1; linkStyle 213 stroke:red
+189v1-->190v1
+165v1-->|0|191v1
+190v1-->|1|191v1
 192v1-->193v1
-193v1-->194v1
+191v1-->192v1
 194v1-->195v1
-193v1-->196v1
+195v1-->196v1
 196v1-->197v1
-197v1-->198v1
-195v1-->|pos|199v1
-198v1--x|neg|199v1; linkStyle 221 stroke:red
-191v1-->|pos|200v1
-198v1--x|neg|200v1; linkStyle 223 stroke:red
-209v1-->332v1
-201v1--x|0|202v1; linkStyle 225 stroke:red
-181v1-->|1|202v1
+160v1--x|0|198v1; linkStyle 218 stroke:red
+197v1-->|1|198v1
+198v1-->199v1
+199v1--x200v1; linkStyle 221 stroke:red
+200v1-->201v1
+201v1-->202v1
 202v1-->203v1
-199v1-->334v1
-195v1-->|pos|205v1
-204v1--x|neg|205v1; linkStyle 230 stroke:red
+201v1-->204v1
+204v1-->205v1
 205v1-->206v1
-206v1-->207v1
-207v1-->208v1
-203v1-->|pos|209v1
-208v1--x|neg|209v1; linkStyle 235 stroke:red
-189v1-->210v1
+203v1-->|pos|207v1
+206v1--x|neg|207v1; linkStyle 229 stroke:red
+199v1-->|pos|208v1
+206v1--x|neg|208v1; linkStyle 231 stroke:red
+217v1-->338v1
+209v1--x|0|210v1; linkStyle 233 stroke:red
+189v1-->|1|210v1
 210v1-->211v1
-212v1-->213v1
-213v1--x214v1; linkStyle 239 stroke:red
+207v1-->340v1
+203v1-->|pos|213v1
+212v1--x|neg|213v1; linkStyle 238 stroke:red
+213v1-->214v1
 214v1-->215v1
 215v1-->216v1
-203v1-->|0|217v1
-207v1-->|1|217v1
-217v1-->218v1
+211v1-->|pos|217v1
+216v1--x|neg|217v1; linkStyle 243 stroke:red
+197v1-->218v1
 218v1-->219v1
-216v1-->|0|220v1
-219v1-->|1|220v1
-221v1-->222v1
 220v1-->221v1
-320v1--o10v1; linkStyle 250 stroke:red
-322v1--o40v1; linkStyle 251 stroke:red
-324v1--o84v1; linkStyle 252 stroke:red
-326v1--o108v1; linkStyle 253 stroke:red
-328v1--o139v1; linkStyle 254 stroke:red
-330v1--o152v1; linkStyle 255 stroke:red
-332v1--o201v1; linkStyle 256 stroke:red
-334v1--o204v1; linkStyle 257 stroke:red
+221v1--x222v1; linkStyle 247 stroke:red
+222v1-->223v1
+223v1-->224v1
+211v1-->|0|225v1
+215v1-->|1|225v1
+225v1-->226v1
+226v1-->227v1
+224v1-->|0|228v1
+227v1-->|1|228v1
+229v1-->230v1
+228v1-->229v1
+326v1--o10v1; linkStyle 258 stroke:red
+328v1--o40v1; linkStyle 259 stroke:red
+330v1--o88v1; linkStyle 260 stroke:red
+332v1--o112v1; linkStyle 261 stroke:red
+334v1--o147v1; linkStyle 262 stroke:red
+336v1--o160v1; linkStyle 263 stroke:red
+338v1--o209v1; linkStyle 264 stroke:red
+340v1--o212v1; linkStyle 265 stroke:red
 2v1
 34v1
 35v1
-63v1
-64v1
-119v1
-120v1
-184v1
-185v1
-221v1
-222v1
-320v1
-322v1
-324v1
+67v1
+68v1
+127v1
+128v1
+192v1
+193v1
+229v1
+230v1
 326v1
 328v1
 330v1
 332v1
 334v1
+336v1
+338v1
+340v1
 subgraph var_stream_0 ["var <tt>stream_0</tt>"]
     style var_stream_0 fill:transparent
     1v1
@@ -520,25 +536,29 @@ subgraph var_stream_10 ["var <tt>stream_10</tt>"]
     style var_stream_10 fill:transparent
     6v1
 end
-subgraph var_stream_102 ["var <tt>stream_102</tt>"]
-    style var_stream_102 fill:transparent
+subgraph var_stream_100 ["var <tt>stream_100</tt>"]
+    style var_stream_100 fill:transparent
     80v1
 end
-subgraph var_stream_105 ["var <tt>stream_105</tt>"]
-    style var_stream_105 fill:transparent
+subgraph var_stream_101 ["var <tt>stream_101</tt>"]
+    style var_stream_101 fill:transparent
     81v1
+end
+subgraph var_stream_102 ["var <tt>stream_102</tt>"]
+    style var_stream_102 fill:transparent
+    82v1
+end
+subgraph var_stream_103 ["var <tt>stream_103</tt>"]
+    style var_stream_103 fill:transparent
+    83v1
 end
 subgraph var_stream_106 ["var <tt>stream_106</tt>"]
     style var_stream_106 fill:transparent
-    82v1
-end
-subgraph var_stream_107 ["var <tt>stream_107</tt>"]
-    style var_stream_107 fill:transparent
-    83v1
+    84v1
 end
 subgraph var_stream_109 ["var <tt>stream_109</tt>"]
     style var_stream_109 fill:transparent
-    84v1
+    85v1
 end
 subgraph var_stream_11 ["var <tt>stream_11</tt>"]
     style var_stream_11 fill:transparent
@@ -546,51 +566,51 @@ subgraph var_stream_11 ["var <tt>stream_11</tt>"]
 end
 subgraph var_stream_110 ["var <tt>stream_110</tt>"]
     style var_stream_110 fill:transparent
-    85v1
+    86v1
 end
 subgraph var_stream_111 ["var <tt>stream_111</tt>"]
     style var_stream_111 fill:transparent
-    86v1
-end
-subgraph var_stream_112 ["var <tt>stream_112</tt>"]
-    style var_stream_112 fill:transparent
     87v1
 end
 subgraph var_stream_113 ["var <tt>stream_113</tt>"]
     style var_stream_113 fill:transparent
     88v1
 end
+subgraph var_stream_114 ["var <tt>stream_114</tt>"]
+    style var_stream_114 fill:transparent
+    89v1
+end
 subgraph var_stream_115 ["var <tt>stream_115</tt>"]
     style var_stream_115 fill:transparent
-    89v1
+    90v1
 end
 subgraph var_stream_116 ["var <tt>stream_116</tt>"]
     style var_stream_116 fill:transparent
-    90v1
+    91v1
 end
 subgraph var_stream_117 ["var <tt>stream_117</tt>"]
     style var_stream_117 fill:transparent
-    91v1
-end
-subgraph var_stream_118 ["var <tt>stream_118</tt>"]
-    style var_stream_118 fill:transparent
     92v1
+end
+subgraph var_stream_119 ["var <tt>stream_119</tt>"]
+    style var_stream_119 fill:transparent
+    93v1
 end
 subgraph var_stream_12 ["var <tt>stream_12</tt>"]
     style var_stream_12 fill:transparent
     8v1
 end
+subgraph var_stream_120 ["var <tt>stream_120</tt>"]
+    style var_stream_120 fill:transparent
+    94v1
+end
 subgraph var_stream_121 ["var <tt>stream_121</tt>"]
     style var_stream_121 fill:transparent
-    93v1
+    95v1
 end
 subgraph var_stream_122 ["var <tt>stream_122</tt>"]
     style var_stream_122 fill:transparent
-    94v1
-end
-subgraph var_stream_123 ["var <tt>stream_123</tt>"]
-    style var_stream_123 fill:transparent
-    95v1
+    96v1
 end
 subgraph var_stream_125 ["var <tt>stream_125</tt>"]
     style var_stream_125 fill:transparent
@@ -604,9 +624,9 @@ subgraph var_stream_127 ["var <tt>stream_127</tt>"]
     style var_stream_127 fill:transparent
     99v1
 end
-subgraph var_stream_128 ["var <tt>stream_128</tt>"]
-    style var_stream_128 fill:transparent
-    100v1
+subgraph var_stream_129 ["var <tt>stream_129</tt>"]
+    style var_stream_129 fill:transparent
+    101v1
 end
 subgraph var_stream_13 ["var <tt>stream_13</tt>"]
     style var_stream_13 fill:transparent
@@ -614,46 +634,42 @@ subgraph var_stream_13 ["var <tt>stream_13</tt>"]
 end
 subgraph var_stream_130 ["var <tt>stream_130</tt>"]
     style var_stream_130 fill:transparent
-    101v1
+    102v1
 end
 subgraph var_stream_131 ["var <tt>stream_131</tt>"]
     style var_stream_131 fill:transparent
-    102v1
-end
-subgraph var_stream_138 ["var <tt>stream_138</tt>"]
-    style var_stream_138 fill:transparent
     103v1
 end
-subgraph var_stream_139 ["var <tt>stream_139</tt>"]
-    style var_stream_139 fill:transparent
+subgraph var_stream_132 ["var <tt>stream_132</tt>"]
+    style var_stream_132 fill:transparent
     104v1
 end
-subgraph var_stream_140 ["var <tt>stream_140</tt>"]
-    style var_stream_140 fill:transparent
+subgraph var_stream_134 ["var <tt>stream_134</tt>"]
+    style var_stream_134 fill:transparent
     105v1
 end
-subgraph var_stream_141 ["var <tt>stream_141</tt>"]
-    style var_stream_141 fill:transparent
+subgraph var_stream_135 ["var <tt>stream_135</tt>"]
+    style var_stream_135 fill:transparent
     106v1
 end
 subgraph var_stream_142 ["var <tt>stream_142</tt>"]
     style var_stream_142 fill:transparent
     107v1
 end
-subgraph var_stream_146 ["var <tt>stream_146</tt>"]
-    style var_stream_146 fill:transparent
+subgraph var_stream_143 ["var <tt>stream_143</tt>"]
+    style var_stream_143 fill:transparent
     108v1
 end
-subgraph var_stream_147 ["var <tt>stream_147</tt>"]
-    style var_stream_147 fill:transparent
+subgraph var_stream_144 ["var <tt>stream_144</tt>"]
+    style var_stream_144 fill:transparent
     109v1
 end
-subgraph var_stream_148 ["var <tt>stream_148</tt>"]
-    style var_stream_148 fill:transparent
+subgraph var_stream_145 ["var <tt>stream_145</tt>"]
+    style var_stream_145 fill:transparent
     110v1
 end
-subgraph var_stream_149 ["var <tt>stream_149</tt>"]
-    style var_stream_149 fill:transparent
+subgraph var_stream_146 ["var <tt>stream_146</tt>"]
+    style var_stream_146 fill:transparent
     111v1
 end
 subgraph var_stream_15 ["var <tt>stream_15</tt>"]
@@ -667,6 +683,10 @@ end
 subgraph var_stream_151 ["var <tt>stream_151</tt>"]
     style var_stream_151 fill:transparent
     113v1
+end
+subgraph var_stream_152 ["var <tt>stream_152</tt>"]
+    style var_stream_152 fill:transparent
+    114v1
 end
 subgraph var_stream_153 ["var <tt>stream_153</tt>"]
     style var_stream_153 fill:transparent
@@ -684,82 +704,66 @@ subgraph var_stream_156 ["var <tt>stream_156</tt>"]
     style var_stream_156 fill:transparent
     118v1
 end
+subgraph var_stream_157 ["var <tt>stream_157</tt>"]
+    style var_stream_157 fill:transparent
+    119v1
+end
+subgraph var_stream_158 ["var <tt>stream_158</tt>"]
+    style var_stream_158 fill:transparent
+    120v1
+end
+subgraph var_stream_159 ["var <tt>stream_159</tt>"]
+    style var_stream_159 fill:transparent
+    121v1
+end
 subgraph var_stream_16 ["var <tt>stream_16</tt>"]
     style var_stream_16 fill:transparent
     11v1
+end
+subgraph var_stream_161 ["var <tt>stream_161</tt>"]
+    style var_stream_161 fill:transparent
+    123v1
+end
+subgraph var_stream_162 ["var <tt>stream_162</tt>"]
+    style var_stream_162 fill:transparent
+    124v1
+end
+subgraph var_stream_163 ["var <tt>stream_163</tt>"]
+    style var_stream_163 fill:transparent
+    125v1
+end
+subgraph var_stream_164 ["var <tt>stream_164</tt>"]
+    style var_stream_164 fill:transparent
+    126v1
 end
 subgraph var_stream_17 ["var <tt>stream_17</tt>"]
     style var_stream_17 fill:transparent
     12v1
 end
-subgraph var_stream_172 ["var <tt>stream_172</tt>"]
-    style var_stream_172 fill:transparent
-    122v1
-    121v1
-end
-subgraph var_stream_173 ["var <tt>stream_173</tt>"]
-    style var_stream_173 fill:transparent
-    123v1
-end
-subgraph var_stream_175 ["var <tt>stream_175</tt>"]
-    style var_stream_175 fill:transparent
-    124v1
-end
-subgraph var_stream_176 ["var <tt>stream_176</tt>"]
-    style var_stream_176 fill:transparent
-    125v1
-end
-subgraph var_stream_177 ["var <tt>stream_177</tt>"]
-    style var_stream_177 fill:transparent
-    126v1
-end
-subgraph var_stream_178 ["var <tt>stream_178</tt>"]
-    style var_stream_178 fill:transparent
-    127v1
-end
 subgraph var_stream_18 ["var <tt>stream_18</tt>"]
     style var_stream_18 fill:transparent
     13v1
 end
-subgraph var_stream_180 ["var <tt>stream_180</tt>"]
-    style var_stream_180 fill:transparent
-    128v1
-end
-subgraph var_stream_181 ["var <tt>stream_181</tt>"]
-    style var_stream_181 fill:transparent
-    129v1
-end
-subgraph var_stream_182 ["var <tt>stream_182</tt>"]
-    style var_stream_182 fill:transparent
-    130v1
-end
-subgraph var_stream_183 ["var <tt>stream_183</tt>"]
-    style var_stream_183 fill:transparent
-    131v1
-end
 subgraph var_stream_184 ["var <tt>stream_184</tt>"]
     style var_stream_184 fill:transparent
-    132v1
+    130v1
+    129v1
 end
 subgraph var_stream_185 ["var <tt>stream_185</tt>"]
     style var_stream_185 fill:transparent
-    133v1
-end
-subgraph var_stream_186 ["var <tt>stream_186</tt>"]
-    style var_stream_186 fill:transparent
-    134v1
+    131v1
 end
 subgraph var_stream_187 ["var <tt>stream_187</tt>"]
     style var_stream_187 fill:transparent
-    135v1
+    132v1
 end
 subgraph var_stream_188 ["var <tt>stream_188</tt>"]
     style var_stream_188 fill:transparent
-    136v1
+    133v1
 end
 subgraph var_stream_189 ["var <tt>stream_189</tt>"]
     style var_stream_189 fill:transparent
-    137v1
+    134v1
 end
 subgraph var_stream_19 ["var <tt>stream_19</tt>"]
     style var_stream_19 fill:transparent
@@ -767,39 +771,39 @@ subgraph var_stream_19 ["var <tt>stream_19</tt>"]
 end
 subgraph var_stream_190 ["var <tt>stream_190</tt>"]
     style var_stream_190 fill:transparent
-    138v1
+    135v1
 end
 subgraph var_stream_192 ["var <tt>stream_192</tt>"]
     style var_stream_192 fill:transparent
-    139v1
+    136v1
 end
 subgraph var_stream_193 ["var <tt>stream_193</tt>"]
     style var_stream_193 fill:transparent
-    140v1
+    137v1
 end
 subgraph var_stream_194 ["var <tt>stream_194</tt>"]
     style var_stream_194 fill:transparent
-    141v1
+    138v1
 end
 subgraph var_stream_195 ["var <tt>stream_195</tt>"]
     style var_stream_195 fill:transparent
-    142v1
+    139v1
 end
 subgraph var_stream_196 ["var <tt>stream_196</tt>"]
     style var_stream_196 fill:transparent
-    143v1
+    140v1
 end
 subgraph var_stream_197 ["var <tt>stream_197</tt>"]
     style var_stream_197 fill:transparent
-    144v1
+    141v1
 end
 subgraph var_stream_198 ["var <tt>stream_198</tt>"]
     style var_stream_198 fill:transparent
-    145v1
+    142v1
 end
 subgraph var_stream_199 ["var <tt>stream_199</tt>"]
     style var_stream_199 fill:transparent
-    146v1
+    143v1
 end
 subgraph var_stream_20 ["var <tt>stream_20</tt>"]
     style var_stream_20 fill:transparent
@@ -807,31 +811,39 @@ subgraph var_stream_20 ["var <tt>stream_20</tt>"]
 end
 subgraph var_stream_200 ["var <tt>stream_200</tt>"]
     style var_stream_200 fill:transparent
-    147v1
+    144v1
 end
 subgraph var_stream_201 ["var <tt>stream_201</tt>"]
     style var_stream_201 fill:transparent
-    148v1
+    145v1
+end
+subgraph var_stream_202 ["var <tt>stream_202</tt>"]
+    style var_stream_202 fill:transparent
+    146v1
 end
 subgraph var_stream_204 ["var <tt>stream_204</tt>"]
     style var_stream_204 fill:transparent
-    150v1
+    147v1
 end
 subgraph var_stream_205 ["var <tt>stream_205</tt>"]
     style var_stream_205 fill:transparent
-    151v1
+    148v1
+end
+subgraph var_stream_206 ["var <tt>stream_206</tt>"]
+    style var_stream_206 fill:transparent
+    149v1
 end
 subgraph var_stream_207 ["var <tt>stream_207</tt>"]
     style var_stream_207 fill:transparent
-    152v1
+    150v1
 end
 subgraph var_stream_208 ["var <tt>stream_208</tt>"]
     style var_stream_208 fill:transparent
-    153v1
+    151v1
 end
 subgraph var_stream_209 ["var <tt>stream_209</tt>"]
     style var_stream_209 fill:transparent
-    154v1
+    152v1
 end
 subgraph var_stream_21 ["var <tt>stream_21</tt>"]
     style var_stream_21 fill:transparent
@@ -839,22 +851,26 @@ subgraph var_stream_21 ["var <tt>stream_21</tt>"]
 end
 subgraph var_stream_210 ["var <tt>stream_210</tt>"]
     style var_stream_210 fill:transparent
-    155v1
+    153v1
 end
 subgraph var_stream_211 ["var <tt>stream_211</tt>"]
     style var_stream_211 fill:transparent
-    156v1
+    154v1
 end
 subgraph var_stream_212 ["var <tt>stream_212</tt>"]
     style var_stream_212 fill:transparent
-    157v1
+    155v1
 end
-subgraph var_stream_215 ["var <tt>stream_215</tt>"]
-    style var_stream_215 fill:transparent
-    158v1
+subgraph var_stream_213 ["var <tt>stream_213</tt>"]
+    style var_stream_213 fill:transparent
+    156v1
 end
 subgraph var_stream_216 ["var <tt>stream_216</tt>"]
     style var_stream_216 fill:transparent
+    158v1
+end
+subgraph var_stream_217 ["var <tt>stream_217</tt>"]
+    style var_stream_217 fill:transparent
     159v1
 end
 subgraph var_stream_219 ["var <tt>stream_219</tt>"]
@@ -865,60 +881,60 @@ subgraph var_stream_22 ["var <tt>stream_22</tt>"]
     style var_stream_22 fill:transparent
     17v1
 end
+subgraph var_stream_220 ["var <tt>stream_220</tt>"]
+    style var_stream_220 fill:transparent
+    161v1
+end
 subgraph var_stream_221 ["var <tt>stream_221</tt>"]
     style var_stream_221 fill:transparent
-    161v1
+    162v1
 end
 subgraph var_stream_222 ["var <tt>stream_222</tt>"]
     style var_stream_222 fill:transparent
-    162v1
+    163v1
 end
 subgraph var_stream_223 ["var <tt>stream_223</tt>"]
     style var_stream_223 fill:transparent
-    163v1
+    164v1
 end
 subgraph var_stream_224 ["var <tt>stream_224</tt>"]
     style var_stream_224 fill:transparent
-    164v1
-end
-subgraph var_stream_225 ["var <tt>stream_225</tt>"]
-    style var_stream_225 fill:transparent
     165v1
-end
-subgraph var_stream_226 ["var <tt>stream_226</tt>"]
-    style var_stream_226 fill:transparent
-    166v1
 end
 subgraph var_stream_227 ["var <tt>stream_227</tt>"]
     style var_stream_227 fill:transparent
-    167v1
+    166v1
 end
 subgraph var_stream_228 ["var <tt>stream_228</tt>"]
     style var_stream_228 fill:transparent
-    168v1
-end
-subgraph var_stream_229 ["var <tt>stream_229</tt>"]
-    style var_stream_229 fill:transparent
-    169v1
+    167v1
 end
 subgraph var_stream_23 ["var <tt>stream_23</tt>"]
     style var_stream_23 fill:transparent
     18v1
 end
-subgraph var_stream_232 ["var <tt>stream_232</tt>"]
-    style var_stream_232 fill:transparent
-    170v1
+subgraph var_stream_231 ["var <tt>stream_231</tt>"]
+    style var_stream_231 fill:transparent
+    168v1
 end
 subgraph var_stream_233 ["var <tt>stream_233</tt>"]
     style var_stream_233 fill:transparent
-    171v1
+    169v1
+end
+subgraph var_stream_234 ["var <tt>stream_234</tt>"]
+    style var_stream_234 fill:transparent
+    170v1
 end
 subgraph var_stream_235 ["var <tt>stream_235</tt>"]
     style var_stream_235 fill:transparent
-    172v1
+    171v1
 end
 subgraph var_stream_236 ["var <tt>stream_236</tt>"]
     style var_stream_236 fill:transparent
+    172v1
+end
+subgraph var_stream_237 ["var <tt>stream_237</tt>"]
+    style var_stream_237 fill:transparent
     173v1
 end
 subgraph var_stream_238 ["var <tt>stream_238</tt>"]
@@ -941,54 +957,61 @@ subgraph var_stream_241 ["var <tt>stream_241</tt>"]
     style var_stream_241 fill:transparent
     177v1
 end
-subgraph var_stream_243 ["var <tt>stream_243</tt>"]
-    style var_stream_243 fill:transparent
-    178v1
-end
 subgraph var_stream_244 ["var <tt>stream_244</tt>"]
     style var_stream_244 fill:transparent
-    179v1
+    178v1
 end
 subgraph var_stream_245 ["var <tt>stream_245</tt>"]
     style var_stream_245 fill:transparent
-    180v1
-end
-subgraph var_stream_246 ["var <tt>stream_246</tt>"]
-    style var_stream_246 fill:transparent
-    181v1
+    179v1
 end
 subgraph var_stream_247 ["var <tt>stream_247</tt>"]
     style var_stream_247 fill:transparent
-    182v1
+    180v1
 end
 subgraph var_stream_248 ["var <tt>stream_248</tt>"]
     style var_stream_248 fill:transparent
-    183v1
+    181v1
 end
 subgraph var_stream_25 ["var <tt>stream_25</tt>"]
     style var_stream_25 fill:transparent
     20v1
 end
+subgraph var_stream_250 ["var <tt>stream_250</tt>"]
+    style var_stream_250 fill:transparent
+    182v1
+end
+subgraph var_stream_251 ["var <tt>stream_251</tt>"]
+    style var_stream_251 fill:transparent
+    183v1
+end
+subgraph var_stream_252 ["var <tt>stream_252</tt>"]
+    style var_stream_252 fill:transparent
+    184v1
+end
+subgraph var_stream_253 ["var <tt>stream_253</tt>"]
+    style var_stream_253 fill:transparent
+    185v1
+end
 subgraph var_stream_255 ["var <tt>stream_255</tt>"]
     style var_stream_255 fill:transparent
     186v1
-    187v1
 end
 subgraph var_stream_256 ["var <tt>stream_256</tt>"]
     style var_stream_256 fill:transparent
-    188v1
+    187v1
 end
 subgraph var_stream_257 ["var <tt>stream_257</tt>"]
     style var_stream_257 fill:transparent
-    189v1
+    188v1
 end
 subgraph var_stream_258 ["var <tt>stream_258</tt>"]
     style var_stream_258 fill:transparent
-    190v1
+    189v1
 end
 subgraph var_stream_259 ["var <tt>stream_259</tt>"]
     style var_stream_259 fill:transparent
-    191v1
+    190v1
 end
 subgraph var_stream_26 ["var <tt>stream_26</tt>"]
     style var_stream_26 fill:transparent
@@ -996,55 +1019,56 @@ subgraph var_stream_26 ["var <tt>stream_26</tt>"]
 end
 subgraph var_stream_260 ["var <tt>stream_260</tt>"]
     style var_stream_260 fill:transparent
-    192v1
-end
-subgraph var_stream_261 ["var <tt>stream_261</tt>"]
-    style var_stream_261 fill:transparent
-    193v1
-end
-subgraph var_stream_262 ["var <tt>stream_262</tt>"]
-    style var_stream_262 fill:transparent
-    194v1
-end
-subgraph var_stream_263 ["var <tt>stream_263</tt>"]
-    style var_stream_263 fill:transparent
-    195v1
-end
-subgraph var_stream_265 ["var <tt>stream_265</tt>"]
-    style var_stream_265 fill:transparent
-    196v1
-end
-subgraph var_stream_266 ["var <tt>stream_266</tt>"]
-    style var_stream_266 fill:transparent
-    197v1
+    191v1
 end
 subgraph var_stream_267 ["var <tt>stream_267</tt>"]
     style var_stream_267 fill:transparent
-    198v1
+    194v1
+    195v1
 end
 subgraph var_stream_268 ["var <tt>stream_268</tt>"]
     style var_stream_268 fill:transparent
-    199v1
+    196v1
+end
+subgraph var_stream_269 ["var <tt>stream_269</tt>"]
+    style var_stream_269 fill:transparent
+    197v1
+end
+subgraph var_stream_270 ["var <tt>stream_270</tt>"]
+    style var_stream_270 fill:transparent
+    198v1
 end
 subgraph var_stream_271 ["var <tt>stream_271</tt>"]
     style var_stream_271 fill:transparent
+    199v1
+end
+subgraph var_stream_272 ["var <tt>stream_272</tt>"]
+    style var_stream_272 fill:transparent
     200v1
 end
 subgraph var_stream_273 ["var <tt>stream_273</tt>"]
     style var_stream_273 fill:transparent
     201v1
 end
-subgraph var_stream_275 ["var <tt>stream_275</tt>"]
-    style var_stream_275 fill:transparent
+subgraph var_stream_274 ["var <tt>stream_274</tt>"]
+    style var_stream_274 fill:transparent
     202v1
 end
-subgraph var_stream_276 ["var <tt>stream_276</tt>"]
-    style var_stream_276 fill:transparent
+subgraph var_stream_275 ["var <tt>stream_275</tt>"]
+    style var_stream_275 fill:transparent
     203v1
+end
+subgraph var_stream_277 ["var <tt>stream_277</tt>"]
+    style var_stream_277 fill:transparent
+    204v1
+end
+subgraph var_stream_278 ["var <tt>stream_278</tt>"]
+    style var_stream_278 fill:transparent
+    205v1
 end
 subgraph var_stream_279 ["var <tt>stream_279</tt>"]
     style var_stream_279 fill:transparent
-    204v1
+    206v1
 end
 subgraph var_stream_28 ["var <tt>stream_28</tt>"]
     style var_stream_28 fill:transparent
@@ -1052,79 +1076,103 @@ subgraph var_stream_28 ["var <tt>stream_28</tt>"]
 end
 subgraph var_stream_280 ["var <tt>stream_280</tt>"]
     style var_stream_280 fill:transparent
-    205v1
-end
-subgraph var_stream_281 ["var <tt>stream_281</tt>"]
-    style var_stream_281 fill:transparent
-    206v1
-end
-subgraph var_stream_282 ["var <tt>stream_282</tt>"]
-    style var_stream_282 fill:transparent
     207v1
 end
 subgraph var_stream_283 ["var <tt>stream_283</tt>"]
     style var_stream_283 fill:transparent
     208v1
 end
-subgraph var_stream_284 ["var <tt>stream_284</tt>"]
-    style var_stream_284 fill:transparent
+subgraph var_stream_285 ["var <tt>stream_285</tt>"]
+    style var_stream_285 fill:transparent
     209v1
+end
+subgraph var_stream_287 ["var <tt>stream_287</tt>"]
+    style var_stream_287 fill:transparent
+    210v1
+end
+subgraph var_stream_288 ["var <tt>stream_288</tt>"]
+    style var_stream_288 fill:transparent
+    211v1
 end
 subgraph var_stream_29 ["var <tt>stream_29</tt>"]
     style var_stream_29 fill:transparent
     23v1
 end
-subgraph var_stream_300 ["var <tt>stream_300</tt>"]
-    style var_stream_300 fill:transparent
-    210v1
-end
-subgraph var_stream_301 ["var <tt>stream_301</tt>"]
-    style var_stream_301 fill:transparent
-    211v1
-end
-subgraph var_stream_302 ["var <tt>stream_302</tt>"]
-    style var_stream_302 fill:transparent
+subgraph var_stream_291 ["var <tt>stream_291</tt>"]
+    style var_stream_291 fill:transparent
     212v1
 end
-subgraph var_stream_303 ["var <tt>stream_303</tt>"]
-    style var_stream_303 fill:transparent
+subgraph var_stream_292 ["var <tt>stream_292</tt>"]
+    style var_stream_292 fill:transparent
     213v1
 end
-subgraph var_stream_304 ["var <tt>stream_304</tt>"]
-    style var_stream_304 fill:transparent
+subgraph var_stream_293 ["var <tt>stream_293</tt>"]
+    style var_stream_293 fill:transparent
     214v1
 end
-subgraph var_stream_305 ["var <tt>stream_305</tt>"]
-    style var_stream_305 fill:transparent
+subgraph var_stream_294 ["var <tt>stream_294</tt>"]
+    style var_stream_294 fill:transparent
     215v1
 end
-subgraph var_stream_306 ["var <tt>stream_306</tt>"]
-    style var_stream_306 fill:transparent
+subgraph var_stream_295 ["var <tt>stream_295</tt>"]
+    style var_stream_295 fill:transparent
     216v1
 end
-subgraph var_stream_309 ["var <tt>stream_309</tt>"]
-    style var_stream_309 fill:transparent
+subgraph var_stream_296 ["var <tt>stream_296</tt>"]
+    style var_stream_296 fill:transparent
     217v1
 end
 subgraph var_stream_31 ["var <tt>stream_31</tt>"]
     style var_stream_31 fill:transparent
     24v1
 end
-subgraph var_stream_310 ["var <tt>stream_310</tt>"]
-    style var_stream_310 fill:transparent
-    218v1
-end
-subgraph var_stream_311 ["var <tt>stream_311</tt>"]
-    style var_stream_311 fill:transparent
-    219v1
-end
 subgraph var_stream_312 ["var <tt>stream_312</tt>"]
     style var_stream_312 fill:transparent
+    218v1
+end
+subgraph var_stream_313 ["var <tt>stream_313</tt>"]
+    style var_stream_313 fill:transparent
+    219v1
+end
+subgraph var_stream_314 ["var <tt>stream_314</tt>"]
+    style var_stream_314 fill:transparent
     220v1
+end
+subgraph var_stream_315 ["var <tt>stream_315</tt>"]
+    style var_stream_315 fill:transparent
+    221v1
+end
+subgraph var_stream_316 ["var <tt>stream_316</tt>"]
+    style var_stream_316 fill:transparent
+    222v1
+end
+subgraph var_stream_317 ["var <tt>stream_317</tt>"]
+    style var_stream_317 fill:transparent
+    223v1
+end
+subgraph var_stream_318 ["var <tt>stream_318</tt>"]
+    style var_stream_318 fill:transparent
+    224v1
 end
 subgraph var_stream_32 ["var <tt>stream_32</tt>"]
     style var_stream_32 fill:transparent
     25v1
+end
+subgraph var_stream_321 ["var <tt>stream_321</tt>"]
+    style var_stream_321 fill:transparent
+    225v1
+end
+subgraph var_stream_322 ["var <tt>stream_322</tt>"]
+    style var_stream_322 fill:transparent
+    226v1
+end
+subgraph var_stream_323 ["var <tt>stream_323</tt>"]
+    style var_stream_323 fill:transparent
+    227v1
+end
+subgraph var_stream_324 ["var <tt>stream_324</tt>"]
+    style var_stream_324 fill:transparent
+    228v1
 end
 subgraph var_stream_33 ["var <tt>stream_33</tt>"]
     style var_stream_33 fill:transparent
@@ -1267,29 +1315,29 @@ subgraph var_stream_70 ["var <tt>stream_70</tt>"]
     style var_stream_70 fill:transparent
     62v1
 end
+subgraph var_stream_71 ["var <tt>stream_71</tt>"]
+    style var_stream_71 fill:transparent
+    63v1
+end
+subgraph var_stream_72 ["var <tt>stream_72</tt>"]
+    style var_stream_72 fill:transparent
+    64v1
+end
+subgraph var_stream_73 ["var <tt>stream_73</tt>"]
+    style var_stream_73 fill:transparent
+    65v1
+end
+subgraph var_stream_74 ["var <tt>stream_74</tt>"]
+    style var_stream_74 fill:transparent
+    66v1
+end
 subgraph var_stream_8 ["var <tt>stream_8</tt>"]
     style var_stream_8 fill:transparent
     4v1
 end
-subgraph var_stream_85 ["var <tt>stream_85</tt>"]
-    style var_stream_85 fill:transparent
-    65v1
-    66v1
-end
-subgraph var_stream_86 ["var <tt>stream_86</tt>"]
-    style var_stream_86 fill:transparent
-    67v1
-end
-subgraph var_stream_87 ["var <tt>stream_87</tt>"]
-    style var_stream_87 fill:transparent
-    68v1
-end
-subgraph var_stream_88 ["var <tt>stream_88</tt>"]
-    style var_stream_88 fill:transparent
-    69v1
-end
 subgraph var_stream_89 ["var <tt>stream_89</tt>"]
     style var_stream_89 fill:transparent
+    69v1
     70v1
 end
 subgraph var_stream_9 ["var <tt>stream_9</tt>"]
@@ -1316,19 +1364,19 @@ subgraph var_stream_94 ["var <tt>stream_94</tt>"]
     style var_stream_94 fill:transparent
     75v1
 end
+subgraph var_stream_95 ["var <tt>stream_95</tt>"]
+    style var_stream_95 fill:transparent
+    76v1
+end
 subgraph var_stream_96 ["var <tt>stream_96</tt>"]
     style var_stream_96 fill:transparent
-    76v1
+    77v1
 end
 subgraph var_stream_97 ["var <tt>stream_97</tt>"]
     style var_stream_97 fill:transparent
-    77v1
+    78v1
 end
 subgraph var_stream_98 ["var <tt>stream_98</tt>"]
     style var_stream_98 fill:transparent
-    78v1
-end
-subgraph var_stream_99 ["var <tt>stream_99</tt>"]
-    style var_stream_99 fill:transparent
     79v1
 end

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__two_pc_bench__tests__two_pc_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__two_pc_bench__tests__two_pc_ir.snap
@@ -1115,22 +1115,48 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         right: Map {
-                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _u | () }),
+                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _u | () }),
                                                                                             input: Filter {
-                                                                                                f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < usize , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | c | * c == 0 }),
-                                                                                                input: Fold {
-                                                                                                    init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | | 0usize }),
-                                                                                                    acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | count , _ | * count += 1 }),
-                                                                                                    input: Tee {
-                                                                                                        inner: <tee 15>: Reduce {
-                                                                                                            f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
-                                                                                                            input: Source {
-                                                                                                                source: Stream(
-                                                                                                                    { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let interval__free = { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; Duration :: from_secs (1) } ; tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval (interval__free)) },
-                                                                                                                ),
+                                                                                                f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | o | o . is_none () }),
+                                                                                                input: ChainFirst {
+                                                                                                    first: Map {
+                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
+                                                                                                        input: Map {
+                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _ | () }),
+                                                                                                            input: Tee {
+                                                                                                                inner: <tee 15>: Reduce {
+                                                                                                                    f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
+                                                                                                                    input: Source {
+                                                                                                                        source: Stream(
+                                                                                                                            { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let interval__free = { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; Duration :: from_secs (1) } ; tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval (interval__free)) },
+                                                                                                                        ),
+                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                            location_kind: Cluster(
+                                                                                                                                2,
+                                                                                                                            ),
+                                                                                                                            output_type: Some(
+                                                                                                                                hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
+                                                                                                                            ),
+                                                                                                                        },
+                                                                                                                    },
+                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                        location_kind: Tick(
+                                                                                                                            0,
+                                                                                                                            Cluster(
+                                                                                                                                2,
+                                                                                                                            ),
+                                                                                                                        ),
+                                                                                                                        output_type: Some(
+                                                                                                                            hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
+                                                                                                                        ),
+                                                                                                                    },
+                                                                                                                },
                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                    location_kind: Cluster(
-                                                                                                                        2,
+                                                                                                                    location_kind: Tick(
+                                                                                                                        0,
+                                                                                                                        Cluster(
+                                                                                                                            2,
+                                                                                                                        ),
                                                                                                                     ),
                                                                                                                     output_type: Some(
                                                                                                                         hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
@@ -1145,7 +1171,7 @@ expression: built.ir()
                                                                                                                     ),
                                                                                                                 ),
                                                                                                                 output_type: Some(
-                                                                                                                    hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
+                                                                                                                    (),
                                                                                                                 ),
                                                                                                             },
                                                                                                         },
@@ -1157,7 +1183,33 @@ expression: built.ir()
                                                                                                                 ),
                                                                                                             ),
                                                                                                             output_type: Some(
-                                                                                                                hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
+                                                                                                                core :: option :: Option < () >,
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    },
+                                                                                                    second: Persist {
+                                                                                                        inner: Source {
+                                                                                                            source: Iter(
+                                                                                                                [:: std :: option :: Option :: None],
+                                                                                                            ),
+                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                location_kind: Cluster(
+                                                                                                                    2,
+                                                                                                                ),
+                                                                                                                output_type: Some(
+                                                                                                                    core :: option :: Option < () >,
+                                                                                                                ),
+                                                                                                            },
+                                                                                                        },
+                                                                                                        metadata: HydroIrMetadata {
+                                                                                                            location_kind: Tick(
+                                                                                                                0,
+                                                                                                                Cluster(
+                                                                                                                    2,
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                            output_type: Some(
+                                                                                                                core :: option :: Option < () >,
                                                                                                             ),
                                                                                                         },
                                                                                                     },
@@ -1169,7 +1221,7 @@ expression: built.ir()
                                                                                                             ),
                                                                                                         ),
                                                                                                         output_type: Some(
-                                                                                                            usize,
+                                                                                                            core :: option :: Option < () >,
                                                                                                         ),
                                                                                                     },
                                                                                                 },
@@ -1181,7 +1233,7 @@ expression: built.ir()
                                                                                                         ),
                                                                                                     ),
                                                                                                     output_type: Some(
-                                                                                                        usize,
+                                                                                                        core :: option :: Option < () >,
                                                                                                     ),
                                                                                                 },
                                                                                             },
@@ -1678,14 +1730,40 @@ expression: built.ir()
                     },
                 },
                 right: Map {
-                    f: stageleft :: runtime_support :: fn1_type_hint :: < usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _u | () }),
+                    f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _u | () }),
                     input: Filter {
-                        f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < usize , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | c | * c == 0 }),
-                        input: Fold {
-                            init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | | 0usize }),
-                            acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | count , _ | * count += 1 }),
-                            input: Tee {
-                                inner: <tee 12>,
+                        f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | o | o . is_none () }),
+                        input: ChainFirst {
+                            first: Map {
+                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
+                                input: Map {
+                                    f: stageleft :: runtime_support :: fn1_type_hint :: < usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ | () }),
+                                    input: Tee {
+                                        inner: <tee 12>,
+                                        metadata: HydroIrMetadata {
+                                            location_kind: Tick(
+                                                4,
+                                                Process(
+                                                    3,
+                                                ),
+                                            ),
+                                            output_type: Some(
+                                                usize,
+                                            ),
+                                        },
+                                    },
+                                    metadata: HydroIrMetadata {
+                                        location_kind: Tick(
+                                            4,
+                                            Process(
+                                                3,
+                                            ),
+                                        ),
+                                        output_type: Some(
+                                            (),
+                                        ),
+                                    },
+                                },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
                                         4,
@@ -1694,7 +1772,33 @@ expression: built.ir()
                                         ),
                                     ),
                                     output_type: Some(
-                                        usize,
+                                        core :: option :: Option < () >,
+                                    ),
+                                },
+                            },
+                            second: Persist {
+                                inner: Source {
+                                    source: Iter(
+                                        [:: std :: option :: Option :: None],
+                                    ),
+                                    metadata: HydroIrMetadata {
+                                        location_kind: Process(
+                                            3,
+                                        ),
+                                        output_type: Some(
+                                            core :: option :: Option < () >,
+                                        ),
+                                    },
+                                },
+                                metadata: HydroIrMetadata {
+                                    location_kind: Tick(
+                                        4,
+                                        Process(
+                                            3,
+                                        ),
+                                    ),
+                                    output_type: Some(
+                                        core :: option :: Option < () >,
                                     ),
                                 },
                             },
@@ -1706,7 +1810,7 @@ expression: built.ir()
                                     ),
                                 ),
                                 output_type: Some(
-                                    usize,
+                                    core :: option :: Option < () >,
                                 ),
                             },
                         },
@@ -1718,7 +1822,7 @@ expression: built.ir()
                                 ),
                             ),
                             output_type: Some(
-                                usize,
+                                core :: option :: Option < () >,
                             ),
                         },
                     },
@@ -2070,14 +2174,40 @@ expression: built.ir()
                     },
                 },
                 right: Map {
-                    f: stageleft :: runtime_support :: fn1_type_hint :: < usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _u | () }),
+                    f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _u | () }),
                     input: Filter {
-                        f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < usize , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | c | * c == 0 }),
-                        input: Fold {
-                            init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | | 0usize }),
-                            acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | count , _ | * count += 1 }),
-                            input: Tee {
-                                inner: <tee 12>,
+                        f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | o | o . is_none () }),
+                        input: ChainFirst {
+                            first: Map {
+                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
+                                input: Map {
+                                    f: stageleft :: runtime_support :: fn1_type_hint :: < usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ | () }),
+                                    input: Tee {
+                                        inner: <tee 12>,
+                                        metadata: HydroIrMetadata {
+                                            location_kind: Tick(
+                                                4,
+                                                Process(
+                                                    3,
+                                                ),
+                                            ),
+                                            output_type: Some(
+                                                usize,
+                                            ),
+                                        },
+                                    },
+                                    metadata: HydroIrMetadata {
+                                        location_kind: Tick(
+                                            4,
+                                            Process(
+                                                3,
+                                            ),
+                                        ),
+                                        output_type: Some(
+                                            (),
+                                        ),
+                                    },
+                                },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
                                         4,
@@ -2086,7 +2216,33 @@ expression: built.ir()
                                         ),
                                     ),
                                     output_type: Some(
-                                        usize,
+                                        core :: option :: Option < () >,
+                                    ),
+                                },
+                            },
+                            second: Persist {
+                                inner: Source {
+                                    source: Iter(
+                                        [:: std :: option :: Option :: None],
+                                    ),
+                                    metadata: HydroIrMetadata {
+                                        location_kind: Process(
+                                            3,
+                                        ),
+                                        output_type: Some(
+                                            core :: option :: Option < () >,
+                                        ),
+                                    },
+                                },
+                                metadata: HydroIrMetadata {
+                                    location_kind: Tick(
+                                        4,
+                                        Process(
+                                            3,
+                                        ),
+                                    ),
+                                    output_type: Some(
+                                        core :: option :: Option < () >,
                                     ),
                                 },
                             },
@@ -2098,7 +2254,7 @@ expression: built.ir()
                                     ),
                                 ),
                                 output_type: Some(
-                                    usize,
+                                    core :: option :: Option < () >,
                                 ),
                             },
                         },
@@ -2110,7 +2266,7 @@ expression: built.ir()
                                 ),
                             ),
                             output_type: Some(
-                                usize,
+                                core :: option :: Option < () >,
                             ),
                         },
                     },

--- a/hydro_test/src/local/negation.rs
+++ b/hydro_test/src/local/negation.rs
@@ -11,7 +11,7 @@ pub fn test_difference<'a>(
     let mut source = process
         .source_iter(q!(0..5))
         .batch(&tick, nondet!(/** test */))
-        .continue_if(
+        .filter_if_some(
             tick_trigger
                 .clone()
                 .batch(&tick, nondet!(/** test */))
@@ -24,7 +24,7 @@ pub fn test_difference<'a>(
     let mut source2 = process
         .source_iter(q!(3..6))
         .batch(&tick, nondet!(/** test */))
-        .continue_if(
+        .filter_if_some(
             tick_trigger
                 .clone()
                 .batch(&tick, nondet!(/** test */))
@@ -36,7 +36,7 @@ pub fn test_difference<'a>(
 
     source
         .filter_not_in(source2)
-        .continue_if(tick_trigger.batch(&tick, nondet!(/** test */)).first())
+        .filter_if_some(tick_trigger.batch(&tick, nondet!(/** test */)).first())
         .all_ticks()
 }
 
@@ -52,7 +52,7 @@ pub fn test_anti_join<'a>(
         .source_iter(q!(0..5))
         .map(q!(|v| (v, v)))
         .batch(&tick, nondet!(/** test */))
-        .continue_if(
+        .filter_if_some(
             tick_trigger
                 .clone()
                 .batch(&tick, nondet!(/** test */))
@@ -65,7 +65,7 @@ pub fn test_anti_join<'a>(
     let mut source2 = process
         .source_iter(q!(3..6))
         .batch(&tick, nondet!(/** test */))
-        .continue_if(
+        .filter_if_some(
             tick_trigger
                 .clone()
                 .batch(&tick, nondet!(/** test */))
@@ -77,7 +77,7 @@ pub fn test_anti_join<'a>(
 
     source
         .anti_join(source2)
-        .continue_if(tick_trigger.batch(&tick, nondet!(/** test */)).first())
+        .filter_if_some(tick_trigger.batch(&tick, nondet!(/** test */)).first())
         .all_ticks()
         .map(q!(|v| v.0))
 }


### PR DESCRIPTION

We don't rely on it in any protocols, its semantics are very funky, and it is generally legacy code at this point.

Skipping a deprecation phase since these APIs were never used in any documentation.
