### PR TITLE
refactor(hydro_lang): simplify decision logging code when replaying simulations #2167

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2214,6 +2214,7 @@ dependencies = [
  "cargo_metadata",
  "chrono",
  "clap",
+ "colored 3.0.0",
  "ctor 0.2.9",
  "data-encoding",
  "dfir_lang",
@@ -2222,6 +2223,7 @@ dependencies = [
  "hydro_build_utils",
  "hydro_deploy",
  "hydro_deploy_integration",
+ "indenter",
  "itertools 0.13.0",
  "libloading",
  "match_box",
@@ -2495,6 +2497,12 @@ dependencies = [
  "quote",
  "syn 2.0.106",
 ]
+
+[[package]]
+name = "indenter"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"

--- a/hydro_lang/Cargo.toml
+++ b/hydro_lang/Cargo.toml
@@ -37,11 +37,13 @@ sim = [
     "deploy",
     "dep:bolero",
     "dep:cargo_metadata",
-    "dep:tempfile",
-    "dep:libloading",
+    "dep:colored",
     "dep:dfir_rs",
-    "dfir_rs/meta", # affects layout of DFIR, thus the ABI
+    "dep:indenter",
+    "dep:libloading",
+    "dep:tempfile",
     "dep:serde_json",
+    "dfir_rs/meta", # affects layout of DFIR, thus the ABI
 ]
 deploy_integration = ["dep:hydro_deploy_integration"]
 build = ["dep:dfir_lang", "dep:backtrace", "dep:ctor"]
@@ -56,10 +58,7 @@ all-features = true
 backtrace = { version = "0.3", optional = true }
 bytes = { version = "1.1.0", features = ["serde"] }
 bincode = "1.3.1"
-bolero = { package = "bolero-hydro", version = "0.13.4", features = ["arbitrary"], optional = true }
 clap = { version = "4.0", features = ["derive"], optional = true }
-cargo_metadata = { version = "0.18.0", optional = true }
-libloading = { version = "0.8", optional = true }
 hydro_deploy = { path = "../hydro_deploy/core", version = "^0.14.0", optional = true }
 hydro_deploy_integration = { path = "../hydro_deploy/hydro_deploy_integration", version = "^0.14.0", optional = true }
 dfir_rs = { path = "../dfir_rs", version = "^0.14.0", default-features = false, optional = true }
@@ -82,7 +81,6 @@ syn = { version = "2.0.46", features = [
     "visit-mut",
     "visit",
 ] }
-tempfile = { version = "3", optional = true }
 tokio = "1.29.0"
 tokio-util = { version = "0.7.5", features = [ "codec" ] }
 tokio-stream = { version = "0.1.3", default-features = false, features = [
@@ -98,6 +96,14 @@ itertools = { version = "0.13.0", optional = true }
 webbrowser = { version = "1.0.2", optional = true }
 data-encoding = { version = "2.6.0", optional = true }
 serde_json = { version = "1.0.132", optional = true }
+
+# For the simulator
+bolero = { package = "bolero-hydro", version = "0.13.4", features = ["arbitrary"], optional = true }
+cargo_metadata = { version = "0.18.0", optional = true }
+colored = { version = "3", optional = true }
+indenter = { version = "0.3", optional = true }
+libloading = { version = "0.8", optional = true }
+tempfile = { version = "3", optional = true }
 
 # coax cargo-smart-release into publishing this crate.
 # https://github.com/hydro-project/hydro/blob/main/RELEASING.md#addendum-adding-new-crates

--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -323,6 +323,7 @@ pub trait DfirBuilder {
         _in_kind: &CollectionKind,
         out_ident: &syn::Ident,
         out_location: &LocationId,
+        op_meta: &HydroIrOpMetadata,
     );
     fn yield_from_tick(
         &mut self,
@@ -387,6 +388,7 @@ impl DfirBuilder for BTreeMap<usize, FlatGraphBuilder> {
         _in_kind: &CollectionKind,
         out_ident: &syn::Ident,
         _out_location: &LocationId,
+        _op_meta: &HydroIrOpMetadata,
     ) {
         let builder = self.get_dfir_mut(in_location.root());
         builder.add_dfir(
@@ -1993,7 +1995,9 @@ impl HydroNode {
                 persist_ident
             }
 
-            HydroNode::Batch { inner, .. } => {
+            HydroNode::Batch {
+                inner, metadata, ..
+            } => {
                 let inner_ident = inner.emit_core(builders_or_callback, built_tees, next_stmt_id);
 
                 let batch_ident =
@@ -2007,6 +2011,7 @@ impl HydroNode {
                             &inner.metadata().collection_kind,
                             &batch_ident,
                             &out_location,
+                            &metadata.op,
                         );
                     }
                     BuildersOrCallback::Callback(_, node_callback) => {

--- a/hydro_lang/src/lib.rs
+++ b/hydro_lang/src/lib.rs
@@ -18,6 +18,8 @@ stageleft::stageleft_no_entry_crate!();
 #[cfg_attr(docsrs, doc(cfg(feature = "runtime_support")))]
 #[doc(hidden)]
 pub mod runtime_support {
+    #[cfg(feature = "sim")]
+    pub use colored;
     pub use {bincode, dfir_rs, stageleft, tokio};
     pub mod resource_measurement;
 }

--- a/hydro_lang/src/sim/compiled.rs
+++ b/hydro_lang/src/sim/compiled.rs
@@ -5,6 +5,7 @@ use std::panic::RefUnwindSafe;
 use std::path::Path;
 
 use bytes::Bytes;
+use colored::Colorize;
 use dfir_rs::scheduled::graph::Dfir;
 use futures::{Stream, StreamExt};
 use libloading::Library;
@@ -35,6 +36,7 @@ impl<'a, T: RefUnwindSafe + Fn() -> CompiledSimInstance<'a>> Instantiator<'a> fo
 type SimLoaded<'a> = libloading::Symbol<
     'a,
     unsafe extern "Rust" fn(
+        bool,
         HashMap<usize, UnboundedSender<Bytes>>,
         HashMap<usize, UnboundedReceiverStream<Bytes>>,
     ) -> (
@@ -47,13 +49,15 @@ type SimLoaded<'a> = libloading::Symbol<
 impl CompiledSim {
     /// Executes the given closure with a single instance of the compiled simulation.
     pub fn with_instance<T>(&self, thunk: impl FnOnce(CompiledSimInstance) -> T) -> T {
-        self.with_instantiator(|instantiator| thunk(instantiator()))
+        self.with_instantiator(|instantiator| thunk(instantiator()), true)
     }
 
     /// Executes the given closure with an [`Instantiator`], which can be called to create
     /// independent instances of the simulation. This is useful for fuzzing, where we need to
     /// re-execute the simulation several times with different decisions.
-    pub fn with_instantiator<T>(&self, thunk: impl FnOnce(&dyn Instantiator) -> T) -> T {
+    ///
+    /// The `log` parameter controls whether to log tick executions and stream releases.
+    pub fn with_instantiator<T>(&self, thunk: impl FnOnce(&dyn Instantiator) -> T, log: bool) -> T {
         let func: SimLoaded = unsafe { self.lib.get(b"__hydro_runtime").unwrap() };
         thunk(
             &(|| CompiledSimInstance {
@@ -61,6 +65,7 @@ impl CompiledSim {
                 remaining_ports: self.external_ports.iter().cloned().collect(),
                 input_ports: HashMap::new(),
                 output_ports: HashMap::new(),
+                log,
             }),
         )
     }
@@ -114,37 +119,19 @@ impl CompiledSim {
                 std::env::set_var("BOLERO_LIBFUZZER_ARGS", libfuzzer_args);
             }
 
-            self.with_instantiator(|instantiator| {
-                bolero::test(bolero::TargetLocation {
-                    package_name: "",
-                    manifest_dir: "",
-                    module_path: "",
-                    file: "",
-                    line: 0,
-                    item_path: "<unknown>::__bolero_item_path__",
-                    test_name: None,
-                })
-                .run(move || {
-                    let instance = instantiator();
-                    tokio::runtime::Builder::new_current_thread()
-                        .build()
-                        .unwrap()
-                        .block_on(async {
-                            let local_set = tokio::task::LocalSet::new();
-                            local_set.run_until(thunk(instance)).await
-                        })
-                })
-            });
-        } else if let Ok(existing_bytes) = std::fs::read(&caller_fuzz_repro_path) {
-            self.with_instance(|instance| {
-                bolero::bolero_engine::any::scope::with(
-                    Box::new(bolero::bolero_engine::driver::object::Object(
-                        bolero::bolero_engine::driver::bytes::Driver::new(
-                            existing_bytes,
-                            &Default::default(),
-                        ),
-                    )),
-                    || {
+            self.with_instantiator(
+                |instantiator| {
+                    bolero::test(bolero::TargetLocation {
+                        package_name: "",
+                        manifest_dir: "",
+                        module_path: "",
+                        file: "",
+                        line: 0,
+                        item_path: "<unknown>::__bolero_item_path__",
+                        test_name: None,
+                    })
+                    .run(move || {
+                        let instance = instantiator();
                         tokio::runtime::Builder::new_current_thread()
                             .build()
                             .unwrap()
@@ -152,27 +139,59 @@ impl CompiledSim {
                                 let local_set = tokio::task::LocalSet::new();
                                 local_set.run_until(thunk(instance)).await
                             })
-                    },
-                )
-            });
+                    })
+                },
+                false,
+            );
+        } else if let Ok(existing_bytes) = std::fs::read(&caller_fuzz_repro_path) {
+            self.fuzz_repro(existing_bytes, thunk);
         } else {
             eprintln!(
                 "Running a fuzz test without `cargo sim` and no reproducer found at {}, defaulting to 8192 iterations with random inputs.",
                 caller_fuzz_repro_path.display()
             );
-            self.with_instantiator(|instantiator| {
-                bolero::test(bolero::TargetLocation {
-                    package_name: "",
-                    manifest_dir: "",
-                    module_path: "",
-                    file: ".",
-                    line: 0,
-                    item_path: "<unknown>::__bolero_item_path__",
-                    test_name: None,
-                })
-                .with_iterations(8192)
-                .run(move || {
-                    let instance = instantiator();
+            self.with_instantiator(
+                |instantiator| {
+                    bolero::test(bolero::TargetLocation {
+                        package_name: "",
+                        manifest_dir: "",
+                        module_path: "",
+                        file: ".",
+                        line: 0,
+                        item_path: "<unknown>::__bolero_item_path__",
+                        test_name: None,
+                    })
+                    .with_iterations(8192)
+                    .run(move || {
+                        let instance = instantiator();
+                        tokio::runtime::Builder::new_current_thread()
+                            .build()
+                            .unwrap()
+                            .block_on(async {
+                                let local_set = tokio::task::LocalSet::new();
+                                local_set.run_until(thunk(instance)).await
+                            })
+                    })
+                },
+                false,
+            );
+        }
+    }
+
+    /// Executes the given closure with a single instance of the compiled simulation, using the
+    /// provided bytes as the source of fuzzing decisions. This can be used to manually reproduce a
+    /// failure found during fuzzing.
+    pub fn fuzz_repro<'a>(
+        &'a self,
+        bytes: Vec<u8>,
+        thunk: impl AsyncFnOnce(CompiledSimInstance) + RefUnwindSafe,
+    ) {
+        self.with_instance(|instance| {
+            bolero::bolero_engine::any::scope::with(
+                Box::new(bolero::bolero_engine::driver::object::Object(
+                    bolero::bolero_engine::driver::bytes::Driver::new(bytes, &Default::default()),
+                )),
+                || {
                     tokio::runtime::Builder::new_current_thread()
                         .build()
                         .unwrap()
@@ -180,9 +199,9 @@ impl CompiledSim {
                             let local_set = tokio::task::LocalSet::new();
                             local_set.run_until(thunk(instance)).await
                         })
-                })
-            });
-        }
+                },
+            )
+        });
     }
 
     /// Exhaustively searches all possible executions of the simulation. The provided
@@ -201,28 +220,31 @@ impl CompiledSim {
             std::process::abort();
         }
 
-        self.with_instantiator(|instantiator| {
-            bolero::test(bolero::TargetLocation {
-                package_name: "",
-                manifest_dir: "",
-                module_path: "",
-                file: "",
-                line: 0,
-                item_path: "<unknown>::__bolero_item_path__",
-                test_name: None,
-            })
-            .exhaustive()
-            .run(move || {
-                let instance = instantiator();
-                tokio::runtime::Builder::new_current_thread()
-                    .build()
-                    .unwrap()
-                    .block_on(async {
-                        let local_set = tokio::task::LocalSet::new();
-                        local_set.run_until(thunk(instance)).await;
-                    })
-            })
-        });
+        self.with_instantiator(
+            |instantiator| {
+                bolero::test(bolero::TargetLocation {
+                    package_name: "",
+                    manifest_dir: "",
+                    module_path: "",
+                    file: "",
+                    line: 0,
+                    item_path: "<unknown>::__bolero_item_path__",
+                    test_name: None,
+                })
+                .exhaustive()
+                .run(move || {
+                    let instance = instantiator();
+                    tokio::runtime::Builder::new_current_thread()
+                        .build()
+                        .unwrap()
+                        .block_on(async {
+                            let local_set = tokio::task::LocalSet::new();
+                            local_set.run_until(thunk(instance)).await;
+                        })
+                })
+            },
+            false,
+        );
     }
 }
 
@@ -233,6 +255,7 @@ pub struct CompiledSimInstance<'a> {
     remaining_ports: HashSet<usize>,
     output_ports: HashMap<usize, UnboundedSender<Bytes>>,
     input_ports: HashMap<usize, UnboundedReceiverStream<Bytes>>,
+    log: bool,
 }
 
 impl<'a> CompiledSimInstance<'a> {
@@ -269,31 +292,90 @@ impl<'a> CompiledSimInstance<'a> {
             )
         }
 
-        let (async_dfir, ticks, hooks) =
-            unsafe { (self.func)(self.output_ports, self.input_ports) };
+        let (async_dfir, ticks, hooks) = unsafe {
+            (self.func)(
+                colored::control::SHOULD_COLORIZE.should_colorize(),
+                self.output_ports,
+                self.input_ports,
+            )
+        };
+
+        let mut logger = if self.log
+            || std::env::var("HYDRO_SIM_LOG")
+                .map(|v| v == "1")
+                .unwrap_or(false)
+        {
+            Some(std::io::stderr())
+        } else {
+            None
+        };
+
+        tokio::task::spawn_local(async move {
+            let mut launched = LaunchedSim {
+                async_dfir,
+                possibly_ready_ticks: vec![],
+                not_ready_ticks: ticks.into_iter().collect(),
+                hooks,
+                log_writer: logger.as_mut().map(|l| l as &mut dyn std::io::Write),
+            };
+
+            launched.scheduler().await;
+        });
+    }
+
+    /// Returns a future that schedules simulation with the given logger for reporting the
+    /// simulation trace.
+    ///
+    /// See [`Self::launch`] for more details.
+    pub async fn schedule_with_logger(self, logger: Option<&mut impl std::io::Write>) {
+        if !self.remaining_ports.is_empty() {
+            panic!(
+                "Cannot launch DFIR because some of the inputs / outputs have not been connected."
+            )
+        }
+
+        let (async_dfir, ticks, hooks) = unsafe {
+            (self.func)(
+                colored::control::SHOULD_COLORIZE.should_colorize(),
+                self.output_ports,
+                self.input_ports,
+            )
+        };
         let mut launched = LaunchedSim {
             async_dfir,
             possibly_ready_ticks: vec![],
             not_ready_ticks: ticks.into_iter().collect(),
             hooks,
+            log_writer: logger.map(|l| l as &mut dyn std::io::Write),
         };
 
-        tokio::task::spawn_local(async move {
-            launched.scheduler().await;
-        });
+        launched.scheduler().await;
+    }
+}
+
+// via https://www.reddit.com/r/rust/comments/t69sld/is_there_a_way_to_allow_either_stdfmtwrite_or/
+struct FmtWriter<W: std::io::Write>(W);
+impl<W: std::io::Write> std::fmt::Write for FmtWriter<W> {
+    fn write_str(&mut self, s: &str) -> Result<(), std::fmt::Error> {
+        self.0.write_all(s.as_bytes()).map_err(|_| std::fmt::Error)
+    }
+
+    fn write_fmt(&mut self, args: std::fmt::Arguments<'_>) -> Result<(), std::fmt::Error> {
+        self.0.write_fmt(args).map_err(|_| std::fmt::Error)
     }
 }
 
 /// A running simulation, which manages the async DFIR and tick DFIRs, and makes decisions
 /// about scheduling ticks and choices for non-deterministic operators like batch.
-struct LaunchedSim {
+struct LaunchedSim<'a> {
     async_dfir: Dfir<'static>,
     possibly_ready_ticks: Vec<(&'static str, Dfir<'static>)>,
     not_ready_ticks: Vec<(&'static str, Dfir<'static>)>,
     hooks: HashMap<&'static str, Vec<Box<dyn SimHook>>>,
+    log_writer: Option<&'a mut dyn std::io::Write>,
 }
 
-impl LaunchedSim {
+impl LaunchedSim<'_> {
     async fn scheduler(&mut self) {
         loop {
             tokio::task::yield_now().await;
@@ -321,6 +403,26 @@ impl LaunchedSim {
                     let mut removed: (&'static str, Dfir<'static>) =
                         self.possibly_ready_ticks.remove(next_tick);
 
+                    if let Some(log_writer) = self.log_writer.as_mut() {
+                        let _ = writeln!(
+                            log_writer,
+                            "\n{}",
+                            "Running Tick".color(colored::Color::Magenta).bold()
+                        );
+                    }
+
+                    let mut fmt_writer = self.log_writer.as_mut().map(FmtWriter);
+                    let mut asterisk_indenter = |_line_no, write: &mut dyn std::fmt::Write| {
+                        write.write_str(&"*".color(colored::Color::Magenta).bold())?;
+                        write.write_str(" ")
+                    };
+
+                    let mut tick_decision_writer = fmt_writer.as_mut().map(|w| {
+                        indenter::indented(w).with_format(indenter::Format::Custom {
+                            inserter: &mut asterisk_indenter,
+                        })
+                    });
+
                     let hooks = self.hooks.get_mut(removed.0).unwrap();
                     let mut remaining_decision_count = hooks.len();
                     let mut made_nontrivial_decision = false;
@@ -343,7 +445,11 @@ impl LaunchedSim {
                                 remaining_decision_count -= 1;
                             }
 
-                            hook.release_decision();
+                            if let Some(log_mut) = tick_decision_writer.as_mut() {
+                                hook.release_decision(Some(log_mut));
+                            } else {
+                                hook.release_decision(None);
+                            }
                         });
                     });
 

--- a/hydro_lang/src/sim/graph.rs
+++ b/hydro_lang/src/sim/graph.rs
@@ -564,6 +564,7 @@ fn compile_sim_graph_trybuild(
 
         #[unsafe(no_mangle)]
         unsafe extern "Rust" fn __hydro_runtime(
+            should_color: bool,
             __hydro_external_out: ::std::collections::HashMap<usize, __root_dfir_rs::tokio::sync::mpsc::UnboundedSender<__root_dfir_rs::bytes::Bytes>>,
             __hydro_external_in: ::std::collections::HashMap<usize, __root_dfir_rs::tokio_stream::wrappers::UnboundedReceiverStream<__root_dfir_rs::bytes::Bytes>>
         ) -> (
@@ -571,6 +572,7 @@ fn compile_sim_graph_trybuild(
             Vec<(&'static str, __root_dfir_rs::scheduled::graph::Dfir<'static>)>,
             ::std::collections::HashMap<&'static str, ::std::vec::Vec<Box<dyn hydro_lang::sim::runtime::SimHook>>>,
         ) {
+            hydro_lang::runtime_support::colored::control::set_override(should_color);
             __hydro_runtime_core(__hydro_external_out, __hydro_external_in)
         }
     };

--- a/hydro_lang/src/sim/runtime.rs
+++ b/hydro_lang/src/sim/runtime.rs
@@ -1,9 +1,11 @@
 use std::cell::RefCell;
 use std::collections::VecDeque;
+use std::fmt::Debug;
 use std::rc::Rc;
 
 use bolero::ValueGenerator;
 use bolero::generator::bolero_generator::driver::object::Borrowed;
+use colored::Colorize;
 use tokio::sync::mpsc::UnboundedSender;
 
 pub trait SimHook {
@@ -14,13 +16,40 @@ pub trait SimHook {
         driver: &mut Borrowed<'a>,
         force_nontrivial: bool,
     ) -> bool;
-    fn release_decision(&mut self);
+    fn release_decision(&mut self, log_writer: Option<&mut dyn std::fmt::Write>);
+}
+
+struct TruncatedVecDebug<'a, T>(&'a Vec<T>, usize, fn(&T) -> Option<String>);
+impl<'a, T> Debug for TruncatedVecDebug<'a, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self(vec, max, elem_debug) = self;
+        if vec.len() > *max {
+            f.debug_list()
+                .entries(
+                    vec[..*max]
+                        .iter()
+                        .map(|v| elem_debug(v).unwrap_or("?".to_string())),
+                )
+                .finish_non_exhaustive()?;
+            write!(f, " ({} total)", vec.len())
+        } else {
+            f.debug_list()
+                .entries(
+                    vec[..]
+                        .iter()
+                        .map(|v| elem_debug(v).unwrap_or("?".to_string())),
+                )
+                .finish()
+        }
+    }
 }
 
 pub struct StreamHook<T> {
     pub input: Rc<RefCell<VecDeque<T>>>,
     pub to_release: Option<Vec<T>>,
     pub output: UnboundedSender<T>,
+    pub batch_location: (&'static str, &'static str, &'static str),
+    pub format_item_debug: fn(&T) -> Option<String>,
 }
 
 impl<T> SimHook for StreamHook<T> {
@@ -41,12 +70,42 @@ impl<T> SimHook for StreamHook<T> {
         let count = ((if force_nontrivial { 1 } else { 0 })..=current_input.len())
             .generate(driver)
             .unwrap();
+
         self.to_release = Some(current_input.drain(0..count).collect());
         count > 0
     }
 
-    fn release_decision(&mut self) {
+    fn release_decision(&mut self, log_writer: Option<&mut dyn std::fmt::Write>) {
         if let Some(to_release) = self.to_release.take() {
+            if let Some(log_writer) = log_writer {
+                let (batch_location, line, caret_indent) = self.batch_location;
+                let note_str = if to_release.is_empty() {
+                    "^ releasing no items".to_string()
+                } else {
+                    format!(
+                        "^ releasing items: {:?}",
+                        TruncatedVecDebug(&to_release, 8, self.format_item_debug)
+                    )
+                };
+
+                let _ = writeln!(
+                    log_writer,
+                    "{} {}",
+                    "-->".color(colored::Color::Blue),
+                    batch_location
+                );
+
+                let _ = writeln!(log_writer, " {}{}", "|".color(colored::Color::Blue), line);
+
+                let _ = writeln!(
+                    log_writer,
+                    " {}{}{}",
+                    "|".color(colored::Color::Blue),
+                    caret_indent,
+                    note_str.color(colored::Color::Green)
+                );
+            }
+
             for item in to_release {
                 self.output.send(item).unwrap();
             }

--- a/hydro_lang/src/sim/tests/mod.rs
+++ b/hydro_lang/src/sim/tests/mod.rs
@@ -225,7 +225,7 @@ fn trace_for_fuzzed_batching() {
             let in_send = compiled.connect_sink_bincode(&port);
             let mut out_recv = compiled.connect_source_bincode(&out_port);
 
-            let schedule = compiled.schedule_with_logger(Some(&mut log_out));
+            let schedule = compiled.schedule_with_logger(&mut log_out);
             let rest = async move {
                 for _ in 0..1000 {
                     in_send(456).unwrap(); // the fuzzer should put these some batches

--- a/hydro_lang/src/sim/tests/snapshots/hydro_lang__sim__tests__trace_for_fuzzed_batching.snap
+++ b/hydro_lang/src/sim/tests/snapshots/hydro_lang__sim__tests__trace_for_fuzzed_batching.snap
@@ -1,0 +1,13 @@
+---
+source: hydro_lang/src/sim/tests/mod.rs
+expression: log_str
+---
+Running Tick
+* --> src/sim/tests/mod.rs:164:10
+*  |        .batch(&tick, nondet!(/** test */))
+*  |         ^ releasing items: ["456", "456", "456", "456", "456", "456", "456", "456", ..] (1000 total)
+
+Running Tick
+* --> src/sim/tests/mod.rs:164:10
+*  |        .batch(&tick, nondet!(/** test */))
+*  |         ^ releasing items: ["100", "23"]


### PR DESCRIPTION
#2167 addendum

two separate atomic commits:
1. get rid of duplicated code via `use<W: std::io::Write>`
2. use `std::io::empty()` instead of `Option<W>`