### PR TITLE
test(hydro_lang): check that simulated unordered batching generates out-of-order cases

### DIFF
--- a/hydro_lang/src/compile/rewrites/snapshots/hydro_lang__compile__rewrites__properties__tests__property_optimized.snap
+++ b/hydro_lang/src/compile/rewrites/snapshots/hydro_lang__compile__rewrites__properties__tests__property_optimized.snap
@@ -132,6 +132,7 @@ expression: built.ir()
                     },
                 },
             },
+            trusted: false,
             metadata: HydroIrMetadata {
                 location_kind: Process(
                     0,

--- a/hydro_lang/src/graph/render.rs
+++ b/hydro_lang/src/graph/render.rs
@@ -603,7 +603,9 @@ impl HydroNode {
 
             // Transform operations with Stream edges - grouped by node/edge type
             HydroNode::Cast { inner, metadata }
-            | HydroNode::ObserveNonDet { inner, metadata }
+            | HydroNode::ObserveNonDet {
+                inner, metadata, ..
+            }
             | HydroNode::DeferTick {
                 input: inner,
                 metadata,

--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -255,6 +255,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
                 self.location.clone(),
                 HydroNode::ObserveNonDet {
                     inner: Box::new(self.ir_node.into_inner()),
+                    trusted: false,
                     metadata: self
                         .location
                         .new_node_metadata(KeyedStream::<K, V, L, B, O2, R>::collection_kind()),
@@ -297,6 +298,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
                 self.location.clone(),
                 HydroNode::ObserveNonDet {
                     inner: Box::new(self.ir_node.into_inner()),
+                    trusted: false,
                     metadata: self
                         .location
                         .new_node_metadata(KeyedStream::<K, V, L, B, O, R2>::collection_kind()),

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -918,6 +918,37 @@ where
                 self.location.clone(),
                 HydroNode::ObserveNonDet {
                     inner: Box::new(self.ir_node.into_inner()),
+                    trusted: false,
+                    metadata: self
+                        .location
+                        .new_node_metadata(Stream::<T, L, B, O2, R>::collection_kind()),
+                },
+            )
+        }
+    }
+
+    // only for internal APIs that have been carefully vetted to ensure that the non-determinism
+    // is not observable
+    fn assume_ordering_trusted<O2: Ordering>(self, _nondet: NonDet) -> Stream<T, L, B, O2, R> {
+        if O::ORDERING_KIND == O2::ORDERING_KIND {
+            Stream::new(self.location, self.ir_node.into_inner())
+        } else if O2::ORDERING_KIND == StreamOrder::NoOrder {
+            // We can always weaken the ordering guarantee
+            Stream::new(
+                self.location.clone(),
+                HydroNode::Cast {
+                    inner: Box::new(self.ir_node.into_inner()),
+                    metadata: self
+                        .location
+                        .new_node_metadata(Stream::<T, L, B, O2, R>::collection_kind()),
+                },
+            )
+        } else {
+            Stream::new(
+                self.location.clone(),
+                HydroNode::ObserveNonDet {
+                    inner: Box::new(self.ir_node.into_inner()),
+                    trusted: true,
                     metadata: self
                         .location
                         .new_node_metadata(Stream::<T, L, B, O2, R>::collection_kind()),
@@ -967,6 +998,37 @@ where
                 self.location.clone(),
                 HydroNode::ObserveNonDet {
                     inner: Box::new(self.ir_node.into_inner()),
+                    trusted: false,
+                    metadata: self
+                        .location
+                        .new_node_metadata(Stream::<T, L, B, O, R2>::collection_kind()),
+                },
+            )
+        }
+    }
+
+    // only for internal APIs that have been carefully vetted to ensure that the non-determinism
+    // is not observable
+    fn assume_retries_trusted<R2: Retries>(self, _nondet: NonDet) -> Stream<T, L, B, O, R2> {
+        if R::RETRIES_KIND == R2::RETRIES_KIND {
+            Stream::new(self.location, self.ir_node.into_inner())
+        } else if R2::RETRIES_KIND == StreamRetry::AtLeastOnce {
+            // We can always weaken the retries guarantee
+            Stream::new(
+                self.location.clone(),
+                HydroNode::Cast {
+                    inner: Box::new(self.ir_node.into_inner()),
+                    metadata: self
+                        .location
+                        .new_node_metadata(Stream::<T, L, B, O, R2>::collection_kind()),
+                },
+            )
+        } else {
+            Stream::new(
+                self.location.clone(),
+                HydroNode::ObserveNonDet {
+                    inner: Box::new(self.ir_node.into_inner()),
+                    trusted: true,
                     metadata: self
                         .location
                         .new_node_metadata(Stream::<T, L, B, O, R2>::collection_kind()),
@@ -1109,6 +1171,21 @@ where
             .reduce(comb)
     }
 
+    // only for internal APIs that have been carefully vetted, will eventually be removed once we
+    // have algebraic verification of these properties
+    fn reduce_commutative_idempotent_trusted<F>(
+        self,
+        comb: impl IntoQuotedMut<'a, F, L>,
+    ) -> Optional<T, L, B>
+    where
+        F: Fn(&mut T, T) + 'a,
+    {
+        let nondet = nondet!(/** the combinator function is commutative and idempotent */);
+        self.assume_ordering_trusted(nondet)
+            .assume_retries_trusted(nondet)
+            .reduce(comb)
+    }
+
     /// Computes the maximum element in the stream as an [`Optional`], which
     /// will be empty until the first element in the input arrives.
     ///
@@ -1130,7 +1207,7 @@ where
     where
         T: Ord,
     {
-        self.reduce_commutative_idempotent(q!(|curr, new| {
+        self.reduce_commutative_idempotent_trusted(q!(|curr, new| {
             if new > *curr {
                 *curr = new;
             }
@@ -1158,7 +1235,7 @@ where
     where
         T: Ord,
     {
-        self.reduce_commutative_idempotent(q!(|curr, new| {
+        self.reduce_commutative_idempotent_trusted(q!(|curr, new| {
             if new < *curr {
                 *curr = new;
             }
@@ -3064,6 +3141,37 @@ mod tests {
     }
 
     #[test]
+    #[should_panic]
+    fn sim_batch_unordered_shuffles() {
+        let flow = FlowBuilder::new();
+        let external = flow.external::<()>();
+        let node = flow.process::<()>();
+
+        let (port, input) = node.source_external_bincode::<_, _, NoOrder, _>(&external);
+
+        let tick = node.tick();
+        let batch = input.batch(&tick, nondet!(/** test */));
+        let out_port = batch
+            .clone()
+            .min()
+            .zip(batch.max())
+            .all_ticks()
+            .send_bincode_external(&external);
+
+        flow.sim().exhaustive(async |mut compiled| {
+            let in_send = compiled.connect(&port);
+            let out_recv = compiled.connect(&out_port);
+            compiled.launch();
+
+            in_send.send_many_unordered([1, 2, 3]).unwrap();
+
+            if out_recv.collect::<Vec<_>>().await == vec![(1, 3), (2, 2)] {
+                panic!("saw both (1, 3) and (2, 2), so batching must have shuffled the order");
+            }
+        });
+    }
+
+    #[test]
     fn sim_batch_unordered_shuffles_count() {
         let flow = FlowBuilder::new();
         let external = flow.external::<()>();
@@ -3087,6 +3195,37 @@ mod tests {
         assert_eq!(
             instance_count,
             75 // ∑ (k=1 to 4) S(4,k) × k! = 75
+        )
+    }
+
+    #[test]
+    #[ignore = "assume_ordering not yet supported on bounded collections"]
+    fn sim_observe_order_batched_count() {
+        let flow = FlowBuilder::new();
+        let external = flow.external::<()>();
+        let node = flow.process::<()>();
+
+        let (port, input) = node.source_external_bincode::<_, _, NoOrder, _>(&external);
+
+        let tick = node.tick();
+        let batch = input.batch(&tick, nondet!(/** test */));
+        let out_port = batch
+            .assume_ordering::<TotalOrder>(nondet!(/** test */))
+            .all_ticks()
+            .send_bincode_external(&external);
+
+        let instance_count = flow.sim().exhaustive(async |mut compiled| {
+            let in_send = compiled.connect(&port);
+            let out_recv = compiled.connect(&out_port);
+            compiled.launch();
+
+            in_send.send_many_unordered([1, 2, 3, 4]).unwrap();
+            let _ = out_recv.collect::<Vec<_>>().await;
+        });
+
+        assert_eq!(
+            instance_count,
+            192 // 4! * 2^{4 - 1}
         )
     }
 }

--- a/hydro_lang/src/sim/builder.rs
+++ b/hydro_lang/src/sim/builder.rs
@@ -233,13 +233,25 @@ impl DfirBuilder for SimBuilder {
 
     fn observe_nondet(
         &mut self,
-        _location: &LocationId,
-        _in_ident: syn::Ident,
+        trusted: bool,
+        location: &LocationId,
+        in_ident: syn::Ident,
         _in_kind: &CollectionKind,
-        _out_ident: &syn::Ident,
+        out_ident: &syn::Ident,
         _out_kind: &CollectionKind,
     ) {
-        todo!()
+        if trusted {
+            let builder = self.get_dfir_mut(location);
+            builder.add_dfir(
+                parse_quote! {
+                    #out_ident = #in_ident;
+                },
+                None,
+                None,
+            );
+        } else {
+            todo!()
+        }
     }
 
     fn create_network(

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__compute_pi__tests__compute_pi_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__compute_pi__tests__compute_pi_ir.snap
@@ -214,6 +214,7 @@ expression: built.ir()
                                                     },
                                                 },
                                             },
+                                            trusted: false,
                                             metadata: HydroIrMetadata {
                                                 location_kind: Process(
                                                     1,
@@ -376,6 +377,7 @@ expression: built.ir()
                     },
                 },
             },
+            trusted: false,
             metadata: HydroIrMetadata {
                 location_kind: Process(
                     1,

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__many_to_many__tests__many_to_many_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__many_to_many__tests__many_to_many_ir.snap
@@ -156,6 +156,7 @@ expression: built.ir()
                                                 },
                                             },
                                         },
+                                        trusted: false,
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
                                                 0,
@@ -284,6 +285,7 @@ expression: built.ir()
                     },
                 },
             },
+            trusted: false,
             metadata: HydroIrMetadata {
                 location_kind: Cluster(
                     0,

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__map_reduce__tests__map_reduce_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__map_reduce__tests__map_reduce_ir.snap
@@ -251,6 +251,7 @@ expression: built.ir()
                                                                                                                                 },
                                                                                                                             },
                                                                                                                         },
+                                                                                                                        trusted: false,
                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                             location_kind: Tick(
                                                                                                                                 0,
@@ -534,6 +535,7 @@ expression: built.ir()
                                             },
                                         },
                                     },
+                                    trusted: false,
                                     metadata: HydroIrMetadata {
                                         location_kind: Process(
                                             0,
@@ -615,6 +617,7 @@ expression: built.ir()
                     },
                 },
             },
+            trusted: false,
             metadata: HydroIrMetadata {
                 location_kind: Process(
                     0,

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir.snap
@@ -231,6 +231,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                         },
+                                                        trusted: true,
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Cluster(
                                                                 0,
@@ -243,6 +244,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                     },
+                                                    trusted: true,
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Cluster(
                                                             0,
@@ -707,6 +709,7 @@ expression: built.ir()
                                                     },
                                                 },
                                             },
+                                            trusted: false,
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
                                                     7,
@@ -1352,6 +1355,7 @@ expression: built.ir()
                                                                                                                                                     },
                                                                                                                                                 },
                                                                                                                                             },
+                                                                                                                                            trusted: false,
                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                 location_kind: Tick(
                                                                                                                                                     9,
@@ -1422,6 +1426,7 @@ expression: built.ir()
                                                                                                                                                                                                                         },
                                                                                                                                                                                                                     },
                                                                                                                                                                                                                 },
+                                                                                                                                                                                                                trusted: false,
                                                                                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                                                                                     location_kind: Cluster(
                                                                                                                                                                                                                         0,
@@ -1434,6 +1439,7 @@ expression: built.ir()
                                                                                                                                                                                                                     },
                                                                                                                                                                                                                 },
                                                                                                                                                                                                             },
+                                                                                                                                                                                                            trusted: false,
                                                                                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                                                                                 location_kind: Cluster(
                                                                                                                                                                                                                     0,
@@ -2026,6 +2032,7 @@ expression: built.ir()
                                                                                                                                     },
                                                                                                                                 },
                                                                                                                             },
+                                                                                                                            trusted: true,
                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                 location_kind: Tick(
                                                                                                                                     2,
@@ -2372,6 +2379,7 @@ expression: built.ir()
                                                 },
                                             },
                                         },
