### PR TITLE
fix: Update default visualizer base URL in config

### DIFF
--- a/hydro_lang/src/viz/config.rs
+++ b/hydro_lang/src/viz/config.rs
@@ -57,7 +57,7 @@ impl GraphConfig {
 /// Controls how graphs are encoded and opened in web browsers.
 #[derive(Debug, Clone)]
 pub struct VisualizerConfig {
-    /// Base URL for the visualizer (default: <https://hydro.run/docs/hydroscope>)
+    /// Base URL for the visualizer (default: <https://hydro.run/hydroscope>)
     pub base_url: String,
     /// Whether to enable compression for small graphs
     pub enable_compression: bool,


### PR DESCRIPTION
spurious `doc` subdir in the URL