### PR TITLE
fix(hydro_std): Staggered client

### DIFF
--- a/hydro_std/src/bench_client/mod.rs
+++ b/hydro_std/src/bench_client/mod.rs
@@ -70,11 +70,23 @@ where
     let client_tick = clients.tick();
 
     // Set up an initial set of payloads on the first tick
-    let start_this_tick = client_tick.optional_first_tick(q!(()));
+    let (new_virtual_client_complete_cycle, new_virtual_client) =
+        client_tick.cycle_with_initial(client_tick.singleton(q!(0u32)));
+    new_virtual_client_complete_cycle.complete_next_tick(
+        new_virtual_client
+            .clone()
+            .map(q!(|virtual_id| virtual_id + 1)),
+    );
 
-    let c_new_payloads_on_start = start_this_tick.clone().flat_map_ordered(q!(move |_| (0
-        ..num_clients_per_node as u32)
-        .map(move |virtual_id| { (virtual_id, None) })));
+    let bounded_virtual_client = new_virtual_client
+        .filter(q!(
+            move |virtual_id| *virtual_id < num_clients_per_node as u32
+        ))
+        .into_stream();
+
+    let c_new_payloads_on_start = bounded_virtual_client
+        .clone()
+        .map(q!(|virtual_id| (virtual_id, None)));
 
     let (c_to_proposers_complete_cycle, c_to_proposers) =
         clients.forward_ref::<Stream<_, _, _, TotalOrder>>();
@@ -105,15 +117,12 @@ where
 
     // Track statistics
     let (c_timers_complete_cycle, c_timers) =
-        client_tick.cycle::<Stream<(usize, Instant), _, _, NoOrder>>();
-    let c_new_timers_when_leader_elected = start_this_tick
-        .map(q!(|_| Instant::now()))
-        .flat_map_ordered(q!(
-            move |now| (0..num_clients_per_node).map(move |virtual_id| (virtual_id, now))
-        ));
+        client_tick.cycle::<Stream<(u32, Instant), _, _, NoOrder>>();
+    let c_new_timers_when_leader_elected =
+        bounded_virtual_client.map(q!(|virtual_id| (virtual_id, Instant::now())));
     let c_updated_timers = c_received_quorum_payloads
         .clone()
