### PR TITLE
feat(hydro_lang): avoid redundant simulations for ordering within unordered batches

### DIFF
--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -2750,7 +2750,7 @@ mod tests {
     use stageleft::q;
 
     use crate::compile::builder::FlowBuilder;
-    use crate::live_collections::stream::{ExactlyOnce, TotalOrder};
+    use crate::live_collections::stream::{ExactlyOnce, NoOrder, TotalOrder};
     use crate::location::Location;
     use crate::nondet::nondet;
 
@@ -3005,5 +3005,88 @@ mod tests {
         external_in.send(1).await.unwrap();
         external_in.send(3).await.unwrap();
         assert_eq!(external_out.next().await.unwrap(), 3);
+    }
+
+    #[test]
+    #[should_panic]
+    fn sim_batch_nondet_size() {
+        let flow = FlowBuilder::new();
+        let external = flow.external::<()>();
+        let node = flow.process::<()>();
+
+        let (port, input) = node.source_external_bincode::<_, _, TotalOrder, _>(&external);
+
+        let tick = node.tick();
+        let out_port = input
+            .batch(&tick, nondet!(/** test */))
+            .count()
+            .all_ticks()
+            .send_bincode_external(&external);
+
+        flow.sim().exhaustive(async |mut compiled| {
+            let in_send = compiled.connect(&port);
+            let mut out_recv = compiled.connect(&out_port);
+            compiled.launch();
+
+            in_send.send(()).unwrap();
+            in_send.send(()).unwrap();
+            in_send.send(()).unwrap();
+
+            assert_eq!(out_recv.next().await.unwrap(), 3); // fails with nondet batching
+        });
+    }
+
+    #[test]
+    fn sim_batch_preserves_order() {
+        let flow = FlowBuilder::new();
+        let external = flow.external::<()>();
+        let node = flow.process::<()>();
+
+        let (port, input) = node.source_external_bincode(&external);
+
+        let tick = node.tick();
+        let out_port = input
+            .batch(&tick, nondet!(/** test */))
+            .all_ticks()
+            .send_bincode_external(&external);
+
+        flow.sim().exhaustive(async |mut compiled| {
+            let in_send = compiled.connect(&port);
+            let out_recv = compiled.connect(&out_port);
+            compiled.launch();
+
+            in_send.send(1).unwrap();
+            in_send.send(2).unwrap();
+            in_send.send(3).unwrap();
+
+            out_recv.assert_yields_only([1, 2, 3]).await;
+        });
+    }
+
+    #[test]
+    fn sim_batch_unordered_shuffles_count() {
+        let flow = FlowBuilder::new();
+        let external = flow.external::<()>();
+        let node = flow.process::<()>();
+
+        let (port, input) = node.source_external_bincode::<_, _, NoOrder, _>(&external);
+
+        let tick = node.tick();
+        let batch = input.batch(&tick, nondet!(/** test */));
+        let out_port = batch.all_ticks().send_bincode_external(&external);
+
+        let instance_count = flow.sim().exhaustive(async |mut compiled| {
+            let in_send = compiled.connect(&port);
+            let out_recv = compiled.connect(&out_port);
+            compiled.launch();
+
+            in_send.send_many_unordered([1, 2, 3, 4]).unwrap();
+            out_recv.assert_yields_only_unordered([1, 2, 3, 4]).await;
+        });
+
+        assert_eq!(
+            instance_count,
+            75 // ∑ (k=1 to 4) S(4,k) × k! = 75
+        )
     }
 }

--- a/hydro_lang/src/sim/flow.rs
+++ b/hydro_lang/src/sim/flow.rs
@@ -61,7 +61,9 @@ impl<'a> SimFlow<'a> {
     /// are no dataflow loops that generate infinite messages. Exhaustive searching provides a
     /// stronger guarantee of correctness than fuzzing, but may take a long time to complete.
     /// Because no fuzzer is involved, you can run exhaustive tests with `cargo test`.
-    pub fn exhaustive(self, thunk: impl AsyncFn(CompiledSimInstance) + RefUnwindSafe) {
+    ///
+    /// Returns the number of distinct executions explored.
+    pub fn exhaustive(self, thunk: impl AsyncFn(CompiledSimInstance) + RefUnwindSafe) -> usize {
         self.compiled().exhaustive(thunk)
     }
 

--- a/hydro_lang/src/sim/tests/snapshots/hydro_lang__sim__tests__trace_for_fuzzed_batching.snap
+++ b/hydro_lang/src/sim/tests/snapshots/hydro_lang__sim__tests__trace_for_fuzzed_batching.snap
@@ -3,11 +3,11 @@ source: hydro_lang/src/sim/tests/mod.rs
 expression: log_str
 ---
 Running Tick
-* --> src/sim/tests/mod.rs:166:10
+* --> src/sim/tests/mod.rs:106:10
 *  |        .batch(&tick, nondet!(/** test */))
 *  |         ^ releasing items: [456, 456, 456, 456, 456, 456, 456, 456, ..] (1000 total)
 
 Running Tick
-* --> src/sim/tests/mod.rs:166:10
+* --> src/sim/tests/mod.rs:106:10
 *  |        .batch(&tick, nondet!(/** test */))
 *  |         ^ releasing items: [100, 23]


### PR DESCRIPTION

Previously, we would select elements for the next released batched in non-deterministic order. This is unnecessary, because the batch itself has `NoOrder` guarantees and so the permutations within the batch are redundant.

Reduces instance count from 192 to 75 for `sequence_payloads_sequences_all`. To avoid regressions, `.sim().exhaustive()` now returns the number of simulation instances, which we can verify against a combinatorial formula.
