### PR TITLE
fix(hydro_deploy): don't emit duplicate leafs for building Rust service

### DIFF
--- a/hydro_deploy/core/src/rust_crate/service.rs
+++ b/hydro_deploy/core/src/rust_crate/service.rs
@@ -204,7 +204,7 @@ impl Service for RustCrateService {
                 .unwrap_or_else(|| format!("service/{}", self.id)),
             None,
             || async {
-                let built = ProgressTracker::leaf("build", self.build()).await?;
+                let built = self.build().await?;
 
                 let host = &self.on;
                 let launched = host.provision(resource_result);


### PR DESCRIPTION

Because the `.build()` API creates a leaf itself, there is no need to wrap it in another leaf (which results in two rows in the progress display).