-        .map(q!(|(key, _payload)| (key as usize, Instant::now())));
+        .map(q!(|(key, _payload)| (key, Instant::now())));
     let c_new_timers = c_timers
         .clone() // Update c_timers in tick+1 so we can record differences during this tick (to track latency)
         .chain(c_new_timers_when_leader_elected)

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir.snap
@@ -3,6 +3,110 @@ source: hydro_test/src/cluster/paxos_bench.rs
 expression: built.ir()
 ---
 [
+    CycleSink {
+        ident: Ident {
+            sym: cycle_0,
+        },
+        input: Map {
+            f: stageleft :: runtime_support :: fn1_type_hint :: < u32 , u32 > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | virtual_id | virtual_id + 1 }),
+            input: Tee {
+                inner: <tee 0>: ChainFirst {
+                    first: DeferTick {
+                        input: CycleSource {
+                            ident: Ident {
+                                sym: cycle_0,
+                            },
+                            metadata: HydroIrMetadata {
+                                location_kind: Tick(
+                                    0,
+                                    Cluster(
+                                        2,
+                                    ),
+                                ),
+                                output_type: Some(
+                                    u32,
+                                ),
+                            },
+                        },
+                        metadata: HydroIrMetadata {
+                            location_kind: Tick(
+                                0,
+                                Cluster(
+                                    2,
+                                ),
+                            ),
+                            output_type: Some(
+                                u32,
+                            ),
+                        },
+                    },
+                    second: Persist {
+                        inner: Source {
+                            source: Iter(
+                                { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let e__free = { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; 0u32 } ; [e__free] },
+                            ),
+                            metadata: HydroIrMetadata {
+                                location_kind: Cluster(
+                                    2,
+                                ),
+                                output_type: Some(
+                                    u32,
+                                ),
+                            },
+                        },
+                        metadata: HydroIrMetadata {
+                            location_kind: Cluster(
+                                2,
+                            ),
+                            output_type: Some(
+                                u32,
+                            ),
+                        },
+                    },
+                    metadata: HydroIrMetadata {
+                        location_kind: Tick(
+                            0,
+                            Cluster(
+                                2,
+                            ),
+                        ),
+                        output_type: Some(
+                            u32,
+                        ),
+                    },
+                },
+                metadata: HydroIrMetadata {
+                    location_kind: Tick(
+                        0,
+                        Cluster(
+                            2,
+                        ),
+                    ),
+                    output_type: Some(
+                        u32,
+                    ),
+                },
+            },
+            metadata: HydroIrMetadata {
+                location_kind: Tick(
+                    0,
+                    Cluster(
+                        2,
+                    ),
+                ),
+                output_type: Some(
+                    u32,
+                ),
+            },
+        },
+        out_location: Tick(
+            0,
+            Cluster(
+                2,
+            ),
+        ),
+        op_metadata: HydroIrOpMetadata,
+    },
     ForEach {
         f: stageleft :: runtime_support :: fn1_type_hint :: < & str , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | s | println ! ("{}" , s) }),
         input: Source {
@@ -39,13 +143,13 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_7,
+            sym: cycle_8,
         },
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , u32) , u32 > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_raw (__hydro_lang_cluster_self_id_0) ; move | (received_max_ballot , ballot_num) | { if received_max_ballot > (Ballot { num : ballot_num , proposer_id : CLUSTER_SELF_ID__free , }) { received_max_ballot . num + 1 } else { ballot_num } } }),
             input: CrossSingleton {
                 left: Tee {
-                    inner: <tee 0>: ChainFirst {
+                    inner: <tee 1>: ChainFirst {
                         first: Reduce {
                             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | curr , new | { if new > * curr { * curr = new ; } } }),
                             input: Persist {
@@ -53,7 +157,7 @@ expression: built.ir()
                                     first: Chain {
                                         first: CycleSource {
                                             ident: Ident {
-                                                sym: cycle_4,
+                                                sym: cycle_5,
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Cluster(
@@ -66,7 +170,7 @@ expression: built.ir()
                                         },
                                         second: CycleSource {
                                             ident: Ident {
-                                                sym: cycle_2,
+                                                sym: cycle_3,
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Cluster(
@@ -91,7 +195,7 @@ expression: built.ir()
                                     },
                                     second: CycleSource {
                                         ident: Ident {
-                                            sym: cycle_5,
+                                            sym: cycle_6,
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Cluster(
@@ -180,11 +284,11 @@ expression: built.ir()
                     },
                 },
                 right: Tee {
-                    inner: <tee 1>: ChainFirst {
+                    inner: <tee 2>: ChainFirst {
                         first: DeferTick {
                             input: CycleSource {
                                 ident: Ident {
-                                    sym: cycle_7,
+                                    sym: cycle_8,
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
@@ -291,10 +395,10 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_5,
+            sym: cycle_6,
         },
         input: Tee {
-            inner: <tee 2>: Map {
+            inner: <tee 3>: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
                 input: Network {
                     serialize_fn: Some(
@@ -383,10 +487,10 @@ expression: built.ir()
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , ()) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _signal) | d }),
                                     input: CrossSingleton {
                                         left: Tee {
-                                            inner: <tee 3>: Map {
+                                            inner: <tee 4>: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < u32 , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_raw (__hydro_lang_cluster_self_id_0) ; move | num | Ballot { num , proposer_id : CLUSTER_SELF_ID__free } }),
                                                 input: Tee {
-                                                    inner: <tee 1>,
+                                                    inner: <tee 2>,
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Tick(
                                                             1,
@@ -426,9 +530,9 @@ expression: built.ir()
                                         right: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _u | () }),
                                             input: Tee {
-                                                inner: <tee 4>: CycleSource {
+                                                inner: <tee 5>: CycleSource {
                                                     ident: Ident {
-                                                        sym: cycle_6,
+                                                        sym: cycle_7,
                                                     },
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Tick(
@@ -601,7 +705,7 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_9,
+            sym: cycle_10,
         },
         input: Difference {
             pos: Map {
@@ -609,15 +713,15 @@ expression: built.ir()
                 input: Filter {
                     f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < (usize , usize) , bool > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; let min__free = 2usize ; move | (success , _error) | success >= & min__free }) ; { let orig = f__free ; move | (_k , v) | orig (v) } }),
                     input: Tee {
-                        inner: <tee 5>: FoldKeyed {
+                        inner: <tee 6>: FoldKeyed {
                             init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | | (0 , 0) }),
                             acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } } }),
                             input: Tee {
-                                inner: <tee 6>: Chain {
+                                inner: <tee 7>: Chain {
                                     first: DeferTick {
                                         input: CycleSource {
                                             ident: Ident {
-                                                sym: cycle_8,
+                                                sym: cycle_9,
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
@@ -644,7 +748,7 @@ expression: built.ir()
                                         },
                                     },
                                     second: Tee {
-                                        inner: <tee 7>: Inspect {
+                                        inner: <tee 8>: Inspect {
                                             f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | p1b | println ! ("Proposer received P1b: {:?}" , p1b) }),
                                             input: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
@@ -661,7 +765,7 @@ expression: built.ir()
                                                         input: CrossSingleton {
                                                             left: CrossSingleton {
                                                                 left: Tee {
-                                                                    inner: <tee 8>: Map {
+                                                                    inner: <tee 9>: Map {
                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
                                                                         input: Network {
                                                                             serialize_fn: Some(
@@ -749,7 +853,7 @@ expression: built.ir()
                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , ()) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _signal) | d }),
                                                                                         input: CrossSingleton {
                                                                                             left: Tee {
-                                                                                                inner: <tee 3>,
+                                                                                                inner: <tee 4>,
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_kind: Tick(
                                                                                                         1,
@@ -777,7 +881,7 @@ expression: built.ir()
                                                                                                                         acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant > , hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | latest , _ | { * latest = Some (Instant :: now ()) ; } }),
                                                                                                                         input: Persist {
                                                                                                                             inner: Tee {
-                                                                                                                                inner: <tee 2>,
+                                                                                                                                inner: <tee 3>,
                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                     location_kind: Cluster(
                                                                                                                                         0,
@@ -827,7 +931,7 @@ expression: built.ir()
                                                                                                                                 input: Map {
                                                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                                                                                                     input: Tee {
-                                                                                                                                        inner: <tee 4>,
+                                                                                                                                        inner: <tee 5>,
                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                             location_kind: Tick(
                                                                                                                                                 1,
@@ -1103,14 +1207,14 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 right: Tee {
-                                                                    inner: <tee 9>: ChainFirst {
+                                                                    inner: <tee 10>: ChainFirst {
                                                                         first: Reduce {
                                                                             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | curr , new | { if new > * curr { * curr = new ; } } }),
                                                                             input: Persist {
                                                                                 inner: Inspect {
                                                                                     f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | p1a | println ! ("Acceptor received P1a: {:?}" , p1a) }),
                                                                                     input: Tee {
-                                                                                        inner: <tee 8>,
+                                                                                        inner: <tee 9>,
                                                                                         metadata: HydroIrMetadata {
                                                                                             location_kind: Tick(
                                                                                                 2,
@@ -1220,7 +1324,7 @@ expression: built.ir()
                                                             },
                                                             right: CycleSource {
                                                                 ident: Ident {
-                                                                    sym: cycle_3,
+                                                                    sym: cycle_4,
                                                                 },
                                                                 metadata: HydroIrMetadata {
                                                                     location_kind: Tick(
@@ -1370,12 +1474,12 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <tee 10>: Map {
+                inner: <tee 11>: Map {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
                     input: Filter {
                         f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < (usize , usize) , bool > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; let max__free = 3usize ; move | (success , error) | (success + error) >= max__free }) ; { let orig = f__free ; move | (_k , v) | orig (v) } }),
                         input: Tee {
-                            inner: <tee 5>,
+                            inner: <tee 6>,
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
                                     1,
@@ -1446,11 +1550,11 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_8,
+            sym: cycle_9,
         },
         input: AntiJoin {
             pos: Tee {
-                inner: <tee 6>,
+                inner: <tee 7>,
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
                         1,
@@ -1464,7 +1568,7 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <tee 10>,
+                inner: <tee 11>,
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
                         1,
@@ -1499,16 +1603,16 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_6,
+            sym: cycle_7,
         },
         input: Tee {
-            inner: <tee 11>: Map {
+            inner: <tee 12>: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (() , ()) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | (d , _signal) | d }),
                 input: CrossSingleton {
                     left: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | _ | () }),
                         input: Tee {
-                            inner: <tee 12>: FilterMap {
+                            inner: <tee 13>: FilterMap {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < ((hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) >) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; move | ((quorum_ballot , quorum_accepted) , my_ballot) | if quorum_ballot == my_ballot { Some (quorum_accepted) } else { None } }),
                                 input: CrossSingleton {
                                     left: Reduce {
@@ -1522,7 +1626,7 @@ expression: built.ir()
                                                     input: AntiJoin {
                                                         pos: AntiJoin {
                                                             pos: Tee {
-                                                                inner: <tee 6>,
+                                                                inner: <tee 7>,
                                                                 metadata: HydroIrMetadata {
                                                                     location_kind: Tick(
                                                                         1,
@@ -1540,7 +1644,7 @@ expression: built.ir()
                                                                 input: Filter {
                                                                     f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < (usize , usize) , bool > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; let min__free = 2usize ; move | (success , _error) | success < & min__free }) ; { let orig = f__free ; move | (_k , v) | orig (v) } }),
                                                                     input: Tee {
-                                                                        inner: <tee 5>,
+                                                                        inner: <tee 6>,
                                                                         metadata: HydroIrMetadata {
                                                                             location_kind: Tick(
                                                                                 1,
@@ -1592,7 +1696,7 @@ expression: built.ir()
                                                         neg: DeferTick {
                                                             input: CycleSource {
                                                                 ident: Ident {
-                                                                    sym: cycle_9,
+                                                                    sym: cycle_10,
                                                                 },
                                                                 metadata: HydroIrMetadata {
                                                                     location_kind: Tick(
@@ -1679,7 +1783,7 @@ expression: built.ir()
                                         },
                                     },
                                     right: Tee {
-                                        inner: <tee 3>,
+                                        inner: <tee 4>,
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
                                                 1,
@@ -1743,13 +1847,13 @@ expression: built.ir()
                     right: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _u | () }),
                         input: Tee {
-                            inner: <tee 13>: Map {
+                            inner: <tee 14>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | _ | () }),
                                 input: Filter {
                                     f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (received_max_ballot , cur_ballot) | * received_max_ballot <= * cur_ballot }),
                                     input: CrossSingleton {
                                         left: Tee {
-                                            inner: <tee 0>,
+                                            inner: <tee 1>,
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
                                                     1,
@@ -1763,7 +1867,7 @@ expression: built.ir()
                                             },
                                         },
                                         right: Tee {
-                                            inner: <tee 3>,
+                                            inner: <tee 4>,
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
                                                     1,
@@ -1882,14 +1986,14 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_4,
+            sym: cycle_5,
         },
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (_ , ballot) | ballot }),
             input: FilterMap {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | (key , res) | match res { Ok (_) => None , Err (e) => Some ((key , e)) , } }),
                 input: Tee {
-                    inner: <tee 7>,
+                    inner: <tee 8>,
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
                             1,
@@ -1930,17 +2034,17 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_10,
+            sym: cycle_11,
         },
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , ()) , hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | (d , _signal) | d }),
             input: CrossSingleton {
                 left: Tee {
-                    inner: <tee 14>: Chain {
+                    inner: <tee 15>: Chain {
                         first: DeferTick {
                             input: CycleSource {
                                 ident: Ident {
-                                    sym: cycle_10,
+                                    sym: cycle_11,
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
@@ -1970,7 +2074,7 @@ expression: built.ir()
                             f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , u32) , hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos_bench :: Client > :: from_raw (__hydro_lang_cluster_self_id_2) ; move | (key , value) | KvPayload { key , value : (CLUSTER_SELF_ID__free , value) } }),
                             input: CycleSource {
                                 ident: Ident {
-                                    sym: cycle_0,
+                                    sym: cycle_1,
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Cluster(
@@ -2024,7 +2128,7 @@ expression: built.ir()
                                 input: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ | () }),
                                     input: Tee {
-                                        inner: <tee 15>: Map {
+                                        inner: <tee 16>: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | ballot | ballot . proposer_id }),
                                             input: Reduce {
                                                 f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | curr , new | { if new > * curr { * curr = new ; } } }),
@@ -2117,7 +2221,7 @@ expression: built.ir()
                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , ()) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _signal) | d }),
                                                                         input: CrossSingleton {
                                                                             left: Tee {
-                                                                                inner: <tee 3>,
+                                                                                inner: <tee 4>,
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_kind: Tick(
                                                                                         1,
@@ -2133,11 +2237,11 @@ expression: built.ir()
                                                                             right: Map {
                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _u | () }),
                                                                                 input: Tee {
-                                                                                    inner: <tee 16>: Map {
+                                                                                    inner: <tee 17>: Map {
                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (() , ()) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | (d , _signal) | d }),
                                                                                         input: CrossSingleton {
                                                                                             left: Tee {
-                                                                                                inner: <tee 11>,
+                                                                                                inner: <tee 12>,
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_kind: Tick(
                                                                                                         1,
@@ -2161,7 +2265,7 @@ expression: built.ir()
                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                                                                                 input: DeferTick {
                                                                                                                     input: Tee {
-                                                                                                                        inner: <tee 11>,
+                                                                                                                        inner: <tee 12>,
                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                             location_kind: Tick(
                                                                                                                                 1,
@@ -2542,17 +2646,17 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_11,
+            sym: cycle_12,
         },
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , usize) , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (num_payloads , base_slot) | base_slot + num_payloads }),
             input: CrossSingleton {
                 left: Tee {
-                    inner: <tee 17>: Fold {
+                    inner: <tee 18>: Fold {
                         init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | | 0usize }),
                         acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , (usize , hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) >) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | count , _ | * count += 1 }),
                         input: Tee {
-                            inner: <tee 18>: Map {
+                            inner: <tee 19>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) >) , usize) , (usize , hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | ((index , payload) , base_slot) | (base_slot + index , payload) }),
                                 input: CrossSingleton {
                                     left: Enumerate {
@@ -2574,7 +2678,7 @@ expression: built.ir()
                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_with_client :: * ; move | (payload , leader_id) | (leader_id , payload) }),
                                                             input: CrossSingleton {
                                                                 left: Tee {
-                                                                    inner: <tee 14>,
+                                                                    inner: <tee 15>,
                                                                     metadata: HydroIrMetadata {
                                                                         location_kind: Tick(
                                                                             10,
@@ -2588,7 +2692,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 right: Tee {
-                                                                    inner: <tee 15>,
+                                                                    inner: <tee 16>,
                                                                     metadata: HydroIrMetadata {
                                                                         location_kind: Tick(
                                                                             10,
@@ -2643,7 +2747,7 @@ expression: built.ir()
                                                 right: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _u | () }),
                                                     input: Tee {
-                                                        inner: <tee 11>,
+                                                        inner: <tee 12>,
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Tick(
                                                                 1,
@@ -2705,16 +2809,16 @@ expression: built.ir()
                                         },
                                     },
                                     right: Tee {
-                                        inner: <tee 19>: ChainFirst {
+                                        inner: <tee 20>: ChainFirst {
                                             first: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < usize , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | max_slot | max_slot + 1 }),
                                                 input: Tee {
-                                                    inner: <tee 20>: Reduce {
+                                                    inner: <tee 21>: Reduce {
                                                         f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | curr , new | { if new > * curr { * curr = new ; } } }),
                                                         input: Map {
                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >)) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
                                                             input: Tee {
-                                                                inner: <tee 21>: Map {
+                                                                inner: <tee 22>: Map {
                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >)) , (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (count , entry) | (count , entry . unwrap ()) }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
                                                                     input: FoldKeyed {
                                                                         init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | | (0 , None) }),
@@ -2724,10 +2828,10 @@ expression: built.ir()
                                                                             input: Map {
                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (_checkpoint , log) | log }),
                                                                                 input: Tee {
-                                                                                    inner: <tee 22>: FlatMap {
+                                                                                    inner: <tee 23>: FlatMap {
                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) > , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | v }),
                                                                                         input: Tee {
-                                                                                            inner: <tee 12>,
+                                                                                            inner: <tee 13>,
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_kind: Tick(
                                                                                                     1,
@@ -2876,7 +2980,7 @@ expression: built.ir()
                                                 first: DeferTick {
                                                     input: CycleSource {
                                                         ident: Ident {
-                                                            sym: cycle_11,
+                                                            sym: cycle_12,
                                                         },
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Tick(
@@ -3022,7 +3126,7 @@ expression: built.ir()
                     },
                 },
                 right: Tee {
-                    inner: <tee 19>,
+                    inner: <tee 20>,
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
                             1,
@@ -3069,22 +3173,22 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_13,
+            sym: cycle_14,
         },
         input: Difference {
             pos: Tee {
-                inner: <tee 23>: FilterMap {
+                inner: <tee 24>: FilterMap {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (usize , usize)) , core :: option :: Option < (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; let min__free = 2usize ; move | (key , (success , _error)) | if success >= min__free { Some (key) } else { None } }),
                     input: Tee {
-                        inner: <tee 24>: FoldKeyed {
+                        inner: <tee 25>: FoldKeyed {
                             init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | | (0 , 0) }),
                             acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } } }),
                             input: Tee {
-                                inner: <tee 25>: Chain {
+                                inner: <tee 26>: Chain {
                                     first: DeferTick {
                                         input: CycleSource {
                                             ident: Ident {
-                                                sym: cycle_12,
+                                                sym: cycle_13,
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
@@ -3111,7 +3215,7 @@ expression: built.ir()
                                         },
                                     },
                                     second: Tee {
-                                        inner: <tee 26>: Map {
+                                        inner: <tee 27>: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
                                             input: Network {
                                                 serialize_fn: Some(
@@ -3125,7 +3229,7 @@ expression: built.ir()
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (p2a , max_ballot) | (p2a . sender , ((p2a . slot , p2a . ballot) , if p2a . ballot == max_ballot { Ok (()) } else { Err (max_ballot) })) }),
                                                     input: CrossSingleton {
                                                         left: Tee {
-                                                            inner: <tee 27>: Map {
+                                                            inner: <tee 28>: Map {
                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer >) , hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
                                                                 input: Network {
                                                                     serialize_fn: Some(
@@ -3210,7 +3314,7 @@ expression: built.ir()
                                                                         right: Map {
                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >) , hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_raw (__hydro_lang_cluster_self_id_0) ; move | ((slot , ballot) , value) | P2a { sender : CLUSTER_SELF_ID__free , ballot , slot , value } }),
                                                                             input: Tee {
-                                                                                inner: <tee 28>: Map {
+                                                                                inner: <tee 29>: Map {
                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >) , ()) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | (d , _signal) | d }),
                                                                                     input: CrossSingleton {
                                                                                         left: Chain {
@@ -3218,7 +3322,7 @@ expression: built.ir()
                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) >) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | ((slot , payload) , ballot) | ((slot , ballot) , Some (payload)) }),
                                                                                                 input: CrossSingleton {
                                                                                                     left: Tee {
-                                                                                                        inner: <tee 18>,
+                                                                                                        inner: <tee 19>,
                                                                                                         metadata: HydroIrMetadata {
                                                                                                             location_kind: Tick(
                                                                                                                 1,
@@ -3232,7 +3336,7 @@ expression: built.ir()
                                                                                                         },
                                                                                                     },
                                                                                                     right: Tee {
-                                                                                                        inner: <tee 3>,
+                                                                                                        inner: <tee 4>,
                                                                                                         metadata: HydroIrMetadata {
                                                                                                             location_kind: Tick(
                                                                                                                 1,
@@ -3275,7 +3379,7 @@ expression: built.ir()
                                                                                                     input: CrossSingleton {
                                                                                                         left: CrossSingleton {
                                                                                                             left: Tee {
-                                                                                                                inner: <tee 21>,
+                                                                                                                inner: <tee 22>,
                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                     location_kind: Tick(
                                                                                                                         1,
@@ -3289,7 +3393,7 @@ expression: built.ir()
                                                                                                                 },
                                                                                                             },
                                                                                                             right: Tee {
-                                                                                                                inner: <tee 3>,
+                                                                                                                inner: <tee 4>,
                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                     location_kind: Tick(
                                                                                                                         1,
@@ -3315,7 +3419,7 @@ expression: built.ir()
                                                                                                             },
                                                                                                         },
                                                                                                         right: Tee {
-                                                                                                            inner: <tee 29>: ChainFirst {
+                                                                                                            inner: <tee 30>: ChainFirst {
                                                                                                                 first: Map {
                                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < usize , core :: option :: Option < usize > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                                                                                                     input: Reduce {
@@ -3323,7 +3427,7 @@ expression: built.ir()
                                                                                                                         input: FilterMap {
                                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , core :: option :: Option < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (checkpoint , _log) | checkpoint }),
                                                                                                                             input: Tee {
-                                                                                                                                inner: <tee 22>,
+                                                                                                                                inner: <tee 23>,
                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                     location_kind: Tick(
                                                                                                                                         1,
@@ -3454,7 +3558,7 @@ expression: built.ir()
                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , core :: option :: Option < usize >) , std :: ops :: Range < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (max_slot , checkpoint) | { if let Some (checkpoint) = checkpoint { (checkpoint + 1) .. max_slot } else { 0 .. max_slot } } }),
                                                                                                                 input: CrossSingleton {
                                                                                                                     left: Tee {
-                                                                                                                        inner: <tee 20>,
+                                                                                                                        inner: <tee 21>,
                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                             location_kind: Tick(
                                                                                                                                 1,
@@ -3468,7 +3572,7 @@ expression: built.ir()
                                                                                                                         },
                                                                                                                     },
                                                                                                                     right: Tee {
-                                                                                                                        inner: <tee 29>,
+                                                                                                                        inner: <tee 30>,
                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                             location_kind: Tick(
                                                                                                                                 1,
@@ -3508,7 +3612,7 @@ expression: built.ir()
                                                                                                             neg: Map {
                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >)) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
                                                                                                                 input: Tee {
-                                                                                                                    inner: <tee 21>,
+                                                                                                                    inner: <tee 22>,
                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                         location_kind: Tick(
                                                                                                                             1,
@@ -3546,7 +3650,7 @@ expression: built.ir()
                                                                                                             },
                                                                                                         },
                                                                                                         right: Tee {
-                                                                                                            inner: <tee 3>,
+                                                                                                            inner: <tee 4>,
                                                                                                             metadata: HydroIrMetadata {
                                                                                                                 location_kind: Tick(
                                                                                                                     1,
@@ -3610,7 +3714,7 @@ expression: built.ir()
                                                                                         right: Map {
                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _u | () }),
                                                                                             input: Tee {
-                                                                                                inner: <tee 11>,
+                                                                                                inner: <tee 12>,
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_kind: Tick(
                                                                                                         1,
@@ -3723,7 +3827,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         right: Tee {
-                                                            inner: <tee 9>,
+                                                            inner: <tee 10>,
                                                             metadata: HydroIrMetadata {
                                                                 location_kind: Tick(
                                                                     2,
@@ -3863,12 +3967,12 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <tee 30>: Map {
+                inner: <tee 31>: Map {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (usize , usize)) , (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
                     input: Filter {
                         f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (usize , usize)) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < (usize , usize) , bool > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; let max__free = 3usize ; move | (success , error) | (success + error) >= max__free }) ; { let orig = f__free ; move | (_k , v) | orig (v) } }),
                         input: Tee {
-                            inner: <tee 24>,
+                            inner: <tee 25>,
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
                                     1,
@@ -3939,11 +4043,11 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_12,
+            sym: cycle_13,
         },
         input: AntiJoin {
             pos: Tee {
-                inner: <tee 25>,
+                inner: <tee 26>,
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
                         1,
@@ -3957,7 +4061,7 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <tee 30>,
+                inner: <tee 31>,
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
                         1,
@@ -3992,15 +4096,15 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_14,
+            sym: cycle_15,
         },
         input: AntiJoin {
             pos: Tee {
-                inner: <tee 31>: Chain {
+                inner: <tee 32>: Chain {
                     first: DeferTick {
                         input: CycleSource {
                             ident: Ident {
-                                sym: cycle_14,
+                                sym: cycle_15,
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
@@ -4027,7 +4131,7 @@ expression: built.ir()
                         },
                     },
                     second: Tee {
-                        inner: <tee 28>,
+                        inner: <tee 29>,
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
                                 1,
@@ -4067,11 +4171,11 @@ expression: built.ir()
             neg: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ()) , (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: request_response :: * ; | (key , _) | key }),
                 input: Tee {
-                    inner: <tee 32>: Map {
+                    inner: <tee 33>: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ()) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | k | (k , ()) }),
                         input: Difference {
                             pos: Tee {
-                                inner: <tee 23>,
+                                inner: <tee 24>,
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
                                         1,
@@ -4087,7 +4191,7 @@ expression: built.ir()
                             neg: DeferTick {
                                 input: CycleSource {
                                     ident: Ident {
-                                        sym: cycle_13,
+                                        sym: cycle_14,
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
@@ -4183,16 +4287,16 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_3,
+            sym: cycle_4,
         },
         input: CrossSingleton {
             left: ChainFirst {
                 first: Map {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < usize , core :: option :: Option < usize > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                     input: Tee {
-                        inner: <tee 33>: CycleSource {
+                        inner: <tee 34>: CycleSource {
                             ident: Ident {
-                                sym: cycle_1,
+                                sym: cycle_2,
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Cluster(
@@ -4275,7 +4379,7 @@ expression: built.ir()
                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (p2a , max_ballot) | if p2a . ballot >= max_ballot { Some ((p2a . slot , LogValue { ballot : p2a . ballot , value : p2a . value , })) } else { None } }),
                             input: CrossSingleton {
                                 left: Tee {
-                                    inner: <tee 27>,
+                                    inner: <tee 28>,
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
                                             2,
@@ -4289,7 +4393,7 @@ expression: built.ir()
                                     },
                                 },
                                 right: Tee {
-                                    inner: <tee 9>,
+                                    inner: <tee 10>,
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
                                             2,
@@ -4339,7 +4443,7 @@ expression: built.ir()
                         },
                     },
                     watermark: Tee {
-                        inner: <tee 33>,
+                        inner: <tee 34>,
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
                                 2,
@@ -4398,14 +4502,14 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_2,
+            sym: cycle_3,
         },
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (_ , ballot) | ballot }),
             input: FilterMap {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , core :: option :: Option < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | (key , res) | match res { Ok (_) => None , Err (e) => Some ((key , e)) , } }),
                 input: Tee {
-                    inner: <tee 26>,
+                    inner: <tee 27>,
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
                             1,
@@ -4446,7 +4550,7 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_15,
+            sym: cycle_16,
         },
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , usize) , hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; | (sorted_payload , _) | { sorted_payload } }),
@@ -4454,7 +4558,7 @@ expression: built.ir()
                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , usize) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; | (sorted_payload , highest_seq) | sorted_payload . seq > * highest_seq }),
                 input: CrossSingleton {
                     left: Tee {
-                        inner: <tee 34>: Sort {
+                        inner: <tee 35>: Sort {
                             input: Chain {
                                 first: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >) , hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; | (slot , kv) | SequencedKv { seq : slot , kv } }),
@@ -4546,7 +4650,7 @@ expression: built.ir()
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > , ())) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > , ())) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: request_response :: * ; | (key , (meta , resp)) | (key , (meta , resp)) }),
                                                         input: Join {
                                                             left: Tee {
-                                                                inner: <tee 31>,
+                                                                inner: <tee 32>,
                                                                 metadata: HydroIrMetadata {
                                                                     location_kind: Tick(
                                                                         1,
@@ -4560,7 +4664,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             right: Tee {
-                                                                inner: <tee 32>,
+                                                                inner: <tee 33>,
                                                                 metadata: HydroIrMetadata {
                                                                     location_kind: Tick(
                                                                         1,
@@ -4648,7 +4752,7 @@ expression: built.ir()
                                 second: DeferTick {
                                     input: CycleSource {
                                         ident: Ident {
-                                            sym: cycle_15,
+                                            sym: cycle_16,
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
@@ -4711,12 +4815,12 @@ expression: built.ir()
                         },
                     },
                     right: Tee {
-                        inner: <tee 35>: Fold {
+                        inner: <tee 36>: Fold {
                             init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; | | 0 }),
                             acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , usize) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; | new_next_slot , (sorted_payload , next_slot) | { if sorted_payload . seq == std :: cmp :: max (* new_next_slot , next_slot) { * new_next_slot = sorted_payload . seq + 1 ; } } }),
                             input: CrossSingleton {
                                 left: Tee {
-                                    inner: <tee 34>,
+                                    inner: <tee 35>,
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
                                             13,
@@ -4730,11 +4834,11 @@ expression: built.ir()
                                     },
                                 },
                                 right: Tee {
-                                    inner: <tee 36>: ChainFirst {
+                                    inner: <tee 37>: ChainFirst {
                                         first: DeferTick {
                                             input: CycleSource {
                                                 ident: Ident {
-                                                    sym: cycle_16,
+                                                    sym: cycle_17,
                                                 },
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
@@ -4889,7 +4993,7 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_16,
+            sym: cycle_17,
         },
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: collections :: hash_map :: HashMap < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , usize) , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; | (_kv_store , next_slot) | next_slot }),
@@ -4898,13 +5002,13 @@ expression: built.ir()
                 acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (std :: collections :: hash_map :: HashMap < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , usize) , hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; | (kv_store , next_slot) , payload | { if let Some (kv) = payload . kv { kv_store . insert (kv . key , kv . value) ; } * next_slot = payload . seq + 1 ; } }),
                 input: Persist {
                     inner: Tee {
-                        inner: <tee 37>: Map {
+                        inner: <tee 38>: Map {
                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , usize) , hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; | (sorted_payload , _) | { sorted_payload } }),
                             input: Filter {
                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , usize) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; | (sorted_payload , highest_seq) | sorted_payload . seq < * highest_seq }),
                                 input: CrossSingleton {
                                     left: Tee {
-                                        inner: <tee 34>,
+                                        inner: <tee 35>,
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
                                                 13,
@@ -4918,7 +5022,7 @@ expression: built.ir()
                                         },
                                     },
                                     right: Tee {
-                                        inner: <tee 35>,
+                                        inner: <tee 36>,
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
                                                 13,
@@ -5025,10 +5129,10 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_17,
+            sym: cycle_18,
         },
         input: Tee {
-            inner: <tee 38>: FilterMap {
+            inner: <tee 39>: FilterMap {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (core :: option :: Option < usize > , usize) , core :: option :: Option < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; let checkpoint_frequency__free = 1000usize ; move | (max_checkpointed_seq , next_slot) | if max_checkpointed_seq . map (| m | next_slot - m >= checkpoint_frequency__free) . unwrap_or (true) { Some (next_slot) } else { None } }),
                 input: CrossSingleton {
                     left: ChainFirst {
@@ -5040,7 +5144,7 @@ expression: built.ir()
                                     inner: DeferTick {
                                         input: CycleSource {
                                             ident: Ident {
-                                                sym: cycle_17,
+                                                sym: cycle_18,
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
@@ -5141,7 +5245,7 @@ expression: built.ir()
                         },
                     },
                     right: Tee {
-                        inner: <tee 36>,
+                        inner: <tee 37>,
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
                                 13,
@@ -5200,7 +5304,7 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_1,
+            sym: cycle_2,
         },
         input: Reduce {
             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | curr , new | { if new < * curr { * curr = new ; } } }),
@@ -5210,7 +5314,7 @@ expression: built.ir()
                     f: stageleft :: runtime_support :: fn1_type_hint :: < ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica > , usize) , ()) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica > , usize) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | (d , _signal) | d }),
                     input: CrossSingleton {
                         left: Tee {
-                            inner: <tee 39>: ReduceKeyed {
+                            inner: <tee 40>: ReduceKeyed {
                                 f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; | curr_seq , seq | { if seq > * curr_seq { * curr_seq = seq ; } } }),
                                 input: Persist {
                                     inner: Network {
@@ -5294,7 +5398,7 @@ expression: built.ir()
                                                 },
                                             },
                                             right: Tee {
-                                                inner: <tee 38>,
+                                                inner: <tee 39>,
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
                                                         13,
@@ -5366,7 +5470,7 @@ expression: built.ir()
                                     init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | | 0usize }),
                                     acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica > , usize) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | count , _ | * count += 1 }),
                                     input: Tee {
-                                        inner: <tee 39>,
+                                        inner: <tee 40>,
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
                                                 14,
@@ -5470,15 +5574,15 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_18,
+            sym: cycle_19,
         },
         input: AntiJoin {
             pos: Tee {
-                inner: <tee 40>: Chain {
+                inner: <tee 41>: Chain {
                     first: DeferTick {
                         input: CycleSource {
                             ident: Ident {
-                                sym: cycle_18,
+                                sym: cycle_19,
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
@@ -5505,7 +5609,7 @@ expression: built.ir()
                         },
                     },
                     second: Tee {
-                        inner: <tee 41>: Map {
+                        inner: <tee 42>: Map {
                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica > , ((u32 , u32) , core :: result :: Result < () , () >)) , ((u32 , u32) , core :: result :: Result < () , () >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
                             input: Network {
                                 serialize_fn: Some(
@@ -5520,7 +5624,7 @@ expression: built.ir()
                                     input: FilterMap {
                                         f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; | payload | payload . kv }),
                                         input: Tee {
-                                            inner: <tee 37>,
+                                            inner: <tee 38>,
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
                                                     13,
@@ -5609,14 +5713,14 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <tee 42>: FilterMap {
+                inner: <tee 43>: FilterMap {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < ((u32 , u32) , (usize , usize)) , core :: option :: Option < (u32 , u32) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; let min__free = 2usize ; move | (key , (success , _error)) | if success >= min__free { Some (key) } else { None } }),
                     input: Tee {
-                        inner: <tee 43>: FoldKeyed {
+                        inner: <tee 44>: FoldKeyed {
                             init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | | (0 , 0) }),
                             acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < () , () > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } } }),
                             input: Tee {
-                                inner: <tee 40>,
+                                inner: <tee 41>,
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
                                         16,
@@ -5699,18 +5803,30 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_0,
+            sym: cycle_1,
         },
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , core :: option :: Option < u32 >) , (u32 , u32) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; move | (virtual_id , payload) | { let value = if let Some (payload) = payload { payload + 1 } else { 0 } ; (virtual_id , value) } }),
             input: Chain {
-                first: FlatMap {
-                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , std :: iter :: Map < std :: ops :: Range < u32 > , _ > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; let num_clients_per_node__free = 100usize ; move | _ | (0 .. num_clients_per_node__free as u32) . map (move | virtual_id | { (virtual_id , None) }) }),
+                first: Map {
+                    f: stageleft :: runtime_support :: fn1_type_hint :: < u32 , (u32 , core :: option :: Option < u32 >) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | virtual_id | (virtual_id , None) }),
                     input: Tee {
-                        inner: <tee 44>: Source {
-                            source: Iter(
-                                { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: tick :: * ; let e__free = { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; () } ; [e__free] },
-                            ),
+                        inner: <tee 45>: Filter {
+                            f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < u32 , bool > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; let num_clients_per_node__free = 100usize ; move | virtual_id | * virtual_id < num_clients_per_node__free as u32 }),
+                            input: Tee {
+                                inner: <tee 0>,
+                                metadata: HydroIrMetadata {
+                                    location_kind: Tick(
+                                        0,
+                                        Cluster(
+                                            2,
+                                        ),
+                                    ),
+                                    output_type: Some(
+                                        u32,
+                                    ),
+                                },
+                            },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
                                     0,
@@ -5719,7 +5835,7 @@ expression: built.ir()
                                     ),
                                 ),
                                 output_type: Some(
-                                    (),
+                                    u32,
                                 ),
                             },
                         },
@@ -5731,7 +5847,7 @@ expression: built.ir()
                                 ),
                             ),
                             output_type: Some(
-                                (),
+                                u32,
                             ),
                         },
                     },
@@ -5748,10 +5864,10 @@ expression: built.ir()
                     },
                 },
                 second: Tee {
-                    inner: <tee 45>: Map {
+                    inner: <tee 46>: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , u32) , (u32 , core :: option :: Option < u32 >) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (virtual_id , payload) | (virtual_id , Some (payload)) }),
                         input: Tee {
-                            inner: <tee 42>,
+                            inner: <tee 43>,
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
                                     16,
@@ -5816,17 +5932,17 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_19,
+            sym: cycle_20,
         },
         input: ReduceKeyed {
             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: time :: Instant , std :: time :: Instant , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | curr_time , new_time | { if new_time > * curr_time { * curr_time = new_time ; } } }),
             input: Chain {
                 first: Chain {
                     first: Tee {
-                        inner: <tee 46>: DeferTick {
+                        inner: <tee 47>: DeferTick {
                             input: CycleSource {
                                 ident: Ident {
-                                    sym: cycle_19,
+                                    sym: cycle_20,
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
@@ -5836,7 +5952,7 @@ expression: built.ir()
                                         ),
                                     ),
                                     output_type: Some(
-                                        (usize , std :: time :: Instant),
+                                        (u32 , std :: time :: Instant),
                                     ),
                                 },
                             },
@@ -5848,7 +5964,7 @@ expression: built.ir()
                                     ),
                                 ),
                                 output_type: Some(
-                                    (usize , std :: time :: Instant),
+                                    (u32 , std :: time :: Instant),
                                 ),
                             },
                         },
@@ -5860,28 +5976,14 @@ expression: built.ir()
                                 ),
                             ),
                             output_type: Some(
-                                (usize , std :: time :: Instant),
+                                (u32 , std :: time :: Instant),
                             ),
                         },
                     },
-                    second: FlatMap {
-                        f: stageleft :: runtime_support :: fn1_type_hint :: < std :: time :: Instant , std :: iter :: Map < std :: ops :: Range < usize > , _ > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; let num_clients_per_node__free = 100usize ; move | now | (0 .. num_clients_per_node__free) . map (move | virtual_id | (virtual_id , now)) }),
-                        input: Map {
-                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , std :: time :: Instant > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | _ | Instant :: now () }),
-                            input: Tee {
-                                inner: <tee 44>,
-                                metadata: HydroIrMetadata {
-                                    location_kind: Tick(
-                                        0,
-                                        Cluster(
-                                            2,
-                                        ),
-                                    ),
-                                    output_type: Some(
-                                        (),
-                                    ),
-                                },
-                            },
+                    second: Map {
+                        f: stageleft :: runtime_support :: fn1_type_hint :: < u32 , (u32 , std :: time :: Instant) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | virtual_id | (virtual_id , Instant :: now ()) }),
+                        input: Tee {
+                            inner: <tee 45>,
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
                                     0,
@@ -5890,7 +5992,7 @@ expression: built.ir()
                                     ),
                                 ),
                                 output_type: Some(
-                                    std :: time :: Instant,
+                                    u32,
                                 ),
                             },
                         },
@@ -5902,7 +6004,7 @@ expression: built.ir()
                                 ),
                             ),
                             output_type: Some(
-                                (usize , std :: time :: Instant),
+                                (u32 , std :: time :: Instant),
                             ),
                         },
                     },
@@ -5914,15 +6016,15 @@ expression: built.ir()
                             ),
                         ),
                         output_type: Some(
-                            (usize , std :: time :: Instant),
+                            (u32 , std :: time :: Instant),
                         ),
                     },
                 },
                 second: Tee {
-                    inner: <tee 47>: Map {
-                        f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , core :: option :: Option < u32 >) , (usize , std :: time :: Instant) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (key , _payload) | (key as usize , Instant :: now ()) }),
+                    inner: <tee 48>: Map {
+                        f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , core :: option :: Option < u32 >) , (u32 , std :: time :: Instant) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (key , _payload) | (key , Instant :: now ()) }),
                         input: Tee {
-                            inner: <tee 45>,
+                            inner: <tee 46>,
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
                                     0,
@@ -5943,7 +6045,7 @@ expression: built.ir()
                                 ),
                             ),
                             output_type: Some(
-                                (usize , std :: time :: Instant),
+                                (u32 , std :: time :: Instant),
                             ),
                         },
                     },
@@ -5955,7 +6057,7 @@ expression: built.ir()
                             ),
                         ),
                         output_type: Some(
-                            (usize , std :: time :: Instant),
+                            (u32 , std :: time :: Instant),
                         ),
                     },
                 },
@@ -5967,7 +6069,7 @@ expression: built.ir()
                         ),
                     ),
                     output_type: Some(
-                        (usize , std :: time :: Instant),
+                        (u32 , std :: time :: Instant),
                     ),
                 },
             },
@@ -5979,7 +6081,7 @@ expression: built.ir()
                     ),
                 ),
                 output_type: Some(
-                    (usize , std :: time :: Instant),
+                    (u32 , std :: time :: Instant),
                 ),
             },
         },
@@ -5997,11 +6099,11 @@ expression: built.ir()
             f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , ()) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | (d , _signal) | d }),
             input: CrossSingleton {
                 left: Tee {
-                    inner: <tee 48>: FilterMap {
+                    inner: <tee 49>: FilterMap {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , usize) , core :: option :: Option < usize > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (num_clients , num_clients_with_throughput) | { if num_clients > num_clients_with_throughput { Some (num_clients - num_clients_with_throughput) } else { None } } }),
                         input: CrossSingleton {
                             left: Tee {
-                                inner: <tee 49>: Fold {
+                                inner: <tee 50>: Fold {
                                     init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | | 0usize }),
                                     acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , ()) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | count , _ | * count += 1 }),
                                     input: FilterMap {
@@ -6086,7 +6188,7 @@ expression: built.ir()
                                 init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | | 0usize }),
                                 acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | count , _ | * count += 1 }),
                                 input: Tee {
-                                    inner: <tee 50>: Filter {
+                                    inner: <tee 51>: Filter {
                                         f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage , bool > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | throughputs | throughputs . sample_mean () > 0.0 }) ; { let orig = f__free ; move | (_k , v) | orig (v) } }),
                                         input: ReduceKeyed {
                                             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | combined , new | { * combined = new ; } }),
@@ -6118,7 +6220,7 @@ expression: built.ir()
                                                                                             init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | | 0usize }),
                                                                                             acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , (u32 , core :: option :: Option < u32 >) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | count , _ | * count += 1 }),
                                                                                             input: Tee {
-                                                                                                inner: <tee 45>,
+                                                                                                inner: <tee 46>,
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_kind: Tick(
                                                                                                         0,
@@ -6153,7 +6255,7 @@ expression: built.ir()
                                                                                                         input: Map {
                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _ | () }),
                                                                                                             input: Tee {
-                                                                                                                inner: <tee 51>: Reduce {
+                                                                                                                inner: <tee 52>: Reduce {
                                                                                                                     f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
                                                                                                                     input: Source {
                                                                                                                         source: Stream(
@@ -6318,7 +6420,7 @@ expression: built.ir()
                                                                                 input: Map {
                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , (usize , bool) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | _ | (0 , true) }),
                                                                                     input: Tee {
-                                                                                        inner: <tee 51>,
+                                                                                        inner: <tee 52>,
                                                                                         metadata: HydroIrMetadata {
                                                                                             location_kind: Tick(
                                                                                                 0,
@@ -6633,7 +6735,7 @@ expression: built.ir()
                                 input: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage) , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (_ , v) | v }),
                                     input: Tee {
-                                        inner: <tee 50>,
+                                        inner: <tee 51>,
                                         metadata: HydroIrMetadata {
                                             location_kind: Process(
                                                 3,
@@ -6733,7 +6835,7 @@ expression: built.ir()
                         },
                     },
                     right: Tee {
-                        inner: <tee 49>,
+                        inner: <tee 50>,
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
                                 17,
@@ -6768,7 +6870,7 @@ expression: built.ir()
                                 input: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ | () }),
                                     input: Tee {
-                                        inner: <tee 48>,
+                                        inner: <tee 49>,
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
                                                 17,
@@ -6928,23 +7030,9 @@ expression: built.ir()
                                                                 acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , core :: time :: Duration , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; move | latencies , latency | { latencies . borrow_mut () . record (latency . as_nanos () as u64) . unwrap () ; } }),
                                                                 input: Persist {
                                                                     inner: Map {
-                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , (std :: time :: Instant , std :: time :: Instant)) , core :: time :: Duration > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (_virtual_id , (prev_time , curr_time)) | curr_time . duration_since (prev_time) }),
+                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , (std :: time :: Instant , std :: time :: Instant)) , core :: time :: Duration > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (_virtual_id , (prev_time , curr_time)) | curr_time . duration_since (prev_time) }),
                                                                         input: Join {
                                                                             left: Tee {
-                                                                                inner: <tee 46>,
-                                                                                metadata: HydroIrMetadata {
-                                                                                    location_kind: Tick(
-                                                                                        0,
-                                                                                        Cluster(
-                                                                                            2,
-                                                                                        ),
-                                                                                    ),
-                                                                                    output_type: Some(
-                                                                                        (usize , std :: time :: Instant),
-                                                                                    ),
-                                                                                },
-                                                                            },
-                                                                            right: Tee {
                                                                                 inner: <tee 47>,
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_kind: Tick(
@@ -6954,7 +7042,21 @@ expression: built.ir()
                                                                                         ),
                                                                                     ),
                                                                                     output_type: Some(
-                                                                                        (usize , std :: time :: Instant),
+                                                                                        (u32 , std :: time :: Instant),
+                                                                                    ),
+                                                                                },
+                                                                            },
+                                                                            right: Tee {
+                                                                                inner: <tee 48>,
+                                                                                metadata: HydroIrMetadata {
+                                                                                    location_kind: Tick(
+                                                                                        0,
+                                                                                        Cluster(
+                                                                                            2,
+                                                                                        ),
+                                                                                    ),
+                                                                                    output_type: Some(
+                                                                                        (u32 , std :: time :: Instant),
                                                                                     ),
                                                                                 },
                                                                             },
@@ -6966,7 +7068,7 @@ expression: built.ir()
                                                                                     ),
                                                                                 ),
                                                                                 output_type: Some(
-                                                                                    (usize , (std :: time :: Instant , std :: time :: Instant)),
+                                                                                    (u32 , (std :: time :: Instant , std :: time :: Instant)),
                                                                                 ),
                                                                             },
                                                                         },
@@ -7212,7 +7314,7 @@ expression: built.ir()
                                 input: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ | () }),
                                     input: Tee {
-                                        inner: <tee 48>,
+                                        inner: <tee 49>,
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
                                                 17,

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir@acceptor_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir@acceptor_mermaid.snap
@@ -118,163 +118,163 @@ linkStyle default stroke:#aaa
 25v1
 35v1
 34v1
-subgraph var_reduce_keyed_watermark_chain_308 ["var <tt>reduce_keyed_watermark_chain_308</tt>"]
-    style var_reduce_keyed_watermark_chain_308 fill:transparent
+subgraph var_reduce_keyed_watermark_chain_315 ["var <tt>reduce_keyed_watermark_chain_315</tt>"]
+    style var_reduce_keyed_watermark_chain_315 fill:transparent
     33v1
 end
-subgraph var_stream_2 ["var <tt>stream_2</tt>"]
-    style var_stream_2 fill:transparent
-    1v1
-end
-subgraph var_stream_261 ["var <tt>stream_261</tt>"]
-    style var_stream_261 fill:transparent
+subgraph var_stream_268 ["var <tt>stream_268</tt>"]
+    style var_stream_268 fill:transparent
     18v1
     19v1
 end
-subgraph var_stream_262 ["var <tt>stream_262</tt>"]
-    style var_stream_262 fill:transparent
+subgraph var_stream_269 ["var <tt>stream_269</tt>"]
+    style var_stream_269 fill:transparent
     20v1
 end
-subgraph var_stream_263 ["var <tt>stream_263</tt>"]
-    style var_stream_263 fill:transparent
+subgraph var_stream_270 ["var <tt>stream_270</tt>"]
+    style var_stream_270 fill:transparent
     21v1
 end
-subgraph var_stream_265 ["var <tt>stream_265</tt>"]
-    style var_stream_265 fill:transparent
+subgraph var_stream_272 ["var <tt>stream_272</tt>"]
+    style var_stream_272 fill:transparent
     22v1
 end
-subgraph var_stream_266 ["var <tt>stream_266</tt>"]
-    style var_stream_266 fill:transparent
+subgraph var_stream_273 ["var <tt>stream_273</tt>"]
+    style var_stream_273 fill:transparent
     23v1
-end
-subgraph var_stream_298 ["var <tt>stream_298</tt>"]
-    style var_stream_298 fill:transparent
-    26v1
-end
-subgraph var_stream_299 ["var <tt>stream_299</tt>"]
-    style var_stream_299 fill:transparent
-    27v1
-end
-subgraph var_stream_300 ["var <tt>stream_300</tt>"]
-    style var_stream_300 fill:transparent
-    28v1
-end
-subgraph var_stream_301 ["var <tt>stream_301</tt>"]
-    style var_stream_301 fill:transparent
-    29v1
-end
-subgraph var_stream_302 ["var <tt>stream_302</tt>"]
-    style var_stream_302 fill:transparent
-    30v1
 end
 subgraph var_stream_305 ["var <tt>stream_305</tt>"]
     style var_stream_305 fill:transparent
-    31v1
+    26v1
 end
 subgraph var_stream_306 ["var <tt>stream_306</tt>"]
     style var_stream_306 fill:transparent
-    32v1
+    27v1
+end
+subgraph var_stream_307 ["var <tt>stream_307</tt>"]
+    style var_stream_307 fill:transparent
+    28v1
 end
 subgraph var_stream_308 ["var <tt>stream_308</tt>"]
     style var_stream_308 fill:transparent
-    36v1
-    37v1
+    29v1
 end
 subgraph var_stream_309 ["var <tt>stream_309</tt>"]
     style var_stream_309 fill:transparent
+    30v1
+end
+subgraph var_stream_312 ["var <tt>stream_312</tt>"]
+    style var_stream_312 fill:transparent
+    31v1
+end
+subgraph var_stream_313 ["var <tt>stream_313</tt>"]
+    style var_stream_313 fill:transparent
+    32v1
+end
+subgraph var_stream_315 ["var <tt>stream_315</tt>"]
+    style var_stream_315 fill:transparent
+    36v1
+    37v1
+end
+subgraph var_stream_316 ["var <tt>stream_316</tt>"]
+    style var_stream_316 fill:transparent
     38v1
 end
-subgraph var_stream_310 ["var <tt>stream_310</tt>"]
-    style var_stream_310 fill:transparent
+subgraph var_stream_317 ["var <tt>stream_317</tt>"]
+    style var_stream_317 fill:transparent
     39v1
-end
-subgraph var_stream_372 ["var <tt>stream_372</tt>"]
-    style var_stream_372 fill:transparent
-    40v1
-    41v1
-end
-subgraph var_stream_373 ["var <tt>stream_373</tt>"]
-    style var_stream_373 fill:transparent
-    42v1
-end
-subgraph var_stream_374 ["var <tt>stream_374</tt>"]
-    style var_stream_374 fill:transparent
-    43v1
-end
-subgraph var_stream_376 ["var <tt>stream_376</tt>"]
-    style var_stream_376 fill:transparent
-    44v1
-end
-subgraph var_stream_377 ["var <tt>stream_377</tt>"]
-    style var_stream_377 fill:transparent
-    45v1
-end
-subgraph var_stream_378 ["var <tt>stream_378</tt>"]
-    style var_stream_378 fill:transparent
-    46v1
 end
 subgraph var_stream_379 ["var <tt>stream_379</tt>"]
     style var_stream_379 fill:transparent
-    47v1
+    40v1
+    41v1
 end
 subgraph var_stream_380 ["var <tt>stream_380</tt>"]
     style var_stream_380 fill:transparent
-    48v1
+    42v1
 end
 subgraph var_stream_381 ["var <tt>stream_381</tt>"]
     style var_stream_381 fill:transparent
+    43v1
+end
+subgraph var_stream_383 ["var <tt>stream_383</tt>"]
+    style var_stream_383 fill:transparent
+    44v1
+end
+subgraph var_stream_384 ["var <tt>stream_384</tt>"]
+    style var_stream_384 fill:transparent
+    45v1
+end
+subgraph var_stream_385 ["var <tt>stream_385</tt>"]
+    style var_stream_385 fill:transparent
+    46v1
+end
+subgraph var_stream_386 ["var <tt>stream_386</tt>"]
+    style var_stream_386 fill:transparent
+    47v1
+end
+subgraph var_stream_387 ["var <tt>stream_387</tt>"]
+    style var_stream_387 fill:transparent
+    48v1
+end
+subgraph var_stream_388 ["var <tt>stream_388</tt>"]
+    style var_stream_388 fill:transparent
     49v1
 end
-subgraph var_stream_382 ["var <tt>stream_382</tt>"]
-    style var_stream_382 fill:transparent
+subgraph var_stream_389 ["var <tt>stream_389</tt>"]
+    style var_stream_389 fill:transparent
     50v1
-end
-subgraph var_stream_75 ["var <tt>stream_75</tt>"]
-    style var_stream_75 fill:transparent
-    3v1
-    4v1
-end
-subgraph var_stream_76 ["var <tt>stream_76</tt>"]
-    style var_stream_76 fill:transparent
-    5v1
-end
-subgraph var_stream_77 ["var <tt>stream_77</tt>"]
-    style var_stream_77 fill:transparent
-    6v1
-end
-subgraph var_stream_79 ["var <tt>stream_79</tt>"]
-    style var_stream_79 fill:transparent
-    7v1
-end
-subgraph var_stream_80 ["var <tt>stream_80</tt>"]
-    style var_stream_80 fill:transparent
-    8v1
-end
-subgraph var_stream_81 ["var <tt>stream_81</tt>"]
-    style var_stream_81 fill:transparent
-    9v1
 end
 subgraph var_stream_82 ["var <tt>stream_82</tt>"]
     style var_stream_82 fill:transparent
-    10v1
+    3v1
+    4v1
 end
 subgraph var_stream_83 ["var <tt>stream_83</tt>"]
     style var_stream_83 fill:transparent
-    11v1
+    5v1
 end
 subgraph var_stream_84 ["var <tt>stream_84</tt>"]
     style var_stream_84 fill:transparent
-    12v1
+    6v1
 end
-subgraph var_stream_85 ["var <tt>stream_85</tt>"]
-    style var_stream_85 fill:transparent
-    13v1
+subgraph var_stream_86 ["var <tt>stream_86</tt>"]
+    style var_stream_86 fill:transparent
+    7v1
 end
 subgraph var_stream_87 ["var <tt>stream_87</tt>"]
     style var_stream_87 fill:transparent
-    14v1
+    8v1
 end
 subgraph var_stream_88 ["var <tt>stream_88</tt>"]
     style var_stream_88 fill:transparent
+    9v1
+end
+subgraph var_stream_89 ["var <tt>stream_89</tt>"]
+    style var_stream_89 fill:transparent
+    10v1
+end
+subgraph var_stream_9 ["var <tt>stream_9</tt>"]
+    style var_stream_9 fill:transparent
+    1v1
+end
+subgraph var_stream_90 ["var <tt>stream_90</tt>"]
+    style var_stream_90 fill:transparent
+    11v1
+end
+subgraph var_stream_91 ["var <tt>stream_91</tt>"]
+    style var_stream_91 fill:transparent
+    12v1
+end
+subgraph var_stream_92 ["var <tt>stream_92</tt>"]
+    style var_stream_92 fill:transparent
+    13v1
+end
+subgraph var_stream_94 ["var <tt>stream_94</tt>"]
+    style var_stream_94 fill:transparent
+    14v1
+end
+subgraph var_stream_95 ["var <tt>stream_95</tt>"]
+    style var_stream_95 fill:transparent
     15v1
 end

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir@proposer_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir@proposer_mermaid.snap
@@ -528,855 +528,855 @@ linkStyle default stroke:#aaa
 336v1
 338v1
 340v1
-subgraph var_stream_0 ["var <tt>stream_0</tt>"]
-    style var_stream_0 fill:transparent
-    1v1
-end
-subgraph var_stream_10 ["var <tt>stream_10</tt>"]
-    style var_stream_10 fill:transparent
-    6v1
-end
 subgraph var_stream_100 ["var <tt>stream_100</tt>"]
     style var_stream_100 fill:transparent
-    80v1
+    74v1
 end
 subgraph var_stream_101 ["var <tt>stream_101</tt>"]
     style var_stream_101 fill:transparent
-    81v1
+    75v1
 end
 subgraph var_stream_102 ["var <tt>stream_102</tt>"]
     style var_stream_102 fill:transparent
-    82v1
+    76v1
 end
 subgraph var_stream_103 ["var <tt>stream_103</tt>"]
     style var_stream_103 fill:transparent
-    83v1
+    77v1
 end
-subgraph var_stream_106 ["var <tt>stream_106</tt>"]
-    style var_stream_106 fill:transparent
-    84v1
+subgraph var_stream_104 ["var <tt>stream_104</tt>"]
+    style var_stream_104 fill:transparent
+    78v1
+end
+subgraph var_stream_105 ["var <tt>stream_105</tt>"]
+    style var_stream_105 fill:transparent
+    79v1
+end
+subgraph var_stream_107 ["var <tt>stream_107</tt>"]
+    style var_stream_107 fill:transparent
+    80v1
+end
+subgraph var_stream_108 ["var <tt>stream_108</tt>"]
+    style var_stream_108 fill:transparent
+    81v1
 end
 subgraph var_stream_109 ["var <tt>stream_109</tt>"]
     style var_stream_109 fill:transparent
-    85v1
-end
-subgraph var_stream_11 ["var <tt>stream_11</tt>"]
-    style var_stream_11 fill:transparent
-    7v1
+    82v1
 end
 subgraph var_stream_110 ["var <tt>stream_110</tt>"]
     style var_stream_110 fill:transparent
-    86v1
-end
-subgraph var_stream_111 ["var <tt>stream_111</tt>"]
-    style var_stream_111 fill:transparent
-    87v1
+    83v1
 end
 subgraph var_stream_113 ["var <tt>stream_113</tt>"]
     style var_stream_113 fill:transparent
-    88v1
-end
-subgraph var_stream_114 ["var <tt>stream_114</tt>"]
-    style var_stream_114 fill:transparent
-    89v1
-end
-subgraph var_stream_115 ["var <tt>stream_115</tt>"]
-    style var_stream_115 fill:transparent
-    90v1
+    84v1
 end
 subgraph var_stream_116 ["var <tt>stream_116</tt>"]
     style var_stream_116 fill:transparent
-    91v1
+    85v1
 end
 subgraph var_stream_117 ["var <tt>stream_117</tt>"]
     style var_stream_117 fill:transparent
-    92v1
+    86v1
 end
-subgraph var_stream_119 ["var <tt>stream_119</tt>"]
-    style var_stream_119 fill:transparent
-    93v1
-end
-subgraph var_stream_12 ["var <tt>stream_12</tt>"]
-    style var_stream_12 fill:transparent
-    8v1
+subgraph var_stream_118 ["var <tt>stream_118</tt>"]
+    style var_stream_118 fill:transparent
+    87v1
 end
 subgraph var_stream_120 ["var <tt>stream_120</tt>"]
     style var_stream_120 fill:transparent
-    94v1
+    88v1
 end
 subgraph var_stream_121 ["var <tt>stream_121</tt>"]
     style var_stream_121 fill:transparent
-    95v1
+    89v1
 end
 subgraph var_stream_122 ["var <tt>stream_122</tt>"]
     style var_stream_122 fill:transparent
-    96v1
+    90v1
 end
-subgraph var_stream_125 ["var <tt>stream_125</tt>"]
-    style var_stream_125 fill:transparent
-    97v1
+subgraph var_stream_123 ["var <tt>stream_123</tt>"]
+    style var_stream_123 fill:transparent
+    91v1
+end
+subgraph var_stream_124 ["var <tt>stream_124</tt>"]
+    style var_stream_124 fill:transparent
+    92v1
 end
 subgraph var_stream_126 ["var <tt>stream_126</tt>"]
     style var_stream_126 fill:transparent
-    98v1
+    93v1
 end
 subgraph var_stream_127 ["var <tt>stream_127</tt>"]
     style var_stream_127 fill:transparent
-    99v1
+    94v1
+end
+subgraph var_stream_128 ["var <tt>stream_128</tt>"]
+    style var_stream_128 fill:transparent
+    95v1
 end
 subgraph var_stream_129 ["var <tt>stream_129</tt>"]
     style var_stream_129 fill:transparent
-    101v1
+    96v1
 end
 subgraph var_stream_13 ["var <tt>stream_13</tt>"]
     style var_stream_13 fill:transparent
-    9v1
-end
-subgraph var_stream_130 ["var <tt>stream_130</tt>"]
-    style var_stream_130 fill:transparent
-    102v1
-end
-subgraph var_stream_131 ["var <tt>stream_131</tt>"]
-    style var_stream_131 fill:transparent
-    103v1
+    3v1
 end
 subgraph var_stream_132 ["var <tt>stream_132</tt>"]
     style var_stream_132 fill:transparent
-    104v1
+    97v1
+end
+subgraph var_stream_133 ["var <tt>stream_133</tt>"]
+    style var_stream_133 fill:transparent
+    98v1
 end
 subgraph var_stream_134 ["var <tt>stream_134</tt>"]
     style var_stream_134 fill:transparent
-    105v1
+    99v1
 end
-subgraph var_stream_135 ["var <tt>stream_135</tt>"]
-    style var_stream_135 fill:transparent
-    106v1
+subgraph var_stream_136 ["var <tt>stream_136</tt>"]
+    style var_stream_136 fill:transparent
+    101v1
+end
+subgraph var_stream_137 ["var <tt>stream_137</tt>"]
+    style var_stream_137 fill:transparent
+    102v1
+end
+subgraph var_stream_138 ["var <tt>stream_138</tt>"]
+    style var_stream_138 fill:transparent
+    103v1
+end
+subgraph var_stream_139 ["var <tt>stream_139</tt>"]
+    style var_stream_139 fill:transparent
+    104v1
+end
+subgraph var_stream_141 ["var <tt>stream_141</tt>"]
+    style var_stream_141 fill:transparent
+    105v1
 end
 subgraph var_stream_142 ["var <tt>stream_142</tt>"]
     style var_stream_142 fill:transparent
+    106v1
+end
+subgraph var_stream_149 ["var <tt>stream_149</tt>"]
+    style var_stream_149 fill:transparent
     107v1
-end
-subgraph var_stream_143 ["var <tt>stream_143</tt>"]
-    style var_stream_143 fill:transparent
-    108v1
-end
-subgraph var_stream_144 ["var <tt>stream_144</tt>"]
-    style var_stream_144 fill:transparent
-    109v1
-end
-subgraph var_stream_145 ["var <tt>stream_145</tt>"]
-    style var_stream_145 fill:transparent
-    110v1
-end
-subgraph var_stream_146 ["var <tt>stream_146</tt>"]
-    style var_stream_146 fill:transparent
-    111v1
 end
 subgraph var_stream_15 ["var <tt>stream_15</tt>"]
     style var_stream_15 fill:transparent
-    10v1
+    4v1
 end
 subgraph var_stream_150 ["var <tt>stream_150</tt>"]
     style var_stream_150 fill:transparent
-    112v1
+    108v1
 end
 subgraph var_stream_151 ["var <tt>stream_151</tt>"]
     style var_stream_151 fill:transparent
-    113v1
+    109v1
 end
 subgraph var_stream_152 ["var <tt>stream_152</tt>"]
     style var_stream_152 fill:transparent
-    114v1
+    110v1
 end
 subgraph var_stream_153 ["var <tt>stream_153</tt>"]
     style var_stream_153 fill:transparent
-    115v1
-end
-subgraph var_stream_154 ["var <tt>stream_154</tt>"]
-    style var_stream_154 fill:transparent
-    116v1
-end
-subgraph var_stream_155 ["var <tt>stream_155</tt>"]
-    style var_stream_155 fill:transparent
-    117v1
-end
-subgraph var_stream_156 ["var <tt>stream_156</tt>"]
-    style var_stream_156 fill:transparent
-    118v1
+    111v1
 end
 subgraph var_stream_157 ["var <tt>stream_157</tt>"]
     style var_stream_157 fill:transparent
-    119v1
+    112v1
 end
 subgraph var_stream_158 ["var <tt>stream_158</tt>"]
     style var_stream_158 fill:transparent
-    120v1
+    113v1
 end
 subgraph var_stream_159 ["var <tt>stream_159</tt>"]
     style var_stream_159 fill:transparent
-    121v1
+    114v1
 end
 subgraph var_stream_16 ["var <tt>stream_16</tt>"]
     style var_stream_16 fill:transparent
-    11v1
+    5v1
+end
+subgraph var_stream_160 ["var <tt>stream_160</tt>"]
+    style var_stream_160 fill:transparent
+    115v1
 end
 subgraph var_stream_161 ["var <tt>stream_161</tt>"]
     style var_stream_161 fill:transparent
-    123v1
+    116v1
 end
 subgraph var_stream_162 ["var <tt>stream_162</tt>"]
     style var_stream_162 fill:transparent
-    124v1
+    117v1
 end
 subgraph var_stream_163 ["var <tt>stream_163</tt>"]
     style var_stream_163 fill:transparent
-    125v1
+    118v1
 end
 subgraph var_stream_164 ["var <tt>stream_164</tt>"]
     style var_stream_164 fill:transparent
-    126v1
+    119v1
+end
+subgraph var_stream_165 ["var <tt>stream_165</tt>"]
+    style var_stream_165 fill:transparent
+    120v1
+end
+subgraph var_stream_166 ["var <tt>stream_166</tt>"]
+    style var_stream_166 fill:transparent
+    121v1
+end
+subgraph var_stream_168 ["var <tt>stream_168</tt>"]
+    style var_stream_168 fill:transparent
+    123v1
+end
+subgraph var_stream_169 ["var <tt>stream_169</tt>"]
+    style var_stream_169 fill:transparent
+    124v1
 end
 subgraph var_stream_17 ["var <tt>stream_17</tt>"]
     style var_stream_17 fill:transparent
-    12v1
+    6v1
+end
+subgraph var_stream_170 ["var <tt>stream_170</tt>"]
+    style var_stream_170 fill:transparent
+    125v1
+end
+subgraph var_stream_171 ["var <tt>stream_171</tt>"]
+    style var_stream_171 fill:transparent
+    126v1
 end
 subgraph var_stream_18 ["var <tt>stream_18</tt>"]
     style var_stream_18 fill:transparent
-    13v1
-end
-subgraph var_stream_184 ["var <tt>stream_184</tt>"]
-    style var_stream_184 fill:transparent
-    130v1
-    129v1
-end
-subgraph var_stream_185 ["var <tt>stream_185</tt>"]
-    style var_stream_185 fill:transparent
-    131v1
-end
-subgraph var_stream_187 ["var <tt>stream_187</tt>"]
-    style var_stream_187 fill:transparent
-    132v1
-end
-subgraph var_stream_188 ["var <tt>stream_188</tt>"]
-    style var_stream_188 fill:transparent
-    133v1
-end
-subgraph var_stream_189 ["var <tt>stream_189</tt>"]
-    style var_stream_189 fill:transparent
-    134v1
+    7v1
 end
 subgraph var_stream_19 ["var <tt>stream_19</tt>"]
     style var_stream_19 fill:transparent
-    14v1
+    8v1
 end
-subgraph var_stream_190 ["var <tt>stream_190</tt>"]
-    style var_stream_190 fill:transparent
-    135v1
+subgraph var_stream_191 ["var <tt>stream_191</tt>"]
+    style var_stream_191 fill:transparent
+    130v1
+    129v1
 end
 subgraph var_stream_192 ["var <tt>stream_192</tt>"]
     style var_stream_192 fill:transparent
-    136v1
-end
-subgraph var_stream_193 ["var <tt>stream_193</tt>"]
-    style var_stream_193 fill:transparent
-    137v1
+    131v1
 end
 subgraph var_stream_194 ["var <tt>stream_194</tt>"]
     style var_stream_194 fill:transparent
-    138v1
+    132v1
 end
 subgraph var_stream_195 ["var <tt>stream_195</tt>"]
     style var_stream_195 fill:transparent
-    139v1
+    133v1
 end
 subgraph var_stream_196 ["var <tt>stream_196</tt>"]
     style var_stream_196 fill:transparent
-    140v1
+    134v1
 end
 subgraph var_stream_197 ["var <tt>stream_197</tt>"]
     style var_stream_197 fill:transparent
-    141v1
-end
-subgraph var_stream_198 ["var <tt>stream_198</tt>"]
-    style var_stream_198 fill:transparent
-    142v1
+    135v1
 end
 subgraph var_stream_199 ["var <tt>stream_199</tt>"]
     style var_stream_199 fill:transparent
-    143v1
+    136v1
 end
 subgraph var_stream_20 ["var <tt>stream_20</tt>"]
     style var_stream_20 fill:transparent
-    15v1
+    9v1
 end
 subgraph var_stream_200 ["var <tt>stream_200</tt>"]
     style var_stream_200 fill:transparent
-    144v1
+    137v1
 end
 subgraph var_stream_201 ["var <tt>stream_201</tt>"]
     style var_stream_201 fill:transparent
-    145v1
+    138v1
 end
 subgraph var_stream_202 ["var <tt>stream_202</tt>"]
     style var_stream_202 fill:transparent
-    146v1
+    139v1
+end
+subgraph var_stream_203 ["var <tt>stream_203</tt>"]
+    style var_stream_203 fill:transparent
+    140v1
 end
 subgraph var_stream_204 ["var <tt>stream_204</tt>"]
     style var_stream_204 fill:transparent
-    147v1
+    141v1
 end
 subgraph var_stream_205 ["var <tt>stream_205</tt>"]
     style var_stream_205 fill:transparent
-    148v1
+    142v1
 end
 subgraph var_stream_206 ["var <tt>stream_206</tt>"]
     style var_stream_206 fill:transparent
-    149v1
+    143v1
 end
 subgraph var_stream_207 ["var <tt>stream_207</tt>"]
     style var_stream_207 fill:transparent
-    150v1
+    144v1
 end
 subgraph var_stream_208 ["var <tt>stream_208</tt>"]
     style var_stream_208 fill:transparent
-    151v1
+    145v1
 end
 subgraph var_stream_209 ["var <tt>stream_209</tt>"]
     style var_stream_209 fill:transparent
-    152v1
-end
-subgraph var_stream_21 ["var <tt>stream_21</tt>"]
-    style var_stream_21 fill:transparent
-    16v1
-end
-subgraph var_stream_210 ["var <tt>stream_210</tt>"]
-    style var_stream_210 fill:transparent
-    153v1
+    146v1
 end
 subgraph var_stream_211 ["var <tt>stream_211</tt>"]
     style var_stream_211 fill:transparent
-    154v1
+    147v1
 end
 subgraph var_stream_212 ["var <tt>stream_212</tt>"]
     style var_stream_212 fill:transparent
-    155v1
+    148v1
 end
 subgraph var_stream_213 ["var <tt>stream_213</tt>"]
     style var_stream_213 fill:transparent
-    156v1
+    149v1
+end
+subgraph var_stream_214 ["var <tt>stream_214</tt>"]
+    style var_stream_214 fill:transparent
+    150v1
+end
+subgraph var_stream_215 ["var <tt>stream_215</tt>"]
+    style var_stream_215 fill:transparent
+    151v1
 end
 subgraph var_stream_216 ["var <tt>stream_216</tt>"]
     style var_stream_216 fill:transparent
-    158v1
+    152v1
 end
 subgraph var_stream_217 ["var <tt>stream_217</tt>"]
     style var_stream_217 fill:transparent
-    159v1
+    153v1
+end
+subgraph var_stream_218 ["var <tt>stream_218</tt>"]
+    style var_stream_218 fill:transparent
+    154v1
 end
 subgraph var_stream_219 ["var <tt>stream_219</tt>"]
     style var_stream_219 fill:transparent
-    160v1
+    155v1
 end
 subgraph var_stream_22 ["var <tt>stream_22</tt>"]
     style var_stream_22 fill:transparent
-    17v1
+    10v1
 end
 subgraph var_stream_220 ["var <tt>stream_220</tt>"]
     style var_stream_220 fill:transparent
-    161v1
-end
-subgraph var_stream_221 ["var <tt>stream_221</tt>"]
-    style var_stream_221 fill:transparent
-    162v1
-end
-subgraph var_stream_222 ["var <tt>stream_222</tt>"]
-    style var_stream_222 fill:transparent
-    163v1
+    156v1
 end
 subgraph var_stream_223 ["var <tt>stream_223</tt>"]
     style var_stream_223 fill:transparent
-    164v1
+    158v1
 end
 subgraph var_stream_224 ["var <tt>stream_224</tt>"]
     style var_stream_224 fill:transparent
-    165v1
+    159v1
+end
+subgraph var_stream_226 ["var <tt>stream_226</tt>"]
+    style var_stream_226 fill:transparent
+    160v1
 end
 subgraph var_stream_227 ["var <tt>stream_227</tt>"]
     style var_stream_227 fill:transparent
-    166v1
+    161v1
 end
 subgraph var_stream_228 ["var <tt>stream_228</tt>"]
     style var_stream_228 fill:transparent
-    167v1
+    162v1
+end
+subgraph var_stream_229 ["var <tt>stream_229</tt>"]
+    style var_stream_229 fill:transparent
+    163v1
 end
 subgraph var_stream_23 ["var <tt>stream_23</tt>"]
     style var_stream_23 fill:transparent
-    18v1
+    11v1
+end
+subgraph var_stream_230 ["var <tt>stream_230</tt>"]
+    style var_stream_230 fill:transparent
+    164v1
 end
 subgraph var_stream_231 ["var <tt>stream_231</tt>"]
     style var_stream_231 fill:transparent
-    168v1
-end
-subgraph var_stream_233 ["var <tt>stream_233</tt>"]
-    style var_stream_233 fill:transparent
-    169v1
+    165v1
 end
 subgraph var_stream_234 ["var <tt>stream_234</tt>"]
     style var_stream_234 fill:transparent
-    170v1
+    166v1
 end
 subgraph var_stream_235 ["var <tt>stream_235</tt>"]
     style var_stream_235 fill:transparent
-    171v1
-end
-subgraph var_stream_236 ["var <tt>stream_236</tt>"]
-    style var_stream_236 fill:transparent
-    172v1
-end
-subgraph var_stream_237 ["var <tt>stream_237</tt>"]
-    style var_stream_237 fill:transparent
-    173v1
+    167v1
 end
 subgraph var_stream_238 ["var <tt>stream_238</tt>"]
     style var_stream_238 fill:transparent
-    174v1
-end
-subgraph var_stream_239 ["var <tt>stream_239</tt>"]
-    style var_stream_239 fill:transparent
-    175v1
+    168v1
 end
 subgraph var_stream_24 ["var <tt>stream_24</tt>"]
     style var_stream_24 fill:transparent
-    19v1
+    12v1
 end
 subgraph var_stream_240 ["var <tt>stream_240</tt>"]
     style var_stream_240 fill:transparent
-    176v1
+    169v1
 end
 subgraph var_stream_241 ["var <tt>stream_241</tt>"]
     style var_stream_241 fill:transparent
-    177v1
+    170v1
+end
+subgraph var_stream_242 ["var <tt>stream_242</tt>"]
+    style var_stream_242 fill:transparent
+    171v1
+end
+subgraph var_stream_243 ["var <tt>stream_243</tt>"]
+    style var_stream_243 fill:transparent
+    172v1
 end
 subgraph var_stream_244 ["var <tt>stream_244</tt>"]
     style var_stream_244 fill:transparent
-    178v1
+    173v1
 end
 subgraph var_stream_245 ["var <tt>stream_245</tt>"]
     style var_stream_245 fill:transparent
-    179v1
+    174v1
+end
+subgraph var_stream_246 ["var <tt>stream_246</tt>"]
+    style var_stream_246 fill:transparent
+    175v1
 end
 subgraph var_stream_247 ["var <tt>stream_247</tt>"]
     style var_stream_247 fill:transparent
-    180v1
+    176v1
 end
 subgraph var_stream_248 ["var <tt>stream_248</tt>"]
     style var_stream_248 fill:transparent
-    181v1
+    177v1
 end
 subgraph var_stream_25 ["var <tt>stream_25</tt>"]
     style var_stream_25 fill:transparent
-    20v1
-end
-subgraph var_stream_250 ["var <tt>stream_250</tt>"]
-    style var_stream_250 fill:transparent
-    182v1
+    13v1
 end
 subgraph var_stream_251 ["var <tt>stream_251</tt>"]
     style var_stream_251 fill:transparent
-    183v1
+    178v1
 end
 subgraph var_stream_252 ["var <tt>stream_252</tt>"]
     style var_stream_252 fill:transparent
-    184v1
+    179v1
 end
-subgraph var_stream_253 ["var <tt>stream_253</tt>"]
-    style var_stream_253 fill:transparent
-    185v1
+subgraph var_stream_254 ["var <tt>stream_254</tt>"]
+    style var_stream_254 fill:transparent
+    180v1
 end
 subgraph var_stream_255 ["var <tt>stream_255</tt>"]
     style var_stream_255 fill:transparent
-    186v1
-end
-subgraph var_stream_256 ["var <tt>stream_256</tt>"]
-    style var_stream_256 fill:transparent
-    187v1
+    181v1
 end
 subgraph var_stream_257 ["var <tt>stream_257</tt>"]
     style var_stream_257 fill:transparent
-    188v1
+    182v1
 end
 subgraph var_stream_258 ["var <tt>stream_258</tt>"]
     style var_stream_258 fill:transparent
-    189v1
+    183v1
 end
 subgraph var_stream_259 ["var <tt>stream_259</tt>"]
     style var_stream_259 fill:transparent
-    190v1
+    184v1
 end
 subgraph var_stream_26 ["var <tt>stream_26</tt>"]
     style var_stream_26 fill:transparent
-    21v1
+    14v1
 end
 subgraph var_stream_260 ["var <tt>stream_260</tt>"]
     style var_stream_260 fill:transparent
-    191v1
+    185v1
+end
+subgraph var_stream_262 ["var <tt>stream_262</tt>"]
+    style var_stream_262 fill:transparent
+    186v1
+end
+subgraph var_stream_263 ["var <tt>stream_263</tt>"]
+    style var_stream_263 fill:transparent
+    187v1
+end
+subgraph var_stream_264 ["var <tt>stream_264</tt>"]
+    style var_stream_264 fill:transparent
+    188v1
+end
+subgraph var_stream_265 ["var <tt>stream_265</tt>"]
+    style var_stream_265 fill:transparent
+    189v1
+end
+subgraph var_stream_266 ["var <tt>stream_266</tt>"]
+    style var_stream_266 fill:transparent
+    190v1
 end
 subgraph var_stream_267 ["var <tt>stream_267</tt>"]
     style var_stream_267 fill:transparent
-    194v1
-    195v1
+    191v1
 end
-subgraph var_stream_268 ["var <tt>stream_268</tt>"]
-    style var_stream_268 fill:transparent
-    196v1
-end
-subgraph var_stream_269 ["var <tt>stream_269</tt>"]
-    style var_stream_269 fill:transparent
-    197v1
-end
-subgraph var_stream_270 ["var <tt>stream_270</tt>"]
-    style var_stream_270 fill:transparent
-    198v1
-end
-subgraph var_stream_271 ["var <tt>stream_271</tt>"]
-    style var_stream_271 fill:transparent
-    199v1
-end
-subgraph var_stream_272 ["var <tt>stream_272</tt>"]
-    style var_stream_272 fill:transparent
-    200v1
-end
-subgraph var_stream_273 ["var <tt>stream_273</tt>"]
-    style var_stream_273 fill:transparent
-    201v1
+subgraph var_stream_27 ["var <tt>stream_27</tt>"]
+    style var_stream_27 fill:transparent
+    15v1
 end
 subgraph var_stream_274 ["var <tt>stream_274</tt>"]
     style var_stream_274 fill:transparent
-    202v1
+    194v1
+    195v1
 end
 subgraph var_stream_275 ["var <tt>stream_275</tt>"]
     style var_stream_275 fill:transparent
-    203v1
+    196v1
+end
+subgraph var_stream_276 ["var <tt>stream_276</tt>"]
+    style var_stream_276 fill:transparent
+    197v1
 end
 subgraph var_stream_277 ["var <tt>stream_277</tt>"]
     style var_stream_277 fill:transparent
-    204v1
+    198v1
 end
 subgraph var_stream_278 ["var <tt>stream_278</tt>"]
     style var_stream_278 fill:transparent
-    205v1
+    199v1
 end
 subgraph var_stream_279 ["var <tt>stream_279</tt>"]
     style var_stream_279 fill:transparent
-    206v1
+    200v1
 end
 subgraph var_stream_28 ["var <tt>stream_28</tt>"]
     style var_stream_28 fill:transparent
-    22v1
+    16v1
 end
 subgraph var_stream_280 ["var <tt>stream_280</tt>"]
     style var_stream_280 fill:transparent
-    207v1
+    201v1
 end
-subgraph var_stream_283 ["var <tt>stream_283</tt>"]
-    style var_stream_283 fill:transparent
-    208v1
+subgraph var_stream_281 ["var <tt>stream_281</tt>"]
+    style var_stream_281 fill:transparent
+    202v1
+end
+subgraph var_stream_282 ["var <tt>stream_282</tt>"]
+    style var_stream_282 fill:transparent
+    203v1
+end
+subgraph var_stream_284 ["var <tt>stream_284</tt>"]
+    style var_stream_284 fill:transparent
+    204v1
 end
 subgraph var_stream_285 ["var <tt>stream_285</tt>"]
     style var_stream_285 fill:transparent
-    209v1
+    205v1
+end
+subgraph var_stream_286 ["var <tt>stream_286</tt>"]
+    style var_stream_286 fill:transparent
+    206v1
 end
 subgraph var_stream_287 ["var <tt>stream_287</tt>"]
     style var_stream_287 fill:transparent
-    210v1
-end
-subgraph var_stream_288 ["var <tt>stream_288</tt>"]
-    style var_stream_288 fill:transparent
-    211v1
+    207v1
 end
 subgraph var_stream_29 ["var <tt>stream_29</tt>"]
     style var_stream_29 fill:transparent
-    23v1
+    17v1
 end
-subgraph var_stream_291 ["var <tt>stream_291</tt>"]
-    style var_stream_291 fill:transparent
-    212v1
+subgraph var_stream_290 ["var <tt>stream_290</tt>"]
+    style var_stream_290 fill:transparent
+    208v1
 end
 subgraph var_stream_292 ["var <tt>stream_292</tt>"]
     style var_stream_292 fill:transparent
-    213v1
-end
-subgraph var_stream_293 ["var <tt>stream_293</tt>"]
-    style var_stream_293 fill:transparent
-    214v1
+    209v1
 end
 subgraph var_stream_294 ["var <tt>stream_294</tt>"]
     style var_stream_294 fill:transparent
-    215v1
+    210v1
 end
 subgraph var_stream_295 ["var <tt>stream_295</tt>"]
     style var_stream_295 fill:transparent
+    211v1
+end
+subgraph var_stream_298 ["var <tt>stream_298</tt>"]
+    style var_stream_298 fill:transparent
+    212v1
+end
+subgraph var_stream_299 ["var <tt>stream_299</tt>"]
+    style var_stream_299 fill:transparent
+    213v1
+end
+subgraph var_stream_30 ["var <tt>stream_30</tt>"]
+    style var_stream_30 fill:transparent
+    18v1
+end
+subgraph var_stream_300 ["var <tt>stream_300</tt>"]
+    style var_stream_300 fill:transparent
+    214v1
+end
+subgraph var_stream_301 ["var <tt>stream_301</tt>"]
+    style var_stream_301 fill:transparent
+    215v1
+end
+subgraph var_stream_302 ["var <tt>stream_302</tt>"]
+    style var_stream_302 fill:transparent
     216v1
 end
-subgraph var_stream_296 ["var <tt>stream_296</tt>"]
-    style var_stream_296 fill:transparent
+subgraph var_stream_303 ["var <tt>stream_303</tt>"]
+    style var_stream_303 fill:transparent
     217v1
 end
 subgraph var_stream_31 ["var <tt>stream_31</tt>"]
     style var_stream_31 fill:transparent
-    24v1
+    19v1
 end
-subgraph var_stream_312 ["var <tt>stream_312</tt>"]
-    style var_stream_312 fill:transparent
+subgraph var_stream_319 ["var <tt>stream_319</tt>"]
+    style var_stream_319 fill:transparent
     218v1
-end
-subgraph var_stream_313 ["var <tt>stream_313</tt>"]
-    style var_stream_313 fill:transparent
-    219v1
-end
-subgraph var_stream_314 ["var <tt>stream_314</tt>"]
-    style var_stream_314 fill:transparent
-    220v1
-end
-subgraph var_stream_315 ["var <tt>stream_315</tt>"]
-    style var_stream_315 fill:transparent
-    221v1
-end
-subgraph var_stream_316 ["var <tt>stream_316</tt>"]
-    style var_stream_316 fill:transparent
-    222v1
-end
-subgraph var_stream_317 ["var <tt>stream_317</tt>"]
-    style var_stream_317 fill:transparent
-    223v1
-end
-subgraph var_stream_318 ["var <tt>stream_318</tt>"]
-    style var_stream_318 fill:transparent
-    224v1
 end
 subgraph var_stream_32 ["var <tt>stream_32</tt>"]
     style var_stream_32 fill:transparent
-    25v1
+    20v1
+end
+subgraph var_stream_320 ["var <tt>stream_320</tt>"]
+    style var_stream_320 fill:transparent
+    219v1
 end
 subgraph var_stream_321 ["var <tt>stream_321</tt>"]
     style var_stream_321 fill:transparent
-    225v1
+    220v1
 end
 subgraph var_stream_322 ["var <tt>stream_322</tt>"]
     style var_stream_322 fill:transparent
-    226v1
+    221v1
 end
 subgraph var_stream_323 ["var <tt>stream_323</tt>"]
     style var_stream_323 fill:transparent
-    227v1
+    222v1
 end
 subgraph var_stream_324 ["var <tt>stream_324</tt>"]
     style var_stream_324 fill:transparent
-    228v1
+    223v1
+end
+subgraph var_stream_325 ["var <tt>stream_325</tt>"]
+    style var_stream_325 fill:transparent
+    224v1
+end
+subgraph var_stream_328 ["var <tt>stream_328</tt>"]
+    style var_stream_328 fill:transparent
+    225v1
+end
+subgraph var_stream_329 ["var <tt>stream_329</tt>"]
+    style var_stream_329 fill:transparent
+    226v1
 end
 subgraph var_stream_33 ["var <tt>stream_33</tt>"]
     style var_stream_33 fill:transparent
-    26v1
+    21v1
 end
-subgraph var_stream_34 ["var <tt>stream_34</tt>"]
-    style var_stream_34 fill:transparent
-    27v1
+subgraph var_stream_330 ["var <tt>stream_330</tt>"]
+    style var_stream_330 fill:transparent
+    227v1
+end
+subgraph var_stream_331 ["var <tt>stream_331</tt>"]
+    style var_stream_331 fill:transparent
+    228v1
 end
 subgraph var_stream_35 ["var <tt>stream_35</tt>"]
     style var_stream_35 fill:transparent
-    28v1
+    22v1
 end
 subgraph var_stream_36 ["var <tt>stream_36</tt>"]
     style var_stream_36 fill:transparent
-    29v1
-end
-subgraph var_stream_37 ["var <tt>stream_37</tt>"]
-    style var_stream_37 fill:transparent
-    30v1
+    23v1
 end
 subgraph var_stream_38 ["var <tt>stream_38</tt>"]
     style var_stream_38 fill:transparent
-    31v1
+    24v1
 end
 subgraph var_stream_39 ["var <tt>stream_39</tt>"]
     style var_stream_39 fill:transparent
-    32v1
+    25v1
 end
 subgraph var_stream_40 ["var <tt>stream_40</tt>"]
     style var_stream_40 fill:transparent
-    33v1
+    26v1
 end
 subgraph var_stream_41 ["var <tt>stream_41</tt>"]
     style var_stream_41 fill:transparent
-    36v1
-    37v1
+    27v1
 end
 subgraph var_stream_42 ["var <tt>stream_42</tt>"]
     style var_stream_42 fill:transparent
-    38v1
+    28v1
 end
 subgraph var_stream_43 ["var <tt>stream_43</tt>"]
     style var_stream_43 fill:transparent
-    39v1
+    29v1
+end
+subgraph var_stream_44 ["var <tt>stream_44</tt>"]
+    style var_stream_44 fill:transparent
+    30v1
 end
 subgraph var_stream_45 ["var <tt>stream_45</tt>"]
     style var_stream_45 fill:transparent
-    40v1
+    31v1
 end
 subgraph var_stream_46 ["var <tt>stream_46</tt>"]
     style var_stream_46 fill:transparent
-    41v1
+    32v1
 end
 subgraph var_stream_47 ["var <tt>stream_47</tt>"]
     style var_stream_47 fill:transparent
-    42v1
+    33v1
 end
 subgraph var_stream_48 ["var <tt>stream_48</tt>"]
     style var_stream_48 fill:transparent
-    43v1
+    36v1
+    37v1
 end
 subgraph var_stream_49 ["var <tt>stream_49</tt>"]
     style var_stream_49 fill:transparent
-    44v1
+    38v1
 end
 subgraph var_stream_50 ["var <tt>stream_50</tt>"]
     style var_stream_50 fill:transparent
-    45v1
+    39v1
+end
+subgraph var_stream_52 ["var <tt>stream_52</tt>"]
+    style var_stream_52 fill:transparent
+    40v1
 end
 subgraph var_stream_53 ["var <tt>stream_53</tt>"]
     style var_stream_53 fill:transparent
-    46v1
+    41v1
 end
 subgraph var_stream_54 ["var <tt>stream_54</tt>"]
     style var_stream_54 fill:transparent
-    47v1
+    42v1
+end
+subgraph var_stream_55 ["var <tt>stream_55</tt>"]
+    style var_stream_55 fill:transparent
+    43v1
 end
 subgraph var_stream_56 ["var <tt>stream_56</tt>"]
     style var_stream_56 fill:transparent
-    48v1
+    44v1
 end
 subgraph var_stream_57 ["var <tt>stream_57</tt>"]
     style var_stream_57 fill:transparent
-    49v1
-end
-subgraph var_stream_58 ["var <tt>stream_58</tt>"]
-    style var_stream_58 fill:transparent
-    50v1
-end
-subgraph var_stream_59 ["var <tt>stream_59</tt>"]
-    style var_stream_59 fill:transparent
-    51v1
-end
-subgraph var_stream_6 ["var <tt>stream_6</tt>"]
-    style var_stream_6 fill:transparent
-    3v1
+    45v1
 end
 subgraph var_stream_60 ["var <tt>stream_60</tt>"]
     style var_stream_60 fill:transparent
-    52v1
+    46v1
 end
 subgraph var_stream_61 ["var <tt>stream_61</tt>"]
     style var_stream_61 fill:transparent
-    53v1
-end
-subgraph var_stream_62 ["var <tt>stream_62</tt>"]
-    style var_stream_62 fill:transparent
-    54v1
+    47v1
 end
 subgraph var_stream_63 ["var <tt>stream_63</tt>"]
     style var_stream_63 fill:transparent
-    55v1
+    48v1
 end
 subgraph var_stream_64 ["var <tt>stream_64</tt>"]
     style var_stream_64 fill:transparent
-    56v1
+    49v1
 end
 subgraph var_stream_65 ["var <tt>stream_65</tt>"]
     style var_stream_65 fill:transparent
-    57v1
+    50v1
 end
 subgraph var_stream_66 ["var <tt>stream_66</tt>"]
     style var_stream_66 fill:transparent
-    58v1
+    51v1
 end
 subgraph var_stream_67 ["var <tt>stream_67</tt>"]
     style var_stream_67 fill:transparent
-    59v1
+    52v1
 end
 subgraph var_stream_68 ["var <tt>stream_68</tt>"]
     style var_stream_68 fill:transparent
-    60v1
+    53v1
 end
 subgraph var_stream_69 ["var <tt>stream_69</tt>"]
     style var_stream_69 fill:transparent
-    61v1
+    54v1
+end
+subgraph var_stream_7 ["var <tt>stream_7</tt>"]
+    style var_stream_7 fill:transparent
+    1v1
 end
 subgraph var_stream_70 ["var <tt>stream_70</tt>"]
     style var_stream_70 fill:transparent
-    62v1
+    55v1
 end
 subgraph var_stream_71 ["var <tt>stream_71</tt>"]
     style var_stream_71 fill:transparent
-    63v1
+    56v1
 end
 subgraph var_stream_72 ["var <tt>stream_72</tt>"]
     style var_stream_72 fill:transparent
-    64v1
+    57v1
 end
 subgraph var_stream_73 ["var <tt>stream_73</tt>"]
     style var_stream_73 fill:transparent
-    65v1
+    58v1
 end
 subgraph var_stream_74 ["var <tt>stream_74</tt>"]
     style var_stream_74 fill:transparent
+    59v1
+end
+subgraph var_stream_75 ["var <tt>stream_75</tt>"]
+    style var_stream_75 fill:transparent
+    60v1
+end
+subgraph var_stream_76 ["var <tt>stream_76</tt>"]
+    style var_stream_76 fill:transparent
+    61v1
+end
+subgraph var_stream_77 ["var <tt>stream_77</tt>"]
+    style var_stream_77 fill:transparent
+    62v1
+end
+subgraph var_stream_78 ["var <tt>stream_78</tt>"]
+    style var_stream_78 fill:transparent
+    63v1
+end
+subgraph var_stream_79 ["var <tt>stream_79</tt>"]
+    style var_stream_79 fill:transparent
+    64v1
+end
+subgraph var_stream_80 ["var <tt>stream_80</tt>"]
+    style var_stream_80 fill:transparent
+    65v1
+end
+subgraph var_stream_81 ["var <tt>stream_81</tt>"]
+    style var_stream_81 fill:transparent
     66v1
-end
-subgraph var_stream_8 ["var <tt>stream_8</tt>"]
-    style var_stream_8 fill:transparent
-    4v1
-end
-subgraph var_stream_89 ["var <tt>stream_89</tt>"]
-    style var_stream_89 fill:transparent
-    69v1
-    70v1
-end
-subgraph var_stream_9 ["var <tt>stream_9</tt>"]
-    style var_stream_9 fill:transparent
-    5v1
-end
-subgraph var_stream_90 ["var <tt>stream_90</tt>"]
-    style var_stream_90 fill:transparent
-    71v1
-end
-subgraph var_stream_91 ["var <tt>stream_91</tt>"]
-    style var_stream_91 fill:transparent
-    72v1
-end
-subgraph var_stream_92 ["var <tt>stream_92</tt>"]
-    style var_stream_92 fill:transparent
-    73v1
-end
-subgraph var_stream_93 ["var <tt>stream_93</tt>"]
-    style var_stream_93 fill:transparent
-    74v1
-end
-subgraph var_stream_94 ["var <tt>stream_94</tt>"]
-    style var_stream_94 fill:transparent
-    75v1
-end
-subgraph var_stream_95 ["var <tt>stream_95</tt>"]
-    style var_stream_95 fill:transparent
-    76v1
 end
 subgraph var_stream_96 ["var <tt>stream_96</tt>"]
     style var_stream_96 fill:transparent
-    77v1
+    69v1
+    70v1
 end
 subgraph var_stream_97 ["var <tt>stream_97</tt>"]
     style var_stream_97 fill:transparent
-    78v1
+    71v1
 end
 subgraph var_stream_98 ["var <tt>stream_98</tt>"]
     style var_stream_98 fill:transparent
-    79v1
+    72v1
+end
+subgraph var_stream_99 ["var <tt>stream_99</tt>"]
+    style var_stream_99 fill:transparent
+    73v1
 end

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__two_pc_bench__tests__two_pc_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__two_pc_bench__tests__two_pc_ir.snap
@@ -5,15 +5,119 @@ expression: built.ir()
 [
     CycleSink {
         ident: Ident {
-            sym: cycle_1,
+            sym: cycle_0,
         },
-        input: AntiJoin {
-            pos: Tee {
-                inner: <tee 0>: Chain {
+        input: Map {
+            f: stageleft :: runtime_support :: fn1_type_hint :: < u32 , u32 > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | virtual_id | virtual_id + 1 }),
+            input: Tee {
+                inner: <tee 0>: ChainFirst {
                     first: DeferTick {
                         input: CycleSource {
                             ident: Ident {
-                                sym: cycle_1,
+                                sym: cycle_0,
+                            },
+                            metadata: HydroIrMetadata {
+                                location_kind: Tick(
+                                    0,
+                                    Cluster(
+                                        2,
+                                    ),
+                                ),
+                                output_type: Some(
+                                    u32,
+                                ),
+                            },
+                        },
+                        metadata: HydroIrMetadata {
+                            location_kind: Tick(
+                                0,
+                                Cluster(
+                                    2,
+                                ),
+                            ),
+                            output_type: Some(
+                                u32,
+                            ),
+                        },
+                    },
+                    second: Persist {
+                        inner: Source {
+                            source: Iter(
+                                { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let e__free = { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; 0u32 } ; [e__free] },
+                            ),
+                            metadata: HydroIrMetadata {
+                                location_kind: Cluster(
+                                    2,
+                                ),
+                                output_type: Some(
+                                    u32,
+                                ),
+                            },
+                        },
+                        metadata: HydroIrMetadata {
+                            location_kind: Cluster(
+                                2,
+                            ),
+                            output_type: Some(
+                                u32,
+                            ),
+                        },
+                    },
+                    metadata: HydroIrMetadata {
+                        location_kind: Tick(
+                            0,
+                            Cluster(
+                                2,
+                            ),
+                        ),
+                        output_type: Some(
+                            u32,
+                        ),
+                    },
+                },
+                metadata: HydroIrMetadata {
+                    location_kind: Tick(
+                        0,
+                        Cluster(
+                            2,
+                        ),
+                    ),
+                    output_type: Some(
+                        u32,
+                    ),
+                },
+            },
+            metadata: HydroIrMetadata {
+                location_kind: Tick(
+                    0,
+                    Cluster(
+                        2,
+                    ),
+                ),
+                output_type: Some(
+                    u32,
+                ),
+            },
+        },
+        out_location: Tick(
+            0,
+            Cluster(
+                2,
+            ),
+        ),
+        op_metadata: HydroIrOpMetadata,
+    },
+    CycleSink {
+        ident: Ident {
+            sym: cycle_2,
+        },
+        input: AntiJoin {
+            pos: Tee {
+                inner: <tee 1>: Chain {
+                    first: DeferTick {
+                        input: CycleSource {
+                            ident: Ident {
+                                sym: cycle_2,
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
@@ -40,7 +144,7 @@ expression: built.ir()
                         },
                     },
                     second: Tee {
-                        inner: <tee 1>: Map {
+                        inner: <tee 2>: Map {
                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , core :: result :: Result < () , () >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: two_pc :: * ; | kv | (kv , Ok :: < () , () > (())) }),
                             input: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
@@ -142,7 +246,7 @@ expression: built.ir()
                                                 ),
                                                 input: CycleSource {
                                                     ident: Ident {
-                                                        sym: cycle_0,
+                                                        sym: cycle_1,
                                                     },
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Cluster(
@@ -247,14 +351,14 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <tee 2>: FilterMap {
+                inner: <tee 3>: FilterMap {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , (usize , usize)) , core :: option :: Option < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; let min__free = 3usize ; move | (key , (success , _error)) | if success >= min__free { Some (key) } else { None } }),
                     input: Tee {
-                        inner: <tee 3>: FoldKeyed {
+                        inner: <tee 4>: FoldKeyed {
                             init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | | (0 , 0) }),
                             acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < () , () > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } } }),
                             input: Tee {
-                                inner: <tee 0>,
+                                inner: <tee 1>,
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
                                         2,
@@ -337,15 +441,15 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_2,
+            sym: cycle_3,
         },
         input: AntiJoin {
             pos: Tee {
-                inner: <tee 4>: Chain {
+                inner: <tee 5>: Chain {
                     first: DeferTick {
                         input: CycleSource {
                             ident: Ident {
-                                sym: cycle_2,
+                                sym: cycle_3,
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
@@ -372,7 +476,7 @@ expression: built.ir()
                         },
                     },
                     second: Tee {
-                        inner: <tee 5>: Map {
+                        inner: <tee 6>: Map {
                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , core :: result :: Result < () , () >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: two_pc :: * ; | kv | (kv , Ok :: < () , () > (())) }),
                             input: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
@@ -465,7 +569,7 @@ expression: built.ir()
                                                 },
                                             },
                                             right: Tee {
-                                                inner: <tee 2>,
+                                                inner: <tee 3>,
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
                                                         2,
@@ -563,14 +667,14 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <tee 6>: FilterMap {
+                inner: <tee 7>: FilterMap {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , (usize , usize)) , core :: option :: Option < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; let min__free = 3usize ; move | (key , (success , _error)) | if success >= min__free { Some (key) } else { None } }),
                     input: Tee {
-                        inner: <tee 7>: FoldKeyed {
+                        inner: <tee 8>: FoldKeyed {
                             init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | | (0 , 0) }),
                             acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < () , () > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } } }),
                             input: Tee {
-                                inner: <tee 4>,
+                                inner: <tee 5>,
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
                                         2,
@@ -653,18 +757,30 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_0,
+            sym: cycle_1,
         },
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , core :: option :: Option < u32 >) , (u32 , u32) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; move | (virtual_id , payload) | { let value = if let Some (payload) = payload { payload + 1 } else { 0 } ; (virtual_id , value) } }),
             input: Chain {
-                first: FlatMap {
-                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , std :: iter :: Map < std :: ops :: Range < u32 > , _ > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; let num_clients_per_node__free = 100usize ; move | _ | (0 .. num_clients_per_node__free as u32) . map (move | virtual_id | { (virtual_id , None) }) }),
+                first: Map {
+                    f: stageleft :: runtime_support :: fn1_type_hint :: < u32 , (u32 , core :: option :: Option < u32 >) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | virtual_id | (virtual_id , None) }),
                     input: Tee {
-                        inner: <tee 8>: Source {
-                            source: Iter(
-                                { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: tick :: * ; let e__free = { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; () } ; [e__free] },
-                            ),
+                        inner: <tee 9>: Filter {
+                            f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < u32 , bool > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; let num_clients_per_node__free = 100usize ; move | virtual_id | * virtual_id < num_clients_per_node__free as u32 }),
+                            input: Tee {
+                                inner: <tee 0>,
+                                metadata: HydroIrMetadata {
+                                    location_kind: Tick(
+                                        0,
+                                        Cluster(
+                                            2,
+                                        ),
+                                    ),
+                                    output_type: Some(
+                                        u32,
+                                    ),
+                                },
+                            },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
                                     0,
@@ -673,7 +789,7 @@ expression: built.ir()
                                     ),
                                 ),
                                 output_type: Some(
-                                    (),
+                                    u32,
                                 ),
                             },
                         },
@@ -685,7 +801,7 @@ expression: built.ir()
                                 ),
                             ),
                             output_type: Some(
-                                (),
+                                u32,
                             ),
                         },
                     },
@@ -702,7 +818,7 @@ expression: built.ir()
                     },
                 },
                 second: Tee {
-                    inner: <tee 9>: Map {
+                    inner: <tee 10>: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , u32) , (u32 , core :: option :: Option < u32 >) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (virtual_id , payload) | (virtual_id , Some (payload)) }),
                         input: Network {
                             serialize_fn: Some(
@@ -713,7 +829,7 @@ expression: built.ir()
                                 | res | { hydro_lang :: runtime_support :: bincode :: deserialize :: < (u32 , u32) > (& res . unwrap ()) . unwrap () },
                             ),
                             input: Tee {
-                                inner: <tee 6>,
+                                inner: <tee 7>,
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
                                         2,
@@ -787,17 +903,17 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_3,
+            sym: cycle_4,
         },
         input: ReduceKeyed {
             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: time :: Instant , std :: time :: Instant , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | curr_time , new_time | { if new_time > * curr_time { * curr_time = new_time ; } } }),
             input: Chain {
                 first: Chain {
                     first: Tee {
-                        inner: <tee 10>: DeferTick {
+                        inner: <tee 11>: DeferTick {
                             input: CycleSource {
                                 ident: Ident {
-                                    sym: cycle_3,
+                                    sym: cycle_4,
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
@@ -807,7 +923,7 @@ expression: built.ir()
                                         ),
                                     ),
                                     output_type: Some(
-                                        (usize , std :: time :: Instant),
+                                        (u32 , std :: time :: Instant),
                                     ),
                                 },
                             },
@@ -819,7 +935,7 @@ expression: built.ir()
                                     ),
                                 ),
                                 output_type: Some(
-                                    (usize , std :: time :: Instant),
+                                    (u32 , std :: time :: Instant),
                                 ),
                             },
                         },
