### PR TITLE
refactor(hydro_lang)!: don't return results from `SimSender::send`

### DIFF
--- a/hydro_lang/src/live_collections/keyed_singleton.rs
+++ b/hydro_lang/src/live_collections/keyed_singleton.rs
@@ -1513,9 +1513,9 @@ mod tests {
 
             instance.launch();
 
-            input.send((1, 123)).unwrap();
-            input.send((1, 456)).unwrap();
-            input.send((2, 123)).unwrap();
+            input.send((1, 123));
+            input.send((1, 456));
+            input.send((2, 123));
 
             let all = output.collect_sorted::<Vec<_>>().await;
             assert_eq!(all.last().unwrap(), &(2, 1));

--- a/hydro_lang/src/live_collections/singleton.rs
+++ b/hydro_lang/src/live_collections/singleton.rs
@@ -1182,7 +1182,7 @@ mod tests {
             compiled.launch();
             assert_eq!(out_recv.next().await.unwrap(), 0);
 
-            in_send.send(123).unwrap();
+            in_send.send(123);
 
             assert_eq!(out_recv.next().await.unwrap(), 123);
         });

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -3134,9 +3134,9 @@ mod tests {
             let mut out_recv = compiled.connect(&out_port);
             compiled.launch();
 
-            in_send.send(()).unwrap();
-            in_send.send(()).unwrap();
-            in_send.send(()).unwrap();
+            in_send.send(());
+            in_send.send(());
+            in_send.send(());
 
             assert_eq!(out_recv.next().await.unwrap(), 3); // fails with nondet batching
         });
@@ -3161,9 +3161,9 @@ mod tests {
             let out_recv = compiled.connect(&out_port);
             compiled.launch();
 
-            in_send.send(1).unwrap();
-            in_send.send(2).unwrap();
-            in_send.send(3).unwrap();
+            in_send.send(1);
+            in_send.send(2);
+            in_send.send(3);
 
             out_recv.assert_yields_only([1, 2, 3]).await;
         });

--- a/hydro_lang/src/live_collections/stream/networking.rs
+++ b/hydro_lang/src/live_collections/stream/networking.rs
@@ -608,9 +608,9 @@ mod tests {
             let out_recv = compiled.connect(&out_port);
             compiled.launch();
 
-            in_send.send(()).unwrap();
-            in_send.send(()).unwrap();
-            in_send.send(()).unwrap();
+            in_send.send(());
+            in_send.send(());
+            in_send.send(());
 
             let received = out_recv.collect::<Vec<_>>().await;
             assert!(received.into_iter().sum::<usize>() == 3);

--- a/hydro_lang/src/location/tick.rs
+++ b/hydro_lang/src/location/tick.rs
@@ -331,9 +331,9 @@ mod tests {
             let mut read_response_recv = compiled.connect(&read_response);
             compiled.launch();
 
-            write_send.send(1).unwrap();
+            write_send.send(1);
             write_ack_recv.assert_yields([1]).await;
-            read_send.send(()).unwrap();
+            read_send.send(());
             assert!(read_response_recv.next().await.is_some_and(|(_, v)| v >= 1));
         });
 
@@ -346,8 +346,8 @@ mod tests {
             let mut read_response_recv = compiled.connect(&read_response);
             compiled.launch();
 
-            write_send.send(1).unwrap();
-            read_send.send(()).unwrap();
+            write_send.send(1);
+            read_send.send(());
             write_ack_recv.assert_yields([1]).await;
             let _ = read_response_recv.next().await;
         });
