### PR TITLE
refactor(hydro_std): reduce atomic pollution in quorum counting

### DIFF
--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -338,6 +338,11 @@ where
         }
     }
 
+    /// Returns the [`Location`] where this stream is being materialized.
+    pub fn location(&self) -> &L {
+        &self.location
+    }
+
     /// Produces a stream based on invoking `f` on each element.
     /// If you do not want to modify the stream and instead only want to view
     /// each item use [`Stream::inspect`] instead.
@@ -2265,11 +2270,6 @@ where
                 metadata: self.location.tick.l.new_node_metadata::<T>(),
             },
         )
-    }
-
-    /// Gets the [`Tick`] inside which this stream is synchronously processed. See [`Stream::atomic`].
-    pub fn atomic_source(&self) -> Tick<L> {
-        self.location.tick.clone()
     }
 }
 

--- a/hydro_std/src/request_response.rs
+++ b/hydro_std/src/request_response.rs
@@ -1,10 +1,10 @@
 use std::hash::Hash;
 
 use hydro_lang::live_collections::stream::NoOrder;
-use hydro_lang::location::{Atomic, Location, NoTick};
+use hydro_lang::location::{Location, NoTick};
 use hydro_lang::prelude::*;
 
-type JoinResponses<K, M, V, L> = Stream<(K, (M, V)), Atomic<L>, Unbounded, NoOrder>;
+type JoinResponses<K, M, V, L> = Stream<(K, (M, V)), L, Unbounded, NoOrder>;
 
 /// Given an incoming stream of request-response responses, joins with metadata generated
 /// at request time that is stored in-memory.
@@ -13,19 +13,22 @@ type JoinResponses<K, M, V, L> = Stream<(K, (M, V)), Atomic<L>, Unbounded, NoOrd
 /// typically at request time. Only one response element should be produced with a given
 /// key, same for the metadata stream.
 pub fn join_responses<'a, K: Clone + Eq + Hash, M: Clone, V: Clone, L: Location<'a> + NoTick>(
-    tick: &Tick<L>,
-    responses: Stream<(K, V), Atomic<L>, Unbounded, NoOrder>,
+    responses: Stream<(K, V), L, Unbounded, NoOrder>,
     metadata: Stream<(K, M), Tick<L>, Bounded, NoOrder>,
 ) -> JoinResponses<K, M, V, L> {
+    let tick = metadata.location().clone();
     let (remaining_to_join_complete_cycle, remaining_to_join) =
         tick.cycle::<Stream<_, _, _, NoOrder>>();
 
     let remaining_and_new: Stream<(K, M), Tick<L>, Bounded, _> = remaining_to_join.chain(metadata);
 
-    let responses = responses.batch_atomic(nondet!(
-        /// Because we persist the metadata, delays resulting from
-        /// batching boundaries do not affect the output contents.
-    ));
+    let responses = responses.batch(
+        &tick,
+        nondet!(
+            /// Because we persist the metadata, delays resulting from
+            /// batching boundaries do not affect the output contents.
+        ),
+    );
 
     // TODO(shadaj): we should have a "split-join" operator
     // that returns both join and anti-join without cloning
@@ -38,5 +41,5 @@ pub fn join_responses<'a, K: Clone + Eq + Hash, M: Clone, V: Clone, L: Location<
     remaining_to_join_complete_cycle
         .complete_next_tick(remaining_and_new.anti_join(responses.map(q!(|(key, _)| key))));
 
-    joined_this_tick.all_ticks_atomic()
+    joined_this_tick.all_ticks()
 }

--- a/hydro_test/src/cluster/compartmentalized_paxos.rs
+++ b/hydro_test/src/cluster/compartmentalized_paxos.rs
@@ -279,7 +279,8 @@ fn sequence_payload<'a, P: PaxosPayload>(
         ))))
         .all_ticks()
         .demux_bincode(proxy_leaders)
-        .values();
+        .values()
+        .atomic(proxy_leader_tick);
 
     // Send to a specific acceptor row
     let num_acceptor_rows = config.acceptor_grid_rows;
@@ -304,6 +305,7 @@ fn sequence_payload<'a, P: PaxosPayload>(
             }
             p2as
         }))
+        .end_atomic()
         .demux_bincode(acceptors)
         .values();
 
@@ -318,28 +320,28 @@ fn sequence_payload<'a, P: PaxosPayload>(
     // TODO: This is a liveness problem if any node in the thrifty quorum fails
     // Need special operator for per-value timeout detection
     let (quorums, fails) = collect_quorum(
-        a_to_proxy_leaders_p2b.atomic(proxy_leader_tick),
+        a_to_proxy_leaders_p2b,
         config.acceptor_grid_cols,
         config.acceptor_grid_cols,
     );
 
     let pl_to_replicas = join_responses(
-        proxy_leader_tick,
         quorums.map(q!(|k| (k, ()))),
-        p_to_proxy_leaders_p2a.batch(proxy_leader_tick, nondet!(/** TODO */)),
+        p_to_proxy_leaders_p2a.batch_atomic(nondet!(
+            /// The metadata will always be generated before we get a quorum
+            /// because our batch of `p_to_proxy_leaders_p2a` is at least after
+            /// what we sent to the acceptors.
+        )),
     );
 
     let pl_failed_p2b_to_proposer = fails
         .map(q!(|(_, ballot)| (ballot.proposer_id, ballot)))
         .inspect(q!(|(_, ballot)| println!("Failed P2b: {:?}", ballot)))
-        .end_atomic()
         .demux_bincode(proposers)
         .values();
 
     (
-        pl_to_replicas
-            .map(q!(|((slot, _ballot), (value, _))| (slot, value)))
-            .end_atomic(),
+        pl_to_replicas.map(q!(|((slot, _ballot), (value, _))| (slot, value))),
         a_log,
         pl_failed_p2b_to_proposer,
     )

--- a/hydro_test/src/cluster/paxos_bench.rs
+++ b/hydro_test/src/cluster/paxos_bench.rs
@@ -102,13 +102,7 @@ pub fn paxos_bench<'a>(
             .values();
 
         // we only mark a transaction as committed when all replicas have applied it
-        collect_quorum::<_, _, _, ()>(
-            c_received_payloads.atomic(&clients.tick()),
-            f + 1,
-            num_replicas,
-        )
-        .0
-        .end_atomic()
+        collect_quorum::<_, _, _, ()>(c_received_payloads, f + 1, num_replicas).0
     };
 
     let bench_results = bench_client(

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir.snap
@@ -817,7 +817,7 @@ expression: built.ir()
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    1,
+                                                    10,
                                                     Cluster(
                                                         0,
                                                     ),
@@ -829,7 +829,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                1,
+                                                10,
                                                 Cluster(
                                                     0,
                                                 ),
@@ -841,67 +841,57 @@ expression: built.ir()
                                     },
                                     second: Batch {
                                         inner: Tee {
-                                            inner: <tee 7>: BeginAtomic {
-                                                inner: Inspect {
-                                                    f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | p1b | println ! ("Proposer received P1b: {:?}" , p1b) }),
-                                                    input: Map {
-                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                                        input: Network {
-                                                            serialize_fn: Some(
-                                                                :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: location :: MemberId < _ > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
-                                                            ),
-                                                            instantiate_fn: <network instantiate>,
-                                                            deserialize_fn: Some(
-                                                                | res | { let (id , b) = res . unwrap () ; (hydro_lang :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Acceptor > :: from_raw (id) , hydro_lang :: runtime_support :: bincode :: deserialize :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > (& b) . unwrap ()) },
-                                                            ),
-                                                            input: YieldConcat {
-                                                                inner: Map {
-                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < ((hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >)) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | ((ballot , max_ballot) , log) | (ballot . proposer_id , (ballot , if ballot == max_ballot { Ok (log) } else { Err (max_ballot) })) }),
-                                                                    input: CrossSingleton {
-                                                                        left: CrossSingleton {
-                                                                            left: Tee {
-                                                                                inner: <tee 8>: Batch {
-                                                                                    inner: Map {
-                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                                                                        input: Network {
-                                                                                            serialize_fn: Some(
-                                                                                                :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: location :: MemberId < _ > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
-                                                                                            ),
-                                                                                            instantiate_fn: <network instantiate>,
-                                                                                            deserialize_fn: Some(
-                                                                                                | res | { let (id , b) = res . unwrap () ; (hydro_lang :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_raw (id) , hydro_lang :: runtime_support :: bincode :: deserialize :: < hydro_test :: __staged :: cluster :: paxos :: Ballot > (& b) . unwrap ()) },
-                                                                                            ),
-                                                                                            input: YieldConcat {
-                                                                                                inner: CrossProduct {
-                                                                                                    left: Map {
-                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ()) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                                                                        input: Batch {
-                                                                                                            inner: FilterMap {
-                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool) , core :: option :: Option < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ()) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < bool , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | v | if v { Some (()) } else { None } }) ; { let orig = f__free ; move | (k , v) | orig (v) . map (| v | (k , v)) } }),
-                                                                                                                input: FoldKeyed {
-                                                                                                                    init: stageleft :: runtime_support :: fn0_type_hint :: < bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | | false }),
-                                                                                                                    acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < bool , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | present , event | { match event { MembershipEvent :: Joined => * present = true , MembershipEvent :: Left => * present = false , } } }),
-                                                                                                                    input: Map {
-                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < & hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | id | (* id , MembershipEvent :: Joined) }),
-                                                                                                                        input: Source {
-                                                                                                                            source: Iter(
-                                                                                                                                { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let underlying_memberids__free = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: location :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >] > (__hydro_lang_cluster_ids_1) } ; underlying_memberids__free },
-                                                                                                                            ),
-                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                location_kind: Cluster(
-                                                                                                                                    0,
-                                                                                                                                ),
-                                                                                                                                output_type: Some(
-                                                                                                                                    & hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
-                                                                                                                                ),
-                                                                                                                            },
-                                                                                                                        },
+                                            inner: <tee 7>: Inspect {
+                                                f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | p1b | println ! ("Proposer received P1b: {:?}" , p1b) }),
+                                                input: Map {
+                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
+                                                    input: Network {
+                                                        serialize_fn: Some(
+                                                            :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: location :: MemberId < _ > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
+                                                        ),
+                                                        instantiate_fn: <network instantiate>,
+                                                        deserialize_fn: Some(
+                                                            | res | { let (id , b) = res . unwrap () ; (hydro_lang :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Acceptor > :: from_raw (id) , hydro_lang :: runtime_support :: bincode :: deserialize :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > (& b) . unwrap ()) },
+                                                        ),
+                                                        input: YieldConcat {
+                                                            inner: Map {
+                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < ((hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >)) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | ((ballot , max_ballot) , log) | (ballot . proposer_id , (ballot , if ballot == max_ballot { Ok (log) } else { Err (max_ballot) })) }),
+                                                                input: CrossSingleton {
+                                                                    left: CrossSingleton {
+                                                                        left: Tee {
+                                                                            inner: <tee 8>: Batch {
+                                                                                inner: Map {
+                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
+                                                                                    input: Network {
+                                                                                        serialize_fn: Some(
+                                                                                            :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: location :: MemberId < _ > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
+                                                                                        ),
+                                                                                        instantiate_fn: <network instantiate>,
+                                                                                        deserialize_fn: Some(
+                                                                                            | res | { let (id , b) = res . unwrap () ; (hydro_lang :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_raw (id) , hydro_lang :: runtime_support :: bincode :: deserialize :: < hydro_test :: __staged :: cluster :: paxos :: Ballot > (& b) . unwrap ()) },
+                                                                                        ),
+                                                                                        input: YieldConcat {
+                                                                                            inner: CrossProduct {
+                                                                                                left: Map {
+                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ()) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
+                                                                                                    input: Batch {
+                                                                                                        inner: FilterMap {
+                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool) , core :: option :: Option < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ()) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < bool , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | v | if v { Some (()) } else { None } }) ; { let orig = f__free ; move | (k , v) | orig (v) . map (| v | (k , v)) } }),
+                                                                                                            input: FoldKeyed {
+                                                                                                                init: stageleft :: runtime_support :: fn0_type_hint :: < bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | | false }),
+                                                                                                                acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < bool , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | present , event | { match event { MembershipEvent :: Joined => * present = true , MembershipEvent :: Left => * present = false , } } }),
+                                                                                                                input: Map {
+                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < & hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | id | (* id , MembershipEvent :: Joined) }),
+                                                                                                                    input: Source {
+                                                                                                                        source: Iter(
+                                                                                                                            { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let underlying_memberids__free = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: location :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >] > (__hydro_lang_cluster_ids_1) } ; underlying_memberids__free },
+                                                                                                                        ),
                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                             location_kind: Cluster(
                                                                                                                                 0,
                                                                                                                             ),
                                                                                                                             output_type: Some(
-                                                                                                                                (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
+                                                                                                                                & hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
                                                                                                                             ),
                                                                                                                         },
                                                                                                                     },
@@ -910,7 +900,7 @@ expression: built.ir()
                                                                                                                             0,
                                                                                                                         ),
                                                                                                                         output_type: Some(
-                                                                                                                            (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool),
+                                                                                                                            (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
                                                                                                                         ),
                                                                                                                     },
                                                                                                                 },
@@ -919,16 +909,13 @@ expression: built.ir()
                                                                                                                         0,
                                                                                                                     ),
                                                                                                                     output_type: Some(
-                                                                                                                        (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ()),
+                                                                                                                        (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool),
                                                                                                                     ),
                                                                                                                 },
                                                                                                             },
                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                location_kind: Tick(
-                                                                                                                    9,
-                                                                                                                    Cluster(
-                                                                                                                        0,
-                                                                                                                    ),
+                                                                                                                location_kind: Cluster(
+                                                                                                                    0,
                                                                                                                 ),
                                                                                                                 output_type: Some(
                                                                                                                     (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ()),
@@ -943,73 +930,73 @@ expression: built.ir()
                                                                                                                 ),
                                                                                                             ),
                                                                                                             output_type: Some(
-                                                                                                                hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
+                                                                                                                (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ()),
                                                                                                             ),
                                                                                                         },
                                                                                                     },
-                                                                                                    right: Batch {
-                                                                                                        inner: Inspect {
-                                                                                                            f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | _ | println ! ("Proposer leader expired, sending P1a") }),
-                                                                                                            input: YieldConcat {
-                                                                                                                inner: Map {
-                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , ()) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _signal) | d }),
-                                                                                                                    input: CrossSingleton {
-                                                                                                                        left: Tee {
-                                                                                                                            inner: <tee 3>,
-                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                location_kind: Tick(
-                                                                                                                                    1,
-                                                                                                                                    Cluster(
-                                                                                                                                        0,
-                                                                                                                                    ),
+                                                                                                    metadata: HydroIrMetadata {
+                                                                                                        location_kind: Tick(
+                                                                                                            9,
+                                                                                                            Cluster(
+                                                                                                                0,
+                                                                                                            ),
+                                                                                                        ),
+                                                                                                        output_type: Some(
+                                                                                                            hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
+                                                                                                        ),
+                                                                                                    },
+                                                                                                },
+                                                                                                right: Batch {
+                                                                                                    inner: Inspect {
+                                                                                                        f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | _ | println ! ("Proposer leader expired, sending P1a") }),
+                                                                                                        input: YieldConcat {
+                                                                                                            inner: Map {
+                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , ()) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _signal) | d }),
+                                                                                                                input: CrossSingleton {
+                                                                                                                    left: Tee {
+                                                                                                                        inner: <tee 3>,
+                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                            location_kind: Tick(
+                                                                                                                                1,
+                                                                                                                                Cluster(
+                                                                                                                                    0,
                                                                                                                                 ),
-                                                                                                                                output_type: Some(
-                                                                                                                                    hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                                                ),
-                                                                                                                            },
+                                                                                                                            ),
+                                                                                                                            output_type: Some(
+                                                                                                                                hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                                                            ),
                                                                                                                         },
-                                                                                                                        right: Map {
-                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _u | () }),
-                                                                                                                            input: Map {
-                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (() , ()) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | (d , _signal) | d }),
-                                                                                                                                input: CrossSingleton {
-                                                                                                                                    left: Map {
-                                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (() , ()) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | (d , _signal) | d }),
-                                                                                                                                        input: CrossSingleton {
-                                                                                                                                            left: Batch {
-                                                                                                                                                inner: YieldConcat {
-                                                                                                                                                    inner: FilterMap {
-                                                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant > , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; let duration__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let i_am_leader_check_timeout__free = 10u64 ; Duration :: from_secs (i_am_leader_check_timeout__free) } ; move | latest_received | { if let Some (latest_received) = latest_received { if Instant :: now () . duration_since (latest_received) > duration__free { Some (()) } else { None } } else { Some (()) } } }),
-                                                                                                                                                        input: Batch {
-                                                                                                                                                            inner: Fold {
-                                                                                                                                                                init: stageleft :: runtime_support :: fn0_type_hint :: < core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | | None }),
-                                                                                                                                                                acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant > , hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | latest , _ | { * latest = Some (Instant :: now ()) ; } }),
-                                                                                                                                                                input: Tee {
-                                                                                                                                                                    inner: <tee 2>,
-                                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                                        location_kind: Cluster(
-                                                                                                                                                                            0,
-                                                                                                                                                                        ),
-                                                                                                                                                                        output_type: Some(
-                                                                                                                                                                            hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                                                                                        ),
-                                                                                                                                                                    },
-                                                                                                                                                                },
+                                                                                                                    },
+                                                                                                                    right: Map {
+                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _u | () }),
+                                                                                                                        input: Map {
+                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (() , ()) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | (d , _signal) | d }),
+                                                                                                                            input: CrossSingleton {
+                                                                                                                                left: Map {
+                                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (() , ()) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | (d , _signal) | d }),
+                                                                                                                                    input: CrossSingleton {
+                                                                                                                                        left: Batch {
+                                                                                                                                            inner: YieldConcat {
+                                                                                                                                                inner: FilterMap {
+                                                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant > , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; let duration__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let i_am_leader_check_timeout__free = 10u64 ; Duration :: from_secs (i_am_leader_check_timeout__free) } ; move | latest_received | { if let Some (latest_received) = latest_received { if Instant :: now () . duration_since (latest_received) > duration__free { Some (()) } else { None } } else { Some (()) } } }),
+                                                                                                                                                    input: Batch {
+                                                                                                                                                        inner: Fold {
+                                                                                                                                                            init: stageleft :: runtime_support :: fn0_type_hint :: < core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | | None }),
+                                                                                                                                                            acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant > , hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | latest , _ | { * latest = Some (Instant :: now ()) ; } }),
+                                                                                                                                                            input: Tee {
+                                                                                                                                                                inner: <tee 2>,
                                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                                     location_kind: Cluster(
                                                                                                                                                                         0,
                                                                                                                                                                     ),
                                                                                                                                                                     output_type: Some(
-                                                                                                                                                                        core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant >,
+                                                                                                                                                                        hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                                                                                                                     ),
                                                                                                                                                                 },
                                                                                                                                                             },
                                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                                location_kind: Tick(
-                                                                                                                                                                    8,
-                                                                                                                                                                    Cluster(
-                                                                                                                                                                        0,
-                                                                                                                                                                    ),
+                                                                                                                                                                location_kind: Cluster(
+                                                                                                                                                                    0,
                                                                                                                                                                 ),
                                                                                                                                                                 output_type: Some(
                                                                                                                                                                     core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant >,
@@ -1024,13 +1011,16 @@ expression: built.ir()
                                                                                                                                                                 ),
                                                                                                                                                             ),
                                                                                                                                                             output_type: Some(
-                                                                                                                                                                (),
+                                                                                                                                                                core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant >,
                                                                                                                                                             ),
                                                                                                                                                         },
                                                                                                                                                     },
                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                        location_kind: Cluster(
-                                                                                                                                                            0,
+                                                                                                                                                        location_kind: Tick(
+                                                                                                                                                            8,
+                                                                                                                                                            Cluster(
+                                                                                                                                                                0,
+                                                                                                                                                            ),
                                                                                                                                                         ),
                                                                                                                                                         output_type: Some(
                                                                                                                                                             (),
@@ -1038,40 +1028,37 @@ expression: built.ir()
                                                                                                                                                     },
                                                                                                                                                 },
                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                    location_kind: Tick(
-                                                                                                                                                        1,
-                                                                                                                                                        Cluster(
-                                                                                                                                                            0,
-                                                                                                                                                        ),
+                                                                                                                                                    location_kind: Cluster(
+                                                                                                                                                        0,
                                                                                                                                                     ),
                                                                                                                                                     output_type: Some(
                                                                                                                                                         (),
                                                                                                                                                     ),
                                                                                                                                                 },
                                                                                                                                             },
-                                                                                                                                            right: Map {
-                                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _u | () }),
-                                                                                                                                                input: Filter {
-                                                                                                                                                    f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_none () }),
-                                                                                                                                                    input: ChainFirst {
-                                                                                                                                                        first: Map {
-                                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                                                                                                                            input: Map {
-                                                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                                                                                                                                input: Tee {
-                                                                                                                                                                    inner: <tee 4>,
-                                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                                        location_kind: Tick(
-                                                                                                                                                                            1,
-                                                                                                                                                                            Cluster(
-                                                                                                                                                                                0,
-                                                                                                                                                                            ),
-                                                                                                                                                                        ),
-                                                                                                                                                                        output_type: Some(
-                                                                                                                                                                            (),
-                                                                                                                                                                        ),
-                                                                                                                                                                    },
-                                                                                                                                                                },
+                                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                                location_kind: Tick(
+                                                                                                                                                    1,
+                                                                                                                                                    Cluster(
+                                                                                                                                                        0,
+                                                                                                                                                    ),
+                                                                                                                                                ),
+                                                                                                                                                output_type: Some(
+                                                                                                                                                    (),
+                                                                                                                                                ),
+                                                                                                                                            },
+                                                                                                                                        },
+                                                                                                                                        right: Map {
+                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _u | () }),
+                                                                                                                                            input: Filter {
+                                                                                                                                                f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_none () }),
+                                                                                                                                                input: ChainFirst {
+                                                                                                                                                    first: Map {
+                                                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
+                                                                                                                                                        input: Map {
+                                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                                                                                                                            input: Tee {
+                                                                                                                                                                inner: <tee 4>,
                                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                                     location_kind: Tick(
                                                                                                                                                                         1,
@@ -1092,26 +1079,26 @@ expression: built.ir()
                                                                                                                                                                     ),
                                                                                                                                                                 ),
                                                                                                                                                                 output_type: Some(
-                                                                                                                                                                    core :: option :: Option < () >,
+                                                                                                                                                                    (),
                                                                                                                                                                 ),
                                                                                                                                                             },
                                                                                                                                                         },
-                                                                                                                                                        second: Source {
-                                                                                                                                                            source: Iter(
-                                                                                                                                                                [:: std :: option :: Option :: None],
+                                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                                            location_kind: Tick(
+                                                                                                                                                                1,
+                                                                                                                                                                Cluster(
+                                                                                                                                                                    0,
+                                                                                                                                                                ),
                                                                                                                                                             ),
-                                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                                location_kind: Tick(
-                                                                                                                                                                    1,
-                                                                                                                                                                    Cluster(
-                                                                                                                                                                        0,
-                                                                                                                                                                    ),
-                                                                                                                                                                ),
-                                                                                                                                                                output_type: Some(
-                                                                                                                                                                    core :: option :: Option < () >,
-                                                                                                                                                                ),
-                                                                                                                                                            },
+                                                                                                                                                            output_type: Some(
+                                                                                                                                                                core :: option :: Option < () >,
+                                                                                                                                                            ),
                                                                                                                                                         },
+                                                                                                                                                    },
+                                                                                                                                                    second: Source {
+                                                                                                                                                        source: Iter(
+                                                                                                                                                            [:: std :: option :: Option :: None],
+                                                                                                                                                        ),
                                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                                             location_kind: Tick(
                                                                                                                                                                 1,
@@ -1144,7 +1131,7 @@ expression: built.ir()
                                                                                                                                                         ),
                                                                                                                                                     ),
                                                                                                                                                     output_type: Some(
-                                                                                                                                                        (),
+                                                                                                                                                        core :: option :: Option < () >,
                                                                                                                                                     ),
                                                                                                                                                 },
                                                                                                                                             },
@@ -1156,7 +1143,7 @@ expression: built.ir()
                                                                                                                                                     ),
                                                                                                                                                 ),
                                                                                                                                                 output_type: Some(
-                                                                                                                                                    (() , ()),
+                                                                                                                                                    (),
                                                                                                                                                 ),
                                                                                                                                             },
                                                                                                                                         },
@@ -1168,34 +1155,34 @@ expression: built.ir()
                                                                                                                                                 ),
                                                                                                                                             ),
                                                                                                                                             output_type: Some(
-                                                                                                                                                (),
+                                                                                                                                                (() , ()),
                                                                                                                                             ),
                                                                                                                                         },
                                                                                                                                     },
-                                                                                                                                    right: Map {
-                                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _u | () }),
-                                                                                                                                        input: Reduce {
-                                                                                                                                            f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
-                                                                                                                                            input: Batch {
-                                                                                                                                                inner: Source {
-                                                                                                                                                    source: Stream(
-                                                                                                                                                        { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let delay__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_raw (__hydro_lang_cluster_self_id_0) ; let i_am_leader_check_timeout_delay_multiplier__free = 15usize ; Duration :: from_secs ((CLUSTER_SELF_ID__free . raw_id * i_am_leader_check_timeout_delay_multiplier__free as u32) . into ()) } ; let interval__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let i_am_leader_check_timeout__free = 10u64 ; Duration :: from_secs (i_am_leader_check_timeout__free) } ; tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval_at (tokio :: time :: Instant :: now () + delay__free , interval__free)) },
-                                                                                                                                                    ),
-                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                        location_kind: Cluster(
-                                                                                                                                                            0,
-                                                                                                                                                        ),
-                                                                                                                                                        output_type: Some(
-                                                                                                                                                            hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
-                                                                                                                                                        ),
-                                                                                                                                                    },
-                                                                                                                                                },
+                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                        location_kind: Tick(
+                                                                                                                                            1,
+                                                                                                                                            Cluster(
+                                                                                                                                                0,
+                                                                                                                                            ),
+                                                                                                                                        ),
+                                                                                                                                        output_type: Some(
+                                                                                                                                            (),
+                                                                                                                                        ),
+                                                                                                                                    },
+                                                                                                                                },
+                                                                                                                                right: Map {
+                                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _u | () }),
+                                                                                                                                    input: Reduce {
+                                                                                                                                        f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
+                                                                                                                                        input: Batch {
+                                                                                                                                            inner: Source {
+                                                                                                                                                source: Stream(
+                                                                                                                                                    { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let delay__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_raw (__hydro_lang_cluster_self_id_0) ; let i_am_leader_check_timeout_delay_multiplier__free = 15usize ; Duration :: from_secs ((CLUSTER_SELF_ID__free . raw_id * i_am_leader_check_timeout_delay_multiplier__free as u32) . into ()) } ; let interval__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let i_am_leader_check_timeout__free = 10u64 ; Duration :: from_secs (i_am_leader_check_timeout__free) } ; tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval_at (tokio :: time :: Instant :: now () + delay__free , interval__free)) },
+                                                                                                                                                ),
                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                    location_kind: Tick(
-                                                                                                                                                        1,
-                                                                                                                                                        Cluster(
-                                                                                                                                                            0,
-                                                                                                                                                        ),
+                                                                                                                                                    location_kind: Cluster(
+                                                                                                                                                        0,
                                                                                                                                                     ),
                                                                                                                                                     output_type: Some(
                                                                                                                                                         hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
@@ -1222,7 +1209,7 @@ expression: built.ir()
                                                                                                                                                 ),
                                                                                                                                             ),
                                                                                                                                             output_type: Some(
-                                                                                                                                                (),
+                                                                                                                                                hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
                                                                                                                                             ),
                                                                                                                                         },
                                                                                                                                     },
@@ -1234,7 +1221,7 @@ expression: built.ir()
                                                                                                                                             ),
                                                                                                                                         ),
                                                                                                                                         output_type: Some(
-                                                                                                                                            (() , ()),
+                                                                                                                                            (),
                                                                                                                                         ),
                                                                                                                                     },
                                                                                                                                 },
@@ -1246,7 +1233,7 @@ expression: built.ir()
                                                                                                                                         ),
                                                                                                                                     ),
                                                                                                                                     output_type: Some(
-                                                                                                                                        (),
+                                                                                                                                        (() , ()),
                                                                                                                                     ),
                                                                                                                                 },
                                                                                                                             },
@@ -1270,7 +1257,7 @@ expression: built.ir()
                                                                                                                                 ),
                                                                                                                             ),
                                                                                                                             output_type: Some(
-                                                                                                                                (hydro_test :: __staged :: cluster :: paxos :: Ballot , ()),
+                                                                                                                                (),
                                                                                                                             ),
                                                                                                                         },
                                                                                                                     },