@@ -831,28 +947,14 @@ expression: built.ir()
                                 ),
                             ),
                             output_type: Some(
-                                (usize , std :: time :: Instant),
+                                (u32 , std :: time :: Instant),
                             ),
                         },
                     },
-                    second: FlatMap {
-                        f: stageleft :: runtime_support :: fn1_type_hint :: < std :: time :: Instant , std :: iter :: Map < std :: ops :: Range < usize > , _ > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; let num_clients_per_node__free = 100usize ; move | now | (0 .. num_clients_per_node__free) . map (move | virtual_id | (virtual_id , now)) }),
-                        input: Map {
-                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , std :: time :: Instant > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | _ | Instant :: now () }),
-                            input: Tee {
-                                inner: <tee 8>,
-                                metadata: HydroIrMetadata {
-                                    location_kind: Tick(
-                                        0,
-                                        Cluster(
-                                            2,
-                                        ),
-                                    ),
-                                    output_type: Some(
-                                        (),
-                                    ),
-                                },
-                            },
+                    second: Map {
+                        f: stageleft :: runtime_support :: fn1_type_hint :: < u32 , (u32 , std :: time :: Instant) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | virtual_id | (virtual_id , Instant :: now ()) }),
+                        input: Tee {
+                            inner: <tee 9>,
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
                                     0,
@@ -861,7 +963,7 @@ expression: built.ir()
                                     ),
                                 ),
                                 output_type: Some(
-                                    std :: time :: Instant,
+                                    u32,
                                 ),
                             },
                         },
