### PR TITLE
feat(hydro_lang): support singletons in simulator

### DIFF
--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -313,6 +313,9 @@ pub enum HydroSource {
 /// In particular, this lets the simulator fuse together all locations into one DFIR graph, spit
 /// out separate graphs for each tick, and emit hooks for controlling non-deterministic operators.
 pub trait DfirBuilder {
+    /// Whether the representation of singletons should include intermediate states.
+    fn singleton_intermediates(&self) -> bool;
+
     /// Gets the DFIR builder for the given location, creating it if necessary.
     fn get_dfir_mut(&mut self, location: &LocationId) -> &mut FlatGraphBuilder;
 
@@ -378,6 +381,10 @@ pub trait DfirBuilder {
 
 #[cfg(feature = "build")]
 impl DfirBuilder for BTreeMap<usize, FlatGraphBuilder> {
+    fn singleton_intermediates(&self) -> bool {
+        false
+    }
+
     fn get_dfir_mut(&mut self, location: &LocationId) -> &mut FlatGraphBuilder {
         self.entry(location.root().raw_id()).or_default()
     }
@@ -1335,6 +1342,11 @@ pub enum HydroNode {
         metadata: HydroIrMetadata,
     },
 
+    SingletonSource {
+        value: DebugExpr,
+        metadata: HydroIrMetadata,
+    },
+
     CycleSource {
         ident: syn::Ident,
         metadata: HydroIrMetadata,
@@ -1581,6 +1593,7 @@ impl HydroNode {
             }
 
             HydroNode::Source { .. }
+            | HydroNode::SingletonSource { .. }
             | HydroNode::CycleSource { .. }
             | HydroNode::ExternalInput { .. } => {}
 
@@ -1677,6 +1690,10 @@ impl HydroNode {
             },
             HydroNode::Source { source, metadata } => HydroNode::Source {
                 source: source.clone(),
+                metadata: metadata.clone(),
+            },
+            HydroNode::SingletonSource { value, metadata } => HydroNode::SingletonSource {
+                value: value.clone(),
                 metadata: metadata.clone(),
             },
             HydroNode::CycleSource { ident, metadata } => HydroNode::CycleSource {
@@ -2125,6 +2142,43 @@ impl HydroNode {
 
                     source_ident
                 }
+            }
+
+            HydroNode::SingletonSource { value, metadata } => {
+                let source_ident =
+                    syn::Ident::new(&format!("stream_{}", *next_stmt_id), Span::call_site());
+
+                match builders_or_callback {
+                    BuildersOrCallback::Builders(graph_builders) => {
+                        let should_replay = !graph_builders.singleton_intermediates();
+                        let builder = graph_builders.get_dfir_mut(&out_location);
+
+                        if should_replay || !metadata.location_kind.is_top_level() {
+                            builder.add_dfir(
+                                parse_quote! {
+                                    #source_ident = source_iter([#value]) -> persist::<'static>();
+                                },
+                                None,
+                                Some(&next_stmt_id.to_string()),
+                            );
+                        } else {
+                            builder.add_dfir(
+                                parse_quote! {
+                                    #source_ident = source_iter([#value]);
+                                },
+                                None,
+                                Some(&next_stmt_id.to_string()),
+                            );
+                        }
+                    }
+                    BuildersOrCallback::Callback(_, node_callback) => {
+                        node_callback(self, next_stmt_id);
+                    }
+                }
+
+                *next_stmt_id += 1;
+
+                source_ident
             }
 
             HydroNode::CycleSource { ident, .. } => {
@@ -2732,15 +2786,9 @@ impl HydroNode {
                     parse_quote!(fold_keyed)
                 };
 
-                let (HydroNode::Fold {
-                    init, acc, input, ..
-                }
-                | HydroNode::FoldKeyed {
-                    init, acc, input, ..
-                }
-                | HydroNode::Scan {
-                    init, acc, input, ..
-                }) = self
+                let (HydroNode::Fold { input, .. }
+                | HydroNode::FoldKeyed { input, .. }
+                | HydroNode::Scan { input, .. }) = self
                 else {
                     unreachable!()
                 };
@@ -2757,19 +2805,50 @@ impl HydroNode {
 
                 let input_ident = input.emit_core(builders_or_callback, built_tees, next_stmt_id);
 
+                let (HydroNode::Fold { init, acc, .. }
+                | HydroNode::FoldKeyed { init, acc, .. }
+                | HydroNode::Scan { init, acc, .. }) = &*self
+                else {
+                    unreachable!()
+                };
+
                 let fold_ident =
                     syn::Ident::new(&format!("stream_{}", *next_stmt_id), Span::call_site());
 
                 match builders_or_callback {
                     BuildersOrCallback::Builders(graph_builders) => {
-                        let builder = graph_builders.get_dfir_mut(&out_location);
-                        builder.add_dfir(
-                            parse_quote! {
-                                #fold_ident = #input_ident -> #operator::<#lifetime>(#init, #acc);
-                            },
-                            None,
-                            Some(&next_stmt_id.to_string()),
-                        );
+                        if matches!(self, HydroNode::Fold { .. })
+                            && self.metadata().location_kind.is_top_level()
+                            && graph_builders.singleton_intermediates()
+                        {
+                            let acc: syn::Expr = parse_quote!({
+                                let mut __inner = #acc;
+                                move |__state, __value| {
+                                    __inner(__state, __value);
+                                    Some(__state.clone())
+                                }
+                            });
+
+                            let builder = graph_builders.get_dfir_mut(&out_location);
+                            builder.add_dfir(
+                                parse_quote! {
+                                    source_iter([(#init)()]) -> [0]#fold_ident;
+                                    #input_ident -> scan::<#lifetime>(#init, #acc) -> [1]#fold_ident;
+                                    #fold_ident = chain();
+                                },
+                                None,
+                                Some(&next_stmt_id.to_string()),
+                            );
+                        } else {
+                            let builder = graph_builders.get_dfir_mut(&out_location);
+                            builder.add_dfir(
+                                parse_quote! {
+                                    #fold_ident = #input_ident -> #operator::<#lifetime>(#init, #acc);
+                                },
+                                None,
+                                Some(&next_stmt_id.to_string()),
+                            );
+                        }
                     }
                     BuildersOrCallback::Callback(_, node_callback) => {
                         node_callback(self, next_stmt_id);
@@ -3053,6 +3132,9 @@ impl HydroNode {
                 HydroSource::Stream(expr) | HydroSource::Iter(expr) => transform(expr),
                 HydroSource::ExternalNetwork() | HydroSource::Spin() => {}
             },
+            HydroNode::SingletonSource { value, .. } => {
+                transform(value);
+            }
             HydroNode::CycleSource { .. }
             | HydroNode::Tee { .. }
             | HydroNode::Persist { .. }
@@ -3124,6 +3206,7 @@ impl HydroNode {
             HydroNode::Cast { metadata, .. } => metadata,
             HydroNode::ObserveNonDet { metadata, .. } => metadata,
             HydroNode::Source { metadata, .. } => metadata,
+            HydroNode::SingletonSource { metadata, .. } => metadata,
             HydroNode::CycleSource { metadata, .. } => metadata,
             HydroNode::Tee { metadata, .. } => metadata,
             HydroNode::Persist { metadata, .. } => metadata,
@@ -3173,6 +3256,7 @@ impl HydroNode {
             HydroNode::Cast { metadata, .. } => metadata,
             HydroNode::ObserveNonDet { metadata, .. } => metadata,
             HydroNode::Source { metadata, .. } => metadata,
+            HydroNode::SingletonSource { metadata, .. } => metadata,
             HydroNode::CycleSource { metadata, .. } => metadata,
             HydroNode::Tee { metadata, .. } => metadata,
             HydroNode::Persist { metadata, .. } => metadata,
@@ -3216,6 +3300,7 @@ impl HydroNode {
                 panic!()
             }
             HydroNode::Source { .. }
+            | HydroNode::SingletonSource { .. }
             | HydroNode::ExternalInput { .. }
             | HydroNode::CycleSource { .. } // CycleSource and Tee should calculate input metadata in separate special ways
             | HydroNode::Tee { .. } => {
@@ -3290,6 +3375,7 @@ impl HydroNode {
             HydroNode::Cast { .. } => "Cast()".to_string(),
             HydroNode::ObserveNonDet { .. } => "ObserveNonDet()".to_string(),
             HydroNode::Source { source, .. } => format!("Source({:?})", source),
+            HydroNode::SingletonSource { value, .. } => format!("SingletonSource({:?})", value),
             HydroNode::CycleSource { ident, .. } => format!("CycleSource({})", ident),
             HydroNode::Tee { inner, .. } => format!("Tee({})", inner.0.borrow().print_root()),
             HydroNode::Persist { .. } => "Persist()".to_string(),

--- a/hydro_lang/src/graph/render.rs
+++ b/hydro_lang/src/graph/render.rs
@@ -561,6 +561,11 @@ impl HydroNode {
                 build_source_node(structure, metadata, label)
             }
 
+            HydroNode::SingletonSource { value, metadata } => {
+                let label = format!("singleton({})", value);
+                build_source_node(structure, metadata, label)
+            }
+
             HydroNode::ExternalInput {
                 from_external_id,
                 from_key,

--- a/hydro_lang/src/location/mod.rs
+++ b/hydro_lang/src/location/mod.rs
@@ -557,38 +557,16 @@ pub trait Location<'a>: dynamic::DynLocation {
         // TODO(shadaj): we mark this as unbounded because we do not yet have a representation
         // for bounded top-level singletons, and this is the only way to generate one
 
-        let e_arr = q!([e]);
-        let e = e_arr.splice_untyped_ctx(self);
+        let e = e.splice_untyped_ctx(self);
 
-        if Self::is_top_level() {
-            Singleton::new(
-                self.clone(),
-                HydroNode::Persist {
-                    inner: Box::new(HydroNode::Source {
-                        source: HydroSource::Iter(e.into()),
-                        metadata: self.new_node_metadata(Stream::<
-                            T,
-                            Self,
-                            Unbounded,
-                            TotalOrder,
-                            ExactlyOnce,
-                        >::collection_kind(
-                        )),
-                    }),
-                    metadata: self
-                        .new_node_metadata(Singleton::<T, Self, Unbounded>::collection_kind()),
-                },
-            )
-        } else {
-            Singleton::new(
-                self.clone(),
-                HydroNode::Source {
-                    source: HydroSource::Iter(e.into()),
-                    metadata: self
-                        .new_node_metadata(Singleton::<T, Self, Unbounded>::collection_kind()),
-                },
-            )
-        }
+        Singleton::new(
+            self.clone(),
+            HydroNode::SingletonSource {
+                value: e.into(),
+                metadata: self
+                    .new_node_metadata(Singleton::<T, Self, Unbounded>::collection_kind()),
+            },
+        )
     }
 
     /// Generates a stream with values emitted at a fixed interval, with

--- a/hydro_lang/src/location/tick.rs
+++ b/hydro_lang/src/location/tick.rs
@@ -134,13 +134,12 @@ where
     where
         T: Clone,
     {
-        let e_arr = q!([e]);
-        let e = e_arr.splice_untyped_ctx(self);
+        let e = e.splice_untyped_ctx(self);
 
         Singleton::new(
             self.clone(),
-            HydroNode::Source {
-                source: HydroSource::Iter(e.into()),
+            HydroNode::SingletonSource {
+                value: e.into(),
                 metadata: self.new_node_metadata(Singleton::<T, Self, Bounded>::collection_kind()),
             },
         )

--- a/hydro_lang/src/sim/compiled.rs
+++ b/hydro_lang/src/sim/compiled.rs
@@ -161,7 +161,7 @@ impl CompiledSim {
                         if instance.log {
                             eprintln!(
                                 "{}",
-                                "\n==== New Simulation Instance ====\n"
+                                "\n==== New Simulation Instance ===="
                                     .color(colored::Color::Cyan)
                                     .bold()
                             );
@@ -286,7 +286,7 @@ impl CompiledSim {
                     if instance.log {
                         eprintln!(
                             "{}",
-                            "\n==== New Simulation Instance ====\n"
+                            "\n==== New Simulation Instance ===="
                                 .color(colored::Color::Cyan)
                                 .bold()
                         );
@@ -630,7 +630,7 @@ impl<W: std::io::Write> LaunchedSim<W> {
     async fn scheduler(&mut self) {
         loop {
             tokio::task::yield_now().await;
-            if self.async_dfir.run_available().await {
+            if self.async_dfir.run_tick().await {
                 self.possibly_ready_ticks.append(&mut self.not_ready_ticks);
                 continue;
             } else {

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir.snap
@@ -282,23 +282,8 @@ expression: built.ir()
                                         },
                                         second: Batch {
                                             inner: Cast {
-                                                inner: Persist {
-                                                    inner: Source {
-                                                        source: Iter(
-                                                            { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let e__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; Ballot { num : 0 , proposer_id : MemberId :: from_raw (0) } } ; [e__free] },
-                                                        ),
-                                                        metadata: HydroIrMetadata {
-                                                            location_kind: Cluster(
-                                                                0,
-                                                            ),
-                                                            collection_kind: Stream {
-                                                                bound: Unbounded,
-                                                                order: TotalOrder,
-                                                                retry: ExactlyOnce,
-                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                            },
-                                                        },
-                                                    },
+                                                inner: SingletonSource {
+                                                    value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; Ballot { num : 0 , proposer_id : MemberId :: from_raw (0) } },
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Cluster(
                                                             0,
@@ -426,10 +411,8 @@ expression: built.ir()
                                     },
                                 },
                                 second: Cast {
-                                    inner: Source {
-                                        source: Iter(
-                                            { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: tick :: * ; let e__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; 0 } ; [e__free] },
-                                        ),
+                                    inner: SingletonSource {
+                                        value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; 0 },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
                                                 1,
@@ -2062,10 +2045,8 @@ expression: built.ir()
                                                                                                                         },
                                                                                                                     },
                                                                                                                     second: Cast {
-                                                                                                                        inner: Source {
-                                                                                                                            source: Iter(
-                                                                                                                                { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: tick :: * ; let e__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; Ballot { num : 0 , proposer_id : MemberId :: from_raw (0) } } ; [e__free] },
-                                                                                                                            ),
+                                                                                                                        inner: SingletonSource {
+                                                                                                                            value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; Ballot { num : 0 , proposer_id : MemberId :: from_raw (0) } },
                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                 location_kind: Tick(
                                                                                                                                     2,
@@ -4802,10 +4783,8 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     second: Cast {
-                                                                        inner: Source {
-                                                                            source: Iter(
-                                                                                { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: tick :: * ; let e__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; 0 } ; [e__free] },
-                                                                            ),
+                                                                        inner: SingletonSource {
+                                                                            value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; 0 },
                                                                             metadata: HydroIrMetadata {
                                                                                 location_kind: Tick(
                                                                                     1,
@@ -7963,10 +7942,8 @@ expression: built.ir()
                                                         },
                                                     },
                                                     second: Cast {
-                                                        inner: Source {
-                                                            source: Iter(
-                                                                { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: tick :: * ; let e__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; 0 } ; [e__free] },
-                                                            ),
+                                                        inner: SingletonSource {
+                                                            value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; 0 },
                                                             metadata: HydroIrMetadata {
                                                                 location_kind: Tick(
                                                                     16,
@@ -8532,10 +8509,8 @@ expression: built.ir()
                                     },
                                 },
                                 second: Cast {
-                                    inner: Source {
-                                        source: Iter(
-                                            { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: tick :: * ; let e__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; 0 } ; [e__free] },
-                                        ),
+                                    inner: SingletonSource {
+                                        value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; 0 },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
                                                 16,

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir@acceptor_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir@acceptor_mermaid.snap
@@ -17,7 +17,7 @@ linkStyle default stroke:#aaa
 7v1["<div style=text-align:center>(7v1)</div> <code><br>inspect({<br>    |p1a| println!(&quot;Acceptor received P1a: {:?}&quot;, p1a)<br>})</code>"]:::otherClass
 8v1["<div style=text-align:center>(8v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
 9v1["<div style=text-align:center>(9v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    |curr, new| {<br>        if new &gt; *curr {<br>            *curr = new;<br>        }<br>    }<br>})</code>"]:::otherClass
-10v1["<div style=text-align:center>(10v1)</div> <code><br>source_iter({<br>    let e__free = {<br>        Ballot {<br>            num: 0,<br>            proposer_id: MemberId::from_raw(0),<br>        }<br>    };<br>    [e__free]<br>})</code>"]:::otherClass
+10v1["<div style=text-align:center>(10v1)</div> <code><br>source_iter([<br>    {<br>        Ballot {<br>            num: 0,<br>            proposer_id: MemberId::from_raw(0),<br>        }<br>    },<br>])</code>"]:::otherClass
 11v1["<div style=text-align:center>(11v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
 12v1["<div style=text-align:center>(12v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
 13v1["<div style=text-align:center>(13v1)</div> <code><br>tee()</code>"]:::otherClass
@@ -120,161 +120,161 @@ linkStyle default stroke:#aaa
 26v1
 36v1
 35v1
-subgraph var_reduce_keyed_watermark_chain_371 ["var <tt>reduce_keyed_watermark_chain_371</tt>"]
-    style var_reduce_keyed_watermark_chain_371 fill:transparent
+subgraph var_reduce_keyed_watermark_chain_370 ["var <tt>reduce_keyed_watermark_chain_370</tt>"]
+    style var_reduce_keyed_watermark_chain_370 fill:transparent
     34v1
 end
-subgraph var_stream_104 ["var <tt>stream_104</tt>"]
-    style var_stream_104 fill:transparent
+subgraph var_stream_103 ["var <tt>stream_103</tt>"]
+    style var_stream_103 fill:transparent
     3v1
     4v1
 end
-subgraph var_stream_105 ["var <tt>stream_105</tt>"]
-    style var_stream_105 fill:transparent
+subgraph var_stream_104 ["var <tt>stream_104</tt>"]
+    style var_stream_104 fill:transparent
     5v1
 end
-subgraph var_stream_107 ["var <tt>stream_107</tt>"]
-    style var_stream_107 fill:transparent
+subgraph var_stream_106 ["var <tt>stream_106</tt>"]
+    style var_stream_106 fill:transparent
     6v1
+end
+subgraph var_stream_108 ["var <tt>stream_108</tt>"]
+    style var_stream_108 fill:transparent
+    7v1
 end
 subgraph var_stream_109 ["var <tt>stream_109</tt>"]
     style var_stream_109 fill:transparent
-    7v1
-end
-subgraph var_stream_110 ["var <tt>stream_110</tt>"]
-    style var_stream_110 fill:transparent
     8v1
+end
+subgraph var_stream_111 ["var <tt>stream_111</tt>"]
+    style var_stream_111 fill:transparent
+    9v1
 end
 subgraph var_stream_112 ["var <tt>stream_112</tt>"]
     style var_stream_112 fill:transparent
-    9v1
-end
-subgraph var_stream_113 ["var <tt>stream_113</tt>"]
-    style var_stream_113 fill:transparent
     10v1
     11v1
 end
+subgraph var_stream_113 ["var <tt>stream_113</tt>"]
+    style var_stream_113 fill:transparent
+    12v1
+end
 subgraph var_stream_114 ["var <tt>stream_114</tt>"]
     style var_stream_114 fill:transparent
-    12v1
+    13v1
 end
 subgraph var_stream_115 ["var <tt>stream_115</tt>"]
     style var_stream_115 fill:transparent
-    13v1
-end
-subgraph var_stream_116 ["var <tt>stream_116</tt>"]
-    style var_stream_116 fill:transparent
     14v1
+end
+subgraph var_stream_117 ["var <tt>stream_117</tt>"]
+    style var_stream_117 fill:transparent
+    15v1
 end
 subgraph var_stream_118 ["var <tt>stream_118</tt>"]
     style var_stream_118 fill:transparent
-    15v1
-end
-subgraph var_stream_119 ["var <tt>stream_119</tt>"]
-    style var_stream_119 fill:transparent
     16v1
 end
 subgraph var_stream_2 ["var <tt>stream_2</tt>"]
     style var_stream_2 fill:transparent
     1v1
 end
-subgraph var_stream_315 ["var <tt>stream_315</tt>"]
-    style var_stream_315 fill:transparent
+subgraph var_stream_314 ["var <tt>stream_314</tt>"]
+    style var_stream_314 fill:transparent
     19v1
     20v1
 end
-subgraph var_stream_316 ["var <tt>stream_316</tt>"]
-    style var_stream_316 fill:transparent
+subgraph var_stream_315 ["var <tt>stream_315</tt>"]
+    style var_stream_315 fill:transparent
     21v1
 end
-subgraph var_stream_318 ["var <tt>stream_318</tt>"]
-    style var_stream_318 fill:transparent
+subgraph var_stream_317 ["var <tt>stream_317</tt>"]
+    style var_stream_317 fill:transparent
     22v1
+end
+subgraph var_stream_319 ["var <tt>stream_319</tt>"]
+    style var_stream_319 fill:transparent
+    23v1
 end
 subgraph var_stream_320 ["var <tt>stream_320</tt>"]
     style var_stream_320 fill:transparent
-    23v1
-end
-subgraph var_stream_321 ["var <tt>stream_321</tt>"]
-    style var_stream_321 fill:transparent
     24v1
+end
+subgraph var_stream_359 ["var <tt>stream_359</tt>"]
+    style var_stream_359 fill:transparent
+    27v1
 end
 subgraph var_stream_360 ["var <tt>stream_360</tt>"]
     style var_stream_360 fill:transparent
-    27v1
+    28v1
 end
 subgraph var_stream_361 ["var <tt>stream_361</tt>"]
     style var_stream_361 fill:transparent
-    28v1
-end
-subgraph var_stream_362 ["var <tt>stream_362</tt>"]
-    style var_stream_362 fill:transparent
     29v1
     30v1
 end
-subgraph var_stream_363 ["var <tt>stream_363</tt>"]
-    style var_stream_363 fill:transparent
+subgraph var_stream_362 ["var <tt>stream_362</tt>"]
+    style var_stream_362 fill:transparent
     31v1
+end
+subgraph var_stream_365 ["var <tt>stream_365</tt>"]
+    style var_stream_365 fill:transparent
+    32v1
 end
 subgraph var_stream_366 ["var <tt>stream_366</tt>"]
     style var_stream_366 fill:transparent
-    32v1
-end
-subgraph var_stream_367 ["var <tt>stream_367</tt>"]
-    style var_stream_367 fill:transparent
     33v1
 end
-subgraph var_stream_371 ["var <tt>stream_371</tt>"]
-    style var_stream_371 fill:transparent
+subgraph var_stream_370 ["var <tt>stream_370</tt>"]
+    style var_stream_370 fill:transparent
     37v1
     38v1
 end
-subgraph var_stream_374 ["var <tt>stream_374</tt>"]
-    style var_stream_374 fill:transparent
+subgraph var_stream_373 ["var <tt>stream_373</tt>"]
+    style var_stream_373 fill:transparent
     39v1
 end
-subgraph var_stream_375 ["var <tt>stream_375</tt>"]
-    style var_stream_375 fill:transparent
+subgraph var_stream_374 ["var <tt>stream_374</tt>"]
+    style var_stream_374 fill:transparent
     40v1
 end
-subgraph var_stream_452 ["var <tt>stream_452</tt>"]
-    style var_stream_452 fill:transparent
+subgraph var_stream_451 ["var <tt>stream_451</tt>"]
+    style var_stream_451 fill:transparent
     41v1
     42v1
 end
-subgraph var_stream_453 ["var <tt>stream_453</tt>"]
-    style var_stream_453 fill:transparent
+subgraph var_stream_452 ["var <tt>stream_452</tt>"]
+    style var_stream_452 fill:transparent
     43v1
 end
-subgraph var_stream_455 ["var <tt>stream_455</tt>"]
-    style var_stream_455 fill:transparent
+subgraph var_stream_454 ["var <tt>stream_454</tt>"]
+    style var_stream_454 fill:transparent
     44v1
+end
+subgraph var_stream_457 ["var <tt>stream_457</tt>"]
+    style var_stream_457 fill:transparent
+    45v1
 end
 subgraph var_stream_458 ["var <tt>stream_458</tt>"]
     style var_stream_458 fill:transparent
-    45v1
+    46v1
 end
 subgraph var_stream_459 ["var <tt>stream_459</tt>"]
     style var_stream_459 fill:transparent
-    46v1
+    47v1
 end
 subgraph var_stream_460 ["var <tt>stream_460</tt>"]
     style var_stream_460 fill:transparent
-    47v1
+    48v1
 end
 subgraph var_stream_461 ["var <tt>stream_461</tt>"]
     style var_stream_461 fill:transparent
-    48v1
+    49v1
 end
 subgraph var_stream_462 ["var <tt>stream_462</tt>"]
     style var_stream_462 fill:transparent
-    49v1
-end
-subgraph var_stream_463 ["var <tt>stream_463</tt>"]
-    style var_stream_463 fill:transparent
     50v1
 end
-subgraph var_stream_465 ["var <tt>stream_465</tt>"]
-    style var_stream_465 fill:transparent
+subgraph var_stream_464 ["var <tt>stream_464</tt>"]
+    style var_stream_464 fill:transparent
     51v1
 end

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir@proposer_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir@proposer_mermaid.snap
@@ -13,12 +13,12 @@ linkStyle default stroke:#aaa
 3v1["<div style=text-align:center>(3v1)</div> <code><br>chain()</code>"]:::otherClass
 4v1["<div style=text-align:center>(4v1)</div> <code><br>chain()</code>"]:::otherClass
 5v1["<div style=text-align:center>(5v1)</div> <code><br>reduce::&lt;<br>    'static,<br>&gt;({<br>    |curr, new| {<br>        if new &gt; *curr {<br>            *curr = new;<br>        }<br>    }<br>})</code>"]:::otherClass
-6v1["<div style=text-align:center>(6v1)</div> <code><br>source_iter({<br>    let e__free = {<br>        Ballot {<br>            num: 0,<br>            proposer_id: MemberId::from_raw(0),<br>        }<br>    };<br>    [e__free]<br>})</code>"]:::otherClass
+6v1["<div style=text-align:center>(6v1)</div> <code><br>source_iter([<br>    {<br>        Ballot {<br>            num: 0,<br>            proposer_id: MemberId::from_raw(0),<br>        }<br>    },<br>])</code>"]:::otherClass
 7v1["<div style=text-align:center>(7v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
 8v1["<div style=text-align:center>(8v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
 9v1["<div style=text-align:center>(9v1)</div> <code><br>tee()</code>"]:::otherClass
 10v1["<div style=text-align:center>(10v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-11v1["<div style=text-align:center>(11v1)</div> <code><br>source_iter({<br>    let e__free = {<br>        0<br>    };<br>    [e__free]<br>})</code>"]:::otherClass
+11v1["<div style=text-align:center>(11v1)</div> <code><br>source_iter([<br>    {<br>        0<br>    },<br>])</code>"]:::otherClass
 12v1["<div style=text-align:center>(12v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
 13v1["<div style=text-align:center>(13v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
 14v1["<div style=text-align:center>(14v1)</div> <code><br>tee()</code>"]:::otherClass
@@ -154,7 +154,7 @@ linkStyle default stroke:#aaa
 146v1["<div style=text-align:center>(146v1)</div> <code><br>tee()</code>"]:::otherClass
 147v1["<div style=text-align:center>(147v1)</div> <code><br>map({<br>    |max_slot| max_slot + 1<br>})</code>"]:::otherClass
 148v1["<div style=text-align:center>(148v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-149v1["<div style=text-align:center>(149v1)</div> <code><br>source_iter({<br>    let e__free = {<br>        0<br>    };<br>    [e__free]<br>})</code>"]:::otherClass
+149v1["<div style=text-align:center>(149v1)</div> <code><br>source_iter([<br>    {<br>        0<br>    },<br>])</code>"]:::otherClass
 150v1["<div style=text-align:center>(150v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
 151v1["<div style=text-align:center>(151v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
 152v1["<div style=text-align:center>(152v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
@@ -534,42 +534,42 @@ subgraph var_stream_0 ["var <tt>stream_0</tt>"]
     style var_stream_0 fill:transparent
     1v1
 end
-subgraph var_stream_100 ["var <tt>stream_100</tt>"]
-    style var_stream_100 fill:transparent
-    65v1
-end
-subgraph var_stream_102 ["var <tt>stream_102</tt>"]
-    style var_stream_102 fill:transparent
+subgraph var_stream_101 ["var <tt>stream_101</tt>"]
+    style var_stream_101 fill:transparent
     66v1
 end
-subgraph var_stream_121 ["var <tt>stream_121</tt>"]
-    style var_stream_121 fill:transparent
+subgraph var_stream_120 ["var <tt>stream_120</tt>"]
+    style var_stream_120 fill:transparent
     69v1
     70v1
 end
+subgraph var_stream_121 ["var <tt>stream_121</tt>"]
+    style var_stream_121 fill:transparent
+    71v1
+end
 subgraph var_stream_122 ["var <tt>stream_122</tt>"]
     style var_stream_122 fill:transparent
-    71v1
+    72v1
 end
 subgraph var_stream_123 ["var <tt>stream_123</tt>"]
     style var_stream_123 fill:transparent
-    72v1
-end
-subgraph var_stream_124 ["var <tt>stream_124</tt>"]
-    style var_stream_124 fill:transparent
     73v1
+end
+subgraph var_stream_125 ["var <tt>stream_125</tt>"]
+    style var_stream_125 fill:transparent
+    74v1
 end
 subgraph var_stream_126 ["var <tt>stream_126</tt>"]
     style var_stream_126 fill:transparent
-    74v1
-end
-subgraph var_stream_127 ["var <tt>stream_127</tt>"]
-    style var_stream_127 fill:transparent
     75v1
+end
+subgraph var_stream_128 ["var <tt>stream_128</tt>"]
+    style var_stream_128 fill:transparent
+    76v1
 end
 subgraph var_stream_129 ["var <tt>stream_129</tt>"]
     style var_stream_129 fill:transparent
-    76v1
+    77v1
 end
 subgraph var_stream_13 ["var <tt>stream_13</tt>"]
     style var_stream_13 fill:transparent
@@ -577,107 +577,107 @@ subgraph var_stream_13 ["var <tt>stream_13</tt>"]
 end
 subgraph var_stream_130 ["var <tt>stream_130</tt>"]
     style var_stream_130 fill:transparent
-    77v1
+    78v1
 end
 subgraph var_stream_131 ["var <tt>stream_131</tt>"]
     style var_stream_131 fill:transparent
-    78v1
-end
-subgraph var_stream_132 ["var <tt>stream_132</tt>"]
-    style var_stream_132 fill:transparent
     79v1
+end
+subgraph var_stream_133 ["var <tt>stream_133</tt>"]
+    style var_stream_133 fill:transparent
+    80v1
 end
 subgraph var_stream_134 ["var <tt>stream_134</tt>"]
     style var_stream_134 fill:transparent
-    80v1
+    81v1
 end
 subgraph var_stream_135 ["var <tt>stream_135</tt>"]
     style var_stream_135 fill:transparent
-    81v1
+    82v1
 end
 subgraph var_stream_136 ["var <tt>stream_136</tt>"]
     style var_stream_136 fill:transparent
-    82v1
-end
-subgraph var_stream_137 ["var <tt>stream_137</tt>"]
-    style var_stream_137 fill:transparent
     83v1
 end
-subgraph var_stream_140 ["var <tt>stream_140</tt>"]
-    style var_stream_140 fill:transparent
+subgraph var_stream_139 ["var <tt>stream_139</tt>"]
+    style var_stream_139 fill:transparent
     84v1
+end
+subgraph var_stream_142 ["var <tt>stream_142</tt>"]
+    style var_stream_142 fill:transparent
+    85v1
 end
 subgraph var_stream_143 ["var <tt>stream_143</tt>"]
     style var_stream_143 fill:transparent
-    85v1
+    86v1
 end
 subgraph var_stream_144 ["var <tt>stream_144</tt>"]
     style var_stream_144 fill:transparent
-    86v1
-end
-subgraph var_stream_145 ["var <tt>stream_145</tt>"]
-    style var_stream_145 fill:transparent
     87v1
+end
+subgraph var_stream_146 ["var <tt>stream_146</tt>"]
+    style var_stream_146 fill:transparent
+    88v1
 end
 subgraph var_stream_147 ["var <tt>stream_147</tt>"]
     style var_stream_147 fill:transparent
-    88v1
+    89v1
 end
 subgraph var_stream_148 ["var <tt>stream_148</tt>"]
     style var_stream_148 fill:transparent
-    89v1
-end
-subgraph var_stream_149 ["var <tt>stream_149</tt>"]
-    style var_stream_149 fill:transparent
     90v1
+end
+subgraph var_stream_151 ["var <tt>stream_151</tt>"]
+    style var_stream_151 fill:transparent
+    91v1
 end
 subgraph var_stream_152 ["var <tt>stream_152</tt>"]
     style var_stream_152 fill:transparent
-    91v1
-end
-subgraph var_stream_153 ["var <tt>stream_153</tt>"]
-    style var_stream_153 fill:transparent
     92v1
 end
-subgraph var_stream_155 ["var <tt>stream_155</tt>"]
-    style var_stream_155 fill:transparent
+subgraph var_stream_154 ["var <tt>stream_154</tt>"]
+    style var_stream_154 fill:transparent
     93v1
+end
+subgraph var_stream_157 ["var <tt>stream_157</tt>"]
+    style var_stream_157 fill:transparent
+    94v1
 end
 subgraph var_stream_158 ["var <tt>stream_158</tt>"]
     style var_stream_158 fill:transparent
-    94v1
+    95v1
 end
 subgraph var_stream_159 ["var <tt>stream_159</tt>"]
     style var_stream_159 fill:transparent
-    95v1
+    96v1
 end
 subgraph var_stream_160 ["var <tt>stream_160</tt>"]
     style var_stream_160 fill:transparent
-    96v1
-end
-subgraph var_stream_161 ["var <tt>stream_161</tt>"]
-    style var_stream_161 fill:transparent
     97v1
+end
+subgraph var_stream_163 ["var <tt>stream_163</tt>"]
+    style var_stream_163 fill:transparent
+    98v1
 end
 subgraph var_stream_164 ["var <tt>stream_164</tt>"]
     style var_stream_164 fill:transparent
-    98v1
+    99v1
 end
 subgraph var_stream_165 ["var <tt>stream_165</tt>"]
     style var_stream_165 fill:transparent
-    99v1
-end
-subgraph var_stream_166 ["var <tt>stream_166</tt>"]
-    style var_stream_166 fill:transparent
     100v1
+end
+subgraph var_stream_167 ["var <tt>stream_167</tt>"]
+    style var_stream_167 fill:transparent
+    102v1
 end
 subgraph var_stream_168 ["var <tt>stream_168</tt>"]
     style var_stream_168 fill:transparent
-    102v1
+    103v1
 end
 subgraph var_stream_169 ["var <tt>stream_169</tt>"]
     style var_stream_169 fill:transparent
-    103v1
+    104v1
 end
 subgraph var_stream_17 ["var <tt>stream_17</tt>"]
     style var_stream_17 fill:transparent
@@ -685,689 +685,686 @@ subgraph var_stream_17 ["var <tt>stream_17</tt>"]
 end
 subgraph var_stream_170 ["var <tt>stream_170</tt>"]
     style var_stream_170 fill:transparent
-    104v1
-end
-subgraph var_stream_171 ["var <tt>stream_171</tt>"]
-    style var_stream_171 fill:transparent
     105v1
+end
+subgraph var_stream_172 ["var <tt>stream_172</tt>"]
+    style var_stream_172 fill:transparent
+    106v1
 end
 subgraph var_stream_173 ["var <tt>stream_173</tt>"]
     style var_stream_173 fill:transparent
-    106v1
-end
-subgraph var_stream_174 ["var <tt>stream_174</tt>"]
-    style var_stream_174 fill:transparent
     107v1
+end
+subgraph var_stream_181 ["var <tt>stream_181</tt>"]
+    style var_stream_181 fill:transparent
+    108v1
 end
 subgraph var_stream_182 ["var <tt>stream_182</tt>"]
     style var_stream_182 fill:transparent
-    108v1
+    109v1
 end
 subgraph var_stream_183 ["var <tt>stream_183</tt>"]
     style var_stream_183 fill:transparent
-    109v1
+    110v1
 end
 subgraph var_stream_184 ["var <tt>stream_184</tt>"]
     style var_stream_184 fill:transparent
-    110v1
-end
-subgraph var_stream_185 ["var <tt>stream_185</tt>"]
-    style var_stream_185 fill:transparent
     111v1
 end
-subgraph var_stream_187 ["var <tt>stream_187</tt>"]
-    style var_stream_187 fill:transparent
+subgraph var_stream_186 ["var <tt>stream_186</tt>"]
+    style var_stream_186 fill:transparent
     112v1
 end
 subgraph var_stream_19 ["var <tt>stream_19</tt>"]
     style var_stream_19 fill:transparent
     6v1
+    7v1
+end
+subgraph var_stream_191 ["var <tt>stream_191</tt>"]
+    style var_stream_191 fill:transparent
+    113v1
 end
 subgraph var_stream_192 ["var <tt>stream_192</tt>"]
     style var_stream_192 fill:transparent
-    113v1
+    114v1
 end
 subgraph var_stream_193 ["var <tt>stream_193</tt>"]
     style var_stream_193 fill:transparent
-    114v1
+    115v1
 end
 subgraph var_stream_194 ["var <tt>stream_194</tt>"]
     style var_stream_194 fill:transparent
-    115v1
-end
-subgraph var_stream_195 ["var <tt>stream_195</tt>"]
-    style var_stream_195 fill:transparent
     116v1
     117v1
 end
+subgraph var_stream_195 ["var <tt>stream_195</tt>"]
+    style var_stream_195 fill:transparent
+    118v1
+end
 subgraph var_stream_196 ["var <tt>stream_196</tt>"]
     style var_stream_196 fill:transparent
-    118v1
+    119v1
 end
 subgraph var_stream_197 ["var <tt>stream_197</tt>"]
     style var_stream_197 fill:transparent
-    119v1
+    120v1
 end
 subgraph var_stream_198 ["var <tt>stream_198</tt>"]
     style var_stream_198 fill:transparent
-    120v1
+    121v1
 end
 subgraph var_stream_199 ["var <tt>stream_199</tt>"]
     style var_stream_199 fill:transparent
-    121v1
-end
-subgraph var_stream_20 ["var <tt>stream_20</tt>"]
-    style var_stream_20 fill:transparent
-    7v1
-end
-subgraph var_stream_200 ["var <tt>stream_200</tt>"]
-    style var_stream_200 fill:transparent
     122v1
+end
+subgraph var_stream_201 ["var <tt>stream_201</tt>"]
+    style var_stream_201 fill:transparent
+    124v1
 end
 subgraph var_stream_202 ["var <tt>stream_202</tt>"]
     style var_stream_202 fill:transparent
-    124v1
+    125v1
 end
 subgraph var_stream_203 ["var <tt>stream_203</tt>"]
     style var_stream_203 fill:transparent
-    125v1
-end
-subgraph var_stream_204 ["var <tt>stream_204</tt>"]
-    style var_stream_204 fill:transparent
     126v1
 end
-subgraph var_stream_207 ["var <tt>stream_207</tt>"]
-    style var_stream_207 fill:transparent
+subgraph var_stream_206 ["var <tt>stream_206</tt>"]
+    style var_stream_206 fill:transparent
     127v1
 end
-subgraph var_stream_22 ["var <tt>stream_22</tt>"]
-    style var_stream_22 fill:transparent
+subgraph var_stream_21 ["var <tt>stream_21</tt>"]
+    style var_stream_21 fill:transparent
     8v1
 end
-subgraph var_stream_230 ["var <tt>stream_230</tt>"]
-    style var_stream_230 fill:transparent
+subgraph var_stream_229 ["var <tt>stream_229</tt>"]
+    style var_stream_229 fill:transparent
     131v1
     130v1
 end
-subgraph var_stream_231 ["var <tt>stream_231</tt>"]
-    style var_stream_231 fill:transparent
+subgraph var_stream_230 ["var <tt>stream_230</tt>"]
+    style var_stream_230 fill:transparent
     132v1
+end
+subgraph var_stream_234 ["var <tt>stream_234</tt>"]
+    style var_stream_234 fill:transparent
+    133v1
 end
 subgraph var_stream_235 ["var <tt>stream_235</tt>"]
     style var_stream_235 fill:transparent
-    133v1
+    134v1
 end
 subgraph var_stream_236 ["var <tt>stream_236</tt>"]
     style var_stream_236 fill:transparent
-    134v1
+    135v1
 end
 subgraph var_stream_237 ["var <tt>stream_237</tt>"]
     style var_stream_237 fill:transparent
-    135v1
-end
-subgraph var_stream_238 ["var <tt>stream_238</tt>"]
-    style var_stream_238 fill:transparent
     136v1
+end
+subgraph var_stream_239 ["var <tt>stream_239</tt>"]
+    style var_stream_239 fill:transparent
+    137v1
+end
+subgraph var_stream_24 ["var <tt>stream_24</tt>"]
+    style var_stream_24 fill:transparent
+    9v1
 end
 subgraph var_stream_240 ["var <tt>stream_240</tt>"]
     style var_stream_240 fill:transparent
-    137v1
+    138v1
 end
 subgraph var_stream_241 ["var <tt>stream_241</tt>"]
     style var_stream_241 fill:transparent
-    138v1
+    139v1
 end
 subgraph var_stream_242 ["var <tt>stream_242</tt>"]
     style var_stream_242 fill:transparent
-    139v1
-end
-subgraph var_stream_243 ["var <tt>stream_243</tt>"]
-    style var_stream_243 fill:transparent
     140v1
+end
+subgraph var_stream_244 ["var <tt>stream_244</tt>"]
+    style var_stream_244 fill:transparent
+    141v1
 end
 subgraph var_stream_245 ["var <tt>stream_245</tt>"]
     style var_stream_245 fill:transparent
-    141v1
+    142v1
 end
 subgraph var_stream_246 ["var <tt>stream_246</tt>"]
     style var_stream_246 fill:transparent
-    142v1
+    143v1
 end
 subgraph var_stream_247 ["var <tt>stream_247</tt>"]
     style var_stream_247 fill:transparent
-    143v1
-end
-subgraph var_stream_248 ["var <tt>stream_248</tt>"]
-    style var_stream_248 fill:transparent
     144v1
 end
-subgraph var_stream_25 ["var <tt>stream_25</tt>"]
-    style var_stream_25 fill:transparent
-    9v1
+subgraph var_stream_249 ["var <tt>stream_249</tt>"]
+    style var_stream_249 fill:transparent
+    145v1
 end
 subgraph var_stream_250 ["var <tt>stream_250</tt>"]
     style var_stream_250 fill:transparent
-    145v1
+    146v1
 end
 subgraph var_stream_251 ["var <tt>stream_251</tt>"]
     style var_stream_251 fill:transparent
-    146v1
-end
-subgraph var_stream_252 ["var <tt>stream_252</tt>"]
-    style var_stream_252 fill:transparent
     147v1
+end
+subgraph var_stream_253 ["var <tt>stream_253</tt>"]
+    style var_stream_253 fill:transparent
+    148v1
 end
 subgraph var_stream_254 ["var <tt>stream_254</tt>"]
     style var_stream_254 fill:transparent
-    148v1
-end
-subgraph var_stream_255 ["var <tt>stream_255</tt>"]
-    style var_stream_255 fill:transparent
     149v1
     150v1
 end
+subgraph var_stream_255 ["var <tt>stream_255</tt>"]
+    style var_stream_255 fill:transparent
+    151v1
+end
 subgraph var_stream_256 ["var <tt>stream_256</tt>"]
     style var_stream_256 fill:transparent
-    151v1
+    152v1
 end
 subgraph var_stream_257 ["var <tt>stream_257</tt>"]
     style var_stream_257 fill:transparent
-    152v1
+    153v1
 end
 subgraph var_stream_258 ["var <tt>stream_258</tt>"]
     style var_stream_258 fill:transparent
-    153v1
+    154v1
 end
 subgraph var_stream_259 ["var <tt>stream_259</tt>"]
     style var_stream_259 fill:transparent
-    154v1
+    155v1
+end
+subgraph var_stream_26 ["var <tt>stream_26</tt>"]
+    style var_stream_26 fill:transparent
+    10v1
 end
 subgraph var_stream_260 ["var <tt>stream_260</tt>"]
     style var_stream_260 fill:transparent
-    155v1
+    156v1
 end
 subgraph var_stream_261 ["var <tt>stream_261</tt>"]
     style var_stream_261 fill:transparent
-    156v1
-end
-subgraph var_stream_262 ["var <tt>stream_262</tt>"]
-    style var_stream_262 fill:transparent
     157v1
+end
+subgraph var_stream_264 ["var <tt>stream_264</tt>"]
+    style var_stream_264 fill:transparent
+    159v1
 end
 subgraph var_stream_265 ["var <tt>stream_265</tt>"]
     style var_stream_265 fill:transparent
-    159v1
-end
-subgraph var_stream_266 ["var <tt>stream_266</tt>"]
-    style var_stream_266 fill:transparent
     160v1
+end
+subgraph var_stream_267 ["var <tt>stream_267</tt>"]
+    style var_stream_267 fill:transparent
+    161v1
 end
 subgraph var_stream_268 ["var <tt>stream_268</tt>"]
     style var_stream_268 fill:transparent
-    161v1
+    162v1
 end
 subgraph var_stream_269 ["var <tt>stream_269</tt>"]
     style var_stream_269 fill:transparent
-    162v1
+    163v1
 end
 subgraph var_stream_27 ["var <tt>stream_27</tt>"]
     style var_stream_27 fill:transparent
-    10v1
+    11v1
+    12v1
 end
 subgraph var_stream_270 ["var <tt>stream_270</tt>"]
     style var_stream_270 fill:transparent
-    163v1
+    164v1
 end
 subgraph var_stream_271 ["var <tt>stream_271</tt>"]
     style var_stream_271 fill:transparent
-    164v1
-end
-subgraph var_stream_272 ["var <tt>stream_272</tt>"]
-    style var_stream_272 fill:transparent
     165v1
 end
-subgraph var_stream_274 ["var <tt>stream_274</tt>"]
-    style var_stream_274 fill:transparent
+subgraph var_stream_273 ["var <tt>stream_273</tt>"]
+    style var_stream_273 fill:transparent
     166v1
+end
+subgraph var_stream_277 ["var <tt>stream_277</tt>"]
+    style var_stream_277 fill:transparent
+    167v1
 end
 subgraph var_stream_278 ["var <tt>stream_278</tt>"]
     style var_stream_278 fill:transparent
-    167v1
-end
-subgraph var_stream_279 ["var <tt>stream_279</tt>"]
-    style var_stream_279 fill:transparent
     168v1
 end
 subgraph var_stream_28 ["var <tt>stream_28</tt>"]
     style var_stream_28 fill:transparent
-    11v1
-    12v1
+    13v1
 end
-subgraph var_stream_282 ["var <tt>stream_282</tt>"]
-    style var_stream_282 fill:transparent
+subgraph var_stream_281 ["var <tt>stream_281</tt>"]
+    style var_stream_281 fill:transparent
     169v1
 end
-subgraph var_stream_284 ["var <tt>stream_284</tt>"]
-    style var_stream_284 fill:transparent
+subgraph var_stream_283 ["var <tt>stream_283</tt>"]
+    style var_stream_283 fill:transparent
     170v1
+end
+subgraph var_stream_285 ["var <tt>stream_285</tt>"]
+    style var_stream_285 fill:transparent
+    171v1
 end
 subgraph var_stream_286 ["var <tt>stream_286</tt>"]
     style var_stream_286 fill:transparent
-    171v1
+    172v1
 end
 subgraph var_stream_287 ["var <tt>stream_287</tt>"]
     style var_stream_287 fill:transparent
-    172v1
-end
-subgraph var_stream_288 ["var <tt>stream_288</tt>"]
-    style var_stream_288 fill:transparent
     173v1
     174v1
 end
+subgraph var_stream_288 ["var <tt>stream_288</tt>"]
+    style var_stream_288 fill:transparent
+    175v1
+end
 subgraph var_stream_289 ["var <tt>stream_289</tt>"]
     style var_stream_289 fill:transparent
-    175v1
+    176v1
 end
 subgraph var_stream_29 ["var <tt>stream_29</tt>"]
     style var_stream_29 fill:transparent
-    13v1
+    14v1
 end
 subgraph var_stream_290 ["var <tt>stream_290</tt>"]
     style var_stream_290 fill:transparent
-    176v1
+    177v1
 end
 subgraph var_stream_291 ["var <tt>stream_291</tt>"]
     style var_stream_291 fill:transparent
-    177v1
-end
-subgraph var_stream_292 ["var <tt>stream_292</tt>"]
-    style var_stream_292 fill:transparent
     178v1
+end
+subgraph var_stream_294 ["var <tt>stream_294</tt>"]
+    style var_stream_294 fill:transparent
+    179v1
 end
 subgraph var_stream_295 ["var <tt>stream_295</tt>"]
     style var_stream_295 fill:transparent
-    179v1
-end
-subgraph var_stream_296 ["var <tt>stream_296</tt>"]
-    style var_stream_296 fill:transparent
     180v1
+end
+subgraph var_stream_297 ["var <tt>stream_297</tt>"]
+    style var_stream_297 fill:transparent
+    181v1
 end
 subgraph var_stream_298 ["var <tt>stream_298</tt>"]
     style var_stream_298 fill:transparent
-    181v1
-end
-subgraph var_stream_299 ["var <tt>stream_299</tt>"]
-    style var_stream_299 fill:transparent
     182v1
 end
 subgraph var_stream_30 ["var <tt>stream_30</tt>"]
     style var_stream_30 fill:transparent
-    14v1
+    15v1
+end
+subgraph var_stream_300 ["var <tt>stream_300</tt>"]
+    style var_stream_300 fill:transparent
+    183v1
 end
 subgraph var_stream_301 ["var <tt>stream_301</tt>"]
     style var_stream_301 fill:transparent
-    183v1
+    184v1
 end
 subgraph var_stream_302 ["var <tt>stream_302</tt>"]
     style var_stream_302 fill:transparent
-    184v1
+    185v1
 end
 subgraph var_stream_303 ["var <tt>stream_303</tt>"]
     style var_stream_303 fill:transparent
-    185v1
-end
-subgraph var_stream_304 ["var <tt>stream_304</tt>"]
-    style var_stream_304 fill:transparent
     186v1
+end
+subgraph var_stream_305 ["var <tt>stream_305</tt>"]
+    style var_stream_305 fill:transparent
+    187v1
 end
 subgraph var_stream_306 ["var <tt>stream_306</tt>"]
     style var_stream_306 fill:transparent
-    187v1
+    188v1
 end
 subgraph var_stream_307 ["var <tt>stream_307</tt>"]
     style var_stream_307 fill:transparent
-    188v1
-end
-subgraph var_stream_308 ["var <tt>stream_308</tt>"]
-    style var_stream_308 fill:transparent
     189v1
+end
+subgraph var_stream_309 ["var <tt>stream_309</tt>"]
+    style var_stream_309 fill:transparent
+    190v1
 end
 subgraph var_stream_31 ["var <tt>stream_31</tt>"]
     style var_stream_31 fill:transparent
-    15v1
+    16v1
 end
 subgraph var_stream_310 ["var <tt>stream_310</tt>"]
     style var_stream_310 fill:transparent
-    190v1
-end
-subgraph var_stream_311 ["var <tt>stream_311</tt>"]
-    style var_stream_311 fill:transparent
     191v1
 end
-subgraph var_stream_313 ["var <tt>stream_313</tt>"]
-    style var_stream_313 fill:transparent
+subgraph var_stream_312 ["var <tt>stream_312</tt>"]
+    style var_stream_312 fill:transparent
     192v1
 end
 subgraph var_stream_32 ["var <tt>stream_32</tt>"]
     style var_stream_32 fill:transparent
-    16v1
+    17v1
 end
-subgraph var_stream_323 ["var <tt>stream_323</tt>"]
-    style var_stream_323 fill:transparent
+subgraph var_stream_322 ["var <tt>stream_322</tt>"]
+    style var_stream_322 fill:transparent
     195v1
     196v1
 end
-subgraph var_stream_324 ["var <tt>stream_324</tt>"]
-    style var_stream_324 fill:transparent
+subgraph var_stream_323 ["var <tt>stream_323</tt>"]
+    style var_stream_323 fill:transparent
     197v1
 end
-subgraph var_stream_325 ["var <tt>stream_325</tt>"]
-    style var_stream_325 fill:transparent
+subgraph var_stream_324 ["var <tt>stream_324</tt>"]
+    style var_stream_324 fill:transparent
     198v1
+end
+subgraph var_stream_326 ["var <tt>stream_326</tt>"]
+    style var_stream_326 fill:transparent
+    199v1
 end
 subgraph var_stream_327 ["var <tt>stream_327</tt>"]
     style var_stream_327 fill:transparent
-    199v1
-end
-subgraph var_stream_328 ["var <tt>stream_328</tt>"]
-    style var_stream_328 fill:transparent
     200v1
+end
+subgraph var_stream_329 ["var <tt>stream_329</tt>"]
+    style var_stream_329 fill:transparent
+    201v1
 end
 subgraph var_stream_33 ["var <tt>stream_33</tt>"]
     style var_stream_33 fill:transparent
-    17v1
+    18v1
 end
 subgraph var_stream_330 ["var <tt>stream_330</tt>"]
     style var_stream_330 fill:transparent
-    201v1
+    202v1
 end
 subgraph var_stream_331 ["var <tt>stream_331</tt>"]
     style var_stream_331 fill:transparent
-    202v1
+    203v1
 end
 subgraph var_stream_332 ["var <tt>stream_332</tt>"]
     style var_stream_332 fill:transparent
-    203v1
-end
-subgraph var_stream_333 ["var <tt>stream_333</tt>"]
-    style var_stream_333 fill:transparent
     204v1
+end
+subgraph var_stream_334 ["var <tt>stream_334</tt>"]
+    style var_stream_334 fill:transparent
+    205v1
 end
 subgraph var_stream_335 ["var <tt>stream_335</tt>"]
     style var_stream_335 fill:transparent
-    205v1
+    206v1
 end
 subgraph var_stream_336 ["var <tt>stream_336</tt>"]
     style var_stream_336 fill:transparent
-    206v1
+    207v1
 end
 subgraph var_stream_337 ["var <tt>stream_337</tt>"]
     style var_stream_337 fill:transparent
-    207v1
-end
-subgraph var_stream_338 ["var <tt>stream_338</tt>"]
-    style var_stream_338 fill:transparent
     208v1
 end
 subgraph var_stream_34 ["var <tt>stream_34</tt>"]
     style var_stream_34 fill:transparent
-    18v1
+    19v1
 end
-subgraph var_stream_341 ["var <tt>stream_341</tt>"]
-    style var_stream_341 fill:transparent
+subgraph var_stream_340 ["var <tt>stream_340</tt>"]
+    style var_stream_340 fill:transparent
     209v1
 end
-subgraph var_stream_343 ["var <tt>stream_343</tt>"]
-    style var_stream_343 fill:transparent
+subgraph var_stream_342 ["var <tt>stream_342</tt>"]
+    style var_stream_342 fill:transparent
     210v1
+end
+subgraph var_stream_345 ["var <tt>stream_345</tt>"]
+    style var_stream_345 fill:transparent
+    211v1
 end
 subgraph var_stream_346 ["var <tt>stream_346</tt>"]
     style var_stream_346 fill:transparent
-    211v1
-end
-subgraph var_stream_347 ["var <tt>stream_347</tt>"]
-    style var_stream_347 fill:transparent
     212v1
+end
+subgraph var_stream_349 ["var <tt>stream_349</tt>"]
+    style var_stream_349 fill:transparent
+    213v1
 end
 subgraph var_stream_35 ["var <tt>stream_35</tt>"]
     style var_stream_35 fill:transparent
-    19v1
+    20v1
 end
 subgraph var_stream_350 ["var <tt>stream_350</tt>"]
     style var_stream_350 fill:transparent
-    213v1
-end
-subgraph var_stream_351 ["var <tt>stream_351</tt>"]
-    style var_stream_351 fill:transparent
     214v1
 end
-subgraph var_stream_353 ["var <tt>stream_353</tt>"]
-    style var_stream_353 fill:transparent
+subgraph var_stream_352 ["var <tt>stream_352</tt>"]
+    style var_stream_352 fill:transparent
     215v1
+end
+subgraph var_stream_354 ["var <tt>stream_354</tt>"]
+    style var_stream_354 fill:transparent
+    216v1
 end
 subgraph var_stream_355 ["var <tt>stream_355</tt>"]
     style var_stream_355 fill:transparent
-    216v1
+    217v1
 end
 subgraph var_stream_356 ["var <tt>stream_356</tt>"]
     style var_stream_356 fill:transparent
-    217v1
-end
-subgraph var_stream_357 ["var <tt>stream_357</tt>"]
-    style var_stream_357 fill:transparent
     218v1
 end
-subgraph var_stream_36 ["var <tt>stream_36</tt>"]
-    style var_stream_36 fill:transparent
-    20v1
+subgraph var_stream_37 ["var <tt>stream_37</tt>"]
+    style var_stream_37 fill:transparent
+    21v1
+end
+subgraph var_stream_378 ["var <tt>stream_378</tt>"]
+    style var_stream_378 fill:transparent
+    219v1
 end
 subgraph var_stream_379 ["var <tt>stream_379</tt>"]
     style var_stream_379 fill:transparent
-    219v1
-end
-subgraph var_stream_38 ["var <tt>stream_38</tt>"]
-    style var_stream_38 fill:transparent
-    21v1
+    220v1
 end
 subgraph var_stream_380 ["var <tt>stream_380</tt>"]
     style var_stream_380 fill:transparent
-    220v1
+    221v1
 end
 subgraph var_stream_381 ["var <tt>stream_381</tt>"]
     style var_stream_381 fill:transparent
-    221v1
+    222v1
 end
 subgraph var_stream_382 ["var <tt>stream_382</tt>"]
     style var_stream_382 fill:transparent
-    222v1
+    223v1
 end
 subgraph var_stream_383 ["var <tt>stream_383</tt>"]
     style var_stream_383 fill:transparent
-    223v1
-end
-subgraph var_stream_384 ["var <tt>stream_384</tt>"]
-    style var_stream_384 fill:transparent
     224v1
 end
-subgraph var_stream_386 ["var <tt>stream_386</tt>"]
-    style var_stream_386 fill:transparent
+subgraph var_stream_385 ["var <tt>stream_385</tt>"]
+    style var_stream_385 fill:transparent
     225v1
+end
+subgraph var_stream_389 ["var <tt>stream_389</tt>"]
+    style var_stream_389 fill:transparent
+    226v1
 end
 subgraph var_stream_390 ["var <tt>stream_390</tt>"]
     style var_stream_390 fill:transparent
-    226v1
-end
-subgraph var_stream_391 ["var <tt>stream_391</tt>"]
-    style var_stream_391 fill:transparent
     227v1
 end
-subgraph var_stream_393 ["var <tt>stream_393</tt>"]
-    style var_stream_393 fill:transparent
+subgraph var_stream_392 ["var <tt>stream_392</tt>"]
+    style var_stream_392 fill:transparent
     228v1
 end
-subgraph var_stream_395 ["var <tt>stream_395</tt>"]
-    style var_stream_395 fill:transparent
+subgraph var_stream_394 ["var <tt>stream_394</tt>"]
+    style var_stream_394 fill:transparent
     229v1
+end
+subgraph var_stream_40 ["var <tt>stream_40</tt>"]
+    style var_stream_40 fill:transparent
+    22v1
 end
 subgraph var_stream_41 ["var <tt>stream_41</tt>"]
     style var_stream_41 fill:transparent
-    22v1
-end
-subgraph var_stream_42 ["var <tt>stream_42</tt>"]
-    style var_stream_42 fill:transparent
     23v1
+end
+subgraph var_stream_43 ["var <tt>stream_43</tt>"]
+    style var_stream_43 fill:transparent
+    24v1
 end
 subgraph var_stream_44 ["var <tt>stream_44</tt>"]
     style var_stream_44 fill:transparent
-    24v1
+    25v1
 end
 subgraph var_stream_45 ["var <tt>stream_45</tt>"]
     style var_stream_45 fill:transparent
-    25v1
+    26v1
 end
 subgraph var_stream_46 ["var <tt>stream_46</tt>"]
     style var_stream_46 fill:transparent
-    26v1
-end
-subgraph var_stream_47 ["var <tt>stream_47</tt>"]
-    style var_stream_47 fill:transparent
     27v1
 end
-subgraph var_stream_50 ["var <tt>stream_50</tt>"]
-    style var_stream_50 fill:transparent
+subgraph var_stream_49 ["var <tt>stream_49</tt>"]
+    style var_stream_49 fill:transparent
     28v1
+end
+subgraph var_stream_51 ["var <tt>stream_51</tt>"]
+    style var_stream_51 fill:transparent
+    29v1
 end
 subgraph var_stream_52 ["var <tt>stream_52</tt>"]
     style var_stream_52 fill:transparent
-    29v1
+    30v1
 end
 subgraph var_stream_53 ["var <tt>stream_53</tt>"]
     style var_stream_53 fill:transparent
-    30v1
+    31v1
 end
 subgraph var_stream_54 ["var <tt>stream_54</tt>"]
     style var_stream_54 fill:transparent
-    31v1
-end
-subgraph var_stream_55 ["var <tt>stream_55</tt>"]
-    style var_stream_55 fill:transparent
     32v1
 end
-subgraph var_stream_58 ["var <tt>stream_58</tt>"]
-    style var_stream_58 fill:transparent
+subgraph var_stream_57 ["var <tt>stream_57</tt>"]
+    style var_stream_57 fill:transparent
     33v1
 end
-subgraph var_stream_60 ["var <tt>stream_60</tt>"]
-    style var_stream_60 fill:transparent
+subgraph var_stream_59 ["var <tt>stream_59</tt>"]
+    style var_stream_59 fill:transparent
     36v1
     37v1
 end
-subgraph var_stream_61 ["var <tt>stream_61</tt>"]
-    style var_stream_61 fill:transparent
+subgraph var_stream_60 ["var <tt>stream_60</tt>"]
+    style var_stream_60 fill:transparent
     38v1
 end
-subgraph var_stream_62 ["var <tt>stream_62</tt>"]
-    style var_stream_62 fill:transparent
+subgraph var_stream_61 ["var <tt>stream_61</tt>"]
+    style var_stream_61 fill:transparent
     39v1
+end
+subgraph var_stream_63 ["var <tt>stream_63</tt>"]
+    style var_stream_63 fill:transparent
+    40v1
 end
 subgraph var_stream_64 ["var <tt>stream_64</tt>"]
     style var_stream_64 fill:transparent
-    40v1
+    41v1
 end
 subgraph var_stream_65 ["var <tt>stream_65</tt>"]
     style var_stream_65 fill:transparent
-    41v1
+    42v1
 end
 subgraph var_stream_66 ["var <tt>stream_66</tt>"]
     style var_stream_66 fill:transparent
-    42v1
+    43v1
 end
 subgraph var_stream_67 ["var <tt>stream_67</tt>"]
     style var_stream_67 fill:transparent
-    43v1
-end
-subgraph var_stream_68 ["var <tt>stream_68</tt>"]
-    style var_stream_68 fill:transparent
     44v1
 end
-subgraph var_stream_70 ["var <tt>stream_70</tt>"]
-    style var_stream_70 fill:transparent
+subgraph var_stream_69 ["var <tt>stream_69</tt>"]
+    style var_stream_69 fill:transparent
     45v1
 end
-subgraph var_stream_76 ["var <tt>stream_76</tt>"]
-    style var_stream_76 fill:transparent
+subgraph var_stream_75 ["var <tt>stream_75</tt>"]
+    style var_stream_75 fill:transparent
     46v1
 end
-subgraph var_stream_78 ["var <tt>stream_78</tt>"]
-    style var_stream_78 fill:transparent
+subgraph var_stream_77 ["var <tt>stream_77</tt>"]
+    style var_stream_77 fill:transparent
     47v1
 end
 subgraph var_stream_8 ["var <tt>stream_8</tt>"]
     style var_stream_8 fill:transparent
     3v1
 end
+subgraph var_stream_81 ["var <tt>stream_81</tt>"]
+    style var_stream_81 fill:transparent
+    48v1
+end
 subgraph var_stream_82 ["var <tt>stream_82</tt>"]
     style var_stream_82 fill:transparent
-    48v1
+    49v1
 end
 subgraph var_stream_83 ["var <tt>stream_83</tt>"]
     style var_stream_83 fill:transparent
-    49v1
-end
-subgraph var_stream_84 ["var <tt>stream_84</tt>"]
-    style var_stream_84 fill:transparent
     50v1
     51v1
 end
+subgraph var_stream_84 ["var <tt>stream_84</tt>"]
+    style var_stream_84 fill:transparent
+    52v1
+end
 subgraph var_stream_85 ["var <tt>stream_85</tt>"]
     style var_stream_85 fill:transparent
-    52v1
+    53v1
 end
 subgraph var_stream_86 ["var <tt>stream_86</tt>"]
     style var_stream_86 fill:transparent
-    53v1
+    54v1
 end
 subgraph var_stream_87 ["var <tt>stream_87</tt>"]
     style var_stream_87 fill:transparent
-    54v1
+    55v1
 end
 subgraph var_stream_88 ["var <tt>stream_88</tt>"]
     style var_stream_88 fill:transparent
-    55v1
+    56v1
 end
 subgraph var_stream_89 ["var <tt>stream_89</tt>"]
     style var_stream_89 fill:transparent
-    56v1
-end
-subgraph var_stream_90 ["var <tt>stream_90</tt>"]
-    style var_stream_90 fill:transparent
     57v1
+end
+subgraph var_stream_91 ["var <tt>stream_91</tt>"]
+    style var_stream_91 fill:transparent
+    58v1
 end
 subgraph var_stream_92 ["var <tt>stream_92</tt>"]
     style var_stream_92 fill:transparent
-    58v1
+    59v1
 end
 subgraph var_stream_93 ["var <tt>stream_93</tt>"]
     style var_stream_93 fill:transparent
-    59v1
+    60v1
 end
 subgraph var_stream_94 ["var <tt>stream_94</tt>"]
     style var_stream_94 fill:transparent
-    60v1
+    61v1
 end
 subgraph var_stream_95 ["var <tt>stream_95</tt>"]
     style var_stream_95 fill:transparent
-    61v1
+    62v1
 end
 subgraph var_stream_96 ["var <tt>stream_96</tt>"]
     style var_stream_96 fill:transparent
-    62v1
+    63v1
 end
 subgraph var_stream_97 ["var <tt>stream_97</tt>"]
     style var_stream_97 fill:transparent
-    63v1
-end
-subgraph var_stream_98 ["var <tt>stream_98</tt>"]
-    style var_stream_98 fill:transparent
     64v1
+end
+subgraph var_stream_99 ["var <tt>stream_99</tt>"]
+    style var_stream_99 fill:transparent
+    65v1
 end


### PR DESCRIPTION

The simulator uses a different representation of singletons than production, streaming every intermediate state instead of just the final value for the current DFIR batch. This lets us simulate all possible snapshots when that happens.

To support `Location::singleton`, which (lazily) spins in production, we instead introduce a proper `SourceSingleton` IR node which only (appropriately) only releases a single item in the simulator.

To simulate snapshots, we have to decide which version of the singleton to advance to. This can include "stutters", where the same version is released multiple times. To avoid an infinite search space, stutters are only allowed when some other input to the tick has made a nontrivial decision (one that makes progress consuming its input). Therefore, if none of the other inputs make progress, the singleton has to make progress.