@@ -1282,13 +1269,16 @@ expression: built.ir()
                                                                                                                             ),
                                                                                                                         ),
                                                                                                                         output_type: Some(
-                                                                                                                            hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                                                            (hydro_test :: __staged :: cluster :: paxos :: Ballot , ()),
                                                                                                                         ),
                                                                                                                     },
                                                                                                                 },
                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                    location_kind: Cluster(
-                                                                                                                        0,
+                                                                                                                    location_kind: Tick(
+                                                                                                                        1,
+                                                                                                                        Cluster(
+                                                                                                                            0,
+                                                                                                                        ),
                                                                                                                     ),
                                                                                                                     output_type: Some(
                                                                                                                         hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -1305,11 +1295,8 @@ expression: built.ir()
                                                                                                             },
                                                                                                         },
                                                                                                         metadata: HydroIrMetadata {
-                                                                                                            location_kind: Tick(
-                                                                                                                9,
-                                                                                                                Cluster(
-                                                                                                                    0,
-                                                                                                                ),
+                                                                                                            location_kind: Cluster(
+                                                                                                                0,
                                                                                                             ),
                                                                                                             output_type: Some(
                                                                                                                 hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -1324,13 +1311,16 @@ expression: built.ir()
                                                                                                             ),
                                                                                                         ),
                                                                                                         output_type: Some(
-                                                                                                            (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                                                            hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                                                         ),
                                                                                                     },
                                                                                                 },
                                                                                                 metadata: HydroIrMetadata {
-                                                                                                    location_kind: Cluster(
-                                                                                                        0,
+                                                                                                    location_kind: Tick(
+                                                                                                        9,
+                                                                                                        Cluster(
+                                                                                                            0,
+                                                                                                        ),
                                                                                                     ),
                                                                                                     output_type: Some(
                                                                                                         (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
@@ -1339,10 +1329,10 @@ expression: built.ir()
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_kind: Cluster(
-                                                                                                    1,
+                                                                                                    0,
                                                                                                 ),
                                                                                                 output_type: Some(
-                                                                                                    (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                                                    (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
                                                                                                 ),
                                                                                             },
                                                                                         },
@@ -1351,16 +1341,13 @@ expression: built.ir()
                                                                                                 1,
                                                                                             ),
                                                                                             output_type: Some(
-                                                                                                hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                                (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
                                                                                             ),
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
-                                                                                        location_kind: Tick(
-                                                                                            2,
-                                                                                            Cluster(
-                                                                                                1,
-                                                                                            ),
+                                                                                        location_kind: Cluster(
+                                                                                            1,
                                                                                         ),
                                                                                         output_type: Some(
                                                                                             hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -1379,27 +1366,27 @@ expression: built.ir()
                                                                                     ),
                                                                                 },
                                                                             },
-                                                                            right: Tee {
-                                                                                inner: <tee 9>: ChainFirst {
-                                                                                    first: Reduce {
-                                                                                        f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | curr , new | { if new > * curr { * curr = new ; } } }),
-                                                                                        input: Persist {
-                                                                                            inner: Inspect {
-                                                                                                f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | p1a | println ! ("Acceptor received P1a: {:?}" , p1a) }),
-                                                                                                input: Tee {
-                                                                                                    inner: <tee 8>,
-                                                                                                    metadata: HydroIrMetadata {
-                                                                                                        location_kind: Tick(
-                                                                                                            2,
-                                                                                                            Cluster(
-                                                                                                                1,
-                                                                                                            ),
-                                                                                                        ),
-                                                                                                        output_type: Some(
-                                                                                                            hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                        ),
-                                                                                                    },
-                                                                                                },
+                                                                            metadata: HydroIrMetadata {
+                                                                                location_kind: Tick(
+                                                                                    2,
+                                                                                    Cluster(
+                                                                                        1,
+                                                                                    ),
+                                                                                ),
+                                                                                output_type: Some(
+                                                                                    hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                ),
+                                                                            },
+                                                                        },
+                                                                        right: Tee {
+                                                                            inner: <tee 9>: ChainFirst {
+                                                                                first: Reduce {
+                                                                                    f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | curr , new | { if new > * curr { * curr = new ; } } }),
+                                                                                    input: Persist {
+                                                                                        inner: Inspect {
+                                                                                            f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | p1a | println ! ("Acceptor received P1a: {:?}" , p1a) }),
+                                                                                            input: Tee {
+                                                                                                inner: <tee 8>,
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_kind: Tick(
                                                                                                         2,
@@ -1436,21 +1423,24 @@ expression: built.ir()
                                                                                             ),
                                                                                         },
                                                                                     },
-                                                                                    second: Batch {
-                                                                                        inner: Persist {
-                                                                                            inner: Source {
-                                                                                                source: Iter(
-                                                                                                    { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let e__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; Ballot { num : 0 , proposer_id : MemberId :: from_raw (0) } } ; [e__free] },
-                                                                                                ),
-                                                                                                metadata: HydroIrMetadata {
-                                                                                                    location_kind: Cluster(
-                                                                                                        1,
-                                                                                                    ),
-                                                                                                    output_type: Some(
-                                                                                                        hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                    ),
-                                                                                                },
-                                                                                            },
+                                                                                    metadata: HydroIrMetadata {
+                                                                                        location_kind: Tick(
+                                                                                            2,
+                                                                                            Cluster(
+                                                                                                1,
+                                                                                            ),
+                                                                                        ),
+                                                                                        output_type: Some(
+                                                                                            hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                        ),
+                                                                                    },
+                                                                                },
+                                                                                second: Batch {
+                                                                                    inner: Persist {
+                                                                                        inner: Source {
+                                                                                            source: Iter(
+                                                                                                { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let e__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; Ballot { num : 0 , proposer_id : MemberId :: from_raw (0) } } ; [e__free] },
+                                                                                            ),
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_kind: Cluster(
                                                                                                     1,
@@ -1461,11 +1451,8 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_kind: Tick(
-                                                                                                2,
-                                                                                                Cluster(
-                                                                                                    1,
-                                                                                                ),
+                                                                                            location_kind: Cluster(
+                                                                                                1,
                                                                                             ),
                                                                                             output_type: Some(
                                                                                                 hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -1504,23 +1491,7 @@ expression: built.ir()
                                                                                     ),
                                                                                 ),
                                                                                 output_type: Some(
-                                                                                    (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot),
-                                                                                ),
-                                                                            },
-                                                                        },
-                                                                        right: CycleSource {
-                                                                            ident: Ident {
-                                                                                sym: cycle_3,
-                                                                            },
-                                                                            metadata: HydroIrMetadata {
-                                                                                location_kind: Tick(
-                                                                                    2,
-                                                                                    Cluster(
-                                                                                        1,
-                                                                                    ),
-                                                                                ),
-                                                                                output_type: Some(
-                                                                                    (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >),
+                                                                                    hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                                 ),
                                                                             },
                                                                         },
@@ -1532,7 +1503,23 @@ expression: built.ir()
                                                                                 ),
                                                                             ),
                                                                             output_type: Some(
-                                                                                ((hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >)),
+                                                                                (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                            ),
+                                                                        },
+                                                                    },
+                                                                    right: CycleSource {
+                                                                        ident: Ident {
+                                                                            sym: cycle_3,
+                                                                        },
+                                                                        metadata: HydroIrMetadata {
+                                                                            location_kind: Tick(
+                                                                                2,
+                                                                                Cluster(
+                                                                                    1,
+                                                                                ),
+                                                                            ),
+                                                                            output_type: Some(
+                                                                                (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >),
                                                                             ),
                                                                         },
                                                                     },
@@ -1544,13 +1531,16 @@ expression: built.ir()
                                                                             ),
                                                                         ),
                                                                         output_type: Some(
-                                                                            (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)),
+                                                                            ((hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >)),
                                                                         ),
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_kind: Cluster(
-                                                                        1,
+                                                                    location_kind: Tick(
+                                                                        2,
+                                                                        Cluster(
+                                                                            1,
+                                                                        ),
                                                                     ),
                                                                     output_type: Some(
                                                                         (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)),
@@ -1559,10 +1549,10 @@ expression: built.ir()
                                                             },
                                                             metadata: HydroIrMetadata {
                                                                 location_kind: Cluster(
-                                                                    0,
+                                                                    1,
                                                                 ),
                                                                 output_type: Some(
-                                                                    (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)),
+                                                                    (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)),
                                                                 ),
                                                             },
                                                         },
@@ -1571,7 +1561,7 @@ expression: built.ir()
                                                                 0,
                                                             ),
                                                             output_type: Some(
-                                                                (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
+                                                                (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)),
                                                             ),
                                                         },
                                                     },
@@ -1585,13 +1575,8 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_kind: Atomic(
-                                                        Tick(
-                                                            1,
-                                                            Cluster(
-                                                                0,
-                                                            ),
-                                                        ),
+                                                    location_kind: Cluster(
+                                                        0,
                                                     ),
                                                     output_type: Some(
                                                         (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
@@ -1599,13 +1584,8 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_kind: Atomic(
-                                                    Tick(
-                                                        1,
-                                                        Cluster(
-                                                            0,
-                                                        ),
-                                                    ),
+                                                location_kind: Cluster(
+                                                    0,
                                                 ),
                                                 output_type: Some(
                                                     (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
@@ -1614,7 +1594,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                1,
+                                                10,
                                                 Cluster(
                                                     0,
                                                 ),
@@ -1626,7 +1606,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            1,
+                                            10,
                                             Cluster(
                                                 0,
                                             ),
@@ -1638,7 +1618,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        1,
+                                        10,
                                         Cluster(
                                             0,
                                         ),
@@ -1650,7 +1630,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    1,
+                                    10,
                                     Cluster(
                                         0,
                                     ),
@@ -1662,7 +1642,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                1,
+                                10,
                                 Cluster(
                                     0,
                                 ),
@@ -1674,7 +1654,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            1,
+                            10,
                             Cluster(
                                 0,
                             ),
@@ -1686,7 +1666,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        1,
+                        10,
                         Cluster(
                             0,
                         ),
@@ -1705,7 +1685,7 @@ expression: built.ir()
                             inner: <tee 5>,
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    1,
+                                    10,
                                     Cluster(
                                         0,
                                     ),
@@ -1717,7 +1697,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                1,
+                                10,
                                 Cluster(
                                     0,
                                 ),
@@ -1729,7 +1709,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            1,
+                            10,
                             Cluster(
                                 0,
                             ),
@@ -1741,7 +1721,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        1,
+                        10,
                         Cluster(
                             0,
                         ),
@@ -1753,7 +1733,7 @@ expression: built.ir()
             },
             metadata: HydroIrMetadata {
                 location_kind: Tick(
-                    1,
+                    10,
                     Cluster(
                         0,
                     ),
@@ -1764,7 +1744,7 @@ expression: built.ir()
             },
         },
         out_location: Tick(
-            1,
+            10,
             Cluster(
                 0,
             ),
@@ -1780,7 +1760,7 @@ expression: built.ir()
                 inner: <tee 6>,
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        1,
+                        10,
                         Cluster(
                             0,
                         ),
@@ -1794,7 +1774,7 @@ expression: built.ir()
                 inner: <tee 10>,
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        1,
+                        10,
                         Cluster(
                             0,
                         ),
@@ -1806,7 +1786,7 @@ expression: built.ir()
             },
             metadata: HydroIrMetadata {
                 location_kind: Tick(
-                    1,
+                    10,
                     Cluster(
                         0,
                     ),
@@ -1817,7 +1797,7 @@ expression: built.ir()
             },
         },
         out_location: Tick(
-            1,
+            10,
             Cluster(
                 0,
             ),
@@ -1838,40 +1818,54 @@ expression: built.ir()
                             inner: <tee 12>: FilterMap {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < ((hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) >) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; move | ((quorum_ballot , quorum_accepted) , my_ballot) | if quorum_ballot == my_ballot { Some (quorum_accepted) } else { None } }),
                                 input: CrossSingleton {
-                                    left: Reduce {
-                                        f: { let key_fn = stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) >) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | t | t . 0 }) ; move | curr , new | { if key_fn (& new) > key_fn (& * curr) { * curr = new ; } } },
-                                        input: Batch {
-                                            inner: FoldKeyed {
-                                                init: stageleft :: runtime_support :: fn0_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | | vec ! [] }),
-                                                acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) > , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | logs , log | { logs . push (log) ; } }),
-                                                input: YieldConcat {
-                                                    inner: FilterMap {
-                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >)) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | (key , res) | match res { Ok (v) => Some ((key , v)) , Err (_) => None , } }),
-                                                        input: AntiJoin {
-                                                            pos: AntiJoin {
-                                                                pos: Tee {
-                                                                    inner: <tee 6>,
-                                                                    metadata: HydroIrMetadata {
-                                                                        location_kind: Tick(
-                                                                            1,
-                                                                            Cluster(
-                                                                                0,
+                                    left: Batch {
+                                        inner: Reduce {
+                                            f: { let key_fn = stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) >) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | t | t . 0 }) ; move | curr , new | { if key_fn (& new) > key_fn (& * curr) { * curr = new ; } } },
+                                            input: FlatMap {
+                                                f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) >) > , core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) >) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | d | d }),
+                                                input: Scan {
+                                                    init: stageleft :: runtime_support :: fn0_type_hint :: < std :: collections :: hash_map :: HashMap < hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: option :: Option < core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) > > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | | HashMap :: new () }),
+                                                    acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: collections :: hash_map :: HashMap < hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: option :: Option < core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) > > > > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >)) , core :: option :: Option < core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) >) > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; let f__free = stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) > > , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: __deps :: hydro_lang :: live_collections :: keyed_stream :: Generate < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; let f__free = stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) > , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let quorum_size__free = 2usize ; move | logs , log | { logs . push (log) ; logs . len () >= quorum_size__free } }) ; move | key_state , v | { if let Some (key_state_value) = key_state . as_mut () { if f__free (key_state_value , v) { Generate :: Return (key_state . take () . unwrap ()) } else { Generate :: Continue } } else { unreachable ! () } } }) ; let init__free = stageleft :: runtime_support :: fn0_type_hint :: < core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; let init__free = stageleft :: runtime_support :: fn0_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | | vec ! [] }) ; move | | Some (init__free ()) }) ; move | acc , (k , v) | { let existing_state = acc . entry (k . clone ()) . or_insert_with (| | Some (init__free ())) ; if let Some (existing_state_value) = existing_state { match f__free (existing_state_value , v) { Generate :: Yield (out) => Some (Some ((k , out))) , Generate :: Return (out) => { let _ = existing_state . take () ; Some (Some ((k , out))) } Generate :: Break => { let _ = existing_state . take () ; Some (None) } Generate :: Continue => Some (None) , } } else { Some (None) } } }),
+                                                    input: YieldConcat {
+                                                        inner: FilterMap {
+                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >)) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | (key , res) | match res { Ok (v) => Some ((key , v)) , Err (_) => None , } }),
+                                                            input: AntiJoin {
+                                                                pos: AntiJoin {
+                                                                    pos: Tee {
+                                                                        inner: <tee 6>,
+                                                                        metadata: HydroIrMetadata {
+                                                                            location_kind: Tick(
+                                                                                10,
+                                                                                Cluster(
+                                                                                    0,
+                                                                                ),
                                                                             ),
-                                                                        ),
-                                                                        output_type: Some(
-                                                                            (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
-                                                                        ),
+                                                                            output_type: Some(
+                                                                                (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
+                                                                            ),
+                                                                        },
                                                                     },
-                                                                },
-                                                                neg: Map {
-                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                                    input: Filter {
-                                                                        f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < (usize , usize) , bool > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; let min__free = 2usize ; move | (success , _error) | success < & min__free }) ; { let orig = f__free ; move | (_k , v) | orig (v) } }),
-                                                                        input: Tee {
-                                                                            inner: <tee 5>,
+                                                                    neg: Map {
+                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
+                                                                        input: Filter {
+                                                                            f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < (usize , usize) , bool > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; let min__free = 2usize ; move | (success , _error) | success < & min__free }) ; { let orig = f__free ; move | (_k , v) | orig (v) } }),
+                                                                            input: Tee {
+                                                                                inner: <tee 5>,
+                                                                                metadata: HydroIrMetadata {
+                                                                                    location_kind: Tick(
+                                                                                        10,
+                                                                                        Cluster(
+                                                                                            0,
+                                                                                        ),
+                                                                                    ),
+                                                                                    output_type: Some(
+                                                                                        (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)),
+                                                                                    ),
+                                                                                },
+                                                                            },
                                                                             metadata: HydroIrMetadata {
                                                                                 location_kind: Tick(
-                                                                                    1,
+                                                                                    10,
                                                                                     Cluster(
                                                                                         0,
                                                                                     ),
@@ -1883,19 +1877,48 @@ expression: built.ir()
                                                                         },
                                                                         metadata: HydroIrMetadata {
                                                                             location_kind: Tick(
-                                                                                1,
+                                                                                10,
                                                                                 Cluster(
                                                                                     0,
                                                                                 ),
                                                                             ),
                                                                             output_type: Some(
-                                                                                (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)),
+                                                                                hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                             ),
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
                                                                         location_kind: Tick(
-                                                                            1,
+                                                                            10,
+                                                                            Cluster(
+                                                                                0,
+                                                                            ),
+                                                                        ),
+                                                                        output_type: Some(
+                                                                            (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
+                                                                        ),
+                                                                    },
+                                                                },
+                                                                neg: DeferTick {
+                                                                    input: CycleSource {
+                                                                        ident: Ident {
+                                                                            sym: cycle_9,
+                                                                        },
+                                                                        metadata: HydroIrMetadata {
+                                                                            location_kind: Tick(
+                                                                                10,
+                                                                                Cluster(
+                                                                                    0,
+                                                                                ),
+                                                                            ),
+                                                                            output_type: Some(
+                                                                                hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                            ),
+                                                                        },
+                                                                    },
+                                                                    metadata: HydroIrMetadata {
+                                                                        location_kind: Tick(
+                                                                            10,
                                                                             Cluster(
                                                                                 0,
                                                                             ),
@@ -1907,7 +1930,7 @@ expression: built.ir()
                                                                 },
                                                                 metadata: HydroIrMetadata {
                                                                     location_kind: Tick(
-                                                                        1,
+                                                                        10,
                                                                         Cluster(
                                                                             0,
                                                                         ),
@@ -1917,53 +1940,21 @@ expression: built.ir()
                                                                     ),
                                                                 },
                                                             },
-                                                            neg: DeferTick {
-                                                                input: CycleSource {
-                                                                    ident: Ident {
-                                                                        sym: cycle_9,
-                                                                    },
-                                                                    metadata: HydroIrMetadata {
-                                                                        location_kind: Tick(
-                                                                            1,
-                                                                            Cluster(
-                                                                                0,
-                                                                            ),
-                                                                        ),
-                                                                        output_type: Some(
-                                                                            hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                        ),
-                                                                    },
-                                                                },
-                                                                metadata: HydroIrMetadata {
-                                                                    location_kind: Tick(
-                                                                        1,
-                                                                        Cluster(
-                                                                            0,
-                                                                        ),
-                                                                    ),
-                                                                    output_type: Some(
-                                                                        hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                    ),
-                                                                },
-                                                            },
                                                             metadata: HydroIrMetadata {
                                                                 location_kind: Tick(
-                                                                    1,
+                                                                    10,
                                                                     Cluster(
                                                                         0,
                                                                     ),
                                                                 ),
                                                                 output_type: Some(
-                                                                    (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
+                                                                    (hydro_test :: __staged :: cluster :: paxos :: Ballot , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >)),
                                                                 ),
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_kind: Tick(
-                                                                1,
-                                                                Cluster(
-                                                                    0,
-                                                                ),
+                                                            location_kind: Cluster(
+                                                                0,
                                                             ),
                                                             output_type: Some(
                                                                 (hydro_test :: __staged :: cluster :: paxos :: Ballot , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >)),
@@ -1971,27 +1962,17 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_kind: Atomic(
-                                                            Tick(
-                                                                1,
-                                                                Cluster(
-                                                                    0,
-                                                                ),
-                                                            ),
+                                                        location_kind: Cluster(
+                                                            0,
                                                         ),
                                                         output_type: Some(
-                                                            (hydro_test :: __staged :: cluster :: paxos :: Ballot , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >)),
+                                                            core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) >) >,
                                                         ),
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_kind: Atomic(
-                                                        Tick(
-                                                            1,
-                                                            Cluster(
-                                                                0,
-                                                            ),
-                                                        ),
+                                                    location_kind: Cluster(
+                                                        0,
                                                     ),
                                                     output_type: Some(
                                                         (hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) >),
@@ -1999,11 +1980,8 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_kind: Tick(
-                                                    1,
-                                                    Cluster(
-                                                        0,
-                                                    ),
+                                                location_kind: Cluster(
+                                                    0,
                                                 ),
                                                 output_type: Some(
                                                     (hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) >),
@@ -2230,36 +2208,16 @@ expression: built.ir()
         },
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (_ , ballot) | ballot }),
-            input: EndAtomic {
-                inner: FilterMap {
-                    f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | (key , res) | match res { Ok (_) => None , Err (e) => Some ((key , e)) , } }),
-                    input: Tee {
-                        inner: <tee 7>,
-                        metadata: HydroIrMetadata {
-                            location_kind: Atomic(
-                                Tick(
-                                    1,
-                                    Cluster(
-                                        0,
-                                    ),
-                                ),
-                            ),
-                            output_type: Some(
-                                (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
-                            ),
-                        },
-                    },
+            input: FilterMap {
+                f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | (key , res) | match res { Ok (_) => None , Err (e) => Some ((key , e)) , } }),
+                input: Tee {
+                    inner: <tee 7>,
                     metadata: HydroIrMetadata {
-                        location_kind: Atomic(
-                            Tick(
-                                1,
-                                Cluster(
-                                    0,
-                                ),
-                            ),
+                        location_kind: Cluster(
+                            0,
                         ),
                         output_type: Some(
-                            (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                            (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
                         ),
                     },
                 },
@@ -2302,7 +2260,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        11,
+                                        12,
                                         Cluster(
                                             2,
                                         ),
@@ -2314,7 +2272,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    11,
+                                    12,
                                     Cluster(
                                         2,
                                     ),
@@ -2351,7 +2309,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    11,
+                                    12,
                                     Cluster(
                                         2,
                                     ),
@@ -2363,7 +2321,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                11,
+                                12,
                                 Cluster(
                                     2,
                                 ),
@@ -2375,7 +2333,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            11,
+                            12,
                             Cluster(
                                 2,
                             ),
@@ -2466,7 +2424,7 @@ expression: built.ir()
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_kind: Tick(
-                                                                                        10,
+                                                                                        11,
                                                                                         Cluster(
                                                                                             0,
                                                                                         ),
@@ -2478,7 +2436,7 @@ expression: built.ir()
                                                                             },
                                                                             metadata: HydroIrMetadata {
                                                                                 location_kind: Tick(
-                                                                                    10,
+                                                                                    11,
                                                                                     Cluster(
                                                                                         0,
                                                                                     ),
@@ -2722,7 +2680,7 @@ expression: built.ir()
                                                                             },
                                                                             metadata: HydroIrMetadata {
                                                                                 location_kind: Tick(
-                                                                                    10,
+                                                                                    11,
                                                                                     Cluster(
                                                                                         0,
                                                                                     ),
@@ -2734,7 +2692,7 @@ expression: built.ir()
                                                                         },
                                                                         metadata: HydroIrMetadata {
                                                                             location_kind: Tick(
-                                                                                10,
+                                                                                11,
                                                                                 Cluster(
                                                                                     0,
                                                                                 ),
@@ -2800,7 +2758,7 @@ expression: built.ir()
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    11,
+                                                    12,
                                                     Cluster(
                                                         2,
                                                     ),
@@ -2812,7 +2770,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                11,
+                                                12,
                                                 Cluster(
                                                     2,
                                                 ),
@@ -2824,7 +2782,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            11,
+                                            12,
                                             Cluster(
                                                 2,
                                             ),
@@ -2836,7 +2794,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        11,
+                                        12,
                                         Cluster(
                                             2,
                                         ),
@@ -2852,7 +2810,7 @@ expression: built.ir()
                                 ),
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        11,
+                                        12,
                                         Cluster(
                                             2,
                                         ),
@@ -2864,7 +2822,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    11,
+                                    12,
                                     Cluster(
                                         2,
                                     ),
@@ -2876,7 +2834,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                11,
+                                12,
                                 Cluster(
                                     2,
                                 ),
@@ -2888,7 +2846,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            11,
+                            12,
                             Cluster(
                                 2,
                             ),
@@ -2900,7 +2858,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        11,
+                        12,
                         Cluster(
                             2,
                         ),
@@ -2912,7 +2870,7 @@ expression: built.ir()
             },
             metadata: HydroIrMetadata {
                 location_kind: Tick(
-                    11,
+                    12,
                     Cluster(
                         2,
                     ),
@@ -2923,7 +2881,7 @@ expression: built.ir()
             },
         },
         out_location: Tick(
-            11,
+            12,
             Cluster(
                 2,
             ),
@@ -2968,7 +2926,7 @@ expression: built.ir()
                                                                             inner: <tee 14>,
                                                                             metadata: HydroIrMetadata {
                                                                                 location_kind: Tick(
-                                                                                    11,
+                                                                                    12,
                                                                                     Cluster(
                                                                                         2,
                                                                                     ),
@@ -2982,7 +2940,7 @@ expression: built.ir()
                                                                             inner: <tee 15>,
                                                                             metadata: HydroIrMetadata {
                                                                                 location_kind: Tick(
-                                                                                    11,
+                                                                                    12,
                                                                                     Cluster(
                                                                                         2,
                                                                                     ),
@@ -2994,7 +2952,7 @@ expression: built.ir()
                                                                         },
                                                                         metadata: HydroIrMetadata {
                                                                             location_kind: Tick(
-                                                                                11,
+                                                                                12,
                                                                                 Cluster(
                                                                                     2,
                                                                                 ),
@@ -3513,7 +3471,7 @@ expression: built.ir()
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    1,
+                                                    14,
                                                     Cluster(
                                                         0,
                                                     ),
@@ -3525,7 +3483,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                1,
+                                                14,
                                                 Cluster(
                                                     0,
                                                 ),
@@ -3537,64 +3495,54 @@ expression: built.ir()
                                     },
                                     second: Batch {
                                         inner: Tee {
-                                            inner: <tee 26>: BeginAtomic {
-                                                inner: Map {
-                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                                    input: Network {
-                                                        serialize_fn: Some(
-                                                            :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: location :: MemberId < _ > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
-                                                        ),
-                                                        instantiate_fn: <network instantiate>,
-                                                        deserialize_fn: Some(
-                                                            | res | { let (id , b) = res . unwrap () ; (hydro_lang :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Acceptor > :: from_raw (id) , hydro_lang :: runtime_support :: bincode :: deserialize :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > (& b) . unwrap ()) },
-                                                        ),
-                                                        input: YieldConcat {
-                                                            inner: Map {
-                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (p2a , max_ballot) | (p2a . sender , ((p2a . slot , p2a . ballot) , if p2a . ballot == max_ballot { Ok (()) } else { Err (max_ballot) })) }),
-                                                                input: CrossSingleton {
-                                                                    left: Tee {
-                                                                        inner: <tee 27>: Batch {
-                                                                            inner: Map {
-                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer >) , hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                                                                input: Network {
-                                                                                    serialize_fn: Some(
-                                                                                        :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: location :: MemberId < _ > , hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer >) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
-                                                                                    ),
-                                                                                    instantiate_fn: <network instantiate>,
-                                                                                    deserialize_fn: Some(
-                                                                                        | res | { let (id , b) = res . unwrap () ; (hydro_lang :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_raw (id) , hydro_lang :: runtime_support :: bincode :: deserialize :: < hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer > > (& b) . unwrap ()) },
-                                                                                    ),
-                                                                                    input: YieldConcat {
-                                                                                        inner: CrossProduct {
-                                                                                            left: Map {
-                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ()) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                                                                input: Batch {
-                                                                                                    inner: FilterMap {
-                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool) , core :: option :: Option < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ()) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < bool , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | v | if v { Some (()) } else { None } }) ; { let orig = f__free ; move | (k , v) | orig (v) . map (| v | (k , v)) } }),
-                                                                                                        input: FoldKeyed {
-                                                                                                            init: stageleft :: runtime_support :: fn0_type_hint :: < bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | | false }),
-                                                                                                            acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < bool , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | present , event | { match event { MembershipEvent :: Joined => * present = true , MembershipEvent :: Left => * present = false , } } }),
-                                                                                                            input: Map {
-                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < & hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | id | (* id , MembershipEvent :: Joined) }),
-                                                                                                                input: Source {
-                                                                                                                    source: Iter(
-                                                                                                                        { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let underlying_memberids__free = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: location :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >] > (__hydro_lang_cluster_ids_1) } ; underlying_memberids__free },
-                                                                                                                    ),
-                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                        location_kind: Cluster(
-                                                                                                                            0,
-                                                                                                                        ),
-                                                                                                                        output_type: Some(
-                                                                                                                            & hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
-                                                                                                                        ),
-                                                                                                                    },
-                                                                                                                },
+                                            inner: <tee 26>: Map {
+                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
+                                                input: Network {
+                                                    serialize_fn: Some(
+                                                        :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: location :: MemberId < _ > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
+                                                    ),
+                                                    instantiate_fn: <network instantiate>,
+                                                    deserialize_fn: Some(
+                                                        | res | { let (id , b) = res . unwrap () ; (hydro_lang :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Acceptor > :: from_raw (id) , hydro_lang :: runtime_support :: bincode :: deserialize :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > (& b) . unwrap ()) },
+                                                    ),
+                                                    input: YieldConcat {
+                                                        inner: Map {
+                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (p2a , max_ballot) | (p2a . sender , ((p2a . slot , p2a . ballot) , if p2a . ballot == max_ballot { Ok (()) } else { Err (max_ballot) })) }),
+                                                            input: CrossSingleton {
+                                                                left: Tee {
+                                                                    inner: <tee 27>: Batch {
+                                                                        inner: Map {
+                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer >) , hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
+                                                                            input: Network {
+                                                                                serialize_fn: Some(
+                                                                                    :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: location :: MemberId < _ > , hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer >) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
+                                                                                ),
+                                                                                instantiate_fn: <network instantiate>,
+                                                                                deserialize_fn: Some(
+                                                                                    | res | { let (id , b) = res . unwrap () ; (hydro_lang :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_raw (id) , hydro_lang :: runtime_support :: bincode :: deserialize :: < hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer > > (& b) . unwrap ()) },
+                                                                                ),
+                                                                                input: YieldConcat {
+                                                                                    inner: CrossProduct {
+                                                                                        left: Map {
+                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ()) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
+                                                                                            input: Batch {
+                                                                                                inner: FilterMap {
+                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool) , core :: option :: Option < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ()) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < bool , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | v | if v { Some (()) } else { None } }) ; { let orig = f__free ; move | (k , v) | orig (v) . map (| v | (k , v)) } }),
+                                                                                                    input: FoldKeyed {
+                                                                                                        init: stageleft :: runtime_support :: fn0_type_hint :: < bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | | false }),
+                                                                                                        acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < bool , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | present , event | { match event { MembershipEvent :: Joined => * present = true , MembershipEvent :: Left => * present = false , } } }),
+                                                                                                        input: Map {
+                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < & hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | id | (* id , MembershipEvent :: Joined) }),
+                                                                                                            input: Source {
+                                                                                                                source: Iter(
+                                                                                                                    { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let underlying_memberids__free = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: location :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >] > (__hydro_lang_cluster_ids_1) } ; underlying_memberids__free },
+                                                                                                                ),
                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                     location_kind: Cluster(
                                                                                                                         0,
                                                                                                                     ),
                                                                                                                     output_type: Some(
-                                                                                                                        (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
+                                                                                                                        & hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
                                                                                                                     ),
                                                                                                                 },
                                                                                                             },
@@ -3603,7 +3551,7 @@ expression: built.ir()
                                                                                                                     0,
                                                                                                                 ),
                                                                                                                 output_type: Some(
-                                                                                                                    (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool),
+                                                                                                                    (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
                                                                                                                 ),
                                                                                                             },
                                                                                                         },
@@ -3612,16 +3560,13 @@ expression: built.ir()
                                                                                                                 0,
                                                                                                             ),
                                                                                                             output_type: Some(
-                                                                                                                (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ()),
+                                                                                                                (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool),
                                                                                                             ),
                                                                                                         },
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
-                                                                                                        location_kind: Tick(
-                                                                                                            12,
-                                                                                                            Cluster(
-                                                                                                                0,
-                                                                                                            ),
+                                                                                                        location_kind: Cluster(
+                                                                                                            0,
                                                                                                         ),
                                                                                                         output_type: Some(
                                                                                                             (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ()),
@@ -3630,57 +3575,43 @@ expression: built.ir()
                                                                                                 },
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_kind: Tick(
-                                                                                                        12,
+                                                                                                        13,
                                                                                                         Cluster(
                                                                                                             0,
                                                                                                         ),
                                                                                                     ),
                                                                                                     output_type: Some(
-                                                                                                        hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
+                                                                                                        (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ()),
                                                                                                     ),
                                                                                                 },
                                                                                             },
-                                                                                            right: Batch {
-                                                                                                inner: Map {
-                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >) , hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_raw (__hydro_lang_cluster_self_id_0) ; move | ((slot , ballot) , value) | P2a { sender : CLUSTER_SELF_ID__free , ballot , slot , value } }),
-                                                                                                    input: EndAtomic {
-                                                                                                        inner: Tee {
-                                                                                                            inner: <tee 28>: YieldConcat {
-                                                                                                                inner: Map {
-                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >) , ()) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | (d , _signal) | d }),
-                                                                                                                    input: CrossSingleton {
-                                                                                                                        left: Chain {
-                                                                                                                            first: Map {
-                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) >) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | ((slot , payload) , ballot) | ((slot , ballot) , Some (payload)) }),
-                                                                                                                                input: CrossSingleton {
-                                                                                                                                    left: Tee {
-                                                                                                                                        inner: <tee 18>,
-                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                            location_kind: Tick(
-                                                                                                                                                1,
-                                                                                                                                                Cluster(
-                                                                                                                                                    0,
-                                                                                                                                                ),
-                                                                                                                                            ),
-                                                                                                                                            output_type: Some(
-                                                                                                                                                (usize , hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) >),
-                                                                                                                                            ),
-                                                                                                                                        },
-                                                                                                                                    },
-                                                                                                                                    right: Tee {
-                                                                                                                                        inner: <tee 3>,
-                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                            location_kind: Tick(
-                                                                                                                                                1,
-                                                                                                                                                Cluster(
-                                                                                                                                                    0,
-                                                                                                                                                ),
-                                                                                                                                            ),
-                                                                                                                                            output_type: Some(
-                                                                                                                                                hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                                                            ),
-                                                                                                                                        },
-                                                                                                                                    },
+                                                                                            metadata: HydroIrMetadata {
+                                                                                                location_kind: Tick(
+                                                                                                    13,
+                                                                                                    Cluster(
+                                                                                                        0,
+                                                                                                    ),
+                                                                                                ),
+                                                                                                output_type: Some(
+                                                                                                    hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
+                                                                                                ),
+                                                                                            },
+                                                                                        },
+                                                                                        right: Batch {
+                                                                                            inner: Map {
+                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >) , hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_raw (__hydro_lang_cluster_self_id_0) ; move | ((slot , ballot) , value) | P2a { sender : CLUSTER_SELF_ID__free , ballot , slot , value } }),
+                                                                                                input: EndAtomic {
+                                                                                                    inner: Tee {
+                                                                                                        inner: <tee 28>: YieldConcat {
+                                                                                                            inner: Map {
+                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >) , ()) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | (d , _signal) | d }),
+                                                                                                                input: CrossSingleton {
+                                                                                                                    left: Chain {
+                                                                                                                        first: Map {
+                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) >) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | ((slot , payload) , ballot) | ((slot , ballot) , Some (payload)) }),
+                                                                                                                            input: CrossSingleton {
+                                                                                                                                left: Tee {
+                                                                                                                                    inner: <tee 18>,
                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                         location_kind: Tick(
                                                                                                                                             1,
@@ -3689,7 +3620,21 @@ expression: built.ir()
                                                                                                                                             ),
                                                                                                                                         ),
                                                                                                                                         output_type: Some(
-                                                                                                                                            ((usize , hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) >) , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                                                                                            (usize , hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) >),
+                                                                                                                                        ),
+                                                                                                                                    },
+                                                                                                                                },
+                                                                                                                                right: Tee {
+                                                                                                                                    inner: <tee 3>,
+                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                        location_kind: Tick(
+                                                                                                                                            1,
+                                                                                                                                            Cluster(
+                                                                                                                                                0,
+                                                                                                                                            ),
+                                                                                                                                        ),
+                                                                                                                                        output_type: Some(
+                                                                                                                                            hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                                                                                         ),
                                                                                                                                     },
                                                                                                                                 },