@@ -873,7 +975,7 @@ expression: built.ir()
                                 ),
                             ),
                             output_type: Some(
-                                (usize , std :: time :: Instant),
+                                (u32 , std :: time :: Instant),
                             ),
                         },
                     },
@@ -885,15 +987,15 @@ expression: built.ir()
                             ),
                         ),
                         output_type: Some(
-                            (usize , std :: time :: Instant),
+                            (u32 , std :: time :: Instant),
                         ),
                     },
                 },
                 second: Tee {
-                    inner: <tee 11>: Map {
-                        f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , core :: option :: Option < u32 >) , (usize , std :: time :: Instant) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (key , _payload) | (key as usize , Instant :: now ()) }),
+                    inner: <tee 12>: Map {
+                        f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , core :: option :: Option < u32 >) , (u32 , std :: time :: Instant) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (key , _payload) | (key , Instant :: now ()) }),
                         input: Tee {
-                            inner: <tee 9>,
+                            inner: <tee 10>,
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
                                     0,
@@ -914,7 +1016,7 @@ expression: built.ir()
                                 ),
                             ),
                             output_type: Some(
-                                (usize , std :: time :: Instant),
+                                (u32 , std :: time :: Instant),
                             ),
                         },
                     },
@@ -926,7 +1028,7 @@ expression: built.ir()
                             ),
                         ),
                         output_type: Some(
-                            (usize , std :: time :: Instant),
+                            (u32 , std :: time :: Instant),
                         ),
                     },
                 },
