### PR TITLE
fix(hydro_lang): properly map from external keys to raw ports in sim

### DIFF
--- a/hydro_lang/src/compile/built.rs
+++ b/hydro_lang/src/compile/built.rs
@@ -251,6 +251,7 @@ impl<'a> BuiltFlow<'a> {
             })
             .collect();
 
+        let all_external_registered = Rc::new(RefCell::new(HashMap::new()));
         let externals = self
             .external_id_name
             .iter()
@@ -259,7 +260,7 @@ impl<'a> BuiltFlow<'a> {
                     id.0,
                     SimExternal {
                         external_ports: external_ports.clone(),
-                        registered: RefCell::new(HashMap::new()),
+                        registered: all_external_registered.clone(),
                     },
                 )
             })
@@ -272,6 +273,7 @@ impl<'a> BuiltFlow<'a> {
             clusters,
             cluster_max_sizes: HashMap::new(),
             externals,
+            external_registered: all_external_registered.clone(),
             _process_id_name: std::mem::take(&mut self.process_id_name),
             _external_id_name: std::mem::take(&mut self.external_id_name),
             _cluster_id_name: std::mem::take(&mut self.cluster_id_name),

--- a/hydro_lang/src/sim/flow.rs
+++ b/hydro_lang/src/sim/flow.rs
@@ -26,6 +26,10 @@ pub struct SimFlow<'a> {
     pub(crate) clusters: HashMap<usize, SimNode>,
     pub(crate) externals: HashMap<usize, SimExternal>,
 
+    /// A mapping from external "keys", which are used for looking up connections, to the IDs
+    /// of the external channels created in the simulation.
+    pub(crate) external_registered: Rc<RefCell<HashMap<usize, usize>>>,
+
     pub(crate) cluster_max_sizes: HashMap<LocationId, usize>,
 
     /// Lists all the processes that were created in the flow, same ID as `processes`
@@ -190,6 +194,7 @@ impl<'a> SimFlow<'a> {
             _path: out,
             lib,
             external_ports,
+            external_registered: self.external_registered.take(),
         }
     }
 }

--- a/hydro_lang/src/sim/graph.rs
+++ b/hydro_lang/src/sim/graph.rs
@@ -49,7 +49,7 @@ impl Node for SimNode {
 #[derive(Clone)]
 pub struct SimExternal {
     pub(crate) external_ports: Rc<RefCell<(Vec<usize>, usize)>>,
-    pub(crate) registered: RefCell<HashMap<usize, usize>>,
+    pub(crate) registered: Rc<RefCell<HashMap<usize, usize>>>,
 }
 
 impl Node for SimExternal {
@@ -77,7 +77,7 @@ impl Node for SimExternal {
 
 impl<'a> RegisterPort<'a, SimDeploy> for SimExternal {
     fn register(&self, key: usize, port: usize) {
-        self.registered.borrow_mut().insert(key, port);
+        assert!(self.registered.borrow_mut().insert(key, port).is_none());
     }
 
     fn raw_port(&self, _key: usize) -> () {


### PR DESCRIPTION

We were getting lucky earlier that the key was the same as the raw port. This fixes the connection logic to properly handle the keyed lookup.
