### PR TITLE
feat(hydro_lang): replay failed simulation instances and show logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,12 +198,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-
-[[package]]
 name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "bolero-engine-hydro"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64b43094b129cee8f712aa402cc7b110c25197971bd2b135db31e97ebc07a6f0"
+checksum = "691790fb2d24fe4984eebd9ef3eb0afc8598a0530471f4d5de499d379e504fc5"
 dependencies = [
  "anyhow",
  "bolero-generator-hydro",
@@ -629,11 +623,10 @@ dependencies = [
 
 [[package]]
 name = "bolero-generator-hydro"
-version = "0.13.5"
+version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532837141f59f35092ea57c594e752de2d98a8cdab639ec4935f584afd643789"
+checksum = "a78618f55ac4dfa3c66dde097f26105478348b52e985249999c859c250c5719e"
 dependencies = [
- "arbitrary",
  "bolero-generator-derive",
  "either",
  "getrandom 0.3.3",
@@ -652,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "bolero-hydro"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb2a21f0ba1166fba3b2d67ebd497a95f0c5ae75d107d82fc5b12c536ba0f29"
+checksum = "ef7956e385b91a5aee997d23d40c65ff65af698e71f49ba5f3d87ee99ea4b6f5"
 dependencies = [
  "bolero-afl",
  "bolero-engine-hydro",
@@ -677,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "bolero-libfuzzer-hydro"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b53fd75fd865d2bd5f9ffac689865140667c10bc2fe5fd439e6b97bc8e9c117"
+checksum = "59a4b5c591eff98751f101412e42edac650f417a9fefbe36d3ecb0773009470c"
 dependencies = [
  "bolero-engine-hydro",
  "cc",
@@ -2257,7 +2250,6 @@ dependencies = [
 name = "hydro_std"
 version = "0.14.0"
 dependencies = [
- "bolero-hydro",
  "ctor 0.2.9",
  "hdrhistogram",
  "hydro_deploy",

--- a/hydro_lang/Cargo.toml
+++ b/hydro_lang/Cargo.toml
@@ -98,7 +98,7 @@ data-encoding = { version = "2.6.0", optional = true }
 serde_json = { version = "1.0.132", optional = true }
 
 # For the simulator
-bolero = { package = "bolero-hydro", version = "0.13.4", features = ["arbitrary"], optional = true }
+bolero = { package = "bolero-hydro", version = "0.13.5", optional = true }
 cargo_metadata = { version = "0.18.0", optional = true }
 colored = { version = "3", optional = true }
 indenter = { version = "0.3", optional = true }

--- a/hydro_lang/src/sim/compiled.rs
+++ b/hydro_lang/src/sim/compiled.rs
@@ -155,16 +155,20 @@ impl CompiledSim {
                         item_path: "<unknown>::__bolero_item_path__",
                         test_name: None,
                     })
-                    .run(move || {
-                        let instance = instantiator();
+                    .run_with_replay(move |is_replay| {
+                        let mut instance = instantiator();
 
                         if instance.log {
                             eprintln!(
                                 "{}",
-                                "\n==== New Simulation Instance ===="
+                                "\n==== New Simulation Instance ====\n"
                                     .color(colored::Color::Cyan)
                                     .bold()
                             );
+                        }
+
+                        if is_replay {
+                            instance.log = true;
                         }
 
                         tokio::runtime::Builder::new_current_thread()
@@ -267,15 +271,19 @@ impl CompiledSim {
                     test_name: None,
                 })
                 .exhaustive()
-                .run(move || {
-                    let instance = instantiator();
+                .run_with_replay(move |is_replay| {
+                    let mut instance = instantiator();
                     if instance.log {
                         eprintln!(
                             "{}",
-                            "\n==== New Simulation Instance ===="
+                            "\n==== New Simulation Instance ====\n"
                                 .color(colored::Color::Cyan)
                                 .bold()
                         );
+                    }
+
+                    if is_replay {
+                        instance.log = true;
                     }
 
                     tokio::runtime::Builder::new_current_thread()

--- a/hydro_std/Cargo.toml
+++ b/hydro_std/Cargo.toml
@@ -29,5 +29,4 @@ hydro_lang = { path = "../hydro_lang", version = "^0.14.0", features = [
     "sim",
 ] }
 hydro_deploy = { path = "../hydro_deploy/core", version = "^0.14.0" }
-bolero = { package = "bolero-hydro", version = "0.13.4", features = ["arbitrary"] }
 ctor = "0.2"


### PR DESCRIPTION

Previously, a failed simulation would only show the backtrace, and would have to be re-run with `HYDRO_SIM_LOG=1` to display the simulation steps. This would result in lots of log pollution since logging would also be enabled for passing instances.

Now, we've made some tweaks to bolero so that it re-executes the test after finding a failing input, passing an `is_replay` flag. We use this to enable rich logging, so that the failure is displayed with all the simulation steps that led to it.
