### PR TITLE
feat(hydro_lang): share `__staged` across trybuild targets

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -21,11 +21,14 @@ test-group = 'serial-integration'
 [[profile.default.overrides]]
 filter = 'package(hydro_lang)'
 test-group = 'hydro-trybuild-group'
+priority = 100
 
 [[profile.default.overrides]]
 filter = 'package(hydro_std)'
 test-group = 'hydro-trybuild-group'
+priority = 100
 
 [[profile.default.overrides]]
 filter = 'package(hydro_test)'
 test-group = 'hydro-trybuild-group'
+priority = 100

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4741,9 +4741,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stageleft"
-version = "0.9.8"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b915ab838401960cb432c92dd04a3b165e8dde9d9f5f81497afe5e224e87b72"
+checksum = "b92cb4d28ec3c2b3aba8ee05487f10c3aa00d7a369a3fe9d4d89e8719f28ca4f"
 dependencies = [
  "ctor 0.4.3",
  "proc-macro-crate 3.3.0",
@@ -4755,9 +4755,9 @@ dependencies = [
 
 [[package]]
 name = "stageleft_macro"
-version = "0.9.8"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c8550ce6539cb7ce3a310c7f3f1d22f7fbfd5e0607f728c6472059e0df02679"
+checksum = "e05624677c37d2abebe0c3e50fa7722f99936d26de2a8a23ac5d2a397be596c0"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -4768,9 +4768,9 @@ dependencies = [
 
 [[package]]
 name = "stageleft_tool"
-version = "0.9.8"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2547c755b850036e86e059d44130d2119beccfb173c583950ba02bee17e6f928"
+checksum = "da14207006ed0031a24197e0a2d3bc84b2a7ecf3a2ca70b70f1886cf1a37b464"
 dependencies = [
  "prettyplease",
  "proc-macro-crate 3.3.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,5 +67,5 @@ uninlined_format_args = "allow"
 upper_case_acronyms = "warn"
 
 [workspace.dependencies]
-stageleft = "0.9.8"
-stageleft_tool = "0.9.8"
+stageleft = "0.10.0"
+stageleft_tool = "0.10.0"

--- a/hydro_deploy/core/src/rust_crate/build.rs
+++ b/hydro_deploy/core/src/rust_crate/build.rs
@@ -101,7 +101,7 @@ pub async fn build_crate_memoized(params: BuildParams) -> Result<&'static BuildO
             ProgressTracker::rich_leaf("build", move |set_msg| async move {
                 tokio::task::spawn_blocking(move || {
                     let mut command = Command::new("cargo");
-                    command.args(["build"]);
+                    command.args(["build", "--locked"]);
 
                     if let Some(profile) = params.profile.as_ref() {
                         command.args(["--profile", profile]);

--- a/hydro_lang/src/deploy/trybuild.rs
+++ b/hydro_lang/src/deploy/trybuild.rs
@@ -3,6 +3,7 @@ use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
 use dfir_lang::graph::DfirGraph;
+use proc_macro2::Span;
 use sha2::{Digest, Sha256};
 use stageleft::internal::quote;
 use syn::visit_mut::VisitMut;
@@ -67,38 +68,30 @@ pub fn create_graph_trybuild(
 
     let generated_code = compile_graph_trybuild(graph, extra_stmts, crate_name.clone(), is_test);
 
-    let inlined_staged: syn::File = if is_test {
+    let inlined_staged = if is_test {
         let gen_staged = stageleft_tool::gen_staged_trybuild(
             &path!(source_dir / "src" / "lib.rs"),
             &path!(source_dir / "Cargo.toml"),
             crate_name.clone(),
-            is_test,
+            Some("hydro___test".to_string()),
         );
 
-        syn::parse_quote! {
-            #[allow(
+        Some(prettyplease::unparse(&syn::parse_quote! {
+            #![allow(
                 unused,
                 ambiguous_glob_reexports,
                 clippy::suspicious_else_formatting,
                 unexpected_cfgs,
                 reason = "generated code"
             )]
-            pub mod __staged {
-                #gen_staged
-            }
-        }
+
+            #gen_staged
+        }))
     } else {
-        let crate_name_ident = syn::Ident::new(crate_name, proc_macro2::Span::call_site());
-        syn::parse_quote!(
-            pub use #crate_name_ident::__staged;
-        )
+        None
     };
 
-    let source = prettyplease::unparse(&syn::parse_quote! {
-        #generated_code
-
-        #inlined_staged
-    });
+    let source = prettyplease::unparse(&generated_code);
 
     let hash = format!("{:X}", Sha256::digest(&source))
         .chars()
@@ -120,6 +113,34 @@ pub fn create_graph_trybuild(
     {
         let _concurrent_test_lock = CONCURRENT_TEST_LOCK.lock().unwrap();
         write_atomic(source.as_ref(), &out_path).unwrap();
+    }
+
+    if let Some(inlined_staged) = inlined_staged {
+        let staged_path = path!(project_dir / "src" / "__staged.rs");
+        {
+            let _concurrent_test_lock = CONCURRENT_TEST_LOCK.lock().unwrap();
+            write_atomic(inlined_staged.as_bytes(), &staged_path).unwrap();
+        }
+    }
+
+    let crate_name_ident = syn::Ident::new(crate_name, Span::call_site());
+    let lib_path = path!(project_dir / "src" / "lib.rs");
+    {
+        let _concurrent_test_lock = CONCURRENT_TEST_LOCK.lock().unwrap();
+        write_atomic(
+            prettyplease::unparse(&syn::parse_quote! {
+                #![allow(unused_imports, unused_crate_dependencies, missing_docs, non_snake_case)]
+
+                #[cfg(feature = "hydro___test")]
+                pub mod __staged;
+
+                #[cfg(not(feature = "hydro___test"))]
+                pub use #crate_name_ident::__staged;
+            })
+            .as_bytes(),
+            &lib_path,
+        )
+        .unwrap();
     }
 
     if is_test {
@@ -165,10 +186,13 @@ pub fn compile_graph_trybuild(
         .visit_expr_mut(&mut dfir_expr);
     }
 
+    let trybuild_crate_name_ident = quote::format_ident!("{}_hydro_trybuild", crate_name);
+
     let source_ast: syn::File = syn::parse_quote! {
         #![allow(unused_imports, unused_crate_dependencies, missing_docs, non_snake_case)]
         use hydro_lang::prelude::*;
         use hydro_lang::runtime_support::dfir_rs as __root_dfir_rs;
+        pub use #trybuild_crate_name_ident::__staged;
 
         #[allow(unused)]
         fn __hydro_runtime<'a>(__hydro_lang_trybuild_cli: &'a hydro_lang::runtime_support::dfir_rs::util::deploy::DeployPorts<hydro_lang::__staged::deploy::deploy_runtime::HydroMeta>) -> hydro_lang::runtime_support::dfir_rs::scheduled::graph::Dfir<'a> {
@@ -295,17 +319,63 @@ pub fn create_trybuild()
         project_lock.lock()?;
 
         let manifest_toml = toml::to_string(&project.manifest)?;
-        write_atomic(manifest_toml.as_ref(), &path!(project.dir / "Cargo.toml"))?;
+        let manifest_with_example = format!(
+            "{}\n\n[[example]]\nname = \"sim-dylib\"\ncrate-type = [\"dylib\"]",
+            manifest_toml
+        );
 
-        let workspace_cargo_lock = path!(project.workspace / "Cargo.lock");
-        if workspace_cargo_lock.exists() {
+        write_atomic(
+            manifest_with_example.as_ref(),
+            &path!(project.dir / "Cargo.toml"),
+        )?;
+
+        let manifest_hash = format!("{:X}", Sha256::digest(&manifest_with_example))
+            .chars()
+            .take(8)
+            .collect::<String>();
+
+        if !check_contents(
+            manifest_hash.as_bytes(),
+            &path!(project.dir / ".hydro-trybuild-manifest"),
+        )
+        .is_ok_and(|b| b)
+        {
+            // this is expensive, so we only do it if the manifest changed
+            let workspace_cargo_lock = path!(project.workspace / "Cargo.lock");
+            if workspace_cargo_lock.exists() {
+                write_atomic(
+                    fs::read_to_string(&workspace_cargo_lock)?.as_ref(),
+                    &path!(project.dir / "Cargo.lock"),
+                )?;
+            } else {
+                let _ = cargo::cargo(&project).arg("generate-lockfile").status();
+            }
+
+            // not `--offline` because some new runtime features may be enabled
+            std::process::Command::new("cargo")
+                .current_dir(&project.dir)
+                .args(["update", "-w"]) // -w to not actually update any versions
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status()
+                .unwrap();
+
             write_atomic(
-                fs::read_to_string(&workspace_cargo_lock)?.as_ref(),
-                &path!(project.dir / "Cargo.lock"),
+                manifest_hash.as_bytes(),
+                &path!(project.dir / ".hydro-trybuild-manifest"),
             )?;
-        } else {
-            let _ = cargo::cargo(&project).arg("generate-lockfile").status();
         }
+
+        let examples_folder = path!(project.dir / "examples");
+        fs::create_dir_all(&examples_folder)?;
+        write_atomic(
+            prettyplease::unparse(&syn::parse_quote! {
+                #![allow(unused_imports, unused_crate_dependencies, missing_docs, non_snake_case)]
+                include!(std::concat!(env!("TRYBUILD_LIB_NAME"), ".rs"));
+            })
+            .as_bytes(),
+            &path!(project.dir / "examples" / "sim-dylib.rs"),
+        )?;
 
         let workspace_dot_cargo_config_toml = path!(project.workspace / ".cargo" / "config.toml");
         if workspace_dot_cargo_config_toml.exists() {
@@ -331,6 +401,20 @@ pub fn create_trybuild()
         path!(project.target_dir / "hydro_trybuild"),
         project.features,
     ))
+}
+
+fn check_contents(contents: &[u8], path: &Path) -> Result<bool, std::io::Error> {
+    let mut file = File::options()
+        .read(true)
+        .write(false)
+        .create(false)
+        .truncate(false)
+        .open(path)?;
+    file.lock()?;
+
+    let mut existing_contents = Vec::new();
+    file.read_to_end(&mut existing_contents)?;
+    Ok(existing_contents == contents)
 }
 
 pub(crate) fn write_atomic(contents: &[u8], path: &Path) -> Result<(), std::io::Error> {

--- a/hydro_lang/src/sim/graph.rs
+++ b/hydro_lang/src/sim/graph.rs
@@ -5,6 +5,7 @@ use std::process::{Command, Stdio};
 use std::rc::Rc;
 
 use dfir_lang::graph::DfirGraph;
+use proc_macro2::Span;
 use quote::quote;
 use sha2::{Digest, Sha256};
 use syn::visit_mut::VisitMut;
@@ -256,7 +257,7 @@ impl<'a> Deploy<'a> for SimDeploy {
         _p2: &Self::Process,
         _p2_port: &Self::Port,
     ) -> syn::Expr {
-        let ident = syn::Ident::new("__hydro_external_in", proc_macro2::Span::call_site());
+        let ident = syn::Ident::new("__hydro_external_in", Span::call_site());
         syn::parse_quote!(
             #ident.remove(&#p1_port).unwrap()
         )
@@ -280,7 +281,7 @@ impl<'a> Deploy<'a> for SimDeploy {
         _p2: &Self::External,
         p2_port: &Self::Port,
     ) -> syn::Expr {
-        let ident = syn::Ident::new("__hydro_external_out", proc_macro2::Span::call_site());
+        let ident = syn::Ident::new("__hydro_external_out", Span::call_site());
         syn::parse_quote!(
             #ident.remove(&#p2_port).unwrap()
         )
@@ -316,8 +317,8 @@ impl<'a> Deploy<'a> for SimDeploy {
 pub(super) fn compile_sim(bin: String, trybuild: TrybuildConfig) -> Result<TempPath, ()> {
     let mut command = Command::new("cargo");
     command.current_dir(&trybuild.project_dir);
-    command.args(["rustc"]);
-    command.args(["--lib"]);
+    command.args(["rustc", "--locked"]);
+    command.args(["--example", "sim-dylib"]);
     command.args(["--target-dir", trybuild.target_dir.to_str().unwrap()]);
     if let Some(features) = &trybuild.features {
         command.args(["--features", &features.join(",")]);
@@ -410,38 +411,30 @@ pub(super) fn create_sim_graph_trybuild(
     let generated_code =
         compile_sim_graph_trybuild(graph, tick_graphs, extra_stmts, crate_name.clone(), is_test);
 
-    let inlined_staged: syn::File = if is_test {
+    let inlined_staged = if is_test {
         let gen_staged = stageleft_tool::gen_staged_trybuild(
             &path!(source_dir / "src" / "lib.rs"),
             &path!(source_dir / "Cargo.toml"),
             crate_name.clone(),
-            is_test,
+            Some("hydro___test".to_string()),
         );
 
-        syn::parse_quote! {
-            #[allow(
+        Some(prettyplease::unparse(&syn::parse_quote! {
+            #![allow(
                 unused,
                 ambiguous_glob_reexports,
                 clippy::suspicious_else_formatting,
                 unexpected_cfgs,
                 reason = "generated code"
             )]
-            pub mod __staged {
-                #gen_staged
-            }
-        }
+
+            #gen_staged
+        }))
     } else {
-        let crate_name_ident = syn::Ident::new(crate_name, proc_macro2::Span::call_site());
-        syn::parse_quote!(
-            pub use #crate_name_ident::__staged;
-        )
+        None
     };
 
-    let source = prettyplease::unparse(&syn::parse_quote! {
-        #generated_code
-
-        #inlined_staged
-    });
+    let source = prettyplease::unparse(&generated_code);
 
     let hash = format!("{:X}", Sha256::digest(&source))
         .chars()
@@ -454,25 +447,38 @@ pub(super) fn create_sim_graph_trybuild(
 
     // TODO(shadaj): garbage collect this directory occasionally
     fs::create_dir_all(path!(project_dir / "src")).unwrap();
+    fs::create_dir_all(path!(project_dir / "examples")).unwrap();
 
-    let out_path = path!(project_dir / "src" / format!("{bin_name}.rs"));
+    let out_path = path!(project_dir / "examples" / format!("{bin_name}.rs"));
     {
         let _concurrent_test_lock = CONCURRENT_TEST_LOCK.lock().unwrap();
         write_atomic(source.as_ref(), &out_path).unwrap();
     }
 
-    let lib_path = path!(project_dir / "src" / format!("lib.rs"));
-    {
-        let _concurrent_test_lock = CONCURRENT_TEST_LOCK.lock().unwrap();
-        write_atomic("#![allow(unused_imports, unused_crate_dependencies, missing_docs, non_snake_case)]\n#[cfg(__hydro_sim)]include!(std::concat!(env!(\"TRYBUILD_LIB_NAME\"), \".rs\"));".as_bytes(), &lib_path).unwrap();
+    if let Some(inlined_staged) = inlined_staged {
+        let staged_path = path!(project_dir / "src" / "__staged.rs");
+        {
+            let _concurrent_test_lock = CONCURRENT_TEST_LOCK.lock().unwrap();
+            write_atomic(inlined_staged.as_bytes(), &staged_path).unwrap();
+        }
     }
 
-    let build_rs_path = path!(project_dir / "build.rs");
+    let crate_name_ident = syn::Ident::new(crate_name, Span::call_site());
+    let lib_path = path!(project_dir / "src" / "lib.rs");
     {
         let _concurrent_test_lock = CONCURRENT_TEST_LOCK.lock().unwrap();
         write_atomic(
-            b"fn main() { println!(\"cargo::rerun-if-env-changed=TRYBUILD_LIB_NAME\"); println!(\"cargo::rustc-check-cfg=cfg(__hydro_sim)\"); if std::env::var(\"TRYBUILD_LIB_NAME\").is_ok() { println!(\"cargo:rustc-cfg=__hydro_sim\"); } }",
-            &build_rs_path,
+            prettyplease::unparse(&syn::parse_quote! {
+                #![allow(unused_imports, unused_crate_dependencies, missing_docs, non_snake_case)]
+
+                #[cfg(feature = "hydro___test")]
+                pub mod __staged;
+
+                #[cfg(not(feature = "hydro___test"))]
+                pub use #crate_name_ident::__staged;
+            })
+            .as_bytes(),
+            &lib_path,
         )
         .unwrap();
     }
@@ -544,9 +550,12 @@ fn compile_sim_graph_trybuild(
         })
         .collect::<Vec<syn::Expr>>();
 
+    let trybuild_crate_name_ident = quote::format_ident!("{}_hydro_trybuild", crate_name);
+
     let source_ast: syn::File = syn::parse_quote! {
         use hydro_lang::prelude::*;
         use hydro_lang::runtime_support::dfir_rs as __root_dfir_rs;
+        pub use #trybuild_crate_name_ident::__staged;
 
         #[allow(unused)]
         fn __hydro_runtime_core<'a>(

--- a/template/hydro/Cargo.toml
+++ b/template/hydro/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2024"
 [dependencies]
 hydro_lang = { git = "{{ hydro_git | default: 'https://github.com/hydro-project/hydro.git' }}", branch = "{{ hydro_branch | default: 'main' }}" }
 hydro_std = { git = "{{ hydro_git | default: 'https://github.com/hydro-project/hydro.git' }}", branch = "{{ hydro_branch | default: 'main' }}" }
-stageleft = "0.9.6"
+stageleft = "0.10.0"
 
 [build-dependencies]
-stageleft_tool = "0.9.6"
+stageleft_tool = "0.10.0"
 
 [dev-dependencies]
 ctor = "0.2"


### PR DESCRIPTION

Previously, each trybuild target (in test-mode) would have its own copy of the `__staged` module containing the entire sources of the original crate. This creates a huge compilation burden that is repeated on every deployment.

With an accompanying change in Stageleft, we are now able to share the `__staged` module in the common `lib.rs`. This also moves the simulation dylibs to be compiled as an example so that they do not conflict with the caching of the shared `lib.rs`.

Also reduces thrashing due to the lockfile having to be updated after each time it is written (because packages have to be removed which were needed in the workspace but not the trybuild).
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydro-project/hydro/pull/2187).
* #2192
* __->__ #2187