+                                        trusted: false,
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
                                                 10,
@@ -2884,6 +2892,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                         },
+                                                                        trusted: false,
                                                                         metadata: HydroIrMetadata {
                                                                             location_kind: Cluster(
                                                                                 0,
@@ -2958,6 +2967,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                 },
+                                                trusted: false,
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Cluster(
                                                         0,
@@ -3571,6 +3581,7 @@ expression: built.ir()
                                                                                                         },
                                                                                                     },
                                                                                                 },
+                                                                                                trusted: false,
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_kind: Tick(
                                                                                                         11,
@@ -4001,6 +4012,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                             },
+                                                            trusted: true,
                                                             metadata: HydroIrMetadata {
                                                                 location_kind: Cluster(
                                                                     2,
@@ -4372,6 +4384,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                             },
+                                                            trusted: false,
                                                             metadata: HydroIrMetadata {
                                                                 location_kind: Cluster(
                                                                     0,
@@ -4594,6 +4607,7 @@ expression: built.ir()
                                                                                                             },
                                                                                                         },
                                                                                                     },
+                                                                                                    trusted: false,
                                                                                                     metadata: HydroIrMetadata {
                                                                                                         location_kind: Tick(
                                                                                                             1,
@@ -4698,6 +4712,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                         },
+                                                                        trusted: true,
                                                                         metadata: HydroIrMetadata {
                                                                             location_kind: Tick(
                                                                                 1,
@@ -5261,6 +5276,7 @@ expression: built.ir()
                                                                                                                                             },
                                                                                                                                         },
                                                                                                                                     },