@@ -938,7 +1040,7 @@ expression: built.ir()
                         ),
                     ),
                     output_type: Some(
-                        (usize , std :: time :: Instant),
+                        (u32 , std :: time :: Instant),
                     ),
                 },
             },
@@ -950,7 +1052,7 @@ expression: built.ir()
                     ),
                 ),
                 output_type: Some(
-                    (usize , std :: time :: Instant),
+                    (u32 , std :: time :: Instant),
                 ),
             },
         },
@@ -968,11 +1070,11 @@ expression: built.ir()
             f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , ()) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | (d , _signal) | d }),
             input: CrossSingleton {
                 left: Tee {
-                    inner: <tee 12>: FilterMap {
+                    inner: <tee 13>: FilterMap {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , usize) , core :: option :: Option < usize > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (num_clients , num_clients_with_throughput) | { if num_clients > num_clients_with_throughput { Some (num_clients - num_clients_with_throughput) } else { None } } }),
                         input: CrossSingleton {
                             left: Tee {
-                                inner: <tee 13>: Fold {
+                                inner: <tee 14>: Fold {
                                     init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | | 0usize }),
                                     acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , ()) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | count , _ | * count += 1 }),
                                     input: FilterMap {
@@ -1057,7 +1159,7 @@ expression: built.ir()
                                 init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | | 0usize }),
                                 acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | count , _ | * count += 1 }),
                                 input: Tee {
-                                    inner: <tee 14>: Filter {
+                                    inner: <tee 15>: Filter {
                                         f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage , bool > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | throughputs | throughputs . sample_mean () > 0.0 }) ; { let orig = f__free ; move | (_k , v) | orig (v) } }),
                                         input: ReduceKeyed {
                                             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | combined , new | { * combined = new ; } }),