@@ -3701,43 +3646,29 @@ expression: built.ir()
                                                                                                                                         ),
                                                                                                                                     ),
                                                                                                                                     output_type: Some(
-                                                                                                                                        ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >),
+                                                                                                                                        ((usize , hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) >) , hydro_test :: __staged :: cluster :: paxos :: Ballot),
                                                                                                                                     ),
                                                                                                                                 },
                                                                                                                             },
-                                                                                                                            second: Chain {
-                                                                                                                                first: FilterMap {
-                                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (((usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >)) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < usize >) , core :: option :: Option < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let f__free = 1usize ; move | (((slot , (count , entry)) , ballot) , checkpoint) | { if count > f__free { return None ; } else if let Some (checkpoint) = checkpoint && slot <= checkpoint { return None ; } Some (((slot , ballot) , entry . value)) } }),
-                                                                                                                                    input: CrossSingleton {
-                                                                                                                                        left: CrossSingleton {
-                                                                                                                                            left: Tee {
-                                                                                                                                                inner: <tee 21>,
-                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                    location_kind: Tick(
-                                                                                                                                                        1,
-                                                                                                                                                        Cluster(
-                                                                                                                                                            0,
-                                                                                                                                                        ),
-                                                                                                                                                    ),
-                                                                                                                                                    output_type: Some(
-                                                                                                                                                        (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >)),
-                                                                                                                                                    ),
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                            right: Tee {
-                                                                                                                                                inner: <tee 3>,
-                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                    location_kind: Tick(
-                                                                                                                                                        1,
-                                                                                                                                                        Cluster(
-                                                                                                                                                            0,
-                                                                                                                                                        ),
-                                                                                                                                                    ),
-                                                                                                                                                    output_type: Some(
-                                                                                                                                                        hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                                                                    ),
-                                                                                                                                                },
-                                                                                                                                            },
+                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                location_kind: Tick(
+                                                                                                                                    1,
+                                                                                                                                    Cluster(
+                                                                                                                                        0,
+                                                                                                                                    ),
+                                                                                                                                ),
+                                                                                                                                output_type: Some(
+                                                                                                                                    ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >),
+                                                                                                                                ),
+                                                                                                                            },
+                                                                                                                        },
+                                                                                                                        second: Chain {
+                                                                                                                            first: FilterMap {
+                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (((usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >)) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < usize >) , core :: option :: Option < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let f__free = 1usize ; move | (((slot , (count , entry)) , ballot) , checkpoint) | { if count > f__free { return None ; } else if let Some (checkpoint) = checkpoint && slot <= checkpoint { return None ; } Some (((slot , ballot) , entry . value)) } }),
+                                                                                                                                input: CrossSingleton {
+                                                                                                                                    left: CrossSingleton {
+                                                                                                                                        left: Tee {
+                                                                                                                                            inner: <tee 21>,
                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                 location_kind: Tick(
                                                                                                                                                     1,
@@ -3746,32 +3677,46 @@ expression: built.ir()
                                                                                                                                                     ),
                                                                                                                                                 ),
                                                                                                                                                 output_type: Some(
-                                                                                                                                                    ((usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >)) , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                                                                                                    (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >)),
                                                                                                                                                 ),
                                                                                                                                             },
                                                                                                                                         },
                                                                                                                                         right: Tee {
-                                                                                                                                            inner: <tee 29>: ChainFirst {
-                                                                                                                                                first: Map {
-                                                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < usize , core :: option :: Option < usize > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                                                                                                                    input: Reduce {
-                                                                                                                                                        f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | curr , new | { if new > * curr { * curr = new ; } } }),
-                                                                                                                                                        input: FilterMap {
-                                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , core :: option :: Option < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (checkpoint , _log) | checkpoint }),
-                                                                                                                                                            input: Tee {
-                                                                                                                                                                inner: <tee 22>,
-                                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                                    location_kind: Tick(
-                                                                                                                                                                        1,
-                                                                                                                                                                        Cluster(
-                                                                                                                                                                            0,
-                                                                                                                                                                        ),
-                                                                                                                                                                    ),
-                                                                                                                                                                    output_type: Some(
-                                                                                                                                                                        (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >),
-                                                                                                                                                                    ),
-                                                                                                                                                                },
-                                                                                                                                                            },
+                                                                                                                                            inner: <tee 3>,
+                                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                                location_kind: Tick(
+                                                                                                                                                    1,
+                                                                                                                                                    Cluster(
+                                                                                                                                                        0,
+                                                                                                                                                    ),
+                                                                                                                                                ),
+                                                                                                                                                output_type: Some(
+                                                                                                                                                    hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                                                                                ),
+                                                                                                                                            },
+                                                                                                                                        },
+                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                            location_kind: Tick(
+                                                                                                                                                1,
+                                                                                                                                                Cluster(
+                                                                                                                                                    0,
+                                                                                                                                                ),
+                                                                                                                                            ),
+                                                                                                                                            output_type: Some(
+                                                                                                                                                ((usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >)) , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                                                                                            ),
+                                                                                                                                        },
+                                                                                                                                    },
+                                                                                                                                    right: Tee {
+                                                                                                                                        inner: <tee 29>: ChainFirst {
+                                                                                                                                            first: Map {
+                                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < usize , core :: option :: Option < usize > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
+                                                                                                                                                input: Reduce {
+                                                                                                                                                    f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | curr , new | { if new > * curr { * curr = new ; } } }),
+                                                                                                                                                    input: FilterMap {
+                                                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , core :: option :: Option < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (checkpoint , _log) | checkpoint }),
+                                                                                                                                                        input: Tee {
+                                                                                                                                                            inner: <tee 22>,
                                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                                 location_kind: Tick(
                                                                                                                                                                     1,
@@ -3780,7 +3725,7 @@ expression: built.ir()
                                                                                                                                                                     ),
                                                                                                                                                                 ),
                                                                                                                                                                 output_type: Some(
-                                                                                                                                                                    usize,
+                                                                                                                                                                    (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >),
                                                                                                                                                                 ),
                                                                                                                                                             },
                                                                                                                                                         },
@@ -3804,26 +3749,26 @@ expression: built.ir()
                                                                                                                                                             ),
                                                                                                                                                         ),
                                                                                                                                                         output_type: Some(
-                                                                                                                                                            core :: option :: Option < usize >,
+                                                                                                                                                            usize,
                                                                                                                                                         ),
                                                                                                                                                     },
                                                                                                                                                 },
-                                                                                                                                                second: Source {
-                                                                                                                                                    source: Iter(
-                                                                                                                                                        [:: std :: option :: Option :: None],
+                                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                                    location_kind: Tick(
+                                                                                                                                                        1,
+                                                                                                                                                        Cluster(
+                                                                                                                                                            0,
+                                                                                                                                                        ),
                                                                                                                                                     ),
-                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                        location_kind: Tick(
-                                                                                                                                                            1,
-                                                                                                                                                            Cluster(
-                                                                                                                                                                0,
-                                                                                                                                                            ),
-                                                                                                                                                        ),
-                                                                                                                                                        output_type: Some(
-                                                                                                                                                            core :: option :: Option < usize >,
-                                                                                                                                                        ),
-                                                                                                                                                    },
+                                                                                                                                                    output_type: Some(
+                                                                                                                                                        core :: option :: Option < usize >,
+                                                                                                                                                    ),
                                                                                                                                                 },
+                                                                                                                                            },
+                                                                                                                                            second: Source {
+                                                                                                                                                source: Iter(
+                                                                                                                                                    [:: std :: option :: Option :: None],
+                                                                                                                                                ),
                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                     location_kind: Tick(
                                                                                                                                                         1,
@@ -3856,7 +3801,7 @@ expression: built.ir()
                                                                                                                                                 ),
                                                                                                                                             ),
                                                                                                                                             output_type: Some(
-                                                                                                                                                (((usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >)) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < usize >),
+                                                                                                                                                core :: option :: Option < usize >,
                                                                                                                                             ),
                                                                                                                                         },
                                                                                                                                     },
@@ -3868,45 +3813,31 @@ expression: built.ir()
                                                                                                                                             ),
                                                                                                                                         ),
                                                                                                                                         output_type: Some(
-                                                                                                                                            ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >),
+                                                                                                                                            (((usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >)) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < usize >),
                                                                                                                                         ),
                                                                                                                                     },
                                                                                                                                 },
-                                                                                                                                second: Map {
-                                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; move | (slot , ballot) | ((slot , ballot) , None) }),
-                                                                                                                                    input: CrossSingleton {
-                                                                                                                                        left: Difference {
-                                                                                                                                            pos: FlatMap {
-                                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , core :: option :: Option < usize >) , std :: ops :: Range < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (max_slot , checkpoint) | { if let Some (checkpoint) = checkpoint { (checkpoint + 1) .. max_slot } else { 0 .. max_slot } } }),
-                                                                                                                                                input: CrossSingleton {
-                                                                                                                                                    left: Tee {
-                                                                                                                                                        inner: <tee 20>,
-                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                            location_kind: Tick(
-                                                                                                                                                                1,
-                                                                                                                                                                Cluster(
-                                                                                                                                                                    0,
-                                                                                                                                                                ),
-                                                                                                                                                            ),
-                                                                                                                                                            output_type: Some(
-                                                                                                                                                                usize,
-                                                                                                                                                            ),
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                    right: Tee {
-                                                                                                                                                        inner: <tee 29>,
-                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                            location_kind: Tick(
-                                                                                                                                                                1,
-                                                                                                                                                                Cluster(
-                                                                                                                                                                    0,
-                                                                                                                                                                ),
-                                                                                                                                                            ),
-                                                                                                                                                            output_type: Some(
-                                                                                                                                                                core :: option :: Option < usize >,
-                                                                                                                                                            ),
-                                                                                                                                                        },
-                                                                                                                                                    },
+                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                    location_kind: Tick(
+                                                                                                                                        1,
+                                                                                                                                        Cluster(
+                                                                                                                                            0,
+                                                                                                                                        ),
+                                                                                                                                    ),
+                                                                                                                                    output_type: Some(
+                                                                                                                                        ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >),
+                                                                                                                                    ),
+                                                                                                                                },
+                                                                                                                            },
+                                                                                                                            second: Map {
+                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; move | (slot , ballot) | ((slot , ballot) , None) }),
+                                                                                                                                input: CrossSingleton {
+                                                                                                                                    left: Difference {
+                                                                                                                                        pos: FlatMap {
+                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , core :: option :: Option < usize >) , std :: ops :: Range < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (max_slot , checkpoint) | { if let Some (checkpoint) = checkpoint { (checkpoint + 1) .. max_slot } else { 0 .. max_slot } } }),
+                                                                                                                                            input: CrossSingleton {
+                                                                                                                                                left: Tee {
+                                                                                                                                                    inner: <tee 20>,
                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                         location_kind: Tick(
                                                                                                                                                             1,
@@ -3915,7 +3846,21 @@ expression: built.ir()
                                                                                                                                                             ),
                                                                                                                                                         ),
                                                                                                                                                         output_type: Some(
-                                                                                                                                                            (usize , core :: option :: Option < usize >),
+                                                                                                                                                            usize,
+                                                                                                                                                        ),
+                                                                                                                                                    },
+                                                                                                                                                },
+                                                                                                                                                right: Tee {
+                                                                                                                                                    inner: <tee 29>,
+                                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                                        location_kind: Tick(
+                                                                                                                                                            1,
+                                                                                                                                                            Cluster(
+                                                                                                                                                                0,
+                                                                                                                                                            ),
+                                                                                                                                                        ),
+                                                                                                                                                        output_type: Some(
+                                                                                                                                                            core :: option :: Option < usize >,
                                                                                                                                                         ),
                                                                                                                                                     },
                                                                                                                                                 },
@@ -3927,35 +3872,7 @@ expression: built.ir()
                                                                                                                                                         ),
                                                                                                                                                     ),
                                                                                                                                                     output_type: Some(
-                                                                                                                                                        usize,
-                                                                                                                                                    ),
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                            neg: Map {
-                                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >)) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                                                                                                                input: Tee {
-                                                                                                                                                    inner: <tee 21>,
-                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                        location_kind: Tick(
-                                                                                                                                                            1,
-                                                                                                                                                            Cluster(
-                                                                                                                                                                0,
-                                                                                                                                                            ),
-                                                                                                                                                        ),
-                                                                                                                                                        output_type: Some(
-                                                                                                                                                            (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >)),
-                                                                                                                                                        ),
-                                                                                                                                                    },
-                                                                                                                                                },
-                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                    location_kind: Tick(
-                                                                                                                                                        1,
-                                                                                                                                                        Cluster(
-                                                                                                                                                            0,
-                                                                                                                                                        ),
-                                                                                                                                                    ),
-                                                                                                                                                    output_type: Some(
-                                                                                                                                                        usize,
+                                                                                                                                                        (usize , core :: option :: Option < usize >),
                                                                                                                                                     ),
                                                                                                                                                 },
                                                                                                                                             },
@@ -3971,8 +3888,22 @@ expression: built.ir()
                                                                                                                                                 ),
                                                                                                                                             },
                                                                                                                                         },
-                                                                                                                                        right: Tee {
-                                                                                                                                            inner: <tee 3>,
+                                                                                                                                        neg: Map {
+                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >)) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
+                                                                                                                                            input: Tee {
+                                                                                                                                                inner: <tee 21>,
+                                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                                    location_kind: Tick(
+                                                                                                                                                        1,
+                                                                                                                                                        Cluster(
+                                                                                                                                                            0,
+                                                                                                                                                        ),
+                                                                                                                                                    ),
+                                                                                                                                                    output_type: Some(
+                                                                                                                                                        (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >)),
+                                                                                                                                                    ),
+                                                                                                                                                },
+                                                                                                                                            },
                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                 location_kind: Tick(
                                                                                                                                                     1,
@@ -3981,7 +3912,7 @@ expression: built.ir()
                                                                                                                                                     ),
                                                                                                                                                 ),
                                                                                                                                                 output_type: Some(
-                                                                                                                                                    hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                                                                                    usize,
                                                                                                                                                 ),
                                                                                                                                             },
                                                                                                                                         },
@@ -3993,7 +3924,21 @@ expression: built.ir()
                                                                                                                                                 ),
                                                                                                                                             ),
                                                                                                                                             output_type: Some(
-                                                                                                                                                (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                                                                                                usize,
+                                                                                                                                            ),
+                                                                                                                                        },
+                                                                                                                                    },
+                                                                                                                                    right: Tee {
+                                                                                                                                        inner: <tee 3>,
+                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                            location_kind: Tick(
+                                                                                                                                                1,
+                                                                                                                                                Cluster(
+                                                                                                                                                    0,
+                                                                                                                                                ),
+                                                                                                                                            ),
+                                                                                                                                            output_type: Some(
+                                                                                                                                                hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                                                                                             ),
                                                                                                                                         },
                                                                                                                                     },
@@ -4005,7 +3950,7 @@ expression: built.ir()
                                                                                                                                             ),
                                                                                                                                         ),
                                                                                                                                         output_type: Some(
-                                                                                                                                            ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >),
+                                                                                                                                            (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot),
                                                                                                                                         ),
                                                                                                                                     },
                                                                                                                                 },
@@ -4033,22 +3978,22 @@ expression: built.ir()
                                                                                                                                 ),
                                                                                                                             },
                                                                                                                         },
-                                                                                                                        right: Map {
-                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _u | () }),
-                                                                                                                            input: Tee {
-                                                                                                                                inner: <tee 11>,
-                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                    location_kind: Tick(
-                                                                                                                                        1,
-                                                                                                                                        Cluster(
-                                                                                                                                            0,
-                                                                                                                                        ),
-                                                                                                                                    ),
-                                                                                                                                    output_type: Some(
-                                                                                                                                        (),
-                                                                                                                                    ),
-                                                                                                                                },
-                                                                                                                            },
+                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                            location_kind: Tick(
+                                                                                                                                1,
+                                                                                                                                Cluster(
+                                                                                                                                    0,
+                                                                                                                                ),
+                                                                                                                            ),
+                                                                                                                            output_type: Some(
+                                                                                                                                ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >),
+                                                                                                                            ),
+                                                                                                                        },
+                                                                                                                    },
+                                                                                                                    right: Map {
+                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _u | () }),
+                                                                                                                        input: Tee {
+                                                                                                                            inner: <tee 11>,
                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                 location_kind: Tick(
                                                                                                                                     1,
@@ -4069,7 +4014,7 @@ expression: built.ir()
                                                                                                                                 ),
                                                                                                                             ),
                                                                                                                             output_type: Some(
-                                                                                                                                (((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >) , ()),
+                                                                                                                                (),
                                                                                                                             ),
                                                                                                                         },
                                                                                                                     },
@@ -4081,17 +4026,15 @@ expression: built.ir()
                                                                                                                             ),
                                                                                                                         ),
                                                                                                                         output_type: Some(
-                                                                                                                            ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >),
+                                                                                                                            (((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >) , ()),
                                                                                                                         ),
                                                                                                                     },
                                                                                                                 },
                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                    location_kind: Atomic(
-                                                                                                                        Tick(
-                                                                                                                            1,
-                                                                                                                            Cluster(
-                                                                                                                                0,
-                                                                                                                            ),
+                                                                                                                    location_kind: Tick(
+                                                                                                                        1,
+                                                                                                                        Cluster(
+                                                                                                                            0,
                                                                                                                         ),
                                                                                                                     ),
                                                                                                                     output_type: Some(
@@ -4114,8 +4057,13 @@ expression: built.ir()
                                                                                                             },
                                                                                                         },
                                                                                                         metadata: HydroIrMetadata {
-                                                                                                            location_kind: Cluster(
-                                                                                                                0,
+                                                                                                            location_kind: Atomic(
+                                                                                                                Tick(
+                                                                                                                    1,
+                                                                                                                    Cluster(
+                                                                                                                        0,
+                                                                                                                    ),
+                                                                                                                ),
                                                                                                             ),
                                                                                                             output_type: Some(
                                                                                                                 ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >),
@@ -4127,16 +4075,13 @@ expression: built.ir()
                                                                                                             0,
                                                                                                         ),
                                                                                                         output_type: Some(
-                                                                                                            hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
+                                                                                                            ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >),
                                                                                                         ),
                                                                                                     },
                                                                                                 },
                                                                                                 metadata: HydroIrMetadata {
-                                                                                                    location_kind: Tick(
-                                                                                                        12,
-                                                                                                        Cluster(
-                                                                                                            0,
-                                                                                                        ),
+                                                                                                    location_kind: Cluster(
+                                                                                                        0,
                                                                                                     ),
                                                                                                     output_type: Some(
                                                                                                         hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
@@ -4145,19 +4090,22 @@ expression: built.ir()
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_kind: Tick(
-                                                                                                    12,
+                                                                                                    13,
                                                                                                     Cluster(
                                                                                                         0,
                                                                                                     ),
                                                                                                 ),
                                                                                                 output_type: Some(
-                                                                                                    (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer >),
+                                                                                                    hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                                                                                 ),
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_kind: Cluster(
-                                                                                                0,
+                                                                                            location_kind: Tick(
+                                                                                                13,
+                                                                                                Cluster(
+                                                                                                    0,
+                                                                                                ),
                                                                                             ),
                                                                                             output_type: Some(
                                                                                                 (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer >),
@@ -4166,10 +4114,10 @@ expression: built.ir()
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_kind: Cluster(
-                                                                                            1,
+                                                                                            0,
                                                                                         ),
                                                                                         output_type: Some(
-                                                                                            (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer >),
+                                                                                            (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer >),
                                                                                         ),
                                                                                     },
                                                                                 },
@@ -4178,16 +4126,13 @@ expression: built.ir()
                                                                                         1,
                                                                                     ),
                                                                                     output_type: Some(
-                                                                                        hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
+                                                                                        (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer >),
                                                                                     ),
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_kind: Tick(
-                                                                                    2,
-                                                                                    Cluster(
-                                                                                        1,
-                                                                                    ),
+                                                                                location_kind: Cluster(
+                                                                                    1,
                                                                                 ),
                                                                                 output_type: Some(
                                                                                     hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
@@ -4206,20 +4151,6 @@ expression: built.ir()
                                                                             ),
                                                                         },
                                                                     },
-                                                                    right: Tee {
-                                                                        inner: <tee 9>,
-                                                                        metadata: HydroIrMetadata {
-                                                                            location_kind: Tick(
-                                                                                2,
-                                                                                Cluster(
-                                                                                    1,
-                                                                                ),
-                                                                            ),
-                                                                            output_type: Some(
-                                                                                hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                            ),
-                                                                        },
-                                                                    },
                                                                     metadata: HydroIrMetadata {
                                                                         location_kind: Tick(
                                                                             2,
@@ -4228,7 +4159,21 @@ expression: built.ir()
                                                                             ),
                                                                         ),
                                                                         output_type: Some(
-                                                                            (hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                            hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
+                                                                        ),
+                                                                    },
+                                                                },
+                                                                right: Tee {
+                                                                    inner: <tee 9>,
+                                                                    metadata: HydroIrMetadata {
+                                                                        location_kind: Tick(
+                                                                            2,
+                                                                            Cluster(
+                                                                                1,
+                                                                            ),
+                                                                        ),
+                                                                        output_type: Some(
+                                                                            hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                         ),
                                                                     },
                                                                 },
@@ -4240,13 +4185,16 @@ expression: built.ir()
                                                                         ),
                                                                     ),
                                                                     output_type: Some(
-                                                                        (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)),
+                                                                        (hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
                                                                     ),
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_kind: Cluster(
-                                                                    1,
+                                                                location_kind: Tick(
+                                                                    2,
+                                                                    Cluster(
+                                                                        1,
+                                                                    ),
                                                                 ),
                                                                 output_type: Some(
                                                                     (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)),
@@ -4255,10 +4203,10 @@ expression: built.ir()
                                                         },
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Cluster(
-                                                                0,
+                                                                1,
                                                             ),
                                                             output_type: Some(
-                                                                (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)),
+                                                                (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)),
                                                             ),
                                                         },
                                                     },