+                                                                                                                                    trusted: false,
                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                         location_kind: Tick(
                                                                                                                                             13,
@@ -5506,6 +5522,7 @@ expression: built.ir()
                                                                                                                                                                                                                 },
                                                                                                                                                                                                             },
                                                                                                                                                                                                         },
+                                                                                                                                                                                                        trusted: true,
                                                                                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                                                                                             location_kind: Tick(
                                                                                                                                                                                                                 1,
@@ -6371,6 +6388,7 @@ expression: built.ir()
                                                 },
                                             },
                                         },
+                                        trusted: false,
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
                                                 14,
@@ -7165,6 +7183,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                     },
+                                                    trusted: false,
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Atomic(
                                                             Tick(
@@ -7259,6 +7278,7 @@ expression: built.ir()
                                         },
                                     },
                                 },
+                                trusted: false,
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
                                         2,
@@ -7558,6 +7578,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                         },
+                                                                        trusted: false,
                                                                         metadata: HydroIrMetadata {
                                                                             location_kind: Tick(
                                                                                 15,
@@ -8789,6 +8810,7 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                             },
+                                                                            trusted: false,
                                                                             metadata: HydroIrMetadata {
                                                                                 location_kind: Tick(
                                                                                     18,
@@ -9060,6 +9082,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                 },
+                                                trusted: false,
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
                                                         17,
@@ -9159,6 +9182,7 @@ expression: built.ir()
                             },
                         },
                     },
