### PR TITLE
chore: pin Rust to 1.89

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,14 +35,12 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
-      - name: Install rust channel and set it as default
-        run: |
-          rustup toolchain add nightly && \
-          rustup default nightly
+      - name: Install nightly Rust channel
+        run: rustup toolchain add nightly
 
       - env:
           RUSTDOCFLAGS: --cfg docsrs -Dwarnings
-        run: cargo doc --no-deps --all-features
+        run: cargo +nightly doc --no-deps --all-features
 
       - name: Move design docs to output
         shell: bash

--- a/dfir_rs/tests/compile-fail-stable/surface_demuxenum_port_extra.stderr
+++ b/dfir_rs/tests/compile-fail-stable/surface_demuxenum_port_extra.stderr
@@ -1,7 +1,7 @@
 error[E0599]: no variant named `Ellipse` found for enum `Shape`
   --> tests/compile-fail-stable/surface_demuxenum_port_extra.rs:21:18
    |
- 6 |     enum Shape {
+6  |     enum Shape {
    |     ---------- variant `Ellipse` not found here
 ...
 21 |         my_demux[Ellipse] -> for_each(std::mem::drop);

--- a/dfir_rs/tests/compile-fail-stable/surface_demuxenum_port_extra_zero.stderr
+++ b/dfir_rs/tests/compile-fail-stable/surface_demuxenum_port_extra_zero.stderr
@@ -1,7 +1,7 @@
 error[E0599]: no variant named `Square` found for enum `Shape`
   --> tests/compile-fail-stable/surface_demuxenum_port_extra_zero.rs:11:18
    |
- 6 |     enum Shape {
+6  |     enum Shape {
    |     ---------- variant `Square` not found here
 ...
 11 |         my_demux[Square] -> for_each(std::mem::drop);

--- a/dfir_rs/tests/compile-fail-stable/surface_demuxenum_port_extramissing.stderr
+++ b/dfir_rs/tests/compile-fail-stable/surface_demuxenum_port_extramissing.stderr
@@ -1,7 +1,7 @@
 error[E0599]: no variant named `Triangle` found for enum `Shape`
   --> tests/compile-fail-stable/surface_demuxenum_port_extramissing.rs:20:18
    |
- 6 |     enum Shape {
+6  |     enum Shape {
    |     ---------- variant `Triangle` not found here
 ...
 20 |         my_demux[Triangle] -> for_each(std::mem::drop);

--- a/dfir_rs/tests/compile-fail-stable/surface_demuxenum_port_wrong_one.stderr
+++ b/dfir_rs/tests/compile-fail-stable/surface_demuxenum_port_wrong_one.stderr
@@ -1,7 +1,7 @@
 error[E0599]: no variant named `Circle` found for enum `Shape`
   --> tests/compile-fail-stable/surface_demuxenum_port_wrong_one.rs:14:18
    |
- 6 |     enum Shape {
+6  |     enum Shape {
    |     ---------- variant `Circle` not found here
 ...
 14 |         my_demux[Circle] -> for_each(std::mem::drop);

--- a/dfir_rs/tests/compile-fail-stable/surface_demuxenum_wrongfields_1.stderr
+++ b/dfir_rs/tests/compile-fail-stable/surface_demuxenum_wrongfields_1.stderr
@@ -9,9 +9,9 @@ error[E0271]: type mismatch resolving `<impl Pusherator<Item = u32> as Pusherato
 note: required for `Shape` to implement `DemuxEnum<(impl Pusherator<Item = (f64,)>, impl Pusherator<Item = (f64, f64)>, impl Pusherator<Item = u32>)>`
   --> tests/compile-fail-stable/surface_demuxenum_wrongfields_1.rs:5:14
    |
- 5 |     #[derive(DemuxEnum)]
+5  |     #[derive(DemuxEnum)]
    |              ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
- 6 |     enum Shape {
+6  |     enum Shape {
    |          ^^^^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: associated types for the current `impl` cannot be restricted in `where` clauses

--- a/dfir_rs/tests/compile-fail-stable/surface_demuxenum_wrongfields_2.stderr
+++ b/dfir_rs/tests/compile-fail-stable/surface_demuxenum_wrongfields_2.stderr
@@ -9,9 +9,9 @@ error[E0271]: type mismatch resolving `<impl Pusherator<Item = (u32,)> as Pusher
 note: required for `Shape` to implement `DemuxEnum<(impl Pusherator<Item = (f64,)>, impl Pusherator<Item = (f64, f64)>, impl Pusherator<Item = (u32,)>)>`
   --> tests/compile-fail-stable/surface_demuxenum_wrongfields_2.rs:5:14
    |
- 5 |     #[derive(DemuxEnum)]
+5  |     #[derive(DemuxEnum)]
    |              ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
- 6 |     enum Shape {
+6  |     enum Shape {
    |          ^^^^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: associated types for the current `impl` cannot be restricted in `where` clauses

--- a/hydro_lang/src/compile/ir/snapshots/hydro_lang__compile__ir__backtrace__tests__backtrace.snap
+++ b/hydro_lang/src/compile/ir/snapshots/hydro_lang__compile__ir__backtrace__tests__backtrace.snap
@@ -24,7 +24,7 @@ expression: elements
     BacktraceElement {
         fn_name: "core::ops::function::FnOnce::call_once",
         lineno: Some(
-            253,
+            250,
         ),
         colno: Some(
             5,

--- a/hydro_lang/src/live_collections/stream/tests/snapshots/hydro_lang__live_collections__stream__tests__backtrace_chained_ops__backtrace_chained_ops-2.snap
+++ b/hydro_lang/src/live_collections/stream/tests/snapshots/hydro_lang__live_collections__stream__tests__backtrace_chained_ops__backtrace_chained_ops-2.snap
@@ -24,7 +24,7 @@ expression: for_each_meta.backtrace.elements()
     BacktraceElement {
         fn_name: "core::ops::function::FnOnce::call_once",
         lineno: Some(
-            253,
+            250,
         ),
         colno: Some(
             5,

--- a/hydro_lang/src/live_collections/stream/tests/snapshots/hydro_lang__live_collections__stream__tests__backtrace_chained_ops__backtrace_chained_ops.snap
+++ b/hydro_lang/src/live_collections/stream/tests/snapshots/hydro_lang__live_collections__stream__tests__backtrace_chained_ops__backtrace_chained_ops.snap
@@ -24,7 +24,7 @@ expression: source_meta.backtrace.elements()
     BacktraceElement {
         fn_name: "core::ops::function::FnOnce::call_once",
         lineno: Some(
-            253,
+            250,
         ),
         colno: Some(
             5,

--- a/precheck.bash
+++ b/precheck.bash
@@ -75,7 +75,7 @@ cargo clippy $TARGETS --all-targets $FEATURES -- -D warnings
 [ "$TEST_ALL" = false ] || cargo check --all-targets --no-default-features
 
 # `--all-targets` is everything except `--doc`: https://github.com/rust-lang/cargo/issues/6669.
-INSTA_FORCE_PASS=1 INSTA_UPDATE=always TRYBUILD=overwrite cargo test $TARGETS --all-targets --no-fail-fast $FEATURES
+INSTA_FORCE_PASS=1 INSTA_UPDATE=always TRYBUILD=overwrite cargo nextest run $TARGETS --all-targets --no-fail-fast $FEATURES
 cargo test $TARGETS --doc
 
 # Test website_playground wasm build.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,5 @@
 [toolchain]
+channel = "1.89"
 components = [
     "rustfmt",
     "clippy",


### PR DESCRIPTION

GitHub Actions is going to be flip/flopping between 1.89 and 1.90, and we have users who need support on 1.89.

Also updates precheck.bash to use nextest for _speed_.
