### PR TITLE
chore(hydro_deploy): only depend on `samply` on supported systems, remove leftover DTrace code

### DIFF
--- a/hydro_deploy/core/Cargo.toml
+++ b/hydro_deploy/core/Cargo.toml
@@ -40,4 +40,6 @@ tempfile = "3.0.0"
 tokio = { version = "1.29.0", features = ["full"] }
 tokio-stream = { version = "0.1.3", default-features = false, features = ["io-util"] }
 tokio-util = { version = "0.7.5", features = ["compat", "io-util"] }
+
+[target.'cfg(any(target_os = "macos", target_family = "windows"))'.dependencies]
 wholesym = "0.8.1"

--- a/hydro_deploy/core/src/localhost/mod.rs
+++ b/hydro_deploy/core/src/localhost/mod.rs
@@ -16,6 +16,8 @@ use crate::{
 
 pub mod launched_binary;
 pub use launched_binary::*;
+
+#[cfg(any(target_os = "macos", target_family = "windows"))]
 mod samply;
 
 #[derive(Debug)]
@@ -143,7 +145,7 @@ impl LaunchedHost for LaunchedLocalhost {
         tracing: Option<TracingOptions>,
     ) -> Result<Box<dyn LaunchedBinary>> {
         let (maybe_perf_outfile, mut command) = if let Some(tracing) = tracing.as_ref() {
-            if cfg!(target_os = "macos") || cfg!(target_family = "windows") {
+            if cfg!(any(target_os = "macos", target_family = "windows")) {
                 // samply
                 ProgressTracker::println(
                     format!("[{id} tracing] Profiling binary with `samply`.",),
@@ -183,7 +185,7 @@ impl LaunchedHost for LaunchedLocalhost {
                 (Some(perf_outfile), command)
             } else {
                 bail!(
-                    "Unknown OS for perf/dtrace tracing: {}",
+                    "Unknown OS for samply/perf tracing: {}",
                     std::env::consts::OS
                 );
             }

--- a/hydro_deploy/core/src/rust_crate/tracing_options.rs
+++ b/hydro_deploy/core/src/rust_crate/tracing_options.rs
@@ -7,7 +7,6 @@
 use std::borrow::Cow;
 use std::path::PathBuf;
 
-use inferno::collapse::dtrace::Options as DtraceOptions;
 use inferno::collapse::perf::Options as PerfOptions;
 
 type FlamegraphOptions = inferno::flamegraph::Options<'static>;
@@ -34,7 +33,6 @@ pub struct TracingOptions {
     // pub perf_script_outfile: Option<PathBuf>,
     /// If set, what the write the folded output to.
     pub fold_outfile: Option<PathBuf>,
-    pub fold_dtrace_options: Option<DtraceOptions>,
     pub fold_perf_options: Option<PerfOptions>,
     /// If set, what to write the output flamegraph SVG file to.
     pub flamegraph_outfile: Option<PathBuf>,


### PR DESCRIPTION

Minimizes dependencies we pull in on Unix.
