### PR TITLE
refactor(hydro_lang): don't pass around locations when emitting DFIR

### DIFF
--- a/hydro_lang/src/live_collections/keyed_singleton.rs
+++ b/hydro_lang/src/live_collections/keyed_singleton.rs
@@ -189,7 +189,6 @@ where
             .push_root(HydroRoot::CycleSink {
                 ident,
                 input: Box::new(self.ir_node.into_inner()),
-                out_location: Location::id(&self.location),
                 op_metadata: HydroIrOpMetadata::new(),
             });
     }

--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -123,7 +123,6 @@ where
             .push_root(HydroRoot::CycleSink {
                 ident,
                 input: Box::new(self.ir_node.into_inner()),
-                out_location: Location::id(&self.location),
                 op_metadata: HydroIrOpMetadata::new(),
             });
     }
@@ -166,7 +165,6 @@ where
             .push_root(HydroRoot::CycleSink {
                 ident,
                 input: Box::new(self.ir_node.into_inner()),
-                out_location: Location::id(&self.location),
                 op_metadata: HydroIrOpMetadata::new(),
             });
     }

--- a/hydro_lang/src/live_collections/optional.rs
+++ b/hydro_lang/src/live_collections/optional.rs
@@ -85,7 +85,6 @@ where
             .push_root(HydroRoot::CycleSink {
                 ident,
                 input: Box::new(self.ir_node.into_inner()),
-                out_location: Location::id(&self.location),
                 op_metadata: HydroIrOpMetadata::new(),
             });
     }
@@ -124,7 +123,6 @@ where
             .push_root(HydroRoot::CycleSink {
                 ident,
                 input: Box::new(self.ir_node.into_inner()),
-                out_location: Location::id(&self.location),
                 op_metadata: HydroIrOpMetadata::new(),
             });
     }
@@ -163,7 +161,6 @@ where
             .push_root(HydroRoot::CycleSink {
                 ident,
                 input: Box::new(self.ir_node.into_inner()),
-                out_location: Location::id(&self.location),
                 op_metadata: HydroIrOpMetadata::new(),
             });
     }

--- a/hydro_lang/src/live_collections/singleton.rs
+++ b/hydro_lang/src/live_collections/singleton.rs
@@ -89,7 +89,6 @@ where
             .push_root(HydroRoot::CycleSink {
                 ident,
                 input: Box::new(self.ir_node.into_inner()),
-                out_location: Location::id(&self.location),
                 op_metadata: HydroIrOpMetadata::new(),
             });
     }
@@ -128,7 +127,6 @@ where
             .push_root(HydroRoot::CycleSink {
                 ident,
                 input: Box::new(self.ir_node.into_inner()),
-                out_location: Location::id(&self.location),
                 op_metadata: HydroIrOpMetadata::new(),
             });
     }
@@ -167,7 +165,6 @@ where
             .push_root(HydroRoot::CycleSink {
                 ident,
                 input: Box::new(self.ir_node.into_inner()),
-                out_location: Location::id(&self.location),
                 op_metadata: HydroIrOpMetadata::new(),
             });
     }

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir.snap
@@ -556,12 +556,6 @@ expression: built.ir()
                 },
             },
         },
-        out_location: Tick(
-            1,
-            Cluster(
-                0,
-            ),
-        ),
         op_metadata: HydroIrOpMetadata,
     },
     CycleSink {
@@ -1150,9 +1144,6 @@ expression: built.ir()
                 },
             },
         },
-        out_location: Cluster(
-            0,
-        ),
         op_metadata: HydroIrOpMetadata,
     },
     CycleSink {
@@ -2646,12 +2637,6 @@ expression: built.ir()
                 },
             },
         },
-        out_location: Tick(
-            10,
-            Cluster(
-                0,
-            ),
-        ),
         op_metadata: HydroIrOpMetadata,
     },
     CycleSink {
@@ -2708,12 +2693,6 @@ expression: built.ir()
                 },
             },
         },
-        out_location: Tick(
-            10,
-            Cluster(
-                0,
-            ),
-        ),
         op_metadata: HydroIrOpMetadata,
     },
     CycleSink {
@@ -3299,12 +3278,6 @@ expression: built.ir()
                 },
             },
         },
-        out_location: Tick(
-            1,
-            Cluster(
-                0,
-            ),
-        ),
         op_metadata: HydroIrOpMetadata,
     },
     CycleSink {
@@ -3353,9 +3326,6 @@ expression: built.ir()
                 },
             },
         },
-        out_location: Cluster(
-            0,
-        ),
         op_metadata: HydroIrOpMetadata,
     },
     CycleSink {
@@ -4276,12 +4246,6 @@ expression: built.ir()
                 },
             },
         },