@@ -4267,18 +4215,13 @@ expression: built.ir()
                                                             0,
                                                         ),
                                                         output_type: Some(
-                                                            ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
+                                                            (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)),
                                                         ),
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_kind: Atomic(
-                                                        Tick(
-                                                            1,
-                                                            Cluster(
-                                                                0,
-                                                            ),
-                                                        ),
+                                                    location_kind: Cluster(
+                                                        0,
                                                     ),
                                                     output_type: Some(
                                                         ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
@@ -4286,13 +4229,8 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_kind: Atomic(
-                                                    Tick(
-                                                        1,
-                                                        Cluster(
-                                                            0,
-                                                        ),
-                                                    ),
+                                                location_kind: Cluster(
+                                                    0,
                                                 ),
                                                 output_type: Some(
                                                     ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
@@ -4301,7 +4239,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                1,
+                                                14,
                                                 Cluster(
                                                     0,
                                                 ),
@@ -4313,7 +4251,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            1,
+                                            14,
                                             Cluster(
                                                 0,
                                             ),
@@ -4325,7 +4263,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        1,
+                                        14,
                                         Cluster(
                                             0,
                                         ),
@@ -4337,7 +4275,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    1,
+                                    14,
                                     Cluster(
                                         0,
                                     ),
@@ -4349,7 +4287,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                1,
+                                14,
                                 Cluster(
                                     0,
                                 ),
@@ -4361,7 +4299,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            1,
+                            14,
                             Cluster(
                                 0,
                             ),
@@ -4373,7 +4311,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        1,
+                        14,
                         Cluster(
                             0,
                         ),
@@ -4392,7 +4330,7 @@ expression: built.ir()
                             inner: <tee 24>,
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    1,
+                                    14,
                                     Cluster(
                                         0,
                                     ),
@@ -4404,7 +4342,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                1,
+                                14,
                                 Cluster(
                                     0,
                                 ),
@@ -4416,7 +4354,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            1,
+                            14,
                             Cluster(
                                 0,
                             ),
@@ -4428,7 +4366,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        1,
+                        14,
                         Cluster(
                             0,
                         ),
@@ -4440,7 +4378,7 @@ expression: built.ir()
             },
             metadata: HydroIrMetadata {
                 location_kind: Tick(
-                    1,
+                    14,
                     Cluster(
                         0,
                     ),
@@ -4451,7 +4389,7 @@ expression: built.ir()
             },
         },
         out_location: Tick(
-            1,
+            14,
             Cluster(
                 0,
             ),
@@ -4467,7 +4405,7 @@ expression: built.ir()
                 inner: <tee 25>,
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        1,
+                        14,
                         Cluster(
                             0,
                         ),
@@ -4481,7 +4419,7 @@ expression: built.ir()
                 inner: <tee 30>,
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        1,
+                        14,
                         Cluster(
                             0,
                         ),
@@ -4493,7 +4431,7 @@ expression: built.ir()
             },
             metadata: HydroIrMetadata {
                 location_kind: Tick(
-                    1,
+                    14,
                     Cluster(
                         0,
                     ),
@@ -4504,7 +4442,7 @@ expression: built.ir()
             },
         },
         out_location: Tick(
-            1,
+            14,
             Cluster(
                 0,
             ),
@@ -4612,7 +4550,7 @@ expression: built.ir()
                                         inner: <tee 23>,
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                1,
+                                                14,
                                                 Cluster(
                                                     0,
                                                 ),
@@ -4629,7 +4567,7 @@ expression: built.ir()
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    1,
+                                                    14,
                                                     Cluster(
                                                         0,
                                                     ),
@@ -4641,7 +4579,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                1,
+                                                14,
                                                 Cluster(
                                                     0,
                                                 ),
@@ -4653,7 +4591,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            1,
+                                            14,
                                             Cluster(
                                                 0,
                                             ),
@@ -4664,13 +4602,8 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_kind: Atomic(
-                                        Tick(
-                                            1,
-                                            Cluster(
-                                                0,
-                                            ),
-                                        ),
+                                    location_kind: Cluster(
+                                        0,
                                     ),
                                     output_type: Some(
                                         (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot),
@@ -4678,13 +4611,8 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_kind: Atomic(
-                                    Tick(
-                                        1,
-                                        Cluster(
-                                            0,
-                                        ),
-                                    ),
+                                location_kind: Cluster(
+                                    0,
                                 ),
                                 output_type: Some(
                                     ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ()),
@@ -5016,36 +4944,16 @@ expression: built.ir()
         },
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (_ , ballot) | ballot }),
-            input: EndAtomic {
-                inner: FilterMap {
-                    f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , core :: option :: Option < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | (key , res) | match res { Ok (_) => None , Err (e) => Some ((key , e)) , } }),
-                    input: Tee {
-                        inner: <tee 26>,
-                        metadata: HydroIrMetadata {
-                            location_kind: Atomic(
-                                Tick(
-                                    1,
-                                    Cluster(
-                                        0,
-                                    ),
-                                ),
-                            ),
-                            output_type: Some(
-                                ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
-                            ),
-                        },
-                    },
+            input: FilterMap {
+                f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , core :: option :: Option < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | (key , res) | match res { Ok (_) => None , Err (e) => Some ((key , e)) , } }),
+                input: Tee {
+                    inner: <tee 26>,
                     metadata: HydroIrMetadata {
-                        location_kind: Atomic(
-                            Tick(
-                                1,
-                                Cluster(
-                                    0,
-                                ),
-                            ),
+                        location_kind: Cluster(
+                            0,
                         ),
                         output_type: Some(
-                            ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                            ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
                         ),
                     },
                 },
@@ -5151,7 +5059,7 @@ expression: built.ir()
                                                                 },
                                                                 metadata: HydroIrMetadata {
                                                                     location_kind: Tick(
-                                                                        13,
+                                                                        15,
                                                                         Cluster(
                                                                             0,
                                                                         ),
@@ -5163,7 +5071,7 @@ expression: built.ir()
                                                             },
                                                             metadata: HydroIrMetadata {
                                                                 location_kind: Tick(
-                                                                    13,
+                                                                    15,
                                                                     Cluster(
                                                                         0,
                                                                     ),
@@ -5176,39 +5084,12 @@ expression: built.ir()
                                                         right: Batch {
                                                             inner: Map {
                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > , ())) , (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | ((slot , _ballot) , (value , _)) | (slot , value) }),
-                                                                input: EndAtomic {
-                                                                    inner: YieldConcat {
-                                                                        inner: Map {
-                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > , ())) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > , ())) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: request_response :: * ; | (key , (meta , resp)) | (key , (meta , resp)) }),
-                                                                            input: Join {
-                                                                                left: Tee {
-                                                                                    inner: <tee 31>,
-                                                                                    metadata: HydroIrMetadata {
-                                                                                        location_kind: Tick(
-                                                                                            1,
-                                                                                            Cluster(
-                                                                                                0,
-                                                                                            ),
-                                                                                        ),
-                                                                                        output_type: Some(
-                                                                                            ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >),
-                                                                                        ),
-                                                                                    },
-                                                                                },
-                                                                                right: Tee {
-                                                                                    inner: <tee 32>,
-                                                                                    metadata: HydroIrMetadata {
-                                                                                        location_kind: Tick(
-                                                                                            1,
-                                                                                            Cluster(
-                                                                                                0,
-                                                                                            ),
-                                                                                        ),
-                                                                                        output_type: Some(
-                                                                                            ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ()),
-                                                                                        ),
-                                                                                    },
-                                                                                },
+                                                                input: YieldConcat {
+                                                                    inner: Map {
+                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > , ())) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > , ())) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: request_response :: * ; | (key , (meta , resp)) | (key , (meta , resp)) }),
+                                                                        input: Join {
+                                                                            left: Tee {
+                                                                                inner: <tee 31>,
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_kind: Tick(
                                                                                         1,
@@ -5217,7 +5098,21 @@ expression: built.ir()
                                                                                         ),
                                                                                     ),
                                                                                     output_type: Some(
-                                                                                        ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > , ())),
+                                                                                        ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >),
+                                                                                    ),
+                                                                                },
+                                                                            },
+                                                                            right: Tee {
+                                                                                inner: <tee 32>,
+                                                                                metadata: HydroIrMetadata {
+                                                                                    location_kind: Tick(
+                                                                                        1,
+                                                                                        Cluster(
+                                                                                            0,
+                                                                                        ),
+                                                                                    ),
+                                                                                    output_type: Some(
+                                                                                        ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ()),
                                                                                     ),
                                                                                 },
                                                                             },