+                    trusted: true,
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
                             17,
@@ -9480,6 +9504,7 @@ expression: built.ir()
                                                 },
                                             },
                                         },
+                                        trusted: false,
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
                                                 19,
@@ -9788,6 +9813,7 @@ expression: built.ir()
                     },
                 },
             },
+            trusted: false,
             metadata: HydroIrMetadata {
                 location_kind: Cluster(
                     2,
@@ -10008,6 +10034,7 @@ expression: built.ir()
                                 },
                             },
                         },
+                        trusted: false,
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
                                 0,
@@ -10213,6 +10240,7 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                             },
+                                                                            trusted: false,
                                                                             metadata: HydroIrMetadata {
                                                                                 location_kind: Tick(
                                                                                     21,
@@ -10342,6 +10370,7 @@ expression: built.ir()
                                                                                                                                                                                     },
                                                                                                                                                                                 },
                                                                                                                                                                             },
+                                                                                                                                                                            trusted: false,
                                                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                                                 location_kind: Tick(
                                                                                                                                                                                     0,
@@ -10876,6 +10905,7 @@ expression: built.ir()
                                                                                                             },
                                                                                                         },
                                                                                                     },
+                                                                                                    trusted: false,
                                                                                                     metadata: HydroIrMetadata {
                                                                                                         location_kind: Process(
                                                                                                             3,
@@ -10967,6 +10997,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                         },
+                                                                        trusted: false,
                                                                         metadata: HydroIrMetadata {
                                                                             location_kind: Tick(
                                                                                 23,
@@ -11228,6 +11259,7 @@ expression: built.ir()
                     },
                 },
             },
