### PR TITLE
fix(lang): validate synchronous forward-ref cycles in FlowStateInner::push_root (fixes #2080)

### DIFF
--- a/hydro_lang/src/compile/builder.rs
+++ b/hydro_lang/src/compile/builder.rs
@@ -39,10 +39,96 @@ impl FlowStateInner {
     }
 
     pub fn push_root(&mut self, root: HydroRoot) {
-        self.roots
-            .as_mut()
-            .expect("Attempted to add a root to a flow that has already been finalized. No roots can be added after the flow has been compiled.")
-            .push(root);
+        if self.roots.is_none() {
+            panic!("Attempted to add a root to a flow that has already been finalized. No roots can be added after the flow has been compiled.");
+        }
+
+        // Validate candidate root for synchronous forward-ref cycles before appending.
+        self.validate_candidate_root(&root);
+
+        let roots_vec = self.roots.as_mut().unwrap();
+        roots_vec.push(root);
+    }
+
+    fn validate_candidate_root(&self, root: &HydroRoot) {
+        use crate::compile::ir::HydroNode;
+
+        if let HydroRoot::CycleSink { ident: sink_ident, input, .. } = root {
+            use std::collections::HashSet;
+            let target = sink_ident.clone();
+            let mut seen: HashSet<usize> = HashSet::new();
+            let mut stack: Vec<*const HydroNode> = vec![&**input as *const HydroNode];
+
+            while let Some(ptr) = stack.pop() {
+                if !seen.insert(ptr as usize) { continue; }
+                let node: &HydroNode = unsafe { &*ptr };
+
+                if matches!(node, HydroNode::DeferTick { .. }) { return; }
+                if let HydroNode::CycleSource { ident: src_ident, .. } = node {
+                    if src_ident == &target {
+                        panic!("Synchronous cycle detected for forward_ref '{}'. A forward_ref was completed with a collection that depends synchronously on the forward reference. This is not allowed.", target);
+                    }
+                    continue;
+                }
+                if let HydroNode::Tee { inner, .. } = node {
+                    stack.push(&*inner.0.borrow() as *const _);
+                    continue;
+                }
+
+                if matches!(node, HydroNode::Source { .. } | HydroNode::Placeholder | HydroNode::ExternalInput { .. }) { continue; }
+
+                match node {
+                    HydroNode::Chain { first, second, .. }
+                    | HydroNode::ChainFirst { first, second, .. } => {
+                        stack.push(&**first as *const _);
+                        stack.push(&**second as *const _);
+                    }
+
+                    HydroNode::CrossSingleton { left, right, .. }
+                    | HydroNode::CrossProduct { left, right, .. }
+                    | HydroNode::Join { left, right, .. }
+                    | HydroNode::Difference { pos: left, neg: right, .. }
+                    | HydroNode::AntiJoin { pos: left, neg: right, .. } => {
+                        stack.push(&**left as *const _);
+                        stack.push(&**right as *const _);
+                    }
+
+                    HydroNode::ReduceKeyedWatermark { input, watermark, .. } => {
+                        stack.push(&**input as *const _);
+                        stack.push(&**watermark as *const _);
+                    }
+
+                    HydroNode::Cast { inner, .. }
+                    | HydroNode::ObserveNonDet { inner, .. }
+                    | HydroNode::Persist { inner, .. }
+                    | HydroNode::BeginAtomic { inner, .. }
+                    | HydroNode::EndAtomic { inner, .. }
+                    | HydroNode::Batch { inner, .. }
+                    | HydroNode::YieldConcat { inner, .. }
+                    | HydroNode::ResolveFutures { input: inner, .. }
+                    | HydroNode::ResolveFuturesOrdered { input: inner, .. }
+                    | HydroNode::Map { input: inner, .. }
+                    | HydroNode::FlatMap { input: inner, .. }
+                    | HydroNode::Filter { input: inner, .. }
+                    | HydroNode::FilterMap { input: inner, .. }
+                    | HydroNode::Enumerate { input: inner, .. }
+                    | HydroNode::Inspect { input: inner, .. }
+                    | HydroNode::Unique { input: inner, .. }
+                    | HydroNode::Sort { input: inner, .. }
+                    | HydroNode::Fold { input: inner, .. }
+                    | HydroNode::FoldKeyed { input: inner, .. }
+                    | HydroNode::Scan { input: inner, .. }
+                    | HydroNode::Reduce { input: inner, .. }
+                    | HydroNode::ReduceKeyed { input: inner, .. }
+                    | HydroNode::Network { input: inner, .. }
+                    | HydroNode::Counter { input: inner, .. } => {
+                        stack.push(&**inner as *const _);
+                    }
+
+                    _ => {}
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Addressing https://github.com/hydro-project/hydro/issues/2080 
This PR introduces additional validation in FlowStateInner::push_root to ensure that candidate roots do not introduce illegal synchronous forward-ref cycles.
Added validate_candidate_root method, which performs a depth-first traversal of the HydroNode IR for a candidate root.
push_root now calls this validation before appending the root to FlowStateInner.

Steps 
1. Allows cycles only if they cross a HydroNode::DeferTick boundary (i.e., asynchronous cycles).

2. Detects when a CycleSink is completed with a collection that synchronously depends on its own CycleSource and rejects it with a panic.