@@ -5234,12 +5129,10 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_kind: Atomic(
-                                                                                Tick(
-                                                                                    1,
-                                                                                    Cluster(
-                                                                                        0,
-                                                                                    ),
+                                                                            location_kind: Tick(
+                                                                                1,
+                                                                                Cluster(
+                                                                                    0,
                                                                                 ),
                                                                             ),
                                                                             output_type: Some(
@@ -5267,7 +5160,7 @@ expression: built.ir()
                                                             },
                                                             metadata: HydroIrMetadata {
                                                                 location_kind: Tick(
-                                                                    13,
+                                                                    15,
                                                                     Cluster(
                                                                         0,
                                                                     ),
@@ -5279,7 +5172,7 @@ expression: built.ir()
                                                         },
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Tick(
-                                                                13,
+                                                                15,
                                                                 Cluster(
                                                                     0,
                                                                 ),
@@ -5327,7 +5220,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            14,
+                                            16,
                                             Cluster(
                                                 4,
                                             ),
@@ -5344,7 +5237,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                14,
+                                                16,
                                                 Cluster(
                                                     4,
                                                 ),
@@ -5356,7 +5249,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            14,
+                                            16,
                                             Cluster(
                                                 4,
                                             ),
@@ -5368,7 +5261,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        14,
+                                        16,
                                         Cluster(
                                             4,
                                         ),
@@ -5380,7 +5273,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    14,
+                                    16,
                                     Cluster(
                                         4,
                                     ),
@@ -5392,7 +5285,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                14,
+                                16,
                                 Cluster(
                                     4,
                                 ),
@@ -5411,7 +5304,7 @@ expression: built.ir()
                                     inner: <tee 34>,
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            14,
+                                            16,
                                             Cluster(
                                                 4,
                                             ),
@@ -5430,7 +5323,7 @@ expression: built.ir()
                                                 },
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
-                                                        14,
+                                                        16,
                                                         Cluster(
                                                             4,
                                                         ),
@@ -5442,7 +5335,7 @@ expression: built.ir()
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    14,
+                                                    16,
                                                     Cluster(
                                                         4,
                                                     ),
@@ -5478,7 +5371,7 @@ expression: built.ir()
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    14,
+                                                    16,
                                                     Cluster(
                                                         4,
                                                     ),
@@ -5490,7 +5383,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                14,
+                                                16,
                                                 Cluster(
                                                     4,
                                                 ),
@@ -5502,7 +5395,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            14,
+                                            16,
                                             Cluster(
                                                 4,
                                             ),
@@ -5514,7 +5407,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        14,
+                                        16,
                                         Cluster(
                                             4,
                                         ),
@@ -5526,7 +5419,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    14,
+                                    16,
                                     Cluster(
                                         4,
                                     ),
@@ -5538,7 +5431,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                14,
+                                16,
                                 Cluster(
                                     4,
                                 ),
@@ -5550,7 +5443,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            14,
+                            16,
                             Cluster(
                                 4,
                             ),
@@ -5562,7 +5455,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        14,
+                        16,
                         Cluster(
                             4,
                         ),
@@ -5574,7 +5467,7 @@ expression: built.ir()
             },
             metadata: HydroIrMetadata {
                 location_kind: Tick(
-                    14,
+                    16,
                     Cluster(
                         4,
                     ),
@@ -5585,7 +5478,7 @@ expression: built.ir()
             },
         },
         out_location: Tick(
-            14,
+            16,
             Cluster(
                 4,
             ),
@@ -5612,7 +5505,7 @@ expression: built.ir()
                                         inner: <tee 34>,
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                14,
+                                                16,
                                                 Cluster(
                                                     4,
                                                 ),
@@ -5626,7 +5519,7 @@ expression: built.ir()
                                         inner: <tee 35>,
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                14,
+                                                16,
                                                 Cluster(
                                                     4,
                                                 ),
@@ -5638,7 +5531,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            14,
+                                            16,
                                             Cluster(
                                                 4,
                                             ),
@@ -5650,7 +5543,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        14,
+                                        16,
                                         Cluster(
                                             4,
                                         ),
@@ -5662,7 +5555,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    14,
+                                    16,
                                     Cluster(
                                         4,
                                     ),
@@ -5674,7 +5567,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                14,
+                                16,
                                 Cluster(
                                     4,
                                 ),
@@ -5686,7 +5579,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            14,
+                            16,
                             Cluster(
                                 4,
                             ),
@@ -5698,7 +5591,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        14,
+                        16,
                         Cluster(
                             4,
                         ),
@@ -5710,7 +5603,7 @@ expression: built.ir()
             },
             metadata: HydroIrMetadata {
                 location_kind: Tick(
-                    14,
+                    16,
                     Cluster(
                         4,
                     ),
@@ -5721,7 +5614,7 @@ expression: built.ir()
             },
         },
         out_location: Tick(
-            14,
+            16,
             Cluster(
                 4,
             ),
@@ -5749,7 +5642,7 @@ expression: built.ir()
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    14,
+                                                    16,
                                                     Cluster(
                                                         4,
                                                     ),
@@ -5761,7 +5654,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                14,
+                                                16,
                                                 Cluster(
                                                     4,
                                                 ),
@@ -5773,7 +5666,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            14,
+                                            16,
                                             Cluster(
                                                 4,
                                             ),
@@ -5785,7 +5678,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        14,
+                                        16,
                                         Cluster(
                                             4,
                                         ),
@@ -5797,7 +5690,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    14,
+                                    16,
                                     Cluster(
                                         4,
                                     ),
@@ -5813,7 +5706,7 @@ expression: built.ir()
                             ),
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    14,
+                                    16,
                                     Cluster(
                                         4,
                                     ),
@@ -5825,7 +5718,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                14,
+                                16,
                                 Cluster(
                                     4,
                                 ),
@@ -5839,7 +5732,7 @@ expression: built.ir()
                         inner: <tee 36>,
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                14,
+                                16,
                                 Cluster(
                                     4,
                                 ),
@@ -5851,7 +5744,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            14,
+                            16,
                             Cluster(
                                 4,
                             ),
@@ -5863,7 +5756,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        14,
+                        16,
                         Cluster(
                             4,
                         ),
@@ -5875,7 +5768,7 @@ expression: built.ir()
             },
             metadata: HydroIrMetadata {
                 location_kind: Tick(
-                    14,
+                    16,
                     Cluster(
                         4,
                     ),
@@ -5886,7 +5779,7 @@ expression: built.ir()
             },
         },
         out_location: Tick(
-            14,
+            16,
             Cluster(
                 4,
             ),
@@ -5971,7 +5864,7 @@ expression: built.ir()
                                                             },
                                                             metadata: HydroIrMetadata {
                                                                 location_kind: Tick(
-                                                                    16,
+                                                                    18,
                                                                     Cluster(
                                                                         4,
                                                                     ),
@@ -5983,7 +5876,7 @@ expression: built.ir()
                                                         },
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Tick(
-                                                                16,
+                                                                18,
                                                                 Cluster(
                                                                     4,
                                                                 ),
@@ -5999,7 +5892,7 @@ expression: built.ir()
                                                                 inner: <tee 38>,
                                                                 metadata: HydroIrMetadata {
                                                                     location_kind: Tick(
-                                                                        14,
+                                                                        16,
                                                                         Cluster(
                                                                             4,
                                                                         ),
@@ -6020,7 +5913,7 @@ expression: built.ir()
                                                         },
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Tick(
-                                                                16,
+                                                                18,
                                                                 Cluster(
                                                                     4,
                                                                 ),
@@ -6032,7 +5925,7 @@ expression: built.ir()
                                                     },
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Tick(
-                                                            16,
+                                                            18,
                                                             Cluster(
                                                                 4,
                                                             ),
@@ -6071,7 +5964,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            15,
+                                            17,
                                             Cluster(
                                                 1,
                                             ),
@@ -6083,7 +5976,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        15,
+                                        17,
                                         Cluster(
                                             1,
                                         ),
@@ -6104,7 +5997,7 @@ expression: built.ir()
                                             inner: <tee 39>,
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    15,
+                                                    17,
                                                     Cluster(
                                                         1,
                                                     ),
@@ -6116,7 +6009,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                15,
+                                                17,
                                                 Cluster(
                                                     1,
                                                 ),
@@ -6128,7 +6021,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            15,
+                                            17,
                                             Cluster(
                                                 1,
                                             ),
@@ -6140,7 +6033,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        15,
+                                        17,
                                         Cluster(
                                             1,
                                         ),
@@ -6152,7 +6045,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    15,
+                                    17,
                                     Cluster(
                                         1,
                                     ),
@@ -6164,7 +6057,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                15,
+                                17,
                                 Cluster(
                                     1,
                                 ),
@@ -6176,7 +6069,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            15,
+                            17,
                             Cluster(
                                 1,
                             ),
@@ -6188,7 +6081,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        15,
+                        17,
                         Cluster(
                             1,
                         ),
@@ -6226,7 +6119,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    17,
+                                    19,
                                     Cluster(
                                         2,
                                     ),
@@ -6238,7 +6131,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                17,
+                                19,
                                 Cluster(
                                     2,
                                 ),
@@ -6250,51 +6143,41 @@ expression: built.ir()
                     },
                     second: Batch {
                         inner: Tee {
-                            inner: <tee 41>: BeginAtomic {
-                                inner: Map {
-                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica > , ((u32 , u32) , core :: result :: Result < () , () >)) , ((u32 , u32) , core :: result :: Result < () , () >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                    input: Network {
-                                        serialize_fn: Some(
-                                            :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: location :: MemberId < _ > , ((u32 , u32) , core :: result :: Result < () , () >)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
-                                        ),
-                                        instantiate_fn: <network instantiate>,
-                                        deserialize_fn: Some(
-                                            | res | { let (id , b) = res . unwrap () ; (hydro_lang :: location :: MemberId :: < hydro_test :: __staged :: cluster :: kv_replica :: Replica > :: from_raw (id) , hydro_lang :: runtime_support :: bincode :: deserialize :: < ((u32 , u32) , core :: result :: Result < () , () >) > (& b) . unwrap ()) },
-                                        ),
-                                        input: Map {
-                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , ((u32 , u32) , core :: result :: Result < () , () >)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; | payload | (payload . value . 0 , ((payload . key , payload . value . 1) , Ok (()))) }),
-                                            input: YieldConcat {
-                                                inner: FilterMap {
-                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; | payload | payload . kv }),
-                                                    input: Tee {
-                                                        inner: <tee 37>,
-                                                        metadata: HydroIrMetadata {
-                                                            location_kind: Tick(
-                                                                14,
-                                                                Cluster(
-                                                                    4,
-                                                                ),
-                                                            ),
-                                                            output_type: Some(
-                                                                hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) >,
-                                                            ),
-                                                        },
-                                                    },
+                            inner: <tee 41>: Map {
+                                f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica > , ((u32 , u32) , core :: result :: Result < () , () >)) , ((u32 , u32) , core :: result :: Result < () , () >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
+                                input: Network {
+                                    serialize_fn: Some(
+                                        :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: location :: MemberId < _ > , ((u32 , u32) , core :: result :: Result < () , () >)) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
+                                    ),
+                                    instantiate_fn: <network instantiate>,
+                                    deserialize_fn: Some(
+                                        | res | { let (id , b) = res . unwrap () ; (hydro_lang :: location :: MemberId :: < hydro_test :: __staged :: cluster :: kv_replica :: Replica > :: from_raw (id) , hydro_lang :: runtime_support :: bincode :: deserialize :: < ((u32 , u32) , core :: result :: Result < () , () >) > (& b) . unwrap ()) },
+                                    ),
+                                    input: Map {
+                                        f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , ((u32 , u32) , core :: result :: Result < () , () >)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; | payload | (payload . value . 0 , ((payload . key , payload . value . 1) , Ok (()))) }),
+                                        input: YieldConcat {
+                                            inner: FilterMap {
+                                                f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; | payload | payload . kv }),
+                                                input: Tee {
+                                                    inner: <tee 37>,
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Tick(
-                                                            14,
+                                                            16,
                                                             Cluster(
                                                                 4,
                                                             ),
                                                         ),
                                                         output_type: Some(
-                                                            hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) >,
+                                                            hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) >,
                                                         ),
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_kind: Cluster(
-                                                        4,
+                                                    location_kind: Tick(
+                                                        16,
+                                                        Cluster(
+                                                            4,
+                                                        ),
                                                     ),
                                                     output_type: Some(
                                                         hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) >,
@@ -6306,16 +6189,16 @@ expression: built.ir()
                                                     4,
                                                 ),
                                                 output_type: Some(
-                                                    (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , ((u32 , u32) , core :: result :: Result < () , () >)),
+                                                    hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) >,
                                                 ),
                                             },
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Cluster(
-                                                2,
+                                                4,
                                             ),
                                             output_type: Some(
-                                                (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica > , ((u32 , u32) , core :: result :: Result < () , () >)),
+                                                (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , ((u32 , u32) , core :: result :: Result < () , () >)),
                                             ),
                                         },
                                     },
@@ -6324,18 +6207,13 @@ expression: built.ir()
                                             2,
                                         ),
                                         output_type: Some(
-                                            ((u32 , u32) , core :: result :: Result < () , () >),
+                                            (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica > , ((u32 , u32) , core :: result :: Result < () , () >)),
                                         ),
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_kind: Atomic(
-                                        Tick(
-                                            17,
-                                            Cluster(
-                                                2,
-                                            ),
-                                        ),
+                                    location_kind: Cluster(
+                                        2,
                                     ),
                                     output_type: Some(
                                         ((u32 , u32) , core :: result :: Result < () , () >),
@@ -6343,13 +6221,8 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_kind: Atomic(
-                                    Tick(
-                                        17,
-                                        Cluster(
-                                            2,
-                                        ),
-                                    ),
+                                location_kind: Cluster(
+                                    2,
                                 ),
                                 output_type: Some(
                                     ((u32 , u32) , core :: result :: Result < () , () >),
@@ -6358,7 +6231,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                17,
+                                19,
                                 Cluster(
                                     2,
                                 ),
@@ -6370,7 +6243,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            17,
+                            19,
                             Cluster(
                                 2,
                             ),
@@ -6382,7 +6255,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        17,
+                        19,
                         Cluster(
                             2,
                         ),
@@ -6403,7 +6276,7 @@ expression: built.ir()
                                 inner: <tee 40>,
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        17,
+                                        19,
                                         Cluster(
                                             2,
                                         ),
@@ -6415,7 +6288,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    17,
+                                    19,
                                     Cluster(
                                         2,
                                     ),
@@ -6427,7 +6300,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                17,
+                                19,
                                 Cluster(
                                     2,
                                 ),
@@ -6439,7 +6312,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            17,
+                            19,
                             Cluster(
                                 2,
                             ),
@@ -6451,7 +6324,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        17,
+                        19,
                         Cluster(
                             2,
                         ),
@@ -6463,7 +6336,7 @@ expression: built.ir()
             },
             metadata: HydroIrMetadata {
                 location_kind: Tick(
-                    17,
+                    19,
                     Cluster(
                         2,
                     ),
@@ -6474,7 +6347,7 @@ expression: built.ir()
             },
         },
         out_location: Tick(
-            17,
+            19,
             Cluster(
                 2,
             ),
@@ -6546,29 +6419,14 @@ expression: built.ir()
                         inner: <tee 45>: Map {
                             f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , u32) , (u32 , core :: option :: Option < u32 >) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (virtual_id , payload) | (virtual_id , Some (payload)) }),
                             input: Batch {
-                                inner: EndAtomic {
-                                    inner: YieldConcat {
-                                        inner: Tee {
-                                            inner: <tee 42>,
-                                            metadata: HydroIrMetadata {
-                                                location_kind: Tick(
-                                                    17,
-                                                    Cluster(
-                                                        2,
-                                                    ),
-                                                ),
-                                                output_type: Some(
-                                                    (u32 , u32),
-                                                ),
-                                            },
-                                        },
+                                inner: YieldConcat {
+                                    inner: Tee {
+                                        inner: <tee 42>,
                                         metadata: HydroIrMetadata {
-                                            location_kind: Atomic(
-                                                Tick(
-                                                    17,
-                                                    Cluster(
-                                                        2,
-                                                    ),
+                                            location_kind: Tick(
+                                                19,
+                                                Cluster(
+                                                    2,
                                                 ),
                                             ),
                                             output_type: Some(
@@ -6901,7 +6759,7 @@ expression: built.ir()
                                                             },
                                                             metadata: HydroIrMetadata {
                                                                 location_kind: Tick(
-                                                                    19,
+                                                                    21,
                                                                     Process(
                                                                         3,
                                                                     ),
@@ -6913,7 +6771,7 @@ expression: built.ir()
                                                         },
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Tick(
-                                                                19,
+                                                                21,
                                                                 Process(
                                                                     3,
                                                                 ),
@@ -6934,7 +6792,7 @@ expression: built.ir()
                                                 },
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
-                                                        18,
+                                                        20,
                                                         Process(
                                                             3,
                                                         ),
@@ -6946,7 +6804,7 @@ expression: built.ir()
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    18,
+                                                    20,
                                                     Process(
                                                         3,
                                                     ),
@@ -7277,7 +7135,7 @@ expression: built.ir()
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
                                                                                             location_kind: Tick(
-                                                                                                20,
+                                                                                                22,
                                                                                                 Cluster(
                                                                                                     2,
                                                                                                 ),
@@ -7307,7 +7165,7 @@ expression: built.ir()
                                                                                                 },
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_kind: Tick(
-                                                                                                        20,
+                                                                                                        22,
                                                                                                         Cluster(
                                                                                                             2,
                                                                                                         ),
@@ -7319,7 +7177,7 @@ expression: built.ir()
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_kind: Tick(
-                                                                                                    20,
+                                                                                                    22,
                                                                                                     Cluster(
                                                                                                         2,
                                                                                                     ),
@@ -7331,7 +7189,7 @@ expression: built.ir()
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
                                                                                             location_kind: Tick(
-                                                                                                20,
+                                                                                                22,
                                                                                                 Cluster(
                                                                                                     2,
                                                                                                 ),
@@ -7343,7 +7201,7 @@ expression: built.ir()
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_kind: Tick(
-                                                                                            20,
+                                                                                            22,
                                                                                             Cluster(
                                                                                                 2,
                                                                                             ),
@@ -7355,7 +7213,7 @@ expression: built.ir()
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_kind: Tick(
-                                                                                        20,
+                                                                                        22,
                                                                                         Cluster(
                                                                                             2,
                                                                                         ),
@@ -7412,7 +7270,7 @@ expression: built.ir()
                                                         },
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Tick(
-                                                                21,
+                                                                23,
                                                                 Process(
                                                                     3,
                                                                 ),
@@ -7424,7 +7282,7 @@ expression: built.ir()
                                                     },
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Tick(
-                                                            21,
+                                                            23,
                                                             Process(
                                                                 3,
                                                             ),
@@ -7445,7 +7303,7 @@ expression: built.ir()
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    18,
+                                                    20,
                                                     Process(
                                                         3,
                                                     ),
@@ -7457,7 +7315,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                18,
+                                                20,
                                                 Process(
                                                     3,
                                                 ),
@@ -7469,7 +7327,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            18,
+                                            20,
                                             Process(
                                                 3,
                                             ),
@@ -7481,7 +7339,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        18,
+                                        20,
                                         Process(
                                             3,
                                         ),
@@ -7502,7 +7360,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                22,
+                                24,
                                 Process(
                                     3,
                                 ),
@@ -7532,7 +7390,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        22,
+                                        24,
                                         Process(
                                             3,
                                         ),
@@ -7544,7 +7402,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    22,
+                                    24,
                                     Process(
                                         3,
                                     ),
@@ -7556,7 +7414,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                22,
+                                24,
                                 Process(
                                     3,
                                 ),
@@ -7568,7 +7426,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            22,
+                            24,
                             Process(
                                 3,
                             ),
@@ -7580,7 +7438,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        22,
+                        24,
                         Process(
                             3,
                         ),
@@ -7633,7 +7491,7 @@ expression: built.ir()
                                                             },
                                                             metadata: HydroIrMetadata {
                                                                 location_kind: Tick(
-                                                                    23,
+                                                                    25,
                                                                     Process(
                                                                         3,
                                                                     ),
@@ -7645,7 +7503,7 @@ expression: built.ir()
                                                         },
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Tick(
-                                                                23,
+                                                                25,
                                                                 Process(
                                                                     3,
                                                                 ),
@@ -7657,7 +7515,7 @@ expression: built.ir()
                                                     },
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Tick(
-                                                            23,
+                                                            25,
                                                             Process(
                                                                 3,
                                                             ),
@@ -7678,7 +7536,7 @@ expression: built.ir()
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    24,
+                                                    26,
                                                     Process(
                                                         3,
                                                     ),
@@ -7708,7 +7566,7 @@ expression: built.ir()
                                                     },
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Tick(
-                                                            24,
+                                                            26,
                                                             Process(
                                                                 3,
                                                             ),
@@ -7720,7 +7578,7 @@ expression: built.ir()
                                                 },
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
-                                                        24,
+                                                        26,
                                                         Process(
                                                             3,
                                                         ),
@@ -7732,7 +7590,7 @@ expression: built.ir()
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    24,
+                                                    26,
                                                     Process(
                                                         3,
                                                     ),
@@ -7744,7 +7602,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                24,
+                                                26,
                                                 Process(
                                                     3,
                                                 ),
@@ -7756,7 +7614,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            24,
+                                            26,
                                             Process(
                                                 3,
                                             ),
@@ -7777,7 +7635,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    18,
+                                    20,
                                     Process(
                                         3,
                                     ),
@@ -7791,7 +7649,7 @@ expression: built.ir()
                             inner: <tee 49>,
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    18,
+                                    20,
                                     Process(
                                         3,
                                     ),
@@ -7803,7 +7661,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                18,
+                                20,
                                 Process(
                                     3,
                                 ),
@@ -7826,7 +7684,7 @@ expression: built.ir()
                                             inner: <tee 48>,
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    18,
+                                                    20,
                                                     Process(
                                                         3,
                                                     ),
@@ -7838,7 +7696,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                18,
+                                                20,
                                                 Process(
                                                     3,
                                                 ),
@@ -7850,7 +7708,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            18,
+                                            20,
                                             Process(
                                                 3,
                                             ),
@@ -7866,7 +7724,7 @@ expression: built.ir()
                                     ),
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            18,
+                                            20,
                                             Process(
                                                 3,
                                             ),
@@ -7878,7 +7736,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        18,
+                                        20,
                                         Process(
                                             3,
                                         ),
@@ -7890,7 +7748,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    18,
+                                    20,
                                     Process(
                                         3,
                                     ),
@@ -7902,7 +7760,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                18,
+                                20,
                                 Process(
                                     3,
                                 ),
@@ -7914,7 +7772,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            18,
+                            20,
                             Process(
                                 3,
                             ),
@@ -7926,7 +7784,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        18,
+                        20,
                         Process(
                             3,
                         ),
@@ -8063,7 +7921,7 @@ expression: built.ir()
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
                                                                                             location_kind: Tick(
-                                                                                                25,
+                                                                                                27,
                                                                                                 Cluster(
                                                                                                     2,
                                                                                                 ),
@@ -8093,7 +7951,7 @@ expression: built.ir()
                                                                                                 },
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_kind: Tick(
-                                                                                                        25,
+                                                                                                        27,
                                                                                                         Cluster(
                                                                                                             2,
                                                                                                         ),
@@ -8105,7 +7963,7 @@ expression: built.ir()
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_kind: Tick(
-                                                                                                    25,
+                                                                                                    27,
                                                                                                     Cluster(
                                                                                                         2,
                                                                                                     ),
@@ -8117,7 +7975,7 @@ expression: built.ir()
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
                                                                                             location_kind: Tick(
-                                                                                                25,
+                                                                                                27,
                                                                                                 Cluster(
                                                                                                     2,
                                                                                                 ),
@@ -8129,7 +7987,7 @@ expression: built.ir()
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_kind: Tick(
-                                                                                            25,
+                                                                                            27,
                                                                                             Cluster(
                                                                                                 2,
                                                                                             ),
@@ -8141,7 +7999,7 @@ expression: built.ir()
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_kind: Tick(
-                                                                                        25,
+                                                                                        27,
                                                                                         Cluster(
                                                                                             2,
                                                                                         ),
@@ -8198,7 +8056,7 @@ expression: built.ir()
                                                         },
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Tick(
-                                                                26,
+                                                                28,
                                                                 Process(
                                                                     3,
                                                                 ),
@@ -8210,7 +8068,7 @@ expression: built.ir()
                                                     },
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Tick(
-                                                            26,
+                                                            28,
                                                             Process(
                                                                 3,
                                                             ),
@@ -8222,7 +8080,7 @@ expression: built.ir()
                                                 },
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
-                                                        26,
+                                                        28,
                                                         Process(
                                                             3,
                                                         ),
@@ -8243,7 +8101,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                27,
+                                                29,
                                                 Process(
                                                     3,
                                                 ),
@@ -8273,7 +8131,7 @@ expression: built.ir()
                                                 },
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
-                                                        27,
+                                                        29,
                                                         Process(
                                                             3,
                                                         ),
@@ -8285,7 +8143,7 @@ expression: built.ir()
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    27,
+                                                    29,
                                                     Process(
                                                         3,
                                                     ),
@@ -8297,7 +8155,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                27,
+                                                29,
                                                 Process(
                                                     3,
                                                 ),
@@ -8309,7 +8167,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            27,
+                                            29,
                                             Process(
                                                 3,
                                             ),
@@ -8321,7 +8179,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        27,
+                                        29,
                                         Process(
                                             3,
                                         ),
@@ -8342,7 +8200,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                18,
+                                20,
                                 Process(
                                     3,
                                 ),
@@ -8365,7 +8223,7 @@ expression: built.ir()
                                             inner: <tee 48>,
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    18,
+                                                    20,
                                                     Process(
                                                         3,
                                                     ),
@@ -8377,7 +8235,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                18,
+                                                20,
                                                 Process(
                                                     3,
                                                 ),
@@ -8389,7 +8247,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            18,
+                                            20,
                                             Process(
                                                 3,
                                             ),
@@ -8405,7 +8263,7 @@ expression: built.ir()
                                     ),
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            18,
+                                            20,
                                             Process(
                                                 3,
                                             ),
@@ -8417,7 +8275,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        18,
+                                        20,
                                         Process(
                                             3,
                                         ),
@@ -8429,7 +8287,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    18,
+                                    20,
                                     Process(
                                         3,
                                     ),
@@ -8441,7 +8299,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                18,
+                                20,
                                 Process(
                                     3,
                                 ),
@@ -8453,7 +8311,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            18,
+                            20,
                             Process(
                                 3,
                             ),
@@ -8465,7 +8323,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        18,
+                        20,
                         Process(
                             3,
                         ),

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir@acceptor_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir@acceptor_mermaid.snap
@@ -118,8 +118,8 @@ linkStyle default stroke:#aaa
 25v1
 35v1
 34v1
-subgraph var_reduce_keyed_watermark_chain_356 ["var <tt>reduce_keyed_watermark_chain_356</tt>"]
-    style var_reduce_keyed_watermark_chain_356 fill:transparent
+subgraph var_reduce_keyed_watermark_chain_357 ["var <tt>reduce_keyed_watermark_chain_357</tt>"]
+    style var_reduce_keyed_watermark_chain_357 fill:transparent
     33v1
 end
 subgraph var_stream_100 ["var <tt>stream_100</tt>"]
@@ -175,103 +175,103 @@ subgraph var_stream_2 ["var <tt>stream_2</tt>"]
     style var_stream_2 fill:transparent
     1v1
 end
-subgraph var_stream_302 ["var <tt>stream_302</tt>"]
-    style var_stream_302 fill:transparent
+subgraph var_stream_303 ["var <tt>stream_303</tt>"]
+    style var_stream_303 fill:transparent
     18v1
     19v1
 end
-subgraph var_stream_303 ["var <tt>stream_303</tt>"]
-    style var_stream_303 fill:transparent
+subgraph var_stream_304 ["var <tt>stream_304</tt>"]
+    style var_stream_304 fill:transparent
     20v1
 end
-subgraph var_stream_305 ["var <tt>stream_305</tt>"]
-    style var_stream_305 fill:transparent
+subgraph var_stream_306 ["var <tt>stream_306</tt>"]
+    style var_stream_306 fill:transparent
     21v1
-end
-subgraph var_stream_307 ["var <tt>stream_307</tt>"]
-    style var_stream_307 fill:transparent
-    22v1
 end
 subgraph var_stream_308 ["var <tt>stream_308</tt>"]
     style var_stream_308 fill:transparent
-    23v1
+    22v1
 end
-subgraph var_stream_346 ["var <tt>stream_346</tt>"]
-    style var_stream_346 fill:transparent
-    26v1
+subgraph var_stream_309 ["var <tt>stream_309</tt>"]
+    style var_stream_309 fill:transparent
+    23v1
 end
 subgraph var_stream_347 ["var <tt>stream_347</tt>"]
     style var_stream_347 fill:transparent
-    27v1
+    26v1
 end
 subgraph var_stream_348 ["var <tt>stream_348</tt>"]
     style var_stream_348 fill:transparent
-    28v1
-    29v1
+    27v1
 end
 subgraph var_stream_349 ["var <tt>stream_349</tt>"]
     style var_stream_349 fill:transparent
-    30v1
+    28v1
+    29v1
 end
-subgraph var_stream_352 ["var <tt>stream_352</tt>"]
-    style var_stream_352 fill:transparent
-    31v1
+subgraph var_stream_350 ["var <tt>stream_350</tt>"]
+    style var_stream_350 fill:transparent
+    30v1
 end
 subgraph var_stream_353 ["var <tt>stream_353</tt>"]
     style var_stream_353 fill:transparent
+    31v1
+end
+subgraph var_stream_354 ["var <tt>stream_354</tt>"]
+    style var_stream_354 fill:transparent
     32v1
 end
-subgraph var_stream_356 ["var <tt>stream_356</tt>"]
-    style var_stream_356 fill:transparent
+subgraph var_stream_357 ["var <tt>stream_357</tt>"]
+    style var_stream_357 fill:transparent
     36v1
     37v1
 end
-subgraph var_stream_358 ["var <tt>stream_358</tt>"]
-    style var_stream_358 fill:transparent
-    38v1
-end
 subgraph var_stream_359 ["var <tt>stream_359</tt>"]
     style var_stream_359 fill:transparent
-    39v1
+    38v1
 end
-subgraph var_stream_432 ["var <tt>stream_432</tt>"]
-    style var_stream_432 fill:transparent
-    40v1
-    41v1
+subgraph var_stream_360 ["var <tt>stream_360</tt>"]
+    style var_stream_360 fill:transparent
+    39v1
 end
 subgraph var_stream_433 ["var <tt>stream_433</tt>"]
     style var_stream_433 fill:transparent
+    40v1
+    41v1
+end
+subgraph var_stream_434 ["var <tt>stream_434</tt>"]
+    style var_stream_434 fill:transparent
     42v1
 end
-subgraph var_stream_435 ["var <tt>stream_435</tt>"]
-    style var_stream_435 fill:transparent
+subgraph var_stream_436 ["var <tt>stream_436</tt>"]
+    style var_stream_436 fill:transparent
     43v1
-end
-subgraph var_stream_437 ["var <tt>stream_437</tt>"]
-    style var_stream_437 fill:transparent
-    44v1
 end
 subgraph var_stream_438 ["var <tt>stream_438</tt>"]
     style var_stream_438 fill:transparent
-    45v1
+    44v1
 end
 subgraph var_stream_439 ["var <tt>stream_439</tt>"]
     style var_stream_439 fill:transparent
-    46v1
+    45v1
 end
 subgraph var_stream_440 ["var <tt>stream_440</tt>"]
     style var_stream_440 fill:transparent
-    47v1
+    46v1
 end
 subgraph var_stream_441 ["var <tt>stream_441</tt>"]
     style var_stream_441 fill:transparent
-    48v1
+    47v1
 end
 subgraph var_stream_442 ["var <tt>stream_442</tt>"]
     style var_stream_442 fill:transparent
-    49v1
+    48v1
 end
 subgraph var_stream_443 ["var <tt>stream_443</tt>"]
     style var_stream_443 fill:transparent
+    49v1
+end
+subgraph var_stream_444 ["var <tt>stream_444</tt>"]
+    style var_stream_444 fill:transparent
     50v1
 end

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir@proposer_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir@proposer_mermaid.snap
@@ -98,143 +98,144 @@ linkStyle default stroke:#aaa
 88v1["<div style=text-align:center>(88v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
 89v1["<div style=text-align:center>(89v1)</div> <code><br>anti_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
 90v1["<div style=text-align:center>(90v1)</div> <code><br>filter_map({<br>    move |(key, res)| match res {<br>        Ok(v) =&gt; Some((key, v)),<br>        Err(_) =&gt; None,<br>    }<br>})</code>"]:::otherClass
-91v1["<div style=text-align:center>(91v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        || vec![]<br>    },<br>    {<br>        |logs, log| {<br>            logs.push(log);<br>        }<br>    },<br>)</code>"]:::otherClass
-92v1["<div style=text-align:center>(92v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    let key_fn = {<br>        |t| t.0<br>    };<br>    move |curr, new| {<br>        if key_fn(&amp;new) &gt; key_fn(&amp;*curr) {<br>            *curr = new;<br>        }<br>    }<br>})</code>"]:::otherClass
-93v1["<div style=text-align:center>(93v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-94v1["<div style=text-align:center>(94v1)</div> <code><br>filter_map({<br>    move |((quorum_ballot, quorum_accepted), my_ballot)| {<br>        if quorum_ballot == my_ballot { Some(quorum_accepted) } else { None }<br>    }<br>})</code>"]:::otherClass
-95v1["<div style=text-align:center>(95v1)</div> <code><br>tee()</code>"]:::otherClass
-96v1["<div style=text-align:center>(96v1)</div> <code><br>map({<br>    |_| ()<br>})</code>"]:::otherClass
-97v1["<div style=text-align:center>(97v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-98v1["<div style=text-align:center>(98v1)</div> <code><br>filter({<br>    |(received_max_ballot, cur_ballot)| *received_max_ballot &lt;= *cur_ballot<br>})</code>"]:::otherClass
-99v1["<div style=text-align:center>(99v1)</div> <code><br>map({<br>    |_| ()<br>})</code>"]:::otherClass
-101v1["<div style=text-align:center>(101v1)</div> <code><br>map({<br>    |_u| ()<br>})</code>"]:::otherClass
-102v1["<div style=text-align:center>(102v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-103v1["<div style=text-align:center>(103v1)</div> <code><br>map({<br>    |(d, _signal)| d<br>})</code>"]:::otherClass
-104v1["<div style=text-align:center>(104v1)</div> <code><br>tee()</code>"]:::otherClass
-105v1["<div style=text-align:center>(105v1)</div> <code><br>filter_map({<br>    move |(key, res)| match res {<br>        Ok(_) =&gt; None,<br>        Err(e) =&gt; Some((key, e)),<br>    }<br>})</code>"]:::otherClass
-106v1["<div style=text-align:center>(106v1)</div> <code><br>map({<br>    |(_, ballot)| ballot<br>})</code>"]:::otherClass
-107v1["<div style=text-align:center>(107v1)</div> <code><br>source_iter({<br>    let underlying_memberids__free = unsafe {<br>        ::std::mem::transmute::&lt;<br>            _,<br>            &amp;[hydro_lang::location::MemberId&lt;<br>                hydro_test::__staged::cluster::paxos_bench::Client,<br>            &gt;],<br>        &gt;(__hydro_lang_cluster_ids_2)<br>    };<br>    underlying_memberids__free<br>})</code>"]:::otherClass
-108v1["<div style=text-align:center>(108v1)</div> <code><br>map({<br>    |id| (*id, MembershipEvent::Joined)<br>})</code>"]:::otherClass
-109v1["<div style=text-align:center>(109v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        || false<br>    },<br>    {<br>        |present, event| {<br>            match event {<br>                MembershipEvent::Joined =&gt; *present = true,<br>                MembershipEvent::Left =&gt; *present = false,<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
-110v1["<div style=text-align:center>(110v1)</div> <code><br>filter_map({<br>    let f__free = {<br>        |v| if v { Some(()) } else { None }<br>    };<br>    {<br>        let orig = f__free;<br>        move |(k, v)| orig(v).map(|v| (k, v))<br>    }<br>})</code>"]:::otherClass
-111v1["<div style=text-align:center>(111v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
-112v1["<div style=text-align:center>(112v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-113v1["<div style=text-align:center>(113v1)</div> <code><br>map({<br>    |_| ()<br>})</code>"]:::otherClass
-114v1["<div style=text-align:center>(114v1)</div> <code><br>map({<br>    |v| Some(v)<br>})</code>"]:::otherClass
-115v1["<div style=text-align:center>(115v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
-116v1["<div style=text-align:center>(116v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
-117v1["<div style=text-align:center>(117v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-118v1["<div style=text-align:center>(118v1)</div> <code><br>filter({<br>    |o| o.is_none()<br>})</code>"]:::otherClass
-119v1["<div style=text-align:center>(119v1)</div> <code><br>map({<br>    |_u| ()<br>})</code>"]:::otherClass
-120v1["<div style=text-align:center>(120v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-121v1["<div style=text-align:center>(121v1)</div> <code><br>map({<br>    |(d, _signal)| d<br>})</code>"]:::otherClass
-123v1["<div style=text-align:center>(123v1)</div> <code><br>map({<br>    |_u| ()<br>})</code>"]:::otherClass
-124v1["<div style=text-align:center>(124v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-125v1["<div style=text-align:center>(125v1)</div> <code><br>map({<br>    |(d, _signal)| d<br>})</code>"]:::otherClass
-126v1["<div style=text-align:center>(126v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-127v1["<div style=text-align:center>(127v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.raw_id,<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
-128v1["<div style=text-align:center>(128v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-129v1["<div style=text-align:center>(129v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
-130v1["<div style=text-align:center>(130v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos_bench::Client,<br>        &gt;::from_raw(id),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            hydro_test::__staged::cluster::kv_replica::KvPayload&lt;<br>                u32,<br>                (<br>                    hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                        hydro_test::__staged::cluster::paxos_bench::Client,<br>                    &gt;,<br>                    u32,<br>                ),<br>            &gt;,<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
-131v1["<div style=text-align:center>(131v1)</div> <code><br>map({<br>    |(_, v)| v<br>})</code>"]:::otherClass
-132v1["<div style=text-align:center>(132v1)</div> <code><br>map({<br>    |_u| ()<br>})</code>"]:::otherClass
-133v1["<div style=text-align:center>(133v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-134v1["<div style=text-align:center>(134v1)</div> <code><br>map({<br>    |(d, _signal)| d<br>})</code>"]:::otherClass
-135v1["<div style=text-align:center>(135v1)</div> <code><br>enumerate::&lt;'tick&gt;()</code>"]:::otherClass
-136v1["<div style=text-align:center>(136v1)</div> <code><br>flat_map({<br>    |v| v<br>})</code>"]:::otherClass
-137v1["<div style=text-align:center>(137v1)</div> <code><br>tee()</code>"]:::otherClass
-138v1["<div style=text-align:center>(138v1)</div> <code><br>map({<br>    |(_checkpoint, log)| log<br>})</code>"]:::otherClass
-139v1["<div style=text-align:center>(139v1)</div> <code><br>flat_map({<br>    |d| d<br>})</code>"]:::otherClass
-140v1["<div style=text-align:center>(140v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        || (0, None)<br>    },<br>    {<br>        |curr_entry, new_entry| {<br>            if let Some(curr_entry_payload) = &amp;mut curr_entry.1 {<br>                let same_values = new_entry.value == curr_entry_payload.value;<br>                let higher_ballot = new_entry.ballot &gt; curr_entry_payload.ballot;<br>                if same_values {<br>                    curr_entry.0 += 1;<br>                }<br>                if higher_ballot {<br>                    curr_entry_payload.ballot = new_entry.ballot;<br>                    if !same_values {<br>                        curr_entry.0 = 1;<br>                        curr_entry_payload.value = new_entry.value;<br>                    }<br>                }<br>            } else {<br>                *curr_entry = (1, Some(new_entry));<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
-141v1["<div style=text-align:center>(141v1)</div> <code><br>map({<br>    let f__free = {<br>        |(count, entry)| (count, entry.unwrap())<br>    };<br>    {<br>        let orig = f__free;<br>        move |(k, v)| (k, orig(v))<br>    }<br>})</code>"]:::otherClass
-142v1["<div style=text-align:center>(142v1)</div> <code><br>tee()</code>"]:::otherClass
-143v1["<div style=text-align:center>(143v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
-144v1["<div style=text-align:center>(144v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    |curr, new| {<br>        if new &gt; *curr {<br>            *curr = new;<br>        }<br>    }<br>})</code>"]:::otherClass
-145v1["<div style=text-align:center>(145v1)</div> <code><br>tee()</code>"]:::otherClass
-146v1["<div style=text-align:center>(146v1)</div> <code><br>map({<br>    |max_slot| max_slot + 1<br>})</code>"]:::otherClass
-147v1["<div style=text-align:center>(147v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-148v1["<div style=text-align:center>(148v1)</div> <code><br>source_iter({<br>    let e__free = {<br>        0<br>    };<br>    [e__free]<br>})</code>"]:::otherClass
-149v1["<div style=text-align:center>(149v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
-150v1["<div style=text-align:center>(150v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+91v1["<div style=text-align:center>(91v1)</div> <code><br>scan::&lt;<br>    'static,<br>&gt;(<br>    {<br>        || HashMap::new()<br>    },<br>    {<br>        let f__free = {<br>            let f__free = {<br>                let quorum_size__free = 2usize;<br>                move |logs, log| {<br>                    logs.push(log);<br>                    logs.len() &gt;= quorum_size__free<br>                }<br>            };<br>            move |key_state, v| {<br>                if let Some(key_state_value) = key_state.as_mut() {<br>                    if f__free(key_state_value, v) {<br>                        Generate::Return(key_state.take().unwrap())<br>                    } else {<br>                        Generate::Continue<br>                    }<br>                } else {<br>                    unreachable!()<br>                }<br>            }<br>        };<br>        let init__free = {<br>            let init__free = {<br>                || vec![]<br>            };<br>            move || Some(init__free())<br>        };<br>        move |acc, (k, v)| {<br>            let existing_state = acc<br>                .entry(k.clone())<br>                .or_insert_with(|| Some(init__free()));<br>            if let Some(existing_state_value) = existing_state {<br>                match f__free(existing_state_value, v) {<br>                    Generate::Yield(out) =&gt; Some(Some((k, out))),<br>                    Generate::Return(out) =&gt; {<br>                        let _ = existing_state.take();<br>                        Some(Some((k, out)))<br>                    }<br>                    Generate::Break =&gt; {<br>                        let _ = existing_state.take();<br>                        Some(None)<br>                    }<br>                    Generate::Continue =&gt; Some(None),<br>                }<br>            } else {<br>                Some(None)<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
+92v1["<div style=text-align:center>(92v1)</div> <code><br>flat_map({<br>    |d| d<br>})</code>"]:::otherClass
+93v1["<div style=text-align:center>(93v1)</div> <code><br>reduce::&lt;<br>    'static,<br>&gt;({<br>    let key_fn = {<br>        |t| t.0<br>    };<br>    move |curr, new| {<br>        if key_fn(&amp;new) &gt; key_fn(&amp;*curr) {<br>            *curr = new;<br>        }<br>    }<br>})</code>"]:::otherClass
+94v1["<div style=text-align:center>(94v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+95v1["<div style=text-align:center>(95v1)</div> <code><br>filter_map({<br>    move |((quorum_ballot, quorum_accepted), my_ballot)| {<br>        if quorum_ballot == my_ballot { Some(quorum_accepted) } else { None }<br>    }<br>})</code>"]:::otherClass
+96v1["<div style=text-align:center>(96v1)</div> <code><br>tee()</code>"]:::otherClass
+97v1["<div style=text-align:center>(97v1)</div> <code><br>map({<br>    |_| ()<br>})</code>"]:::otherClass
+98v1["<div style=text-align:center>(98v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+99v1["<div style=text-align:center>(99v1)</div> <code><br>filter({<br>    |(received_max_ballot, cur_ballot)| *received_max_ballot &lt;= *cur_ballot<br>})</code>"]:::otherClass
+100v1["<div style=text-align:center>(100v1)</div> <code><br>map({<br>    |_| ()<br>})</code>"]:::otherClass
+102v1["<div style=text-align:center>(102v1)</div> <code><br>map({<br>    |_u| ()<br>})</code>"]:::otherClass
+103v1["<div style=text-align:center>(103v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+104v1["<div style=text-align:center>(104v1)</div> <code><br>map({<br>    |(d, _signal)| d<br>})</code>"]:::otherClass
+105v1["<div style=text-align:center>(105v1)</div> <code><br>tee()</code>"]:::otherClass
+106v1["<div style=text-align:center>(106v1)</div> <code><br>filter_map({<br>    move |(key, res)| match res {<br>        Ok(_) =&gt; None,<br>        Err(e) =&gt; Some((key, e)),<br>    }<br>})</code>"]:::otherClass
+107v1["<div style=text-align:center>(107v1)</div> <code><br>map({<br>    |(_, ballot)| ballot<br>})</code>"]:::otherClass
+108v1["<div style=text-align:center>(108v1)</div> <code><br>source_iter({<br>    let underlying_memberids__free = unsafe {<br>        ::std::mem::transmute::&lt;<br>            _,<br>            &amp;[hydro_lang::location::MemberId&lt;<br>                hydro_test::__staged::cluster::paxos_bench::Client,<br>            &gt;],<br>        &gt;(__hydro_lang_cluster_ids_2)<br>    };<br>    underlying_memberids__free<br>})</code>"]:::otherClass
+109v1["<div style=text-align:center>(109v1)</div> <code><br>map({<br>    |id| (*id, MembershipEvent::Joined)<br>})</code>"]:::otherClass
+110v1["<div style=text-align:center>(110v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        || false<br>    },<br>    {<br>        |present, event| {<br>            match event {<br>                MembershipEvent::Joined =&gt; *present = true,<br>                MembershipEvent::Left =&gt; *present = false,<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
+111v1["<div style=text-align:center>(111v1)</div> <code><br>filter_map({<br>    let f__free = {<br>        |v| if v { Some(()) } else { None }<br>    };<br>    {<br>        let orig = f__free;<br>        move |(k, v)| orig(v).map(|v| (k, v))<br>    }<br>})</code>"]:::otherClass
+112v1["<div style=text-align:center>(112v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
+113v1["<div style=text-align:center>(113v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+114v1["<div style=text-align:center>(114v1)</div> <code><br>map({<br>    |_| ()<br>})</code>"]:::otherClass
+115v1["<div style=text-align:center>(115v1)</div> <code><br>map({<br>    |v| Some(v)<br>})</code>"]:::otherClass
+116v1["<div style=text-align:center>(116v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
+117v1["<div style=text-align:center>(117v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
+118v1["<div style=text-align:center>(118v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+119v1["<div style=text-align:center>(119v1)</div> <code><br>filter({<br>    |o| o.is_none()<br>})</code>"]:::otherClass
+120v1["<div style=text-align:center>(120v1)</div> <code><br>map({<br>    |_u| ()<br>})</code>"]:::otherClass
+121v1["<div style=text-align:center>(121v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+122v1["<div style=text-align:center>(122v1)</div> <code><br>map({<br>    |(d, _signal)| d<br>})</code>"]:::otherClass
+124v1["<div style=text-align:center>(124v1)</div> <code><br>map({<br>    |_u| ()<br>})</code>"]:::otherClass
+125v1["<div style=text-align:center>(125v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+126v1["<div style=text-align:center>(126v1)</div> <code><br>map({<br>    |(d, _signal)| d<br>})</code>"]:::otherClass
+127v1["<div style=text-align:center>(127v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+128v1["<div style=text-align:center>(128v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.raw_id,<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+129v1["<div style=text-align:center>(129v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+130v1["<div style=text-align:center>(130v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
+131v1["<div style=text-align:center>(131v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos_bench::Client,<br>        &gt;::from_raw(id),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            hydro_test::__staged::cluster::kv_replica::KvPayload&lt;<br>                u32,<br>                (<br>                    hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                        hydro_test::__staged::cluster::paxos_bench::Client,<br>                    &gt;,<br>                    u32,<br>                ),<br>            &gt;,<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
+132v1["<div style=text-align:center>(132v1)</div> <code><br>map({<br>    |(_, v)| v<br>})</code>"]:::otherClass
+133v1["<div style=text-align:center>(133v1)</div> <code><br>map({<br>    |_u| ()<br>})</code>"]:::otherClass
+134v1["<div style=text-align:center>(134v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+135v1["<div style=text-align:center>(135v1)</div> <code><br>map({<br>    |(d, _signal)| d<br>})</code>"]:::otherClass
+136v1["<div style=text-align:center>(136v1)</div> <code><br>enumerate::&lt;'tick&gt;()</code>"]:::otherClass
+137v1["<div style=text-align:center>(137v1)</div> <code><br>flat_map({<br>    |v| v<br>})</code>"]:::otherClass
+138v1["<div style=text-align:center>(138v1)</div> <code><br>tee()</code>"]:::otherClass
+139v1["<div style=text-align:center>(139v1)</div> <code><br>map({<br>    |(_checkpoint, log)| log<br>})</code>"]:::otherClass
+140v1["<div style=text-align:center>(140v1)</div> <code><br>flat_map({<br>    |d| d<br>})</code>"]:::otherClass
+141v1["<div style=text-align:center>(141v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        || (0, None)<br>    },<br>    {<br>        |curr_entry, new_entry| {<br>            if let Some(curr_entry_payload) = &amp;mut curr_entry.1 {<br>                let same_values = new_entry.value == curr_entry_payload.value;<br>                let higher_ballot = new_entry.ballot &gt; curr_entry_payload.ballot;<br>                if same_values {<br>                    curr_entry.0 += 1;<br>                }<br>                if higher_ballot {<br>                    curr_entry_payload.ballot = new_entry.ballot;<br>                    if !same_values {<br>                        curr_entry.0 = 1;<br>                        curr_entry_payload.value = new_entry.value;<br>                    }<br>                }<br>            } else {<br>                *curr_entry = (1, Some(new_entry));<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
+142v1["<div style=text-align:center>(142v1)</div> <code><br>map({<br>    let f__free = {<br>        |(count, entry)| (count, entry.unwrap())<br>    };<br>    {<br>        let orig = f__free;<br>        move |(k, v)| (k, orig(v))<br>    }<br>})</code>"]:::otherClass
+143v1["<div style=text-align:center>(143v1)</div> <code><br>tee()</code>"]:::otherClass
+144v1["<div style=text-align:center>(144v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
+145v1["<div style=text-align:center>(145v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    |curr, new| {<br>        if new &gt; *curr {<br>            *curr = new;<br>        }<br>    }<br>})</code>"]:::otherClass
+146v1["<div style=text-align:center>(146v1)</div> <code><br>tee()</code>"]:::otherClass
+147v1["<div style=text-align:center>(147v1)</div> <code><br>map({<br>    |max_slot| max_slot + 1<br>})</code>"]:::otherClass
+148v1["<div style=text-align:center>(148v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+149v1["<div style=text-align:center>(149v1)</div> <code><br>source_iter({<br>    let e__free = {<br>        0<br>    };<br>    [e__free]<br>})</code>"]:::otherClass
+150v1["<div style=text-align:center>(150v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
 151v1["<div style=text-align:center>(151v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-152v1["<div style=text-align:center>(152v1)</div> <code><br>tee()</code>"]:::otherClass
-153v1["<div style=text-align:center>(153v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-154v1["<div style=text-align:center>(154v1)</div> <code><br>map({<br>    |((index, payload), base_slot)| (base_slot + index, payload)<br>})</code>"]:::otherClass
-155v1["<div style=text-align:center>(155v1)</div> <code><br>tee()</code>"]:::otherClass
-156v1["<div style=text-align:center>(156v1)</div> <code><br>fold::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        || 0usize<br>    },<br>    {<br>        |count, _| *count += 1<br>    },<br>)</code>"]:::otherClass
-158v1["<div style=text-align:center>(158v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-159v1["<div style=text-align:center>(159v1)</div> <code><br>map({<br>    |(num_payloads, base_slot)| base_slot + num_payloads<br>})</code>"]:::otherClass
-160v1["<div style=text-align:center>(160v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-161v1["<div style=text-align:center>(161v1)</div> <code><br>source_iter({<br>    let underlying_memberids__free = unsafe {<br>        ::std::mem::transmute::&lt;<br>            _,<br>            &amp;[hydro_lang::location::MemberId&lt;<br>                hydro_test::__staged::cluster::paxos::Acceptor,<br>            &gt;],<br>        &gt;(__hydro_lang_cluster_ids_1)<br>    };<br>    underlying_memberids__free<br>})</code>"]:::otherClass
-162v1["<div style=text-align:center>(162v1)</div> <code><br>map({<br>    |id| (*id, MembershipEvent::Joined)<br>})</code>"]:::otherClass
-163v1["<div style=text-align:center>(163v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        || false<br>    },<br>    {<br>        |present, event| {<br>            match event {<br>                MembershipEvent::Joined =&gt; *present = true,<br>                MembershipEvent::Left =&gt; *present = false,<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
-164v1["<div style=text-align:center>(164v1)</div> <code><br>filter_map({<br>    let f__free = {<br>        |v| if v { Some(()) } else { None }<br>    };<br>    {<br>        let orig = f__free;<br>        move |(k, v)| orig(v).map(|v| (k, v))<br>    }<br>})</code>"]:::otherClass
-165v1["<div style=text-align:center>(165v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
-166v1["<div style=text-align:center>(166v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-167v1["<div style=text-align:center>(167v1)</div> <code><br>map({<br>    |((slot, payload), ballot)| ((slot, ballot), Some(payload))<br>})</code>"]:::otherClass
-168v1["<div style=text-align:center>(168v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-169v1["<div style=text-align:center>(169v1)</div> <code><br>filter_map({<br>    |(checkpoint, _log)| checkpoint<br>})</code>"]:::otherClass
-170v1["<div style=text-align:center>(170v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    |curr, new| {<br>        if new &gt; *curr {<br>            *curr = new;<br>        }<br>    }<br>})</code>"]:::otherClass
-171v1["<div style=text-align:center>(171v1)</div> <code><br>map({<br>    |v| Some(v)<br>})</code>"]:::otherClass
-172v1["<div style=text-align:center>(172v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
-173v1["<div style=text-align:center>(173v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
-174v1["<div style=text-align:center>(174v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-175v1["<div style=text-align:center>(175v1)</div> <code><br>tee()</code>"]:::otherClass
-176v1["<div style=text-align:center>(176v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-177v1["<div style=text-align:center>(177v1)</div> <code><br>filter_map({<br>    let f__free = 1usize;<br>    move |(((slot, (count, entry)), ballot), checkpoint)| {<br>        if count &gt; f__free {<br>            return None;<br>        } else if let Some(checkpoint) = checkpoint &amp;&amp; slot &lt;= checkpoint {<br>            return None;<br>        }<br>        Some(((slot, ballot), entry.value))<br>    }<br>})</code>"]:::otherClass
-178v1["<div style=text-align:center>(178v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-179v1["<div style=text-align:center>(179v1)</div> <code><br>flat_map({<br>    |(max_slot, checkpoint)| {<br>        if let Some(checkpoint) = checkpoint {<br>            (checkpoint + 1)..max_slot<br>        } else {<br>            0..max_slot<br>        }<br>    }<br>})</code>"]:::otherClass
-180v1["<div style=text-align:center>(180v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
-181v1["<div style=text-align:center>(181v1)</div> <code><br>difference_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-182v1["<div style=text-align:center>(182v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-183v1["<div style=text-align:center>(183v1)</div> <code><br>map({<br>    move |(slot, ballot)| ((slot, ballot), None)<br>})</code>"]:::otherClass
-184v1["<div style=text-align:center>(184v1)</div> <code><br>chain()</code>"]:::otherClass
+152v1["<div style=text-align:center>(152v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+153v1["<div style=text-align:center>(153v1)</div> <code><br>tee()</code>"]:::otherClass
+154v1["<div style=text-align:center>(154v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+155v1["<div style=text-align:center>(155v1)</div> <code><br>map({<br>    |((index, payload), base_slot)| (base_slot + index, payload)<br>})</code>"]:::otherClass
+156v1["<div style=text-align:center>(156v1)</div> <code><br>tee()</code>"]:::otherClass
+157v1["<div style=text-align:center>(157v1)</div> <code><br>fold::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        || 0usize<br>    },<br>    {<br>        |count, _| *count += 1<br>    },<br>)</code>"]:::otherClass
+159v1["<div style=text-align:center>(159v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+160v1["<div style=text-align:center>(160v1)</div> <code><br>map({<br>    |(num_payloads, base_slot)| base_slot + num_payloads<br>})</code>"]:::otherClass
+161v1["<div style=text-align:center>(161v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+162v1["<div style=text-align:center>(162v1)</div> <code><br>source_iter({<br>    let underlying_memberids__free = unsafe {<br>        ::std::mem::transmute::&lt;<br>            _,<br>            &amp;[hydro_lang::location::MemberId&lt;<br>                hydro_test::__staged::cluster::paxos::Acceptor,<br>            &gt;],<br>        &gt;(__hydro_lang_cluster_ids_1)<br>    };<br>    underlying_memberids__free<br>})</code>"]:::otherClass
+163v1["<div style=text-align:center>(163v1)</div> <code><br>map({<br>    |id| (*id, MembershipEvent::Joined)<br>})</code>"]:::otherClass
+164v1["<div style=text-align:center>(164v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        || false<br>    },<br>    {<br>        |present, event| {<br>            match event {<br>                MembershipEvent::Joined =&gt; *present = true,<br>                MembershipEvent::Left =&gt; *present = false,<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
+165v1["<div style=text-align:center>(165v1)</div> <code><br>filter_map({<br>    let f__free = {<br>        |v| if v { Some(()) } else { None }<br>    };<br>    {<br>        let orig = f__free;<br>        move |(k, v)| orig(v).map(|v| (k, v))<br>    }<br>})</code>"]:::otherClass
+166v1["<div style=text-align:center>(166v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
+167v1["<div style=text-align:center>(167v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+168v1["<div style=text-align:center>(168v1)</div> <code><br>map({<br>    |((slot, payload), ballot)| ((slot, ballot), Some(payload))<br>})</code>"]:::otherClass
+169v1["<div style=text-align:center>(169v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+170v1["<div style=text-align:center>(170v1)</div> <code><br>filter_map({<br>    |(checkpoint, _log)| checkpoint<br>})</code>"]:::otherClass
+171v1["<div style=text-align:center>(171v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    |curr, new| {<br>        if new &gt; *curr {<br>            *curr = new;<br>        }<br>    }<br>})</code>"]:::otherClass
+172v1["<div style=text-align:center>(172v1)</div> <code><br>map({<br>    |v| Some(v)<br>})</code>"]:::otherClass
+173v1["<div style=text-align:center>(173v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
+174v1["<div style=text-align:center>(174v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
+175v1["<div style=text-align:center>(175v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+176v1["<div style=text-align:center>(176v1)</div> <code><br>tee()</code>"]:::otherClass
+177v1["<div style=text-align:center>(177v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+178v1["<div style=text-align:center>(178v1)</div> <code><br>filter_map({<br>    let f__free = 1usize;<br>    move |(((slot, (count, entry)), ballot), checkpoint)| {<br>        if count &gt; f__free {<br>            return None;<br>        } else if let Some(checkpoint) = checkpoint &amp;&amp; slot &lt;= checkpoint {<br>            return None;<br>        }<br>        Some(((slot, ballot), entry.value))<br>    }<br>})</code>"]:::otherClass
+179v1["<div style=text-align:center>(179v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+180v1["<div style=text-align:center>(180v1)</div> <code><br>flat_map({<br>    |(max_slot, checkpoint)| {<br>        if let Some(checkpoint) = checkpoint {<br>            (checkpoint + 1)..max_slot<br>        } else {<br>            0..max_slot<br>        }<br>    }<br>})</code>"]:::otherClass
+181v1["<div style=text-align:center>(181v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
+182v1["<div style=text-align:center>(182v1)</div> <code><br>difference_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+183v1["<div style=text-align:center>(183v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+184v1["<div style=text-align:center>(184v1)</div> <code><br>map({<br>    move |(slot, ballot)| ((slot, ballot), None)<br>})</code>"]:::otherClass
 185v1["<div style=text-align:center>(185v1)</div> <code><br>chain()</code>"]:::otherClass
-186v1["<div style=text-align:center>(186v1)</div> <code><br>map({<br>    |_u| ()<br>})</code>"]:::otherClass
-187v1["<div style=text-align:center>(187v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-188v1["<div style=text-align:center>(188v1)</div> <code><br>map({<br>    |(d, _signal)| d<br>})</code>"]:::otherClass
-189v1["<div style=text-align:center>(189v1)</div> <code><br>tee()</code>"]:::otherClass
-190v1["<div style=text-align:center>(190v1)</div> <code><br>map({<br>    let CLUSTER_SELF_ID__free = hydro_lang::location::MemberId::&lt;<br>        hydro_test::__staged::cluster::paxos::Proposer,<br>    &gt;::from_raw(__hydro_lang_cluster_self_id_0);<br>    move |((slot, ballot), value)| P2a {<br>        sender: CLUSTER_SELF_ID__free,<br>        ballot,<br>        slot,<br>        value,<br>    }<br>})</code>"]:::otherClass
-191v1["<div style=text-align:center>(191v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-192v1["<div style=text-align:center>(192v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.raw_id,<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
-193v1["<div style=text-align:center>(193v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-194v1["<div style=text-align:center>(194v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
-195v1["<div style=text-align:center>(195v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Acceptor,<br>        &gt;::from_raw(id),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            (<br>                (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>                core::result::Result&lt;<br>                    (),<br>                    hydro_test::__staged::cluster::paxos::Ballot,<br>                &gt;,<br>            ),<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
-196v1["<div style=text-align:center>(196v1)</div> <code><br>map({<br>    |(_, v)| v<br>})</code>"]:::otherClass
-197v1["<div style=text-align:center>(197v1)</div> <code><br>tee()</code>"]:::otherClass
-198v1["<div style=text-align:center>(198v1)</div> <code><br>chain()</code>"]:::otherClass
-199v1["<div style=text-align:center>(199v1)</div> <code><br>tee()</code>"]:::otherClass
-200v1["<div style=text-align:center>(200v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        move || (0, 0)<br>    },<br>    {<br>        move |accum, value| {<br>            if value.is_ok() {<br>                accum.0 += 1;<br>            } else {<br>                accum.1 += 1;<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
-201v1["<div style=text-align:center>(201v1)</div> <code><br>tee()</code>"]:::otherClass
-202v1["<div style=text-align:center>(202v1)</div> <code><br>filter_map({<br>    let min__free = 2usize;<br>    move |(key, (success, _error))| {<br>        if success &gt;= min__free { Some(key) } else { None }<br>    }<br>})</code>"]:::otherClass
-203v1["<div style=text-align:center>(203v1)</div> <code><br>tee()</code>"]:::otherClass
-204v1["<div style=text-align:center>(204v1)</div> <code><br>filter({<br>    let f__free = {<br>        let max__free = 3usize;<br>        move |(success, error)| (success + error) &gt;= max__free<br>    };<br>    {<br>        let orig = f__free;<br>        move |(_k, v)| orig(v)<br>    }<br>})</code>"]:::otherClass
-205v1["<div style=text-align:center>(205v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
-206v1["<div style=text-align:center>(206v1)</div> <code><br>tee()</code>"]:::otherClass
-207v1["<div style=text-align:center>(207v1)</div> <code><br>difference_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-208v1["<div style=text-align:center>(208v1)</div> <code><br>anti_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-209v1["<div style=text-align:center>(209v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-210v1["<div style=text-align:center>(210v1)</div> <code><br>chain()</code>"]:::otherClass
-211v1["<div style=text-align:center>(211v1)</div> <code><br>tee()</code>"]:::otherClass
-212v1["<div style=text-align:center>(212v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-213v1["<div style=text-align:center>(213v1)</div> <code><br>difference_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-214v1["<div style=text-align:center>(214v1)</div> <code><br>map({<br>    |k| (k, ())<br>})</code>"]:::otherClass
-215v1["<div style=text-align:center>(215v1)</div> <code><br>tee()</code>"]:::otherClass
-216v1["<div style=text-align:center>(216v1)</div> <code><br>map({<br>    |(key, _)| key<br>})</code>"]:::otherClass
-217v1["<div style=text-align:center>(217v1)</div> <code><br>anti_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-218v1["<div style=text-align:center>(218v1)</div> <code><br>filter_map({<br>    move |(key, res)| match res {<br>        Ok(_) =&gt; None,<br>        Err(e) =&gt; Some((key, e)),<br>    }<br>})</code>"]:::otherClass
-219v1["<div style=text-align:center>(219v1)</div> <code><br>map({<br>    |(_, ballot)| ballot<br>})</code>"]:::otherClass
-220v1["<div style=text-align:center>(220v1)</div> <code><br>source_iter({<br>    let underlying_memberids__free = unsafe {<br>        ::std::mem::transmute::&lt;<br>            _,<br>            &amp;[hydro_lang::location::MemberId&lt;<br>                hydro_test::__staged::cluster::kv_replica::Replica,<br>            &gt;],<br>        &gt;(__hydro_lang_cluster_ids_4)<br>    };<br>    underlying_memberids__free<br>})</code>"]:::otherClass
-221v1["<div style=text-align:center>(221v1)</div> <code><br>map({<br>    |id| (*id, MembershipEvent::Joined)<br>})</code>"]:::otherClass
-222v1["<div style=text-align:center>(222v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        || false<br>    },<br>    {<br>        |present, event| {<br>            match event {<br>                MembershipEvent::Joined =&gt; *present = true,<br>                MembershipEvent::Left =&gt; *present = false,<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
-223v1["<div style=text-align:center>(223v1)</div> <code><br>filter_map({<br>    let f__free = {<br>        |v| if v { Some(()) } else { None }<br>    };<br>    {<br>        let orig = f__free;<br>        move |(k, v)| orig(v).map(|v| (k, v))<br>    }<br>})</code>"]:::otherClass
-224v1["<div style=text-align:center>(224v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
-225v1["<div style=text-align:center>(225v1)</div> <code><br>join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-226v1["<div style=text-align:center>(226v1)</div> <code><br>map({<br>    |(key, (meta, resp))| (key, (meta, resp))<br>})</code>"]:::otherClass
-227v1["<div style=text-align:center>(227v1)</div> <code><br>map({<br>    |((slot, _ballot), (value, _))| (slot, value)<br>})</code>"]:::otherClass
-228v1["<div style=text-align:center>(228v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-229v1["<div style=text-align:center>(229v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.raw_id,<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
-230v1["<div style=text-align:center>(230v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+186v1["<div style=text-align:center>(186v1)</div> <code><br>chain()</code>"]:::otherClass
+187v1["<div style=text-align:center>(187v1)</div> <code><br>map({<br>    |_u| ()<br>})</code>"]:::otherClass
+188v1["<div style=text-align:center>(188v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+189v1["<div style=text-align:center>(189v1)</div> <code><br>map({<br>    |(d, _signal)| d<br>})</code>"]:::otherClass
+190v1["<div style=text-align:center>(190v1)</div> <code><br>tee()</code>"]:::otherClass
+191v1["<div style=text-align:center>(191v1)</div> <code><br>map({<br>    let CLUSTER_SELF_ID__free = hydro_lang::location::MemberId::&lt;<br>        hydro_test::__staged::cluster::paxos::Proposer,<br>    &gt;::from_raw(__hydro_lang_cluster_self_id_0);<br>    move |((slot, ballot), value)| P2a {<br>        sender: CLUSTER_SELF_ID__free,<br>        ballot,<br>        slot,<br>        value,<br>    }<br>})</code>"]:::otherClass
+192v1["<div style=text-align:center>(192v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+193v1["<div style=text-align:center>(193v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.raw_id,<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+194v1["<div style=text-align:center>(194v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+195v1["<div style=text-align:center>(195v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
+196v1["<div style=text-align:center>(196v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Acceptor,<br>        &gt;::from_raw(id),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            (<br>                (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>                core::result::Result&lt;<br>                    (),<br>                    hydro_test::__staged::cluster::paxos::Ballot,<br>                &gt;,<br>            ),<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
+197v1["<div style=text-align:center>(197v1)</div> <code><br>map({<br>    |(_, v)| v<br>})</code>"]:::otherClass
+198v1["<div style=text-align:center>(198v1)</div> <code><br>tee()</code>"]:::otherClass
+199v1["<div style=text-align:center>(199v1)</div> <code><br>chain()</code>"]:::otherClass
+200v1["<div style=text-align:center>(200v1)</div> <code><br>tee()</code>"]:::otherClass
+201v1["<div style=text-align:center>(201v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        move || (0, 0)<br>    },<br>    {<br>        move |accum, value| {<br>            if value.is_ok() {<br>                accum.0 += 1;<br>            } else {<br>                accum.1 += 1;<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
+202v1["<div style=text-align:center>(202v1)</div> <code><br>tee()</code>"]:::otherClass
+203v1["<div style=text-align:center>(203v1)</div> <code><br>filter_map({<br>    let min__free = 2usize;<br>    move |(key, (success, _error))| {<br>        if success &gt;= min__free { Some(key) } else { None }<br>    }<br>})</code>"]:::otherClass
+204v1["<div style=text-align:center>(204v1)</div> <code><br>tee()</code>"]:::otherClass
+205v1["<div style=text-align:center>(205v1)</div> <code><br>filter({<br>    let f__free = {<br>        let max__free = 3usize;<br>        move |(success, error)| (success + error) &gt;= max__free<br>    };<br>    {<br>        let orig = f__free;<br>        move |(_k, v)| orig(v)<br>    }<br>})</code>"]:::otherClass
+206v1["<div style=text-align:center>(206v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
+207v1["<div style=text-align:center>(207v1)</div> <code><br>tee()</code>"]:::otherClass
+208v1["<div style=text-align:center>(208v1)</div> <code><br>difference_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+209v1["<div style=text-align:center>(209v1)</div> <code><br>anti_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+210v1["<div style=text-align:center>(210v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+211v1["<div style=text-align:center>(211v1)</div> <code><br>chain()</code>"]:::otherClass
+212v1["<div style=text-align:center>(212v1)</div> <code><br>tee()</code>"]:::otherClass
+213v1["<div style=text-align:center>(213v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+214v1["<div style=text-align:center>(214v1)</div> <code><br>difference_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+215v1["<div style=text-align:center>(215v1)</div> <code><br>map({<br>    |k| (k, ())<br>})</code>"]:::otherClass
+216v1["<div style=text-align:center>(216v1)</div> <code><br>tee()</code>"]:::otherClass
+217v1["<div style=text-align:center>(217v1)</div> <code><br>map({<br>    |(key, _)| key<br>})</code>"]:::otherClass
+218v1["<div style=text-align:center>(218v1)</div> <code><br>anti_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+219v1["<div style=text-align:center>(219v1)</div> <code><br>filter_map({<br>    move |(key, res)| match res {<br>        Ok(_) =&gt; None,<br>        Err(e) =&gt; Some((key, e)),<br>    }<br>})</code>"]:::otherClass
+220v1["<div style=text-align:center>(220v1)</div> <code><br>map({<br>    |(_, ballot)| ballot<br>})</code>"]:::otherClass
+221v1["<div style=text-align:center>(221v1)</div> <code><br>source_iter({<br>    let underlying_memberids__free = unsafe {<br>        ::std::mem::transmute::&lt;<br>            _,<br>            &amp;[hydro_lang::location::MemberId&lt;<br>                hydro_test::__staged::cluster::kv_replica::Replica,<br>            &gt;],<br>        &gt;(__hydro_lang_cluster_ids_4)<br>    };<br>    underlying_memberids__free<br>})</code>"]:::otherClass
+222v1["<div style=text-align:center>(222v1)</div> <code><br>map({<br>    |id| (*id, MembershipEvent::Joined)<br>})</code>"]:::otherClass
+223v1["<div style=text-align:center>(223v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        || false<br>    },<br>    {<br>        |present, event| {<br>            match event {<br>                MembershipEvent::Joined =&gt; *present = true,<br>                MembershipEvent::Left =&gt; *present = false,<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
+224v1["<div style=text-align:center>(224v1)</div> <code><br>filter_map({<br>    let f__free = {<br>        |v| if v { Some(()) } else { None }<br>    };<br>    {<br>        let orig = f__free;<br>        move |(k, v)| orig(v).map(|v| (k, v))<br>    }<br>})</code>"]:::otherClass
+225v1["<div style=text-align:center>(225v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
+226v1["<div style=text-align:center>(226v1)</div> <code><br>join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+227v1["<div style=text-align:center>(227v1)</div> <code><br>map({<br>    |(key, (meta, resp))| (key, (meta, resp))<br>})</code>"]:::otherClass
+228v1["<div style=text-align:center>(228v1)</div> <code><br>map({<br>    |((slot, _ballot), (value, _))| (slot, value)<br>})</code>"]:::otherClass
+229v1["<div style=text-align:center>(229v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+230v1["<div style=text-align:center>(230v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.raw_id,<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+231v1["<div style=text-align:center>(231v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
 326v1["<div style=text-align:center>(326v1)</div> <code><br>identity()</code>"]:::otherClass
 328v1["<div style=text-align:center>(328v1)</div> <code><br>identity()</code>"]:::otherClass
 330v1["<div style=text-align:center>(330v1)</div> <code><br>identity()</code>"]:::otherClass
@@ -244,8 +245,8 @@ linkStyle default stroke:#aaa
 338v1["<div style=text-align:center>(338v1)</div> <code><br>identity()</code>"]:::otherClass
 340v1["<div style=text-align:center>(340v1)</div> <code><br>identity()</code>"]:::otherClass
 1v1-->2v1
-106v1--x|0|3v1; linkStyle 1 stroke:red
-219v1-->|1|3v1
+107v1--x|0|3v1; linkStyle 1 stroke:red
+220v1-->|1|3v1
 3v1--x|0|4v1; linkStyle 3 stroke:red
 39v1-->|1|4v1
 4v1--x5v1; linkStyle 5 stroke:red
@@ -267,7 +268,7 @@ linkStyle default stroke:#aaa
 20v1-->21v1
 14v1-->22v1
 22v1-->23v1
-104v1-->24v1
+105v1-->24v1
 24v1-->25v1
 23v1-->|input|26v1
 25v1--x|single|26v1; linkStyle 27 stroke:red
@@ -341,185 +342,186 @@ linkStyle default stroke:#aaa
 87v1-->|pos|89v1
 88v1--x|neg|89v1; linkStyle 96 stroke:red
 89v1-->90v1
-90v1--x91v1; linkStyle 98 stroke:red
-91v1--x92v1; linkStyle 99 stroke:red
-92v1-->|input|93v1
-23v1--x|single|93v1; linkStyle 101 stroke:red
-93v1-->94v1
+90v1-->91v1
+91v1-->92v1
+92v1--x93v1; linkStyle 100 stroke:red
+93v1-->|input|94v1
+23v1--x|single|94v1; linkStyle 102 stroke:red
 94v1-->95v1
 95v1-->96v1
-9v1-->|input|97v1
-23v1--x|single|97v1; linkStyle 106 stroke:red
-97v1-->98v1
+96v1-->97v1
+9v1-->|input|98v1
+23v1--x|single|98v1; linkStyle 107 stroke:red
 98v1-->99v1
-99v1-->101v1
-96v1-->|input|102v1
-101v1--x|single|102v1; linkStyle 111 stroke:red
-102v1-->103v1
+99v1-->100v1
+100v1-->102v1
+97v1-->|input|103v1
+102v1--x|single|103v1; linkStyle 112 stroke:red
 103v1-->104v1
-73v1-->105v1
-105v1-->106v1
-107v1-->108v1
-108v1--x109v1; linkStyle 117 stroke:red
-109v1-->110v1
+104v1-->105v1
+73v1-->106v1
+106v1-->107v1
+108v1-->109v1
+109v1--x110v1; linkStyle 118 stroke:red
 110v1-->111v1
-104v1-->332v1
-112v1-->113v1
+111v1-->112v1
+105v1-->332v1
 113v1-->114v1
-115v1-->116v1
-114v1--x|0|117v1; linkStyle 124 stroke:red
-116v1-->|1|117v1
-117v1-->118v1
+114v1-->115v1
+116v1-->117v1
+115v1--x|0|118v1; linkStyle 125 stroke:red
+117v1-->|1|118v1
 118v1-->119v1
-104v1-->|input|120v1
-119v1--x|single|120v1; linkStyle 129 stroke:red
-120v1-->121v1
-121v1-->123v1
-23v1-->|input|124v1
-123v1--x|single|124v1; linkStyle 133 stroke:red
-124v1-->125v1
-111v1-->|0|126v1
-125v1-->|1|126v1
+119v1-->120v1
+105v1-->|input|121v1
+120v1--x|single|121v1; linkStyle 130 stroke:red
+121v1-->122v1
+122v1-->124v1
+23v1-->|input|125v1
+124v1--x|single|125v1; linkStyle 134 stroke:red
+125v1-->126v1
+112v1-->|0|127v1
+126v1-->|1|127v1
+128v1-->129v1
 127v1-->128v1
-126v1-->127v1
-129v1-->130v1
 130v1-->131v1
-104v1-->132v1
-131v1-->|input|133v1
-132v1--x|single|133v1; linkStyle 143 stroke:red
-133v1-->134v1
+131v1-->132v1
+105v1-->133v1
+132v1-->|input|134v1
+133v1--x|single|134v1; linkStyle 144 stroke:red
 134v1-->135v1
-95v1-->136v1
-136v1-->137v1
+135v1-->136v1
+96v1-->137v1
 137v1-->138v1
 138v1-->139v1
-139v1--x140v1; linkStyle 150 stroke:red
-140v1-->141v1
+139v1-->140v1
+140v1--x141v1; linkStyle 151 stroke:red
 141v1-->142v1
 142v1-->143v1
-143v1--x144v1; linkStyle 154 stroke:red
-144v1-->145v1
+143v1-->144v1
+144v1--x145v1; linkStyle 155 stroke:red
 145v1-->146v1
-159v1-->334v1
-148v1-->149v1
-147v1--x|0|150v1; linkStyle 159 stroke:red
-149v1-->|1|150v1
-146v1--x|0|151v1; linkStyle 161 stroke:red
+146v1-->147v1
+160v1-->334v1
+149v1-->150v1
+148v1--x|0|151v1; linkStyle 160 stroke:red
 150v1-->|1|151v1
-151v1-->152v1
-135v1-->|input|153v1
-152v1--x|single|153v1; linkStyle 165 stroke:red
-153v1-->154v1
+147v1--x|0|152v1; linkStyle 162 stroke:red
+151v1-->|1|152v1
+152v1-->153v1
+136v1-->|input|154v1
+153v1--x|single|154v1; linkStyle 166 stroke:red
 154v1-->155v1
-155v1--x156v1; linkStyle 168 stroke:red
-156v1-->|input|158v1
-152v1--x|single|158v1; linkStyle 170 stroke:red
-158v1-->159v1
-208v1-->336v1
-161v1-->162v1
-162v1--x163v1; linkStyle 174 stroke:red
-163v1-->164v1
+155v1-->156v1
+156v1--x157v1; linkStyle 169 stroke:red
+157v1-->|input|159v1
+153v1--x|single|159v1; linkStyle 171 stroke:red
+159v1-->160v1
+209v1-->336v1
+162v1-->163v1
+163v1--x164v1; linkStyle 175 stroke:red
 164v1-->165v1
-155v1-->|input|166v1
-23v1--x|single|166v1; linkStyle 178 stroke:red
-166v1-->167v1
-142v1-->|input|168v1
-23v1--x|single|168v1; linkStyle 181 stroke:red
-137v1-->169v1
-169v1--x170v1; linkStyle 183 stroke:red
-170v1-->171v1
-172v1-->173v1
-171v1--x|0|174v1; linkStyle 186 stroke:red
-173v1-->|1|174v1
-174v1-->175v1
-168v1-->|input|176v1
-175v1--x|single|176v1; linkStyle 190 stroke:red
-176v1-->177v1
-145v1-->|input|178v1
-175v1--x|single|178v1; linkStyle 193 stroke:red
-178v1-->179v1
-142v1-->180v1
-179v1-->|pos|181v1
-180v1--x|neg|181v1; linkStyle 197 stroke:red
-181v1-->|input|182v1
-23v1--x|single|182v1; linkStyle 199 stroke:red
-182v1-->183v1
-177v1--x|0|184v1; linkStyle 201 stroke:red
-183v1-->|1|184v1
-167v1--x|0|185v1; linkStyle 203 stroke:red
+165v1-->166v1
+156v1-->|input|167v1
+23v1--x|single|167v1; linkStyle 179 stroke:red
+167v1-->168v1
+143v1-->|input|169v1
+23v1--x|single|169v1; linkStyle 182 stroke:red
+138v1-->170v1
+170v1--x171v1; linkStyle 184 stroke:red
+171v1-->172v1
+173v1-->174v1
+172v1--x|0|175v1; linkStyle 187 stroke:red
+174v1-->|1|175v1
+175v1-->176v1
+169v1-->|input|177v1
+176v1--x|single|177v1; linkStyle 191 stroke:red
+177v1-->178v1
+146v1-->|input|179v1
+176v1--x|single|179v1; linkStyle 194 stroke:red
+179v1-->180v1
+143v1-->181v1
+180v1-->|pos|182v1
+181v1--x|neg|182v1; linkStyle 198 stroke:red
+182v1-->|input|183v1
+23v1--x|single|183v1; linkStyle 200 stroke:red
+183v1-->184v1
+178v1--x|0|185v1; linkStyle 202 stroke:red
 184v1-->|1|185v1
-104v1-->186v1
-185v1-->|input|187v1
-186v1--x|single|187v1; linkStyle 207 stroke:red
-187v1-->188v1
+168v1--x|0|186v1; linkStyle 204 stroke:red
+185v1-->|1|186v1
+105v1-->187v1
+186v1-->|input|188v1
+187v1--x|single|188v1; linkStyle 208 stroke:red
 188v1-->189v1
 189v1-->190v1
-165v1-->|0|191v1
-190v1-->|1|191v1
+190v1-->191v1
+166v1-->|0|192v1
+191v1-->|1|192v1
+193v1-->194v1
 192v1-->193v1
-191v1-->192v1
-194v1-->195v1
 195v1-->196v1
 196v1-->197v1
-160v1--x|0|198v1; linkStyle 218 stroke:red
-197v1-->|1|198v1
-198v1-->199v1
-199v1--x200v1; linkStyle 221 stroke:red
-200v1-->201v1
+197v1-->198v1
+161v1--x|0|199v1; linkStyle 219 stroke:red
+198v1-->|1|199v1
+199v1-->200v1
+200v1--x201v1; linkStyle 222 stroke:red
 201v1-->202v1
 202v1-->203v1
-201v1-->204v1
-204v1-->205v1
+203v1-->204v1
+202v1-->205v1
 205v1-->206v1
-203v1-->|pos|207v1
-206v1--x|neg|207v1; linkStyle 229 stroke:red
-199v1-->|pos|208v1
-206v1--x|neg|208v1; linkStyle 231 stroke:red
-217v1-->338v1
-209v1--x|0|210v1; linkStyle 233 stroke:red
-189v1-->|1|210v1
-210v1-->211v1
-207v1-->340v1
-203v1-->|pos|213v1
-212v1--x|neg|213v1; linkStyle 238 stroke:red
-213v1-->214v1
+206v1-->207v1
+204v1-->|pos|208v1
+207v1--x|neg|208v1; linkStyle 230 stroke:red
+200v1-->|pos|209v1
+207v1--x|neg|209v1; linkStyle 232 stroke:red
+218v1-->338v1
+210v1--x|0|211v1; linkStyle 234 stroke:red
+190v1-->|1|211v1
+211v1-->212v1
+208v1-->340v1
+204v1-->|pos|214v1
+213v1--x|neg|214v1; linkStyle 239 stroke:red
 214v1-->215v1
 215v1-->216v1
-211v1-->|pos|217v1
-216v1--x|neg|217v1; linkStyle 243 stroke:red
-197v1-->218v1
-218v1-->219v1
-220v1-->221v1
-221v1--x222v1; linkStyle 247 stroke:red
-222v1-->223v1
+216v1-->217v1
+212v1-->|pos|218v1
+217v1--x|neg|218v1; linkStyle 244 stroke:red
+198v1-->219v1
+219v1-->220v1
+221v1-->222v1
+222v1--x223v1; linkStyle 248 stroke:red
 223v1-->224v1
-211v1-->|0|225v1
-215v1-->|1|225v1
-225v1-->226v1
+224v1-->225v1
+212v1-->|0|226v1
+216v1-->|1|226v1
 226v1-->227v1
-224v1-->|0|228v1
-227v1-->|1|228v1
+227v1-->228v1
+225v1-->|0|229v1
+228v1-->|1|229v1
+230v1-->231v1
 229v1-->230v1
-228v1-->229v1
-326v1--o10v1; linkStyle 258 stroke:red
-328v1--o40v1; linkStyle 259 stroke:red
-330v1--o88v1; linkStyle 260 stroke:red
-332v1--o112v1; linkStyle 261 stroke:red
-334v1--o147v1; linkStyle 262 stroke:red
-336v1--o160v1; linkStyle 263 stroke:red
-338v1--o209v1; linkStyle 264 stroke:red
-340v1--o212v1; linkStyle 265 stroke:red
+326v1--o10v1; linkStyle 259 stroke:red
+328v1--o40v1; linkStyle 260 stroke:red
+330v1--o88v1; linkStyle 261 stroke:red
+332v1--o113v1; linkStyle 262 stroke:red
+334v1--o148v1; linkStyle 263 stroke:red
+336v1--o161v1; linkStyle 264 stroke:red
+338v1--o210v1; linkStyle 265 stroke:red
+340v1--o213v1; linkStyle 266 stroke:red
 2v1
 34v1
 35v1
 67v1
 68v1
-127v1
 128v1
-192v1
+129v1
 193v1
-229v1
+194v1
 230v1
+231v1
 326v1
 328v1
 330v1
@@ -625,17 +627,17 @@ subgraph var_stream_146 ["var <tt>stream_146</tt>"]
     style var_stream_146 fill:transparent
     91v1
 end
+subgraph var_stream_147 ["var <tt>stream_147</tt>"]
+    style var_stream_147 fill:transparent
+    92v1
+end
 subgraph var_stream_148 ["var <tt>stream_148</tt>"]
     style var_stream_148 fill:transparent
-    92v1
+    93v1
 end
 subgraph var_stream_15 ["var <tt>stream_15</tt>"]
     style var_stream_15 fill:transparent
     5v1
-end
-subgraph var_stream_150 ["var <tt>stream_150</tt>"]
-    style var_stream_150 fill:transparent
-    93v1
 end
 subgraph var_stream_151 ["var <tt>stream_151</tt>"]
     style var_stream_151 fill:transparent
@@ -649,8 +651,8 @@ subgraph var_stream_153 ["var <tt>stream_153</tt>"]
     style var_stream_153 fill:transparent
     96v1
 end
-subgraph var_stream_156 ["var <tt>stream_156</tt>"]
-    style var_stream_156 fill:transparent
+subgraph var_stream_154 ["var <tt>stream_154</tt>"]
+    style var_stream_154 fill:transparent
     97v1
 end
 subgraph var_stream_157 ["var <tt>stream_157</tt>"]
@@ -661,9 +663,9 @@ subgraph var_stream_158 ["var <tt>stream_158</tt>"]
     style var_stream_158 fill:transparent
     99v1
 end
-subgraph var_stream_160 ["var <tt>stream_160</tt>"]
-    style var_stream_160 fill:transparent
-    101v1
+subgraph var_stream_159 ["var <tt>stream_159</tt>"]
+    style var_stream_159 fill:transparent
+    100v1
 end
 subgraph var_stream_161 ["var <tt>stream_161</tt>"]
     style var_stream_161 fill:transparent
@@ -677,21 +679,21 @@ subgraph var_stream_163 ["var <tt>stream_163</tt>"]
     style var_stream_163 fill:transparent
     104v1
 end
-subgraph var_stream_165 ["var <tt>stream_165</tt>"]
-    style var_stream_165 fill:transparent
+subgraph var_stream_164 ["var <tt>stream_164</tt>"]
+    style var_stream_164 fill:transparent
     105v1
 end
 subgraph var_stream_166 ["var <tt>stream_166</tt>"]
     style var_stream_166 fill:transparent
     106v1
 end
+subgraph var_stream_167 ["var <tt>stream_167</tt>"]
+    style var_stream_167 fill:transparent
+    107v1
+end
 subgraph var_stream_17 ["var <tt>stream_17</tt>"]
     style var_stream_17 fill:transparent
     6v1
-end
-subgraph var_stream_174 ["var <tt>stream_174</tt>"]
-    style var_stream_174 fill:transparent
-    107v1
 end
 subgraph var_stream_175 ["var <tt>stream_175</tt>"]
     style var_stream_175 fill:transparent
@@ -705,16 +707,16 @@ subgraph var_stream_177 ["var <tt>stream_177</tt>"]
     style var_stream_177 fill:transparent
     110v1
 end
-subgraph var_stream_179 ["var <tt>stream_179</tt>"]
-    style var_stream_179 fill:transparent
+subgraph var_stream_178 ["var <tt>stream_178</tt>"]
+    style var_stream_178 fill:transparent
     111v1
 end
 subgraph var_stream_18 ["var <tt>stream_18</tt>"]
     style var_stream_18 fill:transparent
     7v1
 end
-subgraph var_stream_183 ["var <tt>stream_183</tt>"]
-    style var_stream_183 fill:transparent
+subgraph var_stream_180 ["var <tt>stream_180</tt>"]
+    style var_stream_180 fill:transparent
     112v1
 end
 subgraph var_stream_184 ["var <tt>stream_184</tt>"]
@@ -728,10 +730,10 @@ end
 subgraph var_stream_186 ["var <tt>stream_186</tt>"]
     style var_stream_186 fill:transparent
     115v1
-    116v1
 end
 subgraph var_stream_187 ["var <tt>stream_187</tt>"]
     style var_stream_187 fill:transparent
+    116v1
     117v1
 end
 subgraph var_stream_188 ["var <tt>stream_188</tt>"]
@@ -750,9 +752,9 @@ subgraph var_stream_191 ["var <tt>stream_191</tt>"]
     style var_stream_191 fill:transparent
     121v1
 end
-subgraph var_stream_193 ["var <tt>stream_193</tt>"]
-    style var_stream_193 fill:transparent
-    123v1
+subgraph var_stream_192 ["var <tt>stream_192</tt>"]
+    style var_stream_192 fill:transparent
+    122v1
 end
 subgraph var_stream_194 ["var <tt>stream_194</tt>"]
     style var_stream_194 fill:transparent
@@ -762,25 +764,25 @@ subgraph var_stream_195 ["var <tt>stream_195</tt>"]
     style var_stream_195 fill:transparent
     125v1
 end
-subgraph var_stream_198 ["var <tt>stream_198</tt>"]
-    style var_stream_198 fill:transparent
+subgraph var_stream_196 ["var <tt>stream_196</tt>"]
+    style var_stream_196 fill:transparent
     126v1
+end
+subgraph var_stream_199 ["var <tt>stream_199</tt>"]
+    style var_stream_199 fill:transparent
+    127v1
 end
 subgraph var_stream_20 ["var <tt>stream_20</tt>"]
     style var_stream_20 fill:transparent
     8v1
 end
-subgraph var_stream_220 ["var <tt>stream_220</tt>"]
-    style var_stream_220 fill:transparent
-    130v1
-    129v1
-end
 subgraph var_stream_221 ["var <tt>stream_221</tt>"]
     style var_stream_221 fill:transparent
     131v1
+    130v1
 end
-subgraph var_stream_224 ["var <tt>stream_224</tt>"]
-    style var_stream_224 fill:transparent
+subgraph var_stream_222 ["var <tt>stream_222</tt>"]
+    style var_stream_222 fill:transparent
     132v1
 end
 subgraph var_stream_225 ["var <tt>stream_225</tt>"]
@@ -795,8 +797,8 @@ subgraph var_stream_227 ["var <tt>stream_227</tt>"]
     style var_stream_227 fill:transparent
     135v1
 end
-subgraph var_stream_229 ["var <tt>stream_229</tt>"]
-    style var_stream_229 fill:transparent
+subgraph var_stream_228 ["var <tt>stream_228</tt>"]
+    style var_stream_228 fill:transparent
     136v1
 end
 subgraph var_stream_23 ["var <tt>stream_23</tt>"]
@@ -843,8 +845,8 @@ subgraph var_stream_239 ["var <tt>stream_239</tt>"]
     style var_stream_239 fill:transparent
     146v1
 end
-subgraph var_stream_241 ["var <tt>stream_241</tt>"]
-    style var_stream_241 fill:transparent
+subgraph var_stream_240 ["var <tt>stream_240</tt>"]
+    style var_stream_240 fill:transparent
     147v1
 end
 subgraph var_stream_242 ["var <tt>stream_242</tt>"]
@@ -855,8 +857,8 @@ subgraph var_stream_243 ["var <tt>stream_243</tt>"]
     style var_stream_243 fill:transparent
     149v1
 end
-subgraph var_stream_245 ["var <tt>stream_245</tt>"]
-    style var_stream_245 fill:transparent
+subgraph var_stream_244 ["var <tt>stream_244</tt>"]
+    style var_stream_244 fill:transparent
     150v1
 end
 subgraph var_stream_246 ["var <tt>stream_246</tt>"]
@@ -887,16 +889,16 @@ subgraph var_stream_251 ["var <tt>stream_251</tt>"]
     style var_stream_251 fill:transparent
     156v1
 end
-subgraph var_stream_254 ["var <tt>stream_254</tt>"]
-    style var_stream_254 fill:transparent
-    158v1
+subgraph var_stream_252 ["var <tt>stream_252</tt>"]
+    style var_stream_252 fill:transparent
+    157v1
 end
 subgraph var_stream_255 ["var <tt>stream_255</tt>"]
     style var_stream_255 fill:transparent
     159v1
 end
-subgraph var_stream_257 ["var <tt>stream_257</tt>"]
-    style var_stream_257 fill:transparent
+subgraph var_stream_256 ["var <tt>stream_256</tt>"]
+    style var_stream_256 fill:transparent
     160v1
 end
 subgraph var_stream_258 ["var <tt>stream_258</tt>"]
@@ -919,28 +921,28 @@ subgraph var_stream_261 ["var <tt>stream_261</tt>"]
     style var_stream_261 fill:transparent
     164v1
 end
-subgraph var_stream_263 ["var <tt>stream_263</tt>"]
-    style var_stream_263 fill:transparent
+subgraph var_stream_262 ["var <tt>stream_262</tt>"]
+    style var_stream_262 fill:transparent
     165v1
 end
-subgraph var_stream_266 ["var <tt>stream_266</tt>"]
-    style var_stream_266 fill:transparent
+subgraph var_stream_264 ["var <tt>stream_264</tt>"]
+    style var_stream_264 fill:transparent
     166v1
 end
 subgraph var_stream_267 ["var <tt>stream_267</tt>"]
     style var_stream_267 fill:transparent
     167v1
 end
+subgraph var_stream_268 ["var <tt>stream_268</tt>"]
+    style var_stream_268 fill:transparent
+    168v1
+end
 subgraph var_stream_27 ["var <tt>stream_27</tt>"]
     style var_stream_27 fill:transparent
     12v1
 end
-subgraph var_stream_270 ["var <tt>stream_270</tt>"]
-    style var_stream_270 fill:transparent
-    168v1
-end
-subgraph var_stream_272 ["var <tt>stream_272</tt>"]
-    style var_stream_272 fill:transparent
+subgraph var_stream_271 ["var <tt>stream_271</tt>"]
+    style var_stream_271 fill:transparent
     169v1
 end
 subgraph var_stream_273 ["var <tt>stream_273</tt>"]
@@ -954,10 +956,10 @@ end
 subgraph var_stream_275 ["var <tt>stream_275</tt>"]
     style var_stream_275 fill:transparent
     172v1
-    173v1
 end
 subgraph var_stream_276 ["var <tt>stream_276</tt>"]
     style var_stream_276 fill:transparent
+    173v1
     174v1
 end
 subgraph var_stream_277 ["var <tt>stream_277</tt>"]
@@ -972,24 +974,24 @@ subgraph var_stream_279 ["var <tt>stream_279</tt>"]
     style var_stream_279 fill:transparent
     177v1
 end
-subgraph var_stream_282 ["var <tt>stream_282</tt>"]
-    style var_stream_282 fill:transparent
+subgraph var_stream_280 ["var <tt>stream_280</tt>"]
+    style var_stream_280 fill:transparent
     178v1
 end
 subgraph var_stream_283 ["var <tt>stream_283</tt>"]
     style var_stream_283 fill:transparent
     179v1
 end
-subgraph var_stream_285 ["var <tt>stream_285</tt>"]
-    style var_stream_285 fill:transparent
+subgraph var_stream_284 ["var <tt>stream_284</tt>"]
+    style var_stream_284 fill:transparent
     180v1
 end
 subgraph var_stream_286 ["var <tt>stream_286</tt>"]
     style var_stream_286 fill:transparent
     181v1
 end
-subgraph var_stream_288 ["var <tt>stream_288</tt>"]
-    style var_stream_288 fill:transparent
+subgraph var_stream_287 ["var <tt>stream_287</tt>"]
+    style var_stream_287 fill:transparent
     182v1
 end
 subgraph var_stream_289 ["var <tt>stream_289</tt>"]
@@ -1008,8 +1010,8 @@ subgraph var_stream_291 ["var <tt>stream_291</tt>"]
     style var_stream_291 fill:transparent
     185v1
 end
-subgraph var_stream_293 ["var <tt>stream_293</tt>"]
-    style var_stream_293 fill:transparent
+subgraph var_stream_292 ["var <tt>stream_292</tt>"]
+    style var_stream_292 fill:transparent
     186v1
 end
 subgraph var_stream_294 ["var <tt>stream_294</tt>"]
@@ -1020,41 +1022,41 @@ subgraph var_stream_295 ["var <tt>stream_295</tt>"]
     style var_stream_295 fill:transparent
     188v1
 end
-subgraph var_stream_297 ["var <tt>stream_297</tt>"]
-    style var_stream_297 fill:transparent
+subgraph var_stream_296 ["var <tt>stream_296</tt>"]
+    style var_stream_296 fill:transparent
     189v1
 end
 subgraph var_stream_298 ["var <tt>stream_298</tt>"]
     style var_stream_298 fill:transparent
     190v1
 end
+subgraph var_stream_299 ["var <tt>stream_299</tt>"]
+    style var_stream_299 fill:transparent
+    191v1
+end
 subgraph var_stream_30 ["var <tt>stream_30</tt>"]
     style var_stream_30 fill:transparent
     14v1
 end
-subgraph var_stream_300 ["var <tt>stream_300</tt>"]
-    style var_stream_300 fill:transparent
-    191v1
+subgraph var_stream_301 ["var <tt>stream_301</tt>"]
+    style var_stream_301 fill:transparent
+    192v1
 end
 subgraph var_stream_31 ["var <tt>stream_31</tt>"]
     style var_stream_31 fill:transparent
     15v1
 end
-subgraph var_stream_310 ["var <tt>stream_310</tt>"]
-    style var_stream_310 fill:transparent
-    194v1
-    195v1
-end
 subgraph var_stream_311 ["var <tt>stream_311</tt>"]
     style var_stream_311 fill:transparent
+    195v1
     196v1
 end
 subgraph var_stream_312 ["var <tt>stream_312</tt>"]
     style var_stream_312 fill:transparent
     197v1
 end
-subgraph var_stream_314 ["var <tt>stream_314</tt>"]
-    style var_stream_314 fill:transparent
+subgraph var_stream_313 ["var <tt>stream_313</tt>"]
+    style var_stream_313 fill:transparent
     198v1
 end
 subgraph var_stream_315 ["var <tt>stream_315</tt>"]
@@ -1081,8 +1083,8 @@ subgraph var_stream_32 ["var <tt>stream_32</tt>"]
     style var_stream_32 fill:transparent
     16v1
 end
-subgraph var_stream_321 ["var <tt>stream_321</tt>"]
-    style var_stream_321 fill:transparent
+subgraph var_stream_320 ["var <tt>stream_320</tt>"]
+    style var_stream_320 fill:transparent
     204v1
 end
 subgraph var_stream_322 ["var <tt>stream_322</tt>"]
@@ -1097,44 +1099,44 @@ subgraph var_stream_324 ["var <tt>stream_324</tt>"]
     style var_stream_324 fill:transparent
     207v1
 end
-subgraph var_stream_327 ["var <tt>stream_327</tt>"]
-    style var_stream_327 fill:transparent
+subgraph var_stream_325 ["var <tt>stream_325</tt>"]
+    style var_stream_325 fill:transparent
     208v1
 end
-subgraph var_stream_329 ["var <tt>stream_329</tt>"]
-    style var_stream_329 fill:transparent
+subgraph var_stream_328 ["var <tt>stream_328</tt>"]
+    style var_stream_328 fill:transparent
     209v1
 end
 subgraph var_stream_33 ["var <tt>stream_33</tt>"]
     style var_stream_33 fill:transparent
     17v1
 end
-subgraph var_stream_332 ["var <tt>stream_332</tt>"]
-    style var_stream_332 fill:transparent
+subgraph var_stream_330 ["var <tt>stream_330</tt>"]
+    style var_stream_330 fill:transparent
     210v1
 end
 subgraph var_stream_333 ["var <tt>stream_333</tt>"]
     style var_stream_333 fill:transparent
     211v1
 end
-subgraph var_stream_336 ["var <tt>stream_336</tt>"]
-    style var_stream_336 fill:transparent
+subgraph var_stream_334 ["var <tt>stream_334</tt>"]
+    style var_stream_334 fill:transparent
     212v1
 end
 subgraph var_stream_337 ["var <tt>stream_337</tt>"]
     style var_stream_337 fill:transparent
     213v1
 end
-subgraph var_stream_339 ["var <tt>stream_339</tt>"]
-    style var_stream_339 fill:transparent
+subgraph var_stream_338 ["var <tt>stream_338</tt>"]
+    style var_stream_338 fill:transparent
     214v1
 end
 subgraph var_stream_34 ["var <tt>stream_34</tt>"]
     style var_stream_34 fill:transparent
     18v1
 end
-subgraph var_stream_341 ["var <tt>stream_341</tt>"]
-    style var_stream_341 fill:transparent
+subgraph var_stream_340 ["var <tt>stream_340</tt>"]
+    style var_stream_340 fill:transparent
     215v1
 end
 subgraph var_stream_342 ["var <tt>stream_342</tt>"]
@@ -1145,6 +1147,10 @@ subgraph var_stream_343 ["var <tt>stream_343</tt>"]
     style var_stream_343 fill:transparent
     217v1
 end
+subgraph var_stream_344 ["var <tt>stream_344</tt>"]
+    style var_stream_344 fill:transparent
+    218v1
+end
 subgraph var_stream_35 ["var <tt>stream_35</tt>"]
     style var_stream_35 fill:transparent
     19v1
@@ -1152,10 +1158,6 @@ end
 subgraph var_stream_36 ["var <tt>stream_36</tt>"]
     style var_stream_36 fill:transparent
     20v1
-end
-subgraph var_stream_363 ["var <tt>stream_363</tt>"]
-    style var_stream_363 fill:transparent
-    218v1
 end
 subgraph var_stream_364 ["var <tt>stream_364</tt>"]
     style var_stream_364 fill:transparent
@@ -1177,25 +1179,29 @@ subgraph var_stream_368 ["var <tt>stream_368</tt>"]
     style var_stream_368 fill:transparent
     223v1
 end
-subgraph var_stream_370 ["var <tt>stream_370</tt>"]
-    style var_stream_370 fill:transparent
+subgraph var_stream_369 ["var <tt>stream_369</tt>"]
+    style var_stream_369 fill:transparent
     224v1
 end
-subgraph var_stream_373 ["var <tt>stream_373</tt>"]
-    style var_stream_373 fill:transparent
+subgraph var_stream_371 ["var <tt>stream_371</tt>"]
+    style var_stream_371 fill:transparent
     225v1
 end
 subgraph var_stream_374 ["var <tt>stream_374</tt>"]
     style var_stream_374 fill:transparent
     226v1
 end
-subgraph var_stream_376 ["var <tt>stream_376</tt>"]
-    style var_stream_376 fill:transparent
+subgraph var_stream_375 ["var <tt>stream_375</tt>"]
+    style var_stream_375 fill:transparent
     227v1
 end
-subgraph var_stream_378 ["var <tt>stream_378</tt>"]
-    style var_stream_378 fill:transparent
+subgraph var_stream_377 ["var <tt>stream_377</tt>"]
+    style var_stream_377 fill:transparent
     228v1
+end
+subgraph var_stream_379 ["var <tt>stream_379</tt>"]
+    style var_stream_379 fill:transparent
+    229v1
 end
 subgraph var_stream_38 ["var <tt>stream_38</tt>"]
     style var_stream_38 fill:transparent

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__two_pc_bench__tests__two_pc_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__two_pc_bench__tests__two_pc_ir.snap
@@ -41,58 +41,48 @@ expression: built.ir()
                     },
                     second: Batch {
                         inner: Tee {
-                            inner: <tee 1>: BeginAtomic {
-                                inner: Map {
-                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , core :: result :: Result < () , () >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: two_pc :: * ; | kv | (kv , Ok :: < () , () > (())) }),
-                                    input: Map {
-                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
+                            inner: <tee 1>: Map {
+                                f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , core :: result :: Result < () , () >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: two_pc :: * ; | kv | (kv , Ok :: < () , () > (())) }),
+                                input: Map {
+                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
+                                    input: Network {
+                                        serialize_fn: Some(
+                                            :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
+                                        ),
+                                        instantiate_fn: <network instantiate>,
+                                        deserialize_fn: Some(
+                                            | res | { let (id , b) = res . unwrap () ; (hydro_lang :: location :: MemberId :: < hydro_test :: __staged :: cluster :: two_pc :: Participant > :: from_raw (id) , hydro_lang :: runtime_support :: bincode :: deserialize :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) > (& b) . unwrap ()) },
+                                        ),
                                         input: Network {
                                             serialize_fn: Some(
-                                                :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
+                                                :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: location :: MemberId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                             ),
                                             instantiate_fn: <network instantiate>,
                                             deserialize_fn: Some(
-                                                | res | { let (id , b) = res . unwrap () ; (hydro_lang :: location :: MemberId :: < hydro_test :: __staged :: cluster :: two_pc :: Participant > :: from_raw (id) , hydro_lang :: runtime_support :: bincode :: deserialize :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) > (& b) . unwrap ()) },
+                                                | res | { hydro_lang :: runtime_support :: bincode :: deserialize :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) > (& res . unwrap ()) . unwrap () },
                                             ),
-                                            input: Network {
-                                                serialize_fn: Some(
-                                                    :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: location :: MemberId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
-                                                ),
-                                                instantiate_fn: <network instantiate>,
-                                                deserialize_fn: Some(
-                                                    | res | { hydro_lang :: runtime_support :: bincode :: deserialize :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) > (& res . unwrap ()) . unwrap () },
-                                                ),
-                                                input: YieldConcat {
-                                                    inner: CrossProduct {
-                                                        left: Map {
-                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , ()) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                            input: Batch {
-                                                                inner: FilterMap {
-                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , bool) , core :: option :: Option < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , ()) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < bool , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | v | if v { Some (()) } else { None } }) ; { let orig = f__free ; move | (k , v) | orig (v) . map (| v | (k , v)) } }),
-                                                                    input: FoldKeyed {
-                                                                        init: stageleft :: runtime_support :: fn0_type_hint :: < bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | | false }),
-                                                                        acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < bool , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | present , event | { match event { MembershipEvent :: Joined => * present = true , MembershipEvent :: Left => * present = false , } } }),
-                                                                        input: Map {
-                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < & hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | id | (* id , MembershipEvent :: Joined) }),
-                                                                            input: Source {
-                                                                                source: Iter(
-                                                                                    { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let underlying_memberids__free = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: location :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant >] > (__hydro_lang_cluster_ids_1) } ; underlying_memberids__free },
-                                                                                ),
-                                                                                metadata: HydroIrMetadata {
-                                                                                    location_kind: Process(
-                                                                                        0,
-                                                                                    ),
-                                                                                    output_type: Some(
-                                                                                        & hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant >,
-                                                                                    ),
-                                                                                },
-                                                                            },
+                                            input: YieldConcat {
+                                                inner: CrossProduct {
+                                                    left: Map {
+                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , ()) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
+                                                        input: Batch {
+                                                            inner: FilterMap {
+                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , bool) , core :: option :: Option < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , ()) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < bool , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | v | if v { Some (()) } else { None } }) ; { let orig = f__free ; move | (k , v) | orig (v) . map (| v | (k , v)) } }),
+                                                                input: FoldKeyed {
+                                                                    init: stageleft :: runtime_support :: fn0_type_hint :: < bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | | false }),
+                                                                    acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < bool , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | present , event | { match event { MembershipEvent :: Joined => * present = true , MembershipEvent :: Left => * present = false , } } }),
+                                                                    input: Map {
+                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < & hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | id | (* id , MembershipEvent :: Joined) }),
+                                                                        input: Source {
+                                                                            source: Iter(
+                                                                                { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let underlying_memberids__free = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: location :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant >] > (__hydro_lang_cluster_ids_1) } ; underlying_memberids__free },
+                                                                            ),
                                                                             metadata: HydroIrMetadata {
                                                                                 location_kind: Process(
                                                                                     0,
                                                                                 ),
                                                                                 output_type: Some(
-                                                                                    (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
+                                                                                    & hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant >,
                                                                                 ),
                                                                             },
                                                                         },
@@ -101,7 +91,7 @@ expression: built.ir()
                                                                                 0,
                                                                             ),
                                                                             output_type: Some(
-                                                                                (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , bool),
+                                                                                (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
                                                                             ),
                                                                         },
                                                                     },
@@ -110,16 +100,13 @@ expression: built.ir()
                                                                             0,
                                                                         ),
                                                                         output_type: Some(
-                                                                            (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , ()),
+                                                                            (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , bool),
                                                                         ),
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_kind: Tick(
-                                                                        1,
-                                                                        Process(
-                                                                            0,
-                                                                        ),
+                                                                    location_kind: Process(
+                                                                        0,
                                                                     ),
                                                                     output_type: Some(
                                                                         (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , ()),
@@ -134,47 +121,47 @@ expression: built.ir()
                                                                     ),
                                                                 ),
                                                                 output_type: Some(
-                                                                    hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant >,
+                                                                    (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , ()),
                                                                 ),
                                                             },
                                                         },
-                                                        right: Batch {
-                                                            inner: Network {
-                                                                serialize_fn: Some(
-                                                                    :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , u32) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
+                                                        metadata: HydroIrMetadata {
+                                                            location_kind: Tick(
+                                                                1,
+                                                                Process(
+                                                                    0,
                                                                 ),
-                                                                instantiate_fn: <network instantiate>,
-                                                                deserialize_fn: Some(
-                                                                    | res | { let (id , b) = res . unwrap () ; (hydro_lang :: location :: MemberId :: < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > :: from_raw (id) , hydro_lang :: runtime_support :: bincode :: deserialize :: < (u32 , u32) > (& b) . unwrap ()) },
-                                                                ),
-                                                                input: CycleSource {
-                                                                    ident: Ident {
-                                                                        sym: cycle_0,
-                                                                    },
-                                                                    metadata: HydroIrMetadata {
-                                                                        location_kind: Cluster(
-                                                                            2,
-                                                                        ),
-                                                                        output_type: Some(
-                                                                            (u32 , u32),
-                                                                        ),
-                                                                    },
+                                                            ),
+                                                            output_type: Some(
+                                                                hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant >,
+                                                            ),
+                                                        },
+                                                    },
+                                                    right: Batch {
+                                                        inner: Network {
+                                                            serialize_fn: Some(
+                                                                :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , u32) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
+                                                            ),
+                                                            instantiate_fn: <network instantiate>,
+                                                            deserialize_fn: Some(
+                                                                | res | { let (id , b) = res . unwrap () ; (hydro_lang :: location :: MemberId :: < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > :: from_raw (id) , hydro_lang :: runtime_support :: bincode :: deserialize :: < (u32 , u32) > (& b) . unwrap ()) },
+                                                            ),
+                                                            input: CycleSource {
+                                                                ident: Ident {
+                                                                    sym: cycle_0,
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_kind: Process(
-                                                                        0,
+                                                                    location_kind: Cluster(
+                                                                        2,
                                                                     ),
                                                                     output_type: Some(
-                                                                        (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)),
+                                                                        (u32 , u32),
                                                                     ),
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_kind: Tick(
-                                                                    1,
-                                                                    Process(
-                                                                        0,
-                                                                    ),
+                                                                location_kind: Process(
+                                                                    0,
                                                                 ),
                                                                 output_type: Some(
                                                                     (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)),
@@ -189,13 +176,16 @@ expression: built.ir()
                                                                 ),
                                                             ),
                                                             output_type: Some(
-                                                                (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))),
+                                                                (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)),
                                                             ),
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_kind: Process(
-                                                            0,
+                                                        location_kind: Tick(
+                                                            1,
+                                                            Process(
+                                                                0,
+                                                            ),
                                                         ),
                                                         output_type: Some(
                                                             (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))),
@@ -203,20 +193,20 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_kind: Cluster(
-                                                        1,
+                                                    location_kind: Process(
+                                                        0,
                                                     ),
                                                     output_type: Some(
-                                                        (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)),
+                                                        (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))),
                                                     ),
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_kind: Process(
-                                                    0,
+                                                location_kind: Cluster(
+                                                    1,
                                                 ),
                                                 output_type: Some(
-                                                    (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))),
+                                                    (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)),
                                                 ),
                                             },
                                         },
@@ -225,7 +215,7 @@ expression: built.ir()
                                                 0,
                                             ),
                                             output_type: Some(
-                                                (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)),
+                                                (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))),
                                             ),
                                         },
                                     },
@@ -234,18 +224,13 @@ expression: built.ir()
                                             0,
                                         ),
                                         output_type: Some(
-                                            ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , core :: result :: Result < () , () >),
+                                            (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)),
                                         ),
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_kind: Atomic(
-                                        Tick(
-                                            2,
-                                            Process(
-                                                0,
-                                            ),
-                                        ),
+                                    location_kind: Process(
+                                        0,
                                     ),
                                     output_type: Some(
                                         ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , core :: result :: Result < () , () >),
@@ -253,13 +238,8 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_kind: Atomic(
-                                    Tick(
-                                        2,
-                                        Process(
-                                            0,
-                                        ),
-                                    ),
+                                location_kind: Process(
+                                    0,
                                 ),
                                 output_type: Some(
                                     ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , core :: result :: Result < () , () >),
@@ -405,7 +385,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    2,
+                                    4,
                                     Process(
                                         0,
                                     ),
@@ -417,7 +397,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                2,
+                                4,
                                 Process(
                                     0,
                                 ),
@@ -429,58 +409,48 @@ expression: built.ir()
                     },
                     second: Batch {
                         inner: Tee {
-                            inner: <tee 5>: BeginAtomic {
-                                inner: Map {
-                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , core :: result :: Result < () , () >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: two_pc :: * ; | kv | (kv , Ok :: < () , () > (())) }),
-                                    input: Map {
-                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
+                            inner: <tee 5>: Map {
+                                f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , core :: result :: Result < () , () >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: two_pc :: * ; | kv | (kv , Ok :: < () , () > (())) }),
+                                input: Map {
+                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
+                                    input: Network {
+                                        serialize_fn: Some(
+                                            :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
+                                        ),
+                                        instantiate_fn: <network instantiate>,
+                                        deserialize_fn: Some(
+                                            | res | { let (id , b) = res . unwrap () ; (hydro_lang :: location :: MemberId :: < hydro_test :: __staged :: cluster :: two_pc :: Participant > :: from_raw (id) , hydro_lang :: runtime_support :: bincode :: deserialize :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) > (& b) . unwrap ()) },
+                                        ),
                                         input: Network {
                                             serialize_fn: Some(
-                                                :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
+                                                :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: location :: MemberId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                             ),
                                             instantiate_fn: <network instantiate>,
                                             deserialize_fn: Some(
-                                                | res | { let (id , b) = res . unwrap () ; (hydro_lang :: location :: MemberId :: < hydro_test :: __staged :: cluster :: two_pc :: Participant > :: from_raw (id) , hydro_lang :: runtime_support :: bincode :: deserialize :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) > (& b) . unwrap ()) },
+                                                | res | { hydro_lang :: runtime_support :: bincode :: deserialize :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) > (& res . unwrap ()) . unwrap () },
                                             ),
-                                            input: Network {
-                                                serialize_fn: Some(
-                                                    :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: location :: MemberId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , _ > (| (id , data) | { (id . raw_id , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
-                                                ),
-                                                instantiate_fn: <network instantiate>,
-                                                deserialize_fn: Some(
-                                                    | res | { hydro_lang :: runtime_support :: bincode :: deserialize :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) > (& res . unwrap ()) . unwrap () },
-                                                ),
-                                                input: YieldConcat {
-                                                    inner: CrossProduct {
-                                                        left: Map {
-                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , ()) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                            input: Batch {
-                                                                inner: FilterMap {
-                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , bool) , core :: option :: Option < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , ()) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < bool , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | v | if v { Some (()) } else { None } }) ; { let orig = f__free ; move | (k , v) | orig (v) . map (| v | (k , v)) } }),
-                                                                    input: FoldKeyed {
-                                                                        init: stageleft :: runtime_support :: fn0_type_hint :: < bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | | false }),
-                                                                        acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < bool , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | present , event | { match event { MembershipEvent :: Joined => * present = true , MembershipEvent :: Left => * present = false , } } }),
-                                                                        input: Map {
-                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < & hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | id | (* id , MembershipEvent :: Joined) }),
-                                                                            input: Source {
-                                                                                source: Iter(
-                                                                                    { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let underlying_memberids__free = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: location :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant >] > (__hydro_lang_cluster_ids_1) } ; underlying_memberids__free },
-                                                                                ),
-                                                                                metadata: HydroIrMetadata {
-                                                                                    location_kind: Process(
-                                                                                        0,
-                                                                                    ),
-                                                                                    output_type: Some(
-                                                                                        & hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant >,
-                                                                                    ),
-                                                                                },
-                                                                            },
+                                            input: YieldConcat {
+                                                inner: CrossProduct {
+                                                    left: Map {
+                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , ()) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
+                                                        input: Batch {
+                                                            inner: FilterMap {
+                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , bool) , core :: option :: Option < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , ()) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < bool , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | v | if v { Some (()) } else { None } }) ; { let orig = f__free ; move | (k , v) | orig (v) . map (| v | (k , v)) } }),
+                                                                input: FoldKeyed {
+                                                                    init: stageleft :: runtime_support :: fn0_type_hint :: < bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | | false }),
+                                                                    acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < bool , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | present , event | { match event { MembershipEvent :: Joined => * present = true , MembershipEvent :: Left => * present = false , } } }),
+                                                                    input: Map {
+                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < & hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | id | (* id , MembershipEvent :: Joined) }),
+                                                                        input: Source {
+                                                                            source: Iter(
+                                                                                { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let underlying_memberids__free = unsafe { :: std :: mem :: transmute :: < _ , & [hydro_lang :: location :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant >] > (__hydro_lang_cluster_ids_1) } ; underlying_memberids__free },
+                                                                            ),
                                                                             metadata: HydroIrMetadata {
                                                                                 location_kind: Process(
                                                                                     0,
                                                                                 ),
                                                                                 output_type: Some(
-                                                                                    (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
+                                                                                    & hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant >,
                                                                                 ),
                                                                             },
                                                                         },
@@ -489,7 +459,7 @@ expression: built.ir()
                                                                                 0,
                                                                             ),
                                                                             output_type: Some(
-                                                                                (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , bool),
+                                                                                (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
                                                                             ),
                                                                         },
                                                                     },
@@ -498,16 +468,13 @@ expression: built.ir()
                                                                             0,
                                                                         ),
                                                                         output_type: Some(
-                                                                            (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , ()),
+                                                                            (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , bool),
                                                                         ),
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_kind: Tick(
-                                                                        3,
-                                                                        Process(
-                                                                            0,
-                                                                        ),
+                                                                    location_kind: Process(
+                                                                        0,
                                                                     ),
                                                                     output_type: Some(
                                                                         (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , ()),
@@ -522,44 +489,32 @@ expression: built.ir()
                                                                     ),
                                                                 ),
                                                                 output_type: Some(
-                                                                    hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant >,
+                                                                    (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , ()),
                                                                 ),
                                                             },
                                                         },
-                                                        right: Batch {
-                                                            inner: EndAtomic {
-                                                                inner: YieldConcat {
-                                                                    inner: Tee {
-                                                                        inner: <tee 2>,
-                                                                        metadata: HydroIrMetadata {
-                                                                            location_kind: Tick(
-                                                                                2,
-                                                                                Process(
-                                                                                    0,
-                                                                                ),
-                                                                            ),
-                                                                            output_type: Some(
-                                                                                (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)),
-                                                                            ),
-                                                                        },
-                                                                    },
-                                                                    metadata: HydroIrMetadata {
-                                                                        location_kind: Atomic(
-                                                                            Tick(
-                                                                                2,
-                                                                                Process(
-                                                                                    0,
-                                                                                ),
-                                                                            ),
-                                                                        ),
-                                                                        output_type: Some(
-                                                                            (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)),
-                                                                        ),
-                                                                    },
-                                                                },
+                                                        metadata: HydroIrMetadata {
+                                                            location_kind: Tick(
+                                                                3,
+                                                                Process(
+                                                                    0,
+                                                                ),
+                                                            ),
+                                                            output_type: Some(
+                                                                hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant >,
+                                                            ),
+                                                        },
+                                                    },
+                                                    right: Batch {
+                                                        inner: YieldConcat {
+                                                            inner: Tee {
+                                                                inner: <tee 2>,
                                                                 metadata: HydroIrMetadata {
-                                                                    location_kind: Process(
-                                                                        0,
+                                                                    location_kind: Tick(
+                                                                        2,
+                                                                        Process(
+                                                                            0,
+                                                                        ),
                                                                     ),
                                                                     output_type: Some(
                                                                         (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)),
@@ -567,11 +522,8 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_kind: Tick(
-                                                                    3,
-                                                                    Process(
-                                                                        0,
-                                                                    ),
+                                                                location_kind: Process(
+                                                                    0,
                                                                 ),
                                                                 output_type: Some(
                                                                     (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)),
@@ -586,13 +538,16 @@ expression: built.ir()
                                                                 ),
                                                             ),
                                                             output_type: Some(
-                                                                (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))),
+                                                                (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)),
                                                             ),
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_kind: Process(
-                                                            0,
+                                                        location_kind: Tick(
+                                                            3,
+                                                            Process(
+                                                                0,
+                                                            ),
                                                         ),
                                                         output_type: Some(
                                                             (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))),
@@ -600,20 +555,20 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_kind: Cluster(
-                                                        1,
+                                                    location_kind: Process(
+                                                        0,
                                                     ),
                                                     output_type: Some(
-                                                        (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)),
+                                                        (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))),
                                                     ),
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_kind: Process(
-                                                    0,
+                                                location_kind: Cluster(
+                                                    1,
                                                 ),
                                                 output_type: Some(
-                                                    (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))),
+                                                    (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)),
                                                 ),
                                             },
                                         },
@@ -622,7 +577,7 @@ expression: built.ir()
                                                 0,
                                             ),
                                             output_type: Some(
-                                                (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)),
+                                                (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))),
                                             ),
                                         },
                                     },
@@ -631,18 +586,13 @@ expression: built.ir()
                                             0,
                                         ),
                                         output_type: Some(
-                                            ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , core :: result :: Result < () , () >),
+                                            (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)),
                                         ),
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_kind: Atomic(
-                                        Tick(
-                                            2,
-                                            Process(
-                                                0,
-                                            ),
-                                        ),
+                                    location_kind: Process(
+                                        0,
                                     ),
                                     output_type: Some(
                                         ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , core :: result :: Result < () , () >),
@@ -650,13 +600,8 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_kind: Atomic(
-                                    Tick(
-                                        2,
-                                        Process(
-                                            0,
-                                        ),
-                                    ),
+                                location_kind: Process(
+                                    0,
                                 ),
                                 output_type: Some(
                                     ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , core :: result :: Result < () , () >),
@@ -665,7 +610,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                2,
+                                4,
                                 Process(
                                     0,
                                 ),
@@ -677,7 +622,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            2,
+                            4,
                             Process(
                                 0,
                             ),
@@ -689,7 +634,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        2,
+                        4,
                         Process(
                             0,
                         ),
@@ -710,7 +655,7 @@ expression: built.ir()
                                 inner: <tee 4>,
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        2,
+                                        4,
                                         Process(
                                             0,
                                         ),
@@ -722,7 +667,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    2,
+                                    4,
                                     Process(
                                         0,
                                     ),
@@ -734,7 +679,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                2,
+                                4,
                                 Process(
                                     0,
                                 ),
@@ -746,7 +691,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            2,
+                            4,
                             Process(
                                 0,
                             ),
@@ -758,7 +703,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        2,
+                        4,
                         Process(
                             0,
                         ),
@@ -770,7 +715,7 @@ expression: built.ir()
             },
             metadata: HydroIrMetadata {
                 location_kind: Tick(
-                    2,
+                    4,
                     Process(
                         0,
                     ),
@@ -781,7 +726,7 @@ expression: built.ir()
             },
         },
         out_location: Tick(
-            2,
+            4,
             Process(
                 0,
             ),
@@ -861,29 +806,14 @@ expression: built.ir()
                                     deserialize_fn: Some(
                                         | res | { hydro_lang :: runtime_support :: bincode :: deserialize :: < (u32 , u32) > (& res . unwrap ()) . unwrap () },
                                     ),
-                                    input: EndAtomic {
-                                        inner: YieldConcat {
-                                            inner: Tee {
-                                                inner: <tee 6>,
-                                                metadata: HydroIrMetadata {
-                                                    location_kind: Tick(
-                                                        2,
-                                                        Process(
-                                                            0,
-                                                        ),
-                                                    ),
-                                                    output_type: Some(
-                                                        (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)),
-                                                    ),
-                                                },
-                                            },
+                                    input: YieldConcat {
+                                        inner: Tee {
+                                            inner: <tee 6>,
                                             metadata: HydroIrMetadata {
-                                                location_kind: Atomic(
-                                                    Tick(
-                                                        2,
-                                                        Process(
-                                                            0,
-                                                        ),
+                                                location_kind: Tick(
+                                                    4,
+                                                    Process(
+                                                        0,
                                                     ),
                                                 ),
                                                 output_type: Some(
@@ -1225,7 +1155,7 @@ expression: built.ir()
                                                             },
                                                             metadata: HydroIrMetadata {
                                                                 location_kind: Tick(
-                                                                    5,
+                                                                    6,
                                                                     Process(
                                                                         3,
                                                                     ),
@@ -1237,7 +1167,7 @@ expression: built.ir()
                                                         },
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Tick(
-                                                                5,
+                                                                6,
                                                                 Process(
                                                                     3,
                                                                 ),
@@ -1258,7 +1188,7 @@ expression: built.ir()
                                                 },
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
-                                                        4,
+                                                        5,
                                                         Process(
                                                             3,
                                                         ),
@@ -1270,7 +1200,7 @@ expression: built.ir()
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    4,
+                                                    5,
                                                     Process(
                                                         3,
                                                     ),
@@ -1601,7 +1531,7 @@ expression: built.ir()
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
                                                                                             location_kind: Tick(
-                                                                                                6,
+                                                                                                7,
                                                                                                 Cluster(
                                                                                                     2,
                                                                                                 ),
@@ -1631,7 +1561,7 @@ expression: built.ir()
                                                                                                 },
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_kind: Tick(
-                                                                                                        6,
+                                                                                                        7,
                                                                                                         Cluster(
                                                                                                             2,
                                                                                                         ),
@@ -1643,7 +1573,7 @@ expression: built.ir()
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_kind: Tick(
-                                                                                                    6,
+                                                                                                    7,
                                                                                                     Cluster(
                                                                                                         2,
                                                                                                     ),
@@ -1655,7 +1585,7 @@ expression: built.ir()
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
                                                                                             location_kind: Tick(
-                                                                                                6,
+                                                                                                7,
                                                                                                 Cluster(
                                                                                                     2,
                                                                                                 ),
@@ -1667,7 +1597,7 @@ expression: built.ir()
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_kind: Tick(
-                                                                                            6,
+                                                                                            7,
                                                                                             Cluster(
                                                                                                 2,
                                                                                             ),
@@ -1679,7 +1609,7 @@ expression: built.ir()
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_kind: Tick(
-                                                                                        6,
+                                                                                        7,
                                                                                         Cluster(
                                                                                             2,
                                                                                         ),
@@ -1736,7 +1666,7 @@ expression: built.ir()
                                                         },
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Tick(
-                                                                7,
+                                                                8,
                                                                 Process(
                                                                     3,
                                                                 ),
@@ -1748,7 +1678,7 @@ expression: built.ir()
                                                     },
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Tick(
-                                                            7,
+                                                            8,
                                                             Process(
                                                                 3,
                                                             ),
@@ -1769,7 +1699,7 @@ expression: built.ir()
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    4,
+                                                    5,
                                                     Process(
                                                         3,
                                                     ),
@@ -1781,7 +1711,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                4,
+                                                5,
                                                 Process(
                                                     3,
                                                 ),
@@ -1793,7 +1723,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            4,
+                                            5,
                                             Process(
                                                 3,
                                             ),
@@ -1805,7 +1735,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        4,
+                                        5,
                                         Process(
                                             3,
                                         ),
@@ -1826,7 +1756,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                8,
+                                9,
                                 Process(
                                     3,
                                 ),
@@ -1856,7 +1786,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        8,
+                                        9,
                                         Process(
                                             3,
                                         ),
@@ -1868,7 +1798,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    8,
+                                    9,
                                     Process(
                                         3,
                                     ),
@@ -1880,7 +1810,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                8,
+                                9,
                                 Process(
                                     3,
                                 ),
@@ -1892,7 +1822,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            8,
+                            9,
                             Process(
                                 3,
                             ),
@@ -1904,7 +1834,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        8,
+                        9,
                         Process(
                             3,
                         ),
@@ -1957,7 +1887,7 @@ expression: built.ir()
                                                             },
                                                             metadata: HydroIrMetadata {
                                                                 location_kind: Tick(
-                                                                    9,
+                                                                    10,
                                                                     Process(
                                                                         3,
                                                                     ),
@@ -1969,7 +1899,7 @@ expression: built.ir()
                                                         },
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Tick(
-                                                                9,
+                                                                10,
                                                                 Process(
                                                                     3,
                                                                 ),
@@ -1981,7 +1911,7 @@ expression: built.ir()
                                                     },
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Tick(
-                                                            9,
+                                                            10,
                                                             Process(
                                                                 3,
                                                             ),
@@ -2002,7 +1932,7 @@ expression: built.ir()
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    10,
+                                                    11,
                                                     Process(
                                                         3,
                                                     ),
@@ -2032,7 +1962,7 @@ expression: built.ir()
                                                     },
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Tick(
-                                                            10,
+                                                            11,
                                                             Process(
                                                                 3,
                                                             ),
@@ -2044,7 +1974,7 @@ expression: built.ir()
                                                 },
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
-                                                        10,
+                                                        11,
                                                         Process(
                                                             3,
                                                         ),
@@ -2056,7 +1986,7 @@ expression: built.ir()
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    10,
+                                                    11,
                                                     Process(
                                                         3,
                                                     ),
@@ -2068,7 +1998,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                10,
+                                                11,
                                                 Process(
                                                     3,
                                                 ),
@@ -2080,7 +2010,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            10,
+                                            11,
                                             Process(
                                                 3,
                                             ),
@@ -2101,7 +2031,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    4,
+                                    5,
                                     Process(
                                         3,
                                     ),
@@ -2115,7 +2045,7 @@ expression: built.ir()
                             inner: <tee 13>,
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    4,
+                                    5,
                                     Process(
                                         3,
                                     ),
@@ -2127,7 +2057,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                4,
+                                5,
                                 Process(
                                     3,
                                 ),
@@ -2150,7 +2080,7 @@ expression: built.ir()
                                             inner: <tee 12>,
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    4,
+                                                    5,
                                                     Process(
                                                         3,
                                                     ),
@@ -2162,7 +2092,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                4,
+                                                5,
                                                 Process(
                                                     3,
                                                 ),
@@ -2174,7 +2104,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            4,
+                                            5,
                                             Process(
                                                 3,
                                             ),
@@ -2190,7 +2120,7 @@ expression: built.ir()
                                     ),
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            4,
+                                            5,
                                             Process(
                                                 3,
                                             ),
@@ -2202,7 +2132,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        4,
+                                        5,
                                         Process(
                                             3,
                                         ),
@@ -2214,7 +2144,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    4,
+                                    5,
                                     Process(
                                         3,
                                     ),
@@ -2226,7 +2156,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                4,
+                                5,
                                 Process(
                                     3,
                                 ),
@@ -2238,7 +2168,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            4,
+                            5,
                             Process(
                                 3,
                             ),
@@ -2250,7 +2180,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        4,
+                        5,
                         Process(
                             3,
                         ),
@@ -2387,7 +2317,7 @@ expression: built.ir()
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
                                                                                             location_kind: Tick(
-                                                                                                11,
+                                                                                                12,
                                                                                                 Cluster(
                                                                                                     2,
                                                                                                 ),
@@ -2417,7 +2347,7 @@ expression: built.ir()
                                                                                                 },
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_kind: Tick(
-                                                                                                        11,
+                                                                                                        12,
                                                                                                         Cluster(
                                                                                                             2,
                                                                                                         ),
@@ -2429,7 +2359,7 @@ expression: built.ir()
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_kind: Tick(
-                                                                                                    11,
+                                                                                                    12,
                                                                                                     Cluster(
                                                                                                         2,
                                                                                                     ),
@@ -2441,7 +2371,7 @@ expression: built.ir()
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
                                                                                             location_kind: Tick(
-                                                                                                11,
+                                                                                                12,
                                                                                                 Cluster(
                                                                                                     2,
                                                                                                 ),
@@ -2453,7 +2383,7 @@ expression: built.ir()
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_kind: Tick(
-                                                                                            11,
+                                                                                            12,
                                                                                             Cluster(
                                                                                                 2,
                                                                                             ),
@@ -2465,7 +2395,7 @@ expression: built.ir()
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_kind: Tick(
-                                                                                        11,
+                                                                                        12,
                                                                                         Cluster(
                                                                                             2,
                                                                                         ),
@@ -2522,7 +2452,7 @@ expression: built.ir()
                                                         },
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Tick(
-                                                                12,
+                                                                13,
                                                                 Process(
                                                                     3,
                                                                 ),
@@ -2534,7 +2464,7 @@ expression: built.ir()
                                                     },
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Tick(
-                                                            12,
+                                                            13,
                                                             Process(
                                                                 3,
                                                             ),
@@ -2546,7 +2476,7 @@ expression: built.ir()
                                                 },
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
-                                                        12,
+                                                        13,
                                                         Process(
                                                             3,
                                                         ),
@@ -2567,7 +2497,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                13,
+                                                14,
                                                 Process(
                                                     3,
                                                 ),
@@ -2597,7 +2527,7 @@ expression: built.ir()
                                                 },
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
-                                                        13,
+                                                        14,
                                                         Process(
                                                             3,
                                                         ),
@@ -2609,7 +2539,7 @@ expression: built.ir()
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    13,
+                                                    14,
                                                     Process(
                                                         3,
                                                     ),
@@ -2621,7 +2551,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                13,
+                                                14,
                                                 Process(
                                                     3,
                                                 ),
@@ -2633,7 +2563,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            13,
+                                            14,
                                             Process(
                                                 3,
                                             ),
@@ -2645,7 +2575,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        13,
+                                        14,
                                         Process(
                                             3,
                                         ),
@@ -2666,7 +2596,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                4,
+                                5,
                                 Process(
                                     3,
                                 ),
@@ -2689,7 +2619,7 @@ expression: built.ir()
                                             inner: <tee 12>,
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    4,
+                                                    5,
                                                     Process(
                                                         3,
                                                     ),
@@ -2701,7 +2631,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                4,
+                                                5,
                                                 Process(
                                                     3,
                                                 ),
@@ -2713,7 +2643,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            4,
+                                            5,
                                             Process(
                                                 3,
                                             ),
@@ -2729,7 +2659,7 @@ expression: built.ir()
                                     ),
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            4,
+                                            5,
                                             Process(
                                                 3,
                                             ),
@@ -2741,7 +2671,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        4,
+                                        5,
                                         Process(
                                             3,
                                         ),
@@ -2753,7 +2683,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    4,
+                                    5,
                                     Process(
                                         3,
                                     ),
@@ -2765,7 +2695,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                4,
+                                5,
                                 Process(
                                     3,
                                 ),
@@ -2777,7 +2707,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            4,
+                            5,
                             Process(
                                 3,
                             ),
@@ -2789,7 +2719,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        4,
+                        5,
                         Process(
                             3,
                         ),

--- a/hydro_test/src/cluster/two_pc.rs
+++ b/hydro_test/src/cluster/two_pc.rs
@@ -35,11 +35,8 @@ where
         .values();
 
     // collect votes from participant.
-    let coordinator_tick = coordinator.tick();
     let (c_all_vote_yes, _) = collect_quorum(
-        c_votes
-            .map(q!(|kv| (kv, Ok::<(), ()>(()))))
-            .atomic(&coordinator_tick),
+        c_votes.map(q!(|kv| (kv, Ok::<(), ()>(())))),
         num_participants,
         num_participants,
     );
@@ -47,9 +44,7 @@ where
     // TODO: Coordinator log
 
     // broadcast commit transactions to participants.
-    let p_commit = c_all_vote_yes
-        .end_atomic()
-        .broadcast_bincode(participants, nondet!(/** TODO */));
+    let p_commit = c_all_vote_yes.broadcast_bincode(participants, nondet!(/** TODO */));
     // TODO: Participants log
 
     let c_commits = p_commit
@@ -58,13 +53,11 @@ where
         .ir_node_named("c_commits")
         .values();
     let (c_all_commit, _) = collect_quorum(
-        c_commits
-            .map(q!(|kv| (kv, Ok::<(), ()>(()))))
-            .atomic(&coordinator_tick),
+        c_commits.map(q!(|kv| (kv, Ok::<(), ()>(())))),
         num_participants,
         num_participants,
     );
     // TODO: Coordinator log
 
-    c_all_commit.end_atomic()
+    c_all_commit
 }


### PR DESCRIPTION

Also fixes a sync bug in Compartmentalized Paxos. Due to batching semantics, we could end up in a situation where responses have missing metadata (for example if the batch refuses to release any elements).

The simulator would hopefully have caught this, we can use this as an example.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydro-project/hydro/pull/2140).
* #2147
* __->__ #2140