+            trusted: false,
             metadata: HydroIrMetadata {
                 location_kind: Process(
                     3,
@@ -11307,6 +11339,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                     },
+                                                                    trusted: false,
                                                                     metadata: HydroIrMetadata {
                                                                         location_kind: Tick(
                                                                             25,
@@ -11720,6 +11753,7 @@ expression: built.ir()
                     },
                 },
             },
+            trusted: false,
             metadata: HydroIrMetadata {
                 location_kind: Process(
                     3,
@@ -11863,6 +11897,7 @@ expression: built.ir()
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                 },
+                                                                                                                                trusted: false,
                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                     location_kind: Cluster(
                                                                                                                                         2,
@@ -12075,6 +12110,7 @@ expression: built.ir()
                                                                                         },
                                                                                     },
                                                                                 },
+                                                                                trusted: false,
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_kind: Process(
                                                                                         3,
@@ -12128,6 +12164,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                 },
+                                                                trusted: false,
                                                                 metadata: HydroIrMetadata {
                                                                     location_kind: Tick(
                                                                         28,
@@ -12497,6 +12534,7 @@ expression: built.ir()
                     },
                 },
             },
+            trusted: false,
             metadata: HydroIrMetadata {
                 location_kind: Process(
                     3,

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__simple_cluster__tests__simple_cluster_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__simple_cluster__tests__simple_cluster_ir.snap
@@ -215,6 +215,7 @@ expression: built.ir()
                     },
                 },
             },