-        out_location: Tick(
-            12,
-            Cluster(
-                2,
-            ),
-        ),
         op_metadata: HydroIrOpMetadata,
     },
     CycleSink {
@@ -5141,12 +5105,6 @@ expression: built.ir()
                 },
             },
         },
-        out_location: Tick(
-            1,
-            Cluster(
-                0,
-            ),
-        ),
         op_metadata: HydroIrOpMetadata,
     },
     CycleSink {
@@ -6703,12 +6661,6 @@ expression: built.ir()
                 },
             },
         },
-        out_location: Tick(
-            14,
-            Cluster(
-                0,
-            ),
-        ),
         op_metadata: HydroIrOpMetadata,
     },
     CycleSink {
@@ -6765,12 +6717,6 @@ expression: built.ir()
                 },
             },
         },
-        out_location: Tick(
-            14,
-            Cluster(
-                0,
-            ),
-        ),
         op_metadata: HydroIrOpMetadata,
     },
     CycleSink {
@@ -7039,12 +6985,6 @@ expression: built.ir()
                 },
             },
         },
-        out_location: Tick(
-            1,
-            Cluster(
-                0,
-            ),
-        ),
         op_metadata: HydroIrOpMetadata,
     },
     CycleSink {
@@ -7473,12 +7413,6 @@ expression: built.ir()
                 },
             },
         },
-        out_location: Tick(
-            2,
-            Cluster(
-                1,
-            ),
-        ),
         op_metadata: HydroIrOpMetadata,
     },
     CycleSink {
@@ -7527,9 +7461,6 @@ expression: built.ir()
                 },
             },
         },
-        out_location: Cluster(
-            0,
-        ),
         op_metadata: HydroIrOpMetadata,
     },
     CycleSink {
@@ -8288,12 +8219,6 @@ expression: built.ir()
                 },
             },
         },
-        out_location: Tick(
-            16,
-            Cluster(
-                4,
-            ),
-        ),
         op_metadata: HydroIrOpMetadata,
     },
     CycleSink {
@@ -8459,12 +8384,6 @@ expression: built.ir()
                 },
             },
         },
-        out_location: Tick(
-            16,
-            Cluster(
-                4,
-            ),
-        ),
         op_metadata: HydroIrOpMetadata,
     },
     CycleSink {
@@ -8695,12 +8614,6 @@ expression: built.ir()
                 },
             },
         },
-        out_location: Tick(
-            16,
-            Cluster(
-                4,
-            ),
-        ),
         op_metadata: HydroIrOpMetadata,
     },
     CycleSink {
@@ -9279,9 +9192,6 @@ expression: built.ir()
                 },
             },
         },
-        out_location: Cluster(
-            1,
-        ),
         op_metadata: HydroIrOpMetadata,
     },
     CycleSink {
@@ -9685,12 +9595,6 @@ expression: built.ir()
                 },
             },
         },
-        out_location: Tick(
-            19,
-            Cluster(
-                2,
-            ),
-        ),
         op_metadata: HydroIrOpMetadata,
     },
     CycleSink {
@@ -9891,9 +9795,6 @@ expression: built.ir()
                 },
             },
         },
-        out_location: Cluster(
-            2,
-        ),
         op_metadata: HydroIrOpMetadata,
     },
     CycleSink {
@@ -10163,12 +10064,6 @@ expression: built.ir()
                 },
             },
         },
-        out_location: Tick(
-            0,
-            Cluster(
-                2,
-            ),
-        ),
         op_metadata: HydroIrOpMetadata,
     },
     ForEach {

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__two_pc_bench__tests__two_pc_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__two_pc_bench__tests__two_pc_ir.snap
@@ -641,12 +641,6 @@ expression: built.ir()
                 },
             },
         },
-        out_location: Tick(
-            2,
-            Process(
-                0,
-            ),
-        ),
         op_metadata: HydroIrOpMetadata,
     },
     CycleSink {
@@ -1254,12 +1248,6 @@ expression: built.ir()
                 },
             },
         },
-        out_location: Tick(
-            4,
-            Process(
-                0,
-            ),
-        ),
         op_metadata: HydroIrOpMetadata,
     },
     CycleSink {
@@ -1494,9 +1482,6 @@ expression: built.ir()
                 },
             },
         },
-        out_location: Cluster(
-            2,
-        ),
         op_metadata: HydroIrOpMetadata,
     },
     CycleSink {
@@ -1766,12 +1751,6 @@ expression: built.ir()
                 },
             },
         },
-        out_location: Tick(
-            0,
-            Cluster(
-                2,
-            ),
-        ),
         op_metadata: HydroIrOpMetadata,
     },
     ForEach {


### PR DESCRIPTION

Because the IR now includes the location of the output, we can just use that in the codegen process. This cleans up the code and also prepares us for simulator codegen, where the output DFIR will depend on the tick.

Also fixes a bug I found in top-level `unique` while refactoring, and adds a corresponding unit test.
