### PR TITLE
feat(hydro_lang): support `Stream::count` in simulator

### DIFF
--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -1181,8 +1181,15 @@ where
         F: Fn(&mut T, T) + 'a,
     {
         let nondet = nondet!(/** the combinator function is commutative and idempotent */);
-        self.assume_ordering_trusted(nondet)
-            .assume_retries_trusted(nondet)
+
+        let ordered = if B::BOUNDED {
+            self.assume_ordering_trusted(nondet)
+        } else {
+            self.assume_ordering(nondet) // if unbounded, ordering affects intermediate states
+        };
+
+        ordered
+            .assume_retries_trusted(nondet) // retries never affect intermediate states
             .reduce(comb)
     }
 
@@ -1330,7 +1337,10 @@ where
     /// # }));
     /// ```
     pub fn count(self) -> Singleton<usize, L, B> {
-        self.fold_commutative(q!(|| 0usize), q!(|count, _| *count += 1))
+        self.assume_ordering_trusted(nondet!(
+            /// Order does not affect eventual count, and also does not affect intermediate states.
+        ))
+        .fold(q!(|| 0usize), q!(|count, _| *count += 1))
     }
 }
 
@@ -3226,6 +3236,36 @@ mod tests {
         assert_eq!(
             instance_count,
             192 // 4! * 2^{4 - 1}
+        )
+    }
+
+    #[test]
+    fn sim_unordered_count_instance_count() {
+        let flow = FlowBuilder::new();
+        let external = flow.external::<()>();
+        let node = flow.process::<()>();
+
+        let (port, input) = node.source_external_bincode::<_, _, NoOrder, _>(&external);
+
+        let tick = node.tick();
+        let out_port = input
+            .count()
+            .snapshot(&tick, nondet!(/** test */))
+            .all_ticks()
+            .send_bincode_external(&external);
+
+        let instance_count = flow.sim().exhaustive(async |mut compiled| {
+            let in_send = compiled.connect(&port);
+            let out_recv = compiled.connect(&out_port);
+            compiled.launch();
+
+            in_send.send_many_unordered([1, 2, 3, 4]).unwrap();
+            assert!(out_recv.collect::<Vec<_>>().await.last().unwrap() == &4);
+        });
+
+        assert_eq!(
+            instance_count,
+            16 // 2^4, { 0, 1, 2, 3 } can be a snapshot and 4 is always included
         )
     }
 }

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__paxos_bench__tests__paxos_ir.snap
@@ -231,7 +231,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                         },
-                                                        trusted: true,
+                                                        trusted: false,
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Cluster(
                                                                 0,
@@ -3993,7 +3993,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                             },
-                                                            trusted: true,
+                                                            trusted: false,
                                                             metadata: HydroIrMetadata {
                                                                 location_kind: Cluster(
                                                                     2,
@@ -9057,7 +9057,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                 },
-                                                trusted: false,
+                                                trusted: true,
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
                                                         17,
@@ -10215,7 +10215,7 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                             },
-                                                                            trusted: false,
+                                                                            trusted: true,
                                                                             metadata: HydroIrMetadata {
                                                                                 location_kind: Tick(
                                                                                     21,
@@ -10345,7 +10345,7 @@ expression: built.ir()
                                                                                                                                                                                     },
                                                                                                                                                                                 },
                                                                                                                                                                             },
-                                                                                                                                                                            trusted: false,
+                                                                                                                                                                            trusted: true,
                                                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                                                 location_kind: Tick(
                                                                                                                                                                                     0,
@@ -10972,7 +10972,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                         },
-                                                                        trusted: false,
+                                                                        trusted: true,
                                                                         metadata: HydroIrMetadata {
                                                                             location_kind: Tick(
                                                                                 23,

--- a/hydro_test/src/cluster/snapshots/hydro_test__cluster__two_pc_bench__tests__two_pc_ir.snap
+++ b/hydro_test/src/cluster/snapshots/hydro_test__cluster__two_pc_bench__tests__two_pc_ir.snap
@@ -1901,7 +1901,7 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                             },
-                                                                            trusted: false,
+                                                                            trusted: true,
                                                                             metadata: HydroIrMetadata {
                                                                                 location_kind: Tick(
                                                                                     6,
@@ -2031,7 +2031,7 @@ expression: built.ir()
                                                                                                                                                                                     },
                                                                                                                                                                                 },
                                                                                                                                                                             },
-                                                                                                                                                                            trusted: false,
+                                                                                                                                                                            trusted: true,
                                                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                                                 location_kind: Tick(
                                                                                                                                                                                     0,
@@ -2658,7 +2658,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                         },
-                                                                        trusted: false,
+                                                                        trusted: true,
                                                                         metadata: HydroIrMetadata {
                                                                             location_kind: Tick(
                                                                                 8,


### PR DESCRIPTION

This also tweaks the behavior of `reduce_commutative_idempotent_trusted` to make sure that we simulate different orders of intermediate states when the input is unbounded / asynchronous. Right now, we do not actually have any tests for this, since we do not support shuffling unbounded streams, but this will be supported soon.