@@ -1089,7 +1191,7 @@ expression: built.ir()
                                                                                             init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | | 0usize }),
                                                                                             acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , (u32 , core :: option :: Option < u32 >) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | count , _ | * count += 1 }),
                                                                                             input: Tee {
-                                                                                                inner: <tee 9>,
+                                                                                                inner: <tee 10>,
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_kind: Tick(
                                                                                                         0,
@@ -1124,7 +1226,7 @@ expression: built.ir()
                                                                                                         input: Map {
                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _ | () }),
                                                                                                             input: Tee {
-                                                                                                                inner: <tee 15>: Reduce {
+                                                                                                                inner: <tee 16>: Reduce {
                                                                                                                     f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
                                                                                                                     input: Source {
                                                                                                                         source: Stream(
@@ -1289,7 +1391,7 @@ expression: built.ir()
                                                                                 input: Map {
                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , (usize , bool) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | _ | (0 , true) }),
                                                                                     input: Tee {
-                                                                                        inner: <tee 15>,
+                                                                                        inner: <tee 16>,
                                                                                         metadata: HydroIrMetadata {
                                                                                             location_kind: Tick(
                                                                                                 0,
@@ -1604,7 +1706,7 @@ expression: built.ir()
                                 input: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage) , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (_ , v) | v }),
                                     input: Tee {
-                                        inner: <tee 14>,
+                                        inner: <tee 15>,
                                         metadata: HydroIrMetadata {
                                             location_kind: Process(
                                                 3,
@@ -1704,7 +1806,7 @@ expression: built.ir()
                         },
                     },
                     right: Tee {
-                        inner: <tee 13>,
+                        inner: <tee 14>,
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
                                 4,
@@ -1739,7 +1841,7 @@ expression: built.ir()
                                 input: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ | () }),
                                     input: Tee {
-                                        inner: <tee 12>,
+                                        inner: <tee 13>,
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
                                                 4,
@@ -1899,23 +2001,9 @@ expression: built.ir()
                                                                 acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , core :: time :: Duration , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; move | latencies , latency | { latencies . borrow_mut () . record (latency . as_nanos () as u64) . unwrap () ; } }),
                                                                 input: Persist {
                                                                     inner: Map {
-                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , (std :: time :: Instant , std :: time :: Instant)) , core :: time :: Duration > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (_virtual_id , (prev_time , curr_time)) | curr_time . duration_since (prev_time) }),
+                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , (std :: time :: Instant , std :: time :: Instant)) , core :: time :: Duration > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (_virtual_id , (prev_time , curr_time)) | curr_time . duration_since (prev_time) }),
                                                                         input: Join {
                                                                             left: Tee {
-                                                                                inner: <tee 10>,
-                                                                                metadata: HydroIrMetadata {
-                                                                                    location_kind: Tick(
-                                                                                        0,
-                                                                                        Cluster(
-                                                                                            2,
-                                                                                        ),
-                                                                                    ),
-                                                                                    output_type: Some(
-                                                                                        (usize , std :: time :: Instant),
-                                                                                    ),
-                                                                                },
-                                                                            },
-                                                                            right: Tee {
                                                                                 inner: <tee 11>,
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_kind: Tick(
@@ -1925,7 +2013,21 @@ expression: built.ir()
                                                                                         ),
                                                                                     ),
                                                                                     output_type: Some(
-                                                                                        (usize , std :: time :: Instant),
+                                                                                        (u32 , std :: time :: Instant),
+                                                                                    ),
+                                                                                },
+                                                                            },
+                                                                            right: Tee {
+                                                                                inner: <tee 12>,
+                                                                                metadata: HydroIrMetadata {
+                                                                                    location_kind: Tick(
+                                                                                        0,
+                                                                                        Cluster(
+                                                                                            2,
+                                                                                        ),
+                                                                                    ),
+                                                                                    output_type: Some(
+                                                                                        (u32 , std :: time :: Instant),
                                                                                     ),
                                                                                 },
                                                                             },
