### PR TITLE
docs(hydro_lang)!: `*::defer_tick` rustdoc, remove `Singleton::defer_tick`

### DIFF
--- a/hydro_lang/src/live_collections/keyed_singleton.rs
+++ b/hydro_lang/src/live_collections/keyed_singleton.rs
@@ -828,7 +828,44 @@ impl<'a, K, V, L: Location<'a>> KeyedSingleton<K, V, Tick<L>, Bounded> {
         }
     }
 
-    #[expect(missing_docs, reason = "TODO")]
+    /// Shifts the state in `self` to the **next tick**, so that the returned keyed singleton at
+    /// tick `T` always has the entries of `self` at tick `T - 1`.
+    ///
+    /// At tick `0`, the output has no entries, since there is no previous tick.
+    ///
+    /// This operator enables stateful iterative processing with ticks, by sending data from one
+    /// tick to the next. For example, you can use it to compare state across consecutive batches.
+    ///
+    /// # Example
+    /// ```rust
+    /// # use hydro_lang::prelude::*;
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
+    /// let tick = process.tick();
+    /// # // ticks are lazy by default, forces the second tick to run
+    /// # tick.spin_batch(q!(1)).all_ticks().for_each(q!(|_| {}));
+    /// # let batch_first_tick = process
+    /// #   .source_iter(q!(vec![(1, 2), (2, 3)]))
+    /// #   .batch(&tick, nondet!(/** test */))
+    /// #   .into_keyed();
+    /// # let batch_second_tick = process
+    /// #   .source_iter(q!(vec![(2, 4), (3, 5)]))
+    /// #   .batch(&tick, nondet!(/** test */))
+    /// #   .into_keyed()
+    /// #   .defer_tick(); // appears on the second tick
+    /// let input_batch = // first tick: { 1: 2, 2: 3 }, second tick: { 2: 4, 3: 5 }
+    /// # batch_first_tick.chain(batch_second_tick).first();
+    /// input_batch.clone().filter_key_not_in(
+    ///     input_batch.defer_tick().keys() // keys present in the previous tick
+    /// )
+    /// # .entries().all_ticks()
+    /// # }, |mut stream| async move {
+    /// // { 1: 2, 2: 3 } (first tick), { 3: 5 } (second tick)
+    /// # for w in vec![(1, 2), (2, 3), (3, 5)] {
+    /// #     assert_eq!(stream.next().await.unwrap(), w);
+    /// # }
+    /// # }));
+    /// ```
     pub fn defer_tick(self) -> KeyedSingleton<K, V, Tick<L>, Bounded> {
         KeyedSingleton {
             underlying: self.underlying.defer_tick(),

--- a/hydro_lang/src/live_collections/singleton.rs
+++ b/hydro_lang/src/live_collections/singleton.rs
@@ -16,7 +16,7 @@ use crate::forward_handle::{CycleCollection, CycleCollectionWithInitial, Receive
 use crate::forward_handle::{ForwardRef, TickCycle};
 #[cfg(stageleft_runtime)]
 use crate::location::dynamic::{DynLocation, LocationId};
-use crate::location::tick::{Atomic, DeferTick, NoAtomic};
+use crate::location::tick::{Atomic, NoAtomic};
 use crate::location::{Location, NoTick, Tick, check_matching_location};
 use crate::nondet::NonDet;
 
@@ -47,15 +47,6 @@ where
 {
     fn from(singleton: Singleton<T, L, Bounded>) -> Self {
         Singleton::new(singleton.location, singleton.ir_node.into_inner())
-    }
-}
-
-impl<'a, T, L> DeferTick for Singleton<T, Tick<L>, Bounded>
-where
-    L: Location<'a>,
-{
-    fn defer_tick(self) -> Self {
-        Singleton::defer_tick(self)
     }
 }
 
@@ -860,17 +851,6 @@ where
             },
             HydroNode::Persist {
                 inner: Box::new(self.ir_node.into_inner()),
-                metadata: self.location.new_node_metadata::<T>(),
-            },
-        )
-    }
-
-    #[expect(missing_docs, reason = "TODO")]
-    pub fn defer_tick(self) -> Singleton<T, Tick<L>, Bounded> {
-        Singleton::new(
-            self.location.clone(),
-            HydroNode::DeferTick {
-                input: Box::new(self.ir_node.into_inner()),
                 metadata: self.location.new_node_metadata::<T>(),
             },
         )

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -2602,7 +2602,42 @@ where
         )
     }
 
-    #[expect(missing_docs, reason = "TODO")]
+    /// Shifts the elements in `self` to the **next tick**, so that the returned stream at tick `T`
+    /// always has the elements of `self` at tick `T - 1`.
+    ///
+    /// At tick `0`, the output stream is empty, since there is no previous tick.
+    ///
+    /// This operator enables stateful iterative processing with ticks, by sending data from one
+    /// tick to the next. For example, you can use it to compare inputs across consecutive batches.
+    ///
+    /// # Example
+    /// ```rust
+    /// # use hydro_lang::prelude::*;
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
+    /// let tick = process.tick();
+    /// // ticks are lazy by default, forces the second tick to run
+    /// tick.spin_batch(q!(1)).all_ticks().for_each(q!(|_| {}));
+    ///
+    /// let batch_first_tick = process
+    ///   .source_iter(q!(vec![1, 2, 3, 4]))
+    ///   .batch(&tick, nondet!(/** test */));
+    /// let batch_second_tick = process
+    ///   .source_iter(q!(vec![0, 3, 4, 5, 6]))
+    ///   .batch(&tick, nondet!(/** test */))
+    ///   .defer_tick(); // appears on the second tick
+    /// let changes_across_ticks = batch_first_tick.chain(batch_second_tick);
+    ///
+    /// changes_across_ticks.clone().filter_not_in(
+    ///     changes_across_ticks.defer_tick() // the elements from the previous tick
+    /// ).all_ticks()
+    /// # }, |mut stream| async move {
+    /// // [1, 2, 3, 4 /* first tick */, 0, 5, 6 /* second tick */]
+    /// # for w in vec![1, 2, 3, 4, 0, 5, 6] {
+    /// #     assert_eq!(stream.next().await.unwrap(), w);
+    /// # }
+    /// # }));
+    /// ```
     pub fn defer_tick(self) -> Stream<T, Tick<L>, Bounded, O, R> {
         Stream::new(
             self.location.clone(),


### PR DESCRIPTION

We actually can't offer `Singleton::defer_tick`, because its output will be null on the first tick which breaks the `Singleton` invariant. Luckily, we don't use it anywhere!
