### PR TITLE
fix(hydro_lang): update snapshots for Rust 1.90 and remove unused types

### DIFF
--- a/dfir_rs/examples/two_pc_hf/protocol.rs
+++ b/dfir_rs/examples/two_pc_hf/protocol.rs
@@ -1,28 +1,6 @@
 use dfir_rs::DemuxEnum;
 use serde::{Deserialize, Serialize};
 
-#[derive(PartialEq, Eq, Clone, Serialize, Deserialize, Debug, Hash, Copy)]
-pub enum MsgType {
-    Prepare,
-    Commit,
-    Abort,
-    AckP2,
-    End,
-    Ended,
-}
-
-#[derive(PartialEq, Eq, Clone, Serialize, Deserialize, Debug)]
-pub struct CoordMsg {
-    pub xid: u16,
-    pub mtype: MsgType,
-}
-/// Member Response
-#[derive(PartialEq, Eq, Clone, Serialize, Deserialize, Debug)]
-pub struct SubordResponse {
-    pub xid: u16,
-    pub mtype: MsgType,
-}
-
 #[derive(PartialEq, Eq, Clone, Serialize, Deserialize, Debug, Hash, Copy, DemuxEnum)]
 pub enum Msg {
     Prepare(u16),

--- a/dfir_rs/tests/compile-fail-stable/surface_demuxenum_port_extra.stderr
+++ b/dfir_rs/tests/compile-fail-stable/surface_demuxenum_port_extra.stderr
@@ -1,7 +1,7 @@
 error[E0599]: no variant named `Ellipse` found for enum `Shape`
   --> tests/compile-fail-stable/surface_demuxenum_port_extra.rs:21:18
    |
-6  |     enum Shape {
+ 6 |     enum Shape {
    |     ---------- variant `Ellipse` not found here
 ...
 21 |         my_demux[Ellipse] -> for_each(std::mem::drop);

--- a/dfir_rs/tests/compile-fail-stable/surface_demuxenum_port_extra_zero.stderr
+++ b/dfir_rs/tests/compile-fail-stable/surface_demuxenum_port_extra_zero.stderr
@@ -1,7 +1,7 @@
 error[E0599]: no variant named `Square` found for enum `Shape`
   --> tests/compile-fail-stable/surface_demuxenum_port_extra_zero.rs:11:18
    |
-6  |     enum Shape {
+ 6 |     enum Shape {
    |     ---------- variant `Square` not found here
 ...
 11 |         my_demux[Square] -> for_each(std::mem::drop);

--- a/dfir_rs/tests/compile-fail-stable/surface_demuxenum_port_extramissing.stderr
+++ b/dfir_rs/tests/compile-fail-stable/surface_demuxenum_port_extramissing.stderr
@@ -1,7 +1,7 @@
 error[E0599]: no variant named `Triangle` found for enum `Shape`
   --> tests/compile-fail-stable/surface_demuxenum_port_extramissing.rs:20:18
    |
-6  |     enum Shape {
+ 6 |     enum Shape {
    |     ---------- variant `Triangle` not found here
 ...
 20 |         my_demux[Triangle] -> for_each(std::mem::drop);

--- a/dfir_rs/tests/compile-fail-stable/surface_demuxenum_port_wrong_one.stderr
+++ b/dfir_rs/tests/compile-fail-stable/surface_demuxenum_port_wrong_one.stderr
@@ -1,7 +1,7 @@
 error[E0599]: no variant named `Circle` found for enum `Shape`
   --> tests/compile-fail-stable/surface_demuxenum_port_wrong_one.rs:14:18
    |
-6  |     enum Shape {
+ 6 |     enum Shape {
    |     ---------- variant `Circle` not found here
 ...
 14 |         my_demux[Circle] -> for_each(std::mem::drop);

--- a/dfir_rs/tests/compile-fail-stable/surface_demuxenum_wrongfields_1.stderr
+++ b/dfir_rs/tests/compile-fail-stable/surface_demuxenum_wrongfields_1.stderr
@@ -9,9 +9,9 @@ error[E0271]: type mismatch resolving `<impl Pusherator<Item = u32> as Pusherato
 note: required for `Shape` to implement `DemuxEnum<(impl Pusherator<Item = (f64,)>, impl Pusherator<Item = (f64, f64)>, impl Pusherator<Item = u32>)>`
   --> tests/compile-fail-stable/surface_demuxenum_wrongfields_1.rs:5:14
    |
-5  |     #[derive(DemuxEnum)]
+ 5 |     #[derive(DemuxEnum)]
    |              ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
-6  |     enum Shape {
+ 6 |     enum Shape {
    |          ^^^^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: associated types for the current `impl` cannot be restricted in `where` clauses

--- a/dfir_rs/tests/compile-fail-stable/surface_demuxenum_wrongfields_2.stderr
+++ b/dfir_rs/tests/compile-fail-stable/surface_demuxenum_wrongfields_2.stderr
@@ -9,9 +9,9 @@ error[E0271]: type mismatch resolving `<impl Pusherator<Item = (u32,)> as Pusher
 note: required for `Shape` to implement `DemuxEnum<(impl Pusherator<Item = (f64,)>, impl Pusherator<Item = (f64, f64)>, impl Pusherator<Item = (u32,)>)>`
   --> tests/compile-fail-stable/surface_demuxenum_wrongfields_2.rs:5:14
    |
-5  |     #[derive(DemuxEnum)]
+ 5 |     #[derive(DemuxEnum)]
    |              ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
-6  |     enum Shape {
+ 6 |     enum Shape {
    |          ^^^^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: associated types for the current `impl` cannot be restricted in `where` clauses

--- a/hydro_lang/src/compile/ir/snapshots/hydro_lang__compile__ir__backtrace__tests__backtrace.snap
+++ b/hydro_lang/src/compile/ir/snapshots/hydro_lang__compile__ir__backtrace__tests__backtrace.snap
@@ -24,7 +24,7 @@ expression: elements
     BacktraceElement {
         fn_name: "core::ops::function::FnOnce::call_once",
         lineno: Some(
-            250,
+            253,
         ),
         colno: Some(
             5,

--- a/hydro_lang/src/live_collections/stream/tests/snapshots/hydro_lang__live_collections__stream__tests__backtrace_chained_ops__backtrace_chained_ops-2.snap
+++ b/hydro_lang/src/live_collections/stream/tests/snapshots/hydro_lang__live_collections__stream__tests__backtrace_chained_ops__backtrace_chained_ops-2.snap
@@ -24,7 +24,7 @@ expression: for_each_meta.backtrace.elements()
     BacktraceElement {
         fn_name: "core::ops::function::FnOnce::call_once",
         lineno: Some(
-            250,
+            253,
         ),
         colno: Some(
             5,

--- a/hydro_lang/src/live_collections/stream/tests/snapshots/hydro_lang__live_collections__stream__tests__backtrace_chained_ops__backtrace_chained_ops.snap
+++ b/hydro_lang/src/live_collections/stream/tests/snapshots/hydro_lang__live_collections__stream__tests__backtrace_chained_ops__backtrace_chained_ops.snap
@@ -24,7 +24,7 @@ expression: source_meta.backtrace.elements()
     BacktraceElement {
         fn_name: "core::ops::function::FnOnce::call_once",
         lineno: Some(
-            250,
+            253,
         ),
         colno: Some(
             5,


### PR DESCRIPTION

The line number of `core::ops::function::FnOnce::call_once` in the standard library changed.