+            trusted: false,
             metadata: HydroIrMetadata {
                 location_kind: Process(
                     0,

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__two_pc_bench__tests__two_pc_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__two_pc_bench__tests__two_pc_ir.snap
@@ -209,6 +209,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                     },
+                                                                    trusted: false,
                                                                     metadata: HydroIrMetadata {
                                                                         location_kind: Tick(
                                                                             1,
@@ -521,6 +522,7 @@ expression: built.ir()
                                                 },
                                             },
                                         },
+                                        trusted: false,
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
                                                 2,
@@ -849,6 +851,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                     },
+                                                                    trusted: false,
                                                                     metadata: HydroIrMetadata {
                                                                         location_kind: Tick(
                                                                             3,
@@ -1128,6 +1131,7 @@ expression: built.ir()
                                                 },
                                             },
                                         },
+                                        trusted: false,
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
                                                 4,
@@ -1470,6 +1474,7 @@ expression: built.ir()
                     },
                 },
             },
+            trusted: false,
             metadata: HydroIrMetadata {
                 location_kind: Cluster(
                     2,
@@ -1690,6 +1695,7 @@ expression: built.ir()
                                 },
                             },
                         },
+                        trusted: false,
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
                                 0,
@@ -1895,6 +1901,7 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                             },
+                                                                            trusted: false,
                                                                             metadata: HydroIrMetadata {
                                                                                 location_kind: Tick(
                                                                                     6,
@@ -2024,6 +2031,7 @@ expression: built.ir()
                                                                                                                                                                                     },
                                                                                                                                                                                 },
                                                                                                                                                                             },
+                                                                                                                                                                            trusted: false,
                                                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                                                 location_kind: Tick(
                                                                                                                                                                                     0,
@@ -2558,6 +2566,7 @@ expression: built.ir()
                                                                                                             },
                                                                                                         },
                                                                                                     },
+                                                                                                    trusted: false,
                                                                                                     metadata: HydroIrMetadata {
                                                                                                         location_kind: Process(
                                                                                                             3,
@@ -2649,6 +2658,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                         },
+                                                                        trusted: false,
                                                                         metadata: HydroIrMetadata {
                                                                             location_kind: Tick(
                                                                                 8,
@@ -2910,6 +2920,7 @@ expression: built.ir()
                     },
                 },
             },
+            trusted: false,
             metadata: HydroIrMetadata {
                 location_kind: Process(
                     3,
@@ -2989,6 +3000,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                     },
+                                                                    trusted: false,
                                                                     metadata: HydroIrMetadata {
                                                                         location_kind: Tick(
                                                                             10,
@@ -3402,6 +3414,7 @@ expression: built.ir()
                     },
                 },
             },
+            trusted: false,
             metadata: HydroIrMetadata {
                 location_kind: Process(
                     3,
@@ -3545,6 +3558,7 @@ expression: built.ir()
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                 },
+                                                                                                                                trusted: false,
                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                     location_kind: Cluster(
                                                                                                                                         2,
@@ -3757,6 +3771,7 @@ expression: built.ir()
                                                                                         },
                                                                                     },
                                                                                 },
+                                                                                trusted: false,
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_kind: Process(
                                                                                         3,
@@ -3810,6 +3825,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                 },
+                                                                trusted: false,
                                                                 metadata: HydroIrMetadata {
                                                                     location_kind: Tick(
                                                                         13,
@@ -4179,6 +4195,7 @@ expression: built.ir()
                     },
                 },
             },
+            trusted: false,
             metadata: HydroIrMetadata {
                 location_kind: Process(
                     3,


### PR DESCRIPTION

Until we can simulate `assume_ordering` inside a tick, we need some way for getting the decisions out. All the `*_commutative` APIs currently call `assume_ordering`, but we introduce an `_trusted` variant for `min` / `max` that bypasses `assume_ordering` because we have carefully checked that the function is indeed commutative and we do not need to simulate shuffles.

Eventually, the decision whether we need to simulate shuffled executions of `_commutative` methods will be driven by algebraic verification, so that user code can similarly benefit from the reduction in search space.