@@ -389,9 +389,9 @@ mod tests {
             let mut read_response_recv = compiled.connect(&read_response);
             compiled.launch();
 
-            write_send.send(1).unwrap();
+            write_send.send(1);
             write_ack_recv.assert_yields([1]).await;
-            read_send.send(()).unwrap();
+            read_send.send(());
 
             if let Some((_, v)) = read_response_recv.next().await {
                 assert_eq!(v, 1);

--- a/hydro_lang/src/sim/tests/mod.rs
+++ b/hydro_lang/src/sim/tests/mod.rs
@@ -25,7 +25,7 @@ fn sim_crash_in_output() {
         let mut out_recv = compiled.connect(&out_port);
         compiled.launch();
 
-        in_send.send(bolero::any::<Vec<u8>>().into()).unwrap();
+        in_send.send(bolero::any::<Vec<u8>>().into());
 
         let x = out_recv.next().await.unwrap();
         if !x.is_empty() && x[0] == 42 && x.len() > 1 && x[1] == 43 && x.len() > 2 && x[2] == 44 {
@@ -54,7 +54,7 @@ fn sim_crash_in_output_with_filter() {
         let mut out_recv = compiled.connect(&out_port);
         compiled.launch();
 
-        in_send.send(bolero::any::<Vec<u8>>().into()).unwrap();
+        in_send.send(bolero::any::<Vec<u8>>().into());
 
         if let Some(x) = out_recv.next().await
             && x.len() > 2
@@ -85,9 +85,9 @@ fn sim_batch_preserves_order_fuzzed() {
         let mut out_recv = compiled.connect(&out_port);
         compiled.launch();
 
-        in_send.send(1).unwrap();
-        in_send.send(2).unwrap();
-        in_send.send(3).unwrap();
+        in_send.send(1);
+        in_send.send(2);
+        in_send.send(3);
 
         assert_eq!(out_recv.next().await.unwrap(), 1);
         assert_eq!(out_recv.next().await.unwrap(), 2);
@@ -128,13 +128,13 @@ fn sim_crash_with_fuzzed_batching() {
         compiled.launch();
 
         for _ in 0..1000 {
-            in_send.send(456).unwrap(); // the fuzzer should put these some batches
+            in_send.send(456); // the fuzzer should put these some batches
         }
 
-        in_send.send(100).unwrap();
-        in_send.send(23).unwrap(); // the fuzzer must put these in one batch
+        in_send.send(100);
+        in_send.send(23); // the fuzzer must put these in one batch
 
-        in_send.send(99).unwrap(); // the fuzzer must put this in a later batch
+        in_send.send(99); // the fuzzer must put this in a later batch
 
         while let Some(out) = out_recv.next().await {
             if out == 456 {
@@ -173,13 +173,13 @@ fn trace_for_fuzzed_batching() {
             let schedule = compiled.schedule_with_logger(&mut log_out);
             let rest = async move {
                 for _ in 0..1000 {
-                    in_send.send(456).unwrap(); // the fuzzer should put these some batches
+                    in_send.send(456); // the fuzzer should put these some batches
                 }
 
-                in_send.send(100).unwrap();
-                in_send.send(23).unwrap(); // the fuzzer must put these in one batch
+                in_send.send(100);
+                in_send.send(23); // the fuzzer must put these in one batch
 
-                in_send.send(99).unwrap(); // the fuzzer must put this in a later batch
+                in_send.send(99); // the fuzzer must put this in a later batch
 
                 while let Some(out) = out_recv.next().await {
                     if out == 456 {

--- a/hydro_std/src/quorum.rs
+++ b/hydro_std/src/quorum.rs
@@ -195,12 +195,12 @@ mod tests {
             let out_recv = compiled.connect(&out_port);
             compiled.launch();
 
-            in_send.send((1, Ok::<(), ()>(()))).unwrap();
-            in_send.send((1, Ok(()))).unwrap();
-            in_send.send((1, Ok(()))).unwrap();
-            in_send.send((2, Ok(()))).unwrap();
-            in_send.send((2, Ok(()))).unwrap();
-            in_send.send((2, Ok(()))).unwrap();
+            in_send.send((1, Ok::<(), ()>(())));
+            in_send.send((1, Ok(())));
+            in_send.send((1, Ok(())));
+            in_send.send((2, Ok(())));
+            in_send.send((2, Ok(())));
+            in_send.send((2, Ok(())));
 
             assert_eq!(
                 out_recv.collect::<Vec<_>>().await,
@@ -233,8 +233,8 @@ mod tests {
             let error_recv = compiled.connect(&error_port);
             compiled.launch();
 
-            in_send.send((1, Ok::<(), ()>(()))).unwrap();
-            in_send.send((1, Ok(()))).unwrap();
+            in_send.send((1, Ok::<(), ()>(())));
+            in_send.send((1, Ok(())));
 
             success_recv.assert_yields_only_unordered([1]).await;
             error_recv.assert_no_more().await;
@@ -247,9 +247,9 @@ mod tests {
             let error_recv = compiled.connect(&error_port);
             compiled.launch();
 
-            in_send.send((2, Ok::<(), ()>(()))).unwrap();
-            in_send.send((2, Ok(()))).unwrap();
-            in_send.send((2, Err(()))).unwrap();
+            in_send.send((2, Ok::<(), ()>(())));
+            in_send.send((2, Ok(())));
+            in_send.send((2, Err(())));
 
             success_recv.assert_yields_only_unordered([2]).await;
             error_recv.assert_yields_only([(2, ())]).await;
@@ -262,9 +262,9 @@ mod tests {
             let error_recv = compiled.connect(&error_port);
             compiled.launch();
 
-            in_send.send((3, Ok::<(), ()>(()))).unwrap();
-            in_send.send((3, Err(()))).unwrap();
-            in_send.send((3, Err(()))).unwrap();
+            in_send.send((3, Ok::<(), ()>(())));
+            in_send.send((3, Err(())));
+            in_send.send((3, Err(())));
 
             success_recv.assert_no_more().await;
             error_recv.assert_yields_only([(3, ()), (3, ())]).await;
@@ -277,9 +277,9 @@ mod tests {
             let error_recv = compiled.connect(&error_port);
             compiled.launch();
 
-            in_send.send((4, Ok::<(), ()>(()))).unwrap();
-            in_send.send((4, Ok(()))).unwrap();
-            in_send.send((4, Ok(()))).unwrap(); // This should be ignored after quorum
+            in_send.send((4, Ok::<(), ()>(())));
+            in_send.send((4, Ok(())));
+            in_send.send((4, Ok(()))); // This should be ignored after quorum
 
             success_recv.assert_yields_only_unordered([4]).await;
             error_recv.assert_no_more().await;
@@ -292,9 +292,9 @@ mod tests {
             let error_recv = compiled.connect(&error_port);
             compiled.launch();
 
-            in_send.send((5, Err::<(), ()>(()))).unwrap();
-            in_send.send((5, Err(()))).unwrap();
-            in_send.send((5, Err(()))).unwrap();
+            in_send.send((5, Err::<(), ()>(())));
+            in_send.send((5, Err(())));
+            in_send.send((5, Err(())));
 
             success_recv.assert_no_more().await;
             error_recv
@@ -309,9 +309,9 @@ mod tests {
             let error_recv = compiled.connect(&error_port);
             compiled.launch();
 
-            in_send.send((6, Err::<(), ()>(()))).unwrap();
-            in_send.send((6, Ok(()))).unwrap();
-            in_send.send((6, Ok(()))).unwrap();
+            in_send.send((6, Err::<(), ()>(())));
+            in_send.send((6, Ok(())));
+            in_send.send((6, Ok(())));
 
             success_recv.assert_yields_only_unordered([6]).await;
             error_recv.assert_yields_only([(6, ())]).await;
@@ -335,16 +335,16 @@ mod tests {
             compiled.launch();
 
             // When min == max, we need exactly that many responses
-            in_send.send((1, Ok::<(), ()>(()))).unwrap();
-            in_send.send((1, Ok(()))).unwrap();
+            in_send.send((1, Ok::<(), ()>(())));
+            in_send.send((1, Ok(())));
 
             // This key gets exactly 2 responses (1 success, 1 error) - should not reach quorum
-            in_send.send((2, Ok(()))).unwrap();
-            in_send.send((2, Err(()))).unwrap();
+            in_send.send((2, Ok(())));
+            in_send.send((2, Err(())));
 
             // This key gets 2 successes - should reach quorum
-            in_send.send((3, Ok(()))).unwrap();
-            in_send.send((3, Ok(()))).unwrap();
+            in_send.send((3, Ok(())));
+            in_send.send((3, Ok(())));
 
             // Only keys 1 and 3 should reach quorum (both have 2 successes)
             success_recv.assert_yields_only_unordered([1, 3]).await;
@@ -368,9 +368,9 @@ mod tests {
             compiled.launch();
 
             // With min=max=1, any single success should immediately reach quorum
-            in_send.send((1, Ok::<(), ()>(()))).unwrap();
-            in_send.send((2, Err(()))).unwrap();
-            in_send.send((3, Ok(()))).unwrap();
+            in_send.send((1, Ok::<(), ()>(())));
+            in_send.send((2, Err(())));
+            in_send.send((3, Ok(())));
 
             // Keys 1 and 3 should reach quorum immediately
             success_recv.assert_yields_only_unordered([1, 3]).await;
@@ -416,18 +416,18 @@ mod tests {
             compiled.launch();
 
             // Key 1: First reaches quorum with 2 successes
-            in_send.send((1, Ok::<(), ()>(()))).unwrap();
-            in_send.send((1, Ok(()))).unwrap();
+            in_send.send((1, Ok::<(), ()>(())));
+            in_send.send((1, Ok(())));
 
             // Key 1: Additional responses after quorum - should not trigger quorum again
-            in_send.send((1, Ok(()))).unwrap();
-            in_send.send((1, Ok(()))).unwrap();
+            in_send.send((1, Ok(())));
+            in_send.send((1, Ok(())));
 
             // Key 2: Reaches quorum later with mixed responses
-            in_send.send((2, Err(()))).unwrap();
-            in_send.send((2, Ok(()))).unwrap();
-            in_send.send((2, Ok(()))).unwrap();
-            in_send.send((2, Err(()))).unwrap(); // Additional error after quorum
+            in_send.send((2, Err(())));
+            in_send.send((2, Ok(())));
+            in_send.send((2, Ok(())));
+            in_send.send((2, Err(()))); // Additional error after quorum
 
             // Each key should appear exactly once, even though they received
             // additional responses after reaching quorum

--- a/hydro_test/src/cluster/paxos.rs
+++ b/hydro_test/src/cluster/paxos.rs
@@ -906,10 +906,10 @@ mod tests {
             let out_recv = compiled.connect(&out_port);
             compiled.launch();
 
-            in_send.send(1).unwrap();
-            in_send.send(2).unwrap();
-            in_send.send(3).unwrap();
-            in_send.send(4).unwrap();
+            in_send.send(1);
+            in_send.send(2);
+            in_send.send(3);
+            in_send.send(4);
 
             out_recv
                 .assert_yields_only([(0, 1), (1, 2), (2, 3), (3, 4)])
@@ -942,10 +942,10 @@ mod tests {
             let mut out_recv = compiled.connect(&out_port);
             compiled.launch();
 
-            in_send.send(1).unwrap();
-            in_send.send(2).unwrap();
-            in_send.send(3).unwrap();
-            in_send.send(4).unwrap();
+            in_send.send(1);
+            in_send.send(2);
+            in_send.send(3);
+            in_send.send(4);
 
             let mut next_expected = 0;
             for i in 1..=4 {


### PR DESCRIPTION

Also makes the `assert_*` APIs on `SimReceiver` more general to support asymmetric `PartialEq`
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydro-project/hydro/pull/2243).
* #2227
* __->__ #2243