@@ -1937,7 +2039,7 @@ expression: built.ir()
                                                                                     ),
                                                                                 ),
                                                                                 output_type: Some(
-                                                                                    (usize , (std :: time :: Instant , std :: time :: Instant)),
+                                                                                    (u32 , (std :: time :: Instant , std :: time :: Instant)),
                                                                                 ),
                                                                             },
                                                                         },
@@ -2183,7 +2285,7 @@ expression: built.ir()
                                 input: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ | () }),
                                     input: Tee {
-                                        inner: <tee 12>,
+                                        inner: <tee 13>,
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
                                                 4,

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__two_pc_bench__tests__two_pc_ir@coordinator_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__two_pc_bench__tests__two_pc_ir@coordinator_mermaid.snap
@@ -105,138 +105,138 @@ linkStyle default stroke:#aaa
 46v1
 56v1
 58v1
-subgraph var_stream_1 ["var <tt>stream_1</tt>"]
-    style var_stream_1 fill:transparent
-    1v1
+subgraph var_stream_10 ["var <tt>stream_10</tt>"]
+    style var_stream_10 fill:transparent
+    3v1
 end
 subgraph var_stream_11 ["var <tt>stream_11</tt>"]
     style var_stream_11 fill:transparent
-    13v1
-    12v1
+    4v1
 end
 subgraph var_stream_12 ["var <tt>stream_12</tt>"]
     style var_stream_12 fill:transparent
-    14v1
+    5v1
 end
 subgraph var_stream_13 ["var <tt>stream_13</tt>"]
     style var_stream_13 fill:transparent
-    15v1
+    6v1
 end
 subgraph var_stream_15 ["var <tt>stream_15</tt>"]
     style var_stream_15 fill:transparent
-    17v1
-end
-subgraph var_stream_16 ["var <tt>stream_16</tt>"]
-    style var_stream_16 fill:transparent
-    18v1
-end
-subgraph var_stream_18 ["var <tt>stream_18</tt>"]
-    style var_stream_18 fill:transparent
-    19v1
-end
-subgraph var_stream_2 ["var <tt>stream_2</tt>"]
-    style var_stream_2 fill:transparent
-    2v1
-end
-subgraph var_stream_20 ["var <tt>stream_20</tt>"]
-    style var_stream_20 fill:transparent
-    21v1
-end
-subgraph var_stream_21 ["var <tt>stream_21</tt>"]
-    style var_stream_21 fill:transparent
-    22v1
-end
-subgraph var_stream_22 ["var <tt>stream_22</tt>"]
-    style var_stream_22 fill:transparent
-    23v1
-end
-subgraph var_stream_24 ["var <tt>stream_24</tt>"]
-    style var_stream_24 fill:transparent
-    24v1
-end
-subgraph var_stream_25 ["var <tt>stream_25</tt>"]
-    style var_stream_25 fill:transparent
-    25v1
-end
-subgraph var_stream_26 ["var <tt>stream_26</tt>"]
-    style var_stream_26 fill:transparent
-    26v1
-end
-subgraph var_stream_27 ["var <tt>stream_27</tt>"]
-    style var_stream_27 fill:transparent
-    27v1
-end
-subgraph var_stream_28 ["var <tt>stream_28</tt>"]
-    style var_stream_28 fill:transparent
-    28v1
-end
-subgraph var_stream_29 ["var <tt>stream_29</tt>"]
-    style var_stream_29 fill:transparent
-    29v1
-end
-subgraph var_stream_3 ["var <tt>stream_3</tt>"]
-    style var_stream_3 fill:transparent
-    3v1
-end
-subgraph var_stream_31 ["var <tt>stream_31</tt>"]
-    style var_stream_31 fill:transparent
-    30v1
-end
-subgraph var_stream_33 ["var <tt>stream_33</tt>"]
-    style var_stream_33 fill:transparent
-    34v1
-    33v1
-end
-subgraph var_stream_34 ["var <tt>stream_34</tt>"]
-    style var_stream_34 fill:transparent
-    35v1
-end
-subgraph var_stream_35 ["var <tt>stream_35</tt>"]
-    style var_stream_35 fill:transparent
-    36v1
-end
-subgraph var_stream_37 ["var <tt>stream_37</tt>"]
-    style var_stream_37 fill:transparent
-    38v1
-end
-subgraph var_stream_38 ["var <tt>stream_38</tt>"]
-    style var_stream_38 fill:transparent
-    39v1
-end
-subgraph var_stream_4 ["var <tt>stream_4</tt>"]
-    style var_stream_4 fill:transparent
-    4v1
-end
-subgraph var_stream_40 ["var <tt>stream_40</tt>"]
-    style var_stream_40 fill:transparent
-    40v1
-end
-subgraph var_stream_42 ["var <tt>stream_42</tt>"]
-    style var_stream_42 fill:transparent
-    42v1
-end
-subgraph var_stream_43 ["var <tt>stream_43</tt>"]
-    style var_stream_43 fill:transparent
-    43v1
-end
-subgraph var_stream_44 ["var <tt>stream_44</tt>"]
-    style var_stream_44 fill:transparent
-    44v1
-end
-subgraph var_stream_5 ["var <tt>stream_5</tt>"]
-    style var_stream_5 fill:transparent
-    5v1
-end
-subgraph var_stream_6 ["var <tt>stream_6</tt>"]
-    style var_stream_6 fill:transparent
-    6v1
-end
-subgraph var_stream_8 ["var <tt>stream_8</tt>"]
-    style var_stream_8 fill:transparent
     8v1
     7v1
 end
+subgraph var_stream_16 ["var <tt>stream_16</tt>"]
+    style var_stream_16 fill:transparent
+    9v1
+end
+subgraph var_stream_18 ["var <tt>stream_18</tt>"]
+    style var_stream_18 fill:transparent
+    13v1
+    12v1
+end
+subgraph var_stream_19 ["var <tt>stream_19</tt>"]
+    style var_stream_19 fill:transparent
+    14v1
+end
+subgraph var_stream_20 ["var <tt>stream_20</tt>"]
+    style var_stream_20 fill:transparent
+    15v1
+end
+subgraph var_stream_22 ["var <tt>stream_22</tt>"]
+    style var_stream_22 fill:transparent
+    17v1
+end
+subgraph var_stream_23 ["var <tt>stream_23</tt>"]
+    style var_stream_23 fill:transparent
+    18v1
+end
+subgraph var_stream_25 ["var <tt>stream_25</tt>"]
+    style var_stream_25 fill:transparent
+    19v1
+end
+subgraph var_stream_27 ["var <tt>stream_27</tt>"]
+    style var_stream_27 fill:transparent
+    21v1
+end
+subgraph var_stream_28 ["var <tt>stream_28</tt>"]
+    style var_stream_28 fill:transparent
+    22v1
+end
+subgraph var_stream_29 ["var <tt>stream_29</tt>"]
+    style var_stream_29 fill:transparent
+    23v1
+end
+subgraph var_stream_31 ["var <tt>stream_31</tt>"]
+    style var_stream_31 fill:transparent
+    24v1
+end
+subgraph var_stream_32 ["var <tt>stream_32</tt>"]
+    style var_stream_32 fill:transparent
+    25v1
+end
+subgraph var_stream_33 ["var <tt>stream_33</tt>"]
+    style var_stream_33 fill:transparent
+    26v1
+end
+subgraph var_stream_34 ["var <tt>stream_34</tt>"]
+    style var_stream_34 fill:transparent
+    27v1
+end
+subgraph var_stream_35 ["var <tt>stream_35</tt>"]
+    style var_stream_35 fill:transparent
+    28v1
+end
+subgraph var_stream_36 ["var <tt>stream_36</tt>"]
+    style var_stream_36 fill:transparent
+    29v1
+end
+subgraph var_stream_38 ["var <tt>stream_38</tt>"]
+    style var_stream_38 fill:transparent
+    30v1
+end
+subgraph var_stream_40 ["var <tt>stream_40</tt>"]
+    style var_stream_40 fill:transparent
+    34v1
+    33v1
+end
+subgraph var_stream_41 ["var <tt>stream_41</tt>"]
+    style var_stream_41 fill:transparent
+    35v1
+end
+subgraph var_stream_42 ["var <tt>stream_42</tt>"]
+    style var_stream_42 fill:transparent
+    36v1
+end
+subgraph var_stream_44 ["var <tt>stream_44</tt>"]
+    style var_stream_44 fill:transparent
+    38v1
+end
+subgraph var_stream_45 ["var <tt>stream_45</tt>"]
+    style var_stream_45 fill:transparent
+    39v1
+end
+subgraph var_stream_47 ["var <tt>stream_47</tt>"]
+    style var_stream_47 fill:transparent
+    40v1
+end
+subgraph var_stream_49 ["var <tt>stream_49</tt>"]
+    style var_stream_49 fill:transparent
+    42v1
+end
+subgraph var_stream_50 ["var <tt>stream_50</tt>"]
+    style var_stream_50 fill:transparent
+    43v1
+end
+subgraph var_stream_51 ["var <tt>stream_51</tt>"]
+    style var_stream_51 fill:transparent
+    44v1
+end
+subgraph var_stream_8 ["var <tt>stream_8</tt>"]
+    style var_stream_8 fill:transparent
+    1v1
+end
 subgraph var_stream_9 ["var <tt>stream_9</tt>"]
     style var_stream_9 fill:transparent
-    9v1
+    2v1
 end

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__two_pc_bench__tests__two_pc_ir@participants_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__two_pc_bench__tests__two_pc_ir@participants_mermaid.snap
@@ -26,13 +26,13 @@ linkStyle default stroke:#aaa
 4v1
 7v1
 8v1
-subgraph var_stream_10 ["var <tt>stream_10</tt>"]
-    style var_stream_10 fill:transparent
+subgraph var_stream_17 ["var <tt>stream_17</tt>"]
+    style var_stream_17 fill:transparent
     1v1
     2v1
 end
-subgraph var_stream_32 ["var <tt>stream_32</tt>"]
-    style var_stream_32 fill:transparent
+subgraph var_stream_39 ["var <tt>stream_39</tt>"]
+    style var_stream_39 fill:transparent
     5v1
     6v1
 end


### PR DESCRIPTION
Client initially outputs 1 message per tick instead of all messages in 1 giant batch, so if downstream operators do not dynamically adjust the batch size, they are not overwhelmed