### PR TITLE
feat(hydro_lang,hydro_std): add APIs for unordered stream assertions and tests for `collect_quorum`

### DIFF
--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -2064,6 +2064,7 @@ mod tests {
     use stageleft::q;
 
     use crate::compile::builder::FlowBuilder;
+    use crate::live_collections::stream::ExactlyOnce;
     use crate::location::Location;
     use crate::nondet::nondet;
 
@@ -2113,7 +2114,8 @@ mod tests {
         let flow = FlowBuilder::new();
         let node = flow.process::<()>();
         let external = flow.external::<()>();
-        let (tick_send, tick_trigger) = node.source_external_bincode(&external);
+        let (tick_send, tick_trigger) =
+            node.source_external_bincode::<_, _, _, ExactlyOnce>(&external);
 
         let node_tick = node.tick();
         let (watermark_complete_cycle, watermark) =

--- a/hydro_lang/src/live_collections/singleton.rs
+++ b/hydro_lang/src/live_collections/singleton.rs
@@ -1063,6 +1063,7 @@ mod tests {
     use stageleft::q;
 
     use crate::compile::builder::FlowBuilder;
+    use crate::live_collections::stream::ExactlyOnce;
     use crate::location::Location;
     use crate::nondet::nondet;
 
@@ -1074,7 +1075,7 @@ mod tests {
         let node = flow.process::<()>();
         let external = flow.external::<()>();
 
-        let (input_send, input) = node.source_external_bincode(&external);
+        let (input_send, input) = node.source_external_bincode::<_, _, _, ExactlyOnce>(&external);
 
         let node_tick = node.tick();
         let (complete_cycle, singleton) = node_tick.cycle_with_initial(node_tick.singleton(q!(0)));

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -2750,6 +2750,7 @@ mod tests {
     use stageleft::q;
 
     use crate::compile::builder::FlowBuilder;
+    use crate::live_collections::stream::{ExactlyOnce, TotalOrder};
     use crate::location::Location;
     use crate::nondet::nondet;
 
@@ -2869,7 +2870,8 @@ mod tests {
         let node = flow.process::<()>();
         let external = flow.external::<()>();
 
-        let (input_port, input) = node.source_external_bincode(&external);
+        let (input_port, input) =
+            node.source_external_bincode::<_, _, TotalOrder, ExactlyOnce>(&external);
         let tick = node.tick();
 
         let out = input
@@ -2978,7 +2980,8 @@ mod tests {
         let node = flow.process::<()>();
         let external = flow.external::<()>();
 
-        let (input_port, input) = node.source_external_bincode(&external);
+        let (input_port, input) =
+            node.source_external_bincode::<_, _, TotalOrder, ExactlyOnce>(&external);
         let out = input.unique().send_bincode_external(&external);
 
         let nodes = flow

--- a/hydro_lang/src/location/external_process.rs
+++ b/hydro_lang/src/location/external_process.rs
@@ -26,16 +26,20 @@ impl Clone for ExternalBytesPort<Many> {
     }
 }
 
-pub struct ExternalBincodeSink<Type, Many = NotMany>
-where
+pub struct ExternalBincodeSink<
+    Type,
+    Many = NotMany,
+    O: Ordering = TotalOrder,
+    R: Retries = ExactlyOnce,
+> where
     Type: Serialize,
 {
     pub(crate) process_id: usize,
     pub(crate) port_id: usize,
-    pub(crate) _phantom: PhantomData<(Type, Many)>,
+    pub(crate) _phantom: PhantomData<(Type, Many, O, R)>,
 }
 
-impl<T: Serialize> Clone for ExternalBincodeSink<T, Many> {
+impl<T: Serialize, O: Ordering, R: Retries> Clone for ExternalBincodeSink<T, Many, O, R> {
     fn clone(&self) -> Self {
         Self {
             process_id: self.process_id,

--- a/hydro_lang/src/sim/tests/mod.rs
+++ b/hydro_lang/src/sim/tests/mod.rs
@@ -1,6 +1,7 @@
 use bytes::Bytes;
 use stageleft::q;
 
+use crate::live_collections::stream::TotalOrder;
 use crate::location::external_process::{ExternalBincodeSink, ExternalBincodeStream};
 use crate::location::{External, Location, Process};
 use crate::nondet::nondet;
@@ -41,7 +42,7 @@ fn sim_crash_in_output_with_filter() {
     let external = flow.external::<()>();
     let node = flow.process::<()>();
 
-    let (port, input) = node.source_external_bincode::<_, Bytes>(&external);
+    let (port, input) = node.source_external_bincode::<_, Bytes, _, _>(&external);
 
     let out_port = input
         .filter(q!(|x| x.len() > 1 && x[0] == 42 && x[1] == 43))
@@ -70,7 +71,7 @@ fn sim_batch_nondet_size() {
     let external = flow.external::<()>();
     let node = flow.process::<()>();
 
-    let (port, input) = node.source_external_bincode(&external);
+    let (port, input) = node.source_external_bincode::<_, _, TotalOrder, _>(&external);
 
     let tick = node.tick();
     let out_port = input

--- a/hydro_lang/src/sim/tests/snapshots/hydro_lang__sim__tests__trace_for_fuzzed_batching.snap
+++ b/hydro_lang/src/sim/tests/snapshots/hydro_lang__sim__tests__trace_for_fuzzed_batching.snap
@@ -3,11 +3,11 @@ source: hydro_lang/src/sim/tests/mod.rs
 expression: log_str
 ---
 Running Tick
-* --> src/sim/tests/mod.rs:165:10
+* --> src/sim/tests/mod.rs:166:10
 *  |        .batch(&tick, nondet!(/** test */))
 *  |         ^ releasing items: [456, 456, 456, 456, 456, 456, 456, 456, ..] (1000 total)
 
 Running Tick
-* --> src/sim/tests/mod.rs:165:10
+* --> src/sim/tests/mod.rs:166:10
 *  |        .batch(&tick, nondet!(/** test */))
 *  |         ^ releasing items: [100, 23]

--- a/hydro_test/src/cluster/paxos.rs
+++ b/hydro_test/src/cluster/paxos.rs
@@ -911,8 +911,9 @@ mod tests {
             in_send.send(3).unwrap();
             in_send.send(4).unwrap();
 
-            let all_out = out_recv.collect::<Vec<_>>().await;
-            assert_eq!(all_out, vec![(0, 1), (1, 2), (2, 3), (3, 4),]);
+            out_recv
+                .assert_yields_only([(0, 1), (1, 2), (2, 3), (3, 4)])
+                .await;
         });
     }
 


### PR DESCRIPTION

AI Disclosure: all the tests were generated using Kiro (!)

Currently, the core functionality test has to be split up into several exhaustive units because otherwise the search space becomes too large for CI (~400s). Eventually, keyed streams may help but splitting up the test is a reasonable short-term fix.
