### PR TITLE
feat(hydro_deploy): enable automatic AWS CloudWatch metric reporting (DFIR, Tokio, cpu/mem/netstat)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2777,6 +2777,7 @@ dependencies = [
  "bincode",
  "bolero-hydro",
  "bollard",
+ "buildstructor",
  "bytes",
  "cargo_metadata",
  "chrono",
@@ -2817,6 +2818,7 @@ dependencies = [
  "tar",
  "tempfile",
  "tokio",
+ "tokio-metrics",
  "tokio-stream",
  "tokio-test",
  "tokio-util",
@@ -5917,6 +5919,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "tokio-metrics"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a34e87dd30650518a4e041bca77c931f3f5a19621eecdcd794f5c1813bca9e98"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/hydro_lang/Cargo.toml
+++ b/hydro_lang/Cargo.toml
@@ -43,7 +43,7 @@ sim = [
     "dep:pin-project-lite",
     "dep:tempfile",
     "dep:serde_json",
-    "dfir_rs/meta", # affects layout of DFIR, thus the ABI
+    "dfir_rs/meta",         # affects layout of DFIR, thus the ABI
 ]
 
 docker_deploy = [
@@ -101,6 +101,7 @@ all-features = true
 [dependencies]
 backtrace = { version = "0.3", optional = true }
 bincode = "1.3.1"
+buildstructor = "0.6.0"
 bytes = { version = "1.1.0", features = ["serde"] }
 chrono = "0.4.42"
 clap = { version = "4.0", features = ["derive"], optional = true }
@@ -131,10 +132,11 @@ syn = { version = "2.0.46", features = [
     "visit",
 ] }
 tokio = "1.29.0"
-tokio-util = { version = "0.7.5", features = [ "codec" ] }
+tokio-metrics = "0.4.6"
 tokio-stream = { version = "0.1.3", default-features = false, features = [
     "time",
 ] }
+tokio-util = { version = "0.7.5", features = ["codec"] }
 toml = { version = "0.9", optional = true }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
@@ -151,7 +153,9 @@ urlencoding = { version = "2.1", optional = true }
 
 # For docker deployments
 anyhow = { version = "1.0.100", optional = true }
-bollard = { version = "0.19.4", default-features = false, features = ["pipe"], optional = true }
+bollard = { version = "0.19.4", default-features = false, features = [
+    "pipe",
+], optional = true }
 http-body-util = { version = "0.1", optional = true }
 nanoid = { version = "0.4.0", optional = true }
 tar = { version = "0.4", optional = true }

--- a/hydro_lang/src/compile/builder.rs
+++ b/hydro_lang/src/compile/builder.rs
@@ -57,6 +57,7 @@ impl FlowStateInner {
 }
 
 pub struct FlowBuilder<'a> {
+    /// Hydro IR and associated counters
     flow_state: FlowState,
 
     /// Locations and their type.
@@ -94,11 +95,12 @@ impl Drop for FlowBuilder<'_> {
 
 #[expect(missing_docs, reason = "TODO")]
 impl<'a> FlowBuilder<'a> {
+    /// Creates a new `FlowBuilder` to construct a Hydro program, using the Cargo package name as the program name.
     #[expect(
         clippy::new_without_default,
         reason = "call `new` explicitly, not `default`"
     )]
-    pub fn new() -> FlowBuilder<'a> {
+    pub fn new() -> Self {
         let mut name = std::env::var("CARGO_PKG_NAME").unwrap_or_else(|_| "unknown".to_owned());
         if let Ok(bin_path) = std::env::current_exe()
             && let Some(bin_name) = bin_path.file_stem()
@@ -108,8 +110,9 @@ impl<'a> FlowBuilder<'a> {
         Self::with_name(name)
     }
 
+    /// Creates a new `FlowBuilder` to construct a Hydro program, with the given program name.
     pub fn with_name(name: impl Into<String>) -> Self {
-        FlowBuilder {
+        Self {
             flow_state: Rc::new(RefCell::new(FlowStateInner {
                 roots: Some(vec![]),
                 next_external_port: ExternalPortId(0),

--- a/hydro_lang/src/compile/built.rs
+++ b/hydro_lang/src/compile/built.rs
@@ -204,7 +204,7 @@ impl<'a> BuiltFlow<'a> {
     #[cfg(feature = "sim")]
     /// Creates a simulation for this builder, which can be used to run deterministic simulations
     /// of the Hydro program.
-    pub fn sim(mut self) -> SimFlow<'a> {
+    pub fn sim(self) -> SimFlow<'a> {
         use std::cell::RefCell;
         use std::rc::Rc;
 
@@ -243,7 +243,7 @@ impl<'a> BuiltFlow<'a> {
         }
 
         SimFlow {
-            ir: std::mem::take(&mut self.ir),
+            ir: self.ir,
             processes,
             clusters,
             externals,

--- a/hydro_lang/src/compile/trybuild/generate.rs
+++ b/hydro_lang/src/compile/trybuild/generate.rs
@@ -290,6 +290,9 @@ pub fn compile_graph_trybuild(
                 let #dfir_ident = __hydro_runtime(&ports);
                 println!("ack start");
 
+                // TODO(mingwei): initialize `tracing` at this point in execution.
+                // After "ack start" is when we can print whatever we want.
+
                 let local_set = #root::runtime_support::tokio::task::LocalSet::new();
                 #(
                     let _ = local_set.spawn_local( #sidecars ); // Uses #dfir_ident

--- a/hydro_lang/src/deploy/deploy_graph_containerized.rs
+++ b/hydro_lang/src/deploy/deploy_graph_containerized.rs
@@ -93,7 +93,7 @@ impl Node for DockerDeployProcess {
     #[instrument(level = "trace", skip_all, fields(key = %self.key, name = self.name))]
     fn update_meta(&self, _meta: &Self::Meta) {}
 
-    #[instrument(level = "trace", skip_all, fields(key = %self.key, name = self.name, ?meta, extra_stmts = extra_stmts.len()))]
+    #[instrument(level = "trace", skip_all, fields(key = %self.key, name = self.name, ?meta, extra_stmts = extra_stmts.len(), sidecars = sidecars.len()))]
     fn instantiate(
         &self,
         _env: &mut Self::InstantiateEnv,

--- a/hydro_lang/src/runtime_support/launch.rs
+++ b/hydro_lang/src/runtime_support/launch.rs
@@ -1,7 +1,5 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
-#[cfg(feature = "runtime_measure")]
-use std::panic::AssertUnwindSafe;
 
 #[cfg(feature = "runtime_measure")]
 use dfir_rs::futures::FutureExt;
@@ -22,7 +20,7 @@ pub async fn run_stdin_commands(flow: Dfir<'_>) {
 #[cfg(feature = "runtime_measure")]
 pub async fn run_stdin_commands(flow: Dfir<'_>) {
     // Make sure to print CPU even if we crash
-    let res = AssertUnwindSafe(launch_flow_stdin_commands(flow))
+    let res = std::panic::AssertUnwindSafe(launch_flow_stdin_commands(flow))
         .catch_unwind()
         .await;
 

--- a/hydro_lang/src/telemetry/emf.rs
+++ b/hydro_lang/src/telemetry/emf.rs
@@ -1,0 +1,313 @@
+//! AWS CloudWatch embedded metric format (EMF).
+//!
+//! <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html>
+use std::marker::Unpin;
+use std::panic::AssertUnwindSafe;
+use std::time::{Duration, SystemTime};
+
+use dfir_rs::Never;
+use dfir_rs::scheduled::graph::Dfir;
+use dfir_rs::scheduled::metrics::DfirMetrics;
+use futures::FutureExt;
+use quote::quote;
+use serde_json::json;
+use syn::parse_quote;
+use tokio::io::{AsyncWrite, AsyncWriteExt};
+use tokio_metrics::RuntimeMetrics;
+
+use crate::location::{LocationKey, LocationType};
+use crate::staging_util::get_this_crate;
+use crate::telemetry::Sidecar;
+
+/// Default file path for [`RecordMetricsSidecar`].
+pub const DEFAULT_FILE_PATH: &str = "/var/log/hydro/metrics.log";
+/// Default interval for [`RecordMetricsSidecar`].
+pub const DEFAULT_INTERVAL: Duration = Duration::from_secs(30);
+
+/// A sidecar which records metrics to a file via EMF.
+pub struct RecordMetricsSidecar {
+    file_path: String,
+    interval: Duration,
+}
+
+#[buildstructor::buildstructor]
+impl RecordMetricsSidecar {
+    /// Build an instance. Any `None` will be replaced with the default value.
+    #[builder]
+    pub fn new(file_path: Option<String>, interval: Option<Duration>) -> Self {
+        Self {
+            file_path: file_path.unwrap_or_else(|| DEFAULT_FILE_PATH.to_owned()),
+            interval: interval.unwrap_or(DEFAULT_INTERVAL),
+        }
+    }
+}
+
+impl Sidecar for RecordMetricsSidecar {
+    fn to_expr(
+        &self,
+        flow_name: &str,
+        _location_key: LocationKey,
+        _location_type: LocationType,
+        location_name: &str,
+        dfir_ident: &syn::Ident,
+    ) -> syn::Expr {
+        let Self {
+            file_path,
+            interval,
+        } = self;
+
+        let root = get_this_crate();
+        let namespace = flow_name.replace(char::is_whitespace, "_");
+        let interval: proc_macro2::TokenStream = {
+            let secs = interval.as_secs();
+            let nanos = interval.subsec_nanos();
+            quote!(::std::time::Duration::new(#secs, #nanos))
+        };
+
+        parse_quote! {
+            #root::telemetry::emf::record_metrics_sidecar(&#dfir_ident, #namespace, #location_name, #file_path, #interval)
+        }
+    }
+}
+
+/// Record both Dfir and Tokio metrics, at the given interval, forever.
+#[doc(hidden)]
+pub fn record_metrics_sidecar(
+    dfir: &Dfir<'_>,
+    namespace: &'static str,
+    location_name: &'static str,
+    file_path: &'static str,
+    interval: Duration,
+) -> impl 'static + Future<Output = Never> {
+    assert!(!namespace.contains(char::is_whitespace));
+
+    let mut dfir_intervals = dfir.metrics_intervals();
+
+    async move {
+        // Attempt to create log file parent dir.
+        if let Some(parent_dir) = std::path::Path::new(file_path).parent()
+            && let Err(e) = tokio::fs::create_dir_all(parent_dir).await
+        {
+            // TODO(minwgei): use `tracing` once deployments set up tracing logging (setup moved out of stdout)
+            eprintln!("Failed to create log file directory for EMF metrics: {}", e);
+        }
+
+        // Only attempt to get Tokio runtime within async to be safe.
+        let rt_monitor = tokio_metrics::RuntimeMonitor::new(&tokio::runtime::Handle::current());
+        let mut rt_intervals = rt_monitor.intervals();
+
+        loop {
+            let _ = tokio::time::sleep(interval).await;
+
+            let dfir_metrics = dfir_intervals.take_interval();
+            let rt_metrics = rt_intervals.next().unwrap();
+
+            let unwind_result = AssertUnwindSafe(async {
+                let timestamp = SystemTime::now();
+
+                let file = tokio::fs::OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .truncate(false)
+                    .append(true)
+                    .open(file_path)
+                    .await
+                    .expect("Failed to open log file for EMF metrics.");
+                let mut writer = tokio::io::BufWriter::new(file);
+
+                record_metrics_dfir(
+                    namespace,
+                    location_name,
+                    timestamp,
+                    dfir_metrics,
+                    &mut writer,
+                )
+                .await
+                .unwrap();
+
+                record_metrics_tokio(namespace, location_name, timestamp, rt_metrics, &mut writer)
+                    .await
+                    .unwrap();
+
+                writer.shutdown().await.unwrap();
+            })
+            .catch_unwind()
+            .await;
+
+            if let Err(panic_reason) = unwind_result {
+                // TODO(minwgei): use `tracing` once deployments set up tracing logging (setup coordination moved out of stdout)
+                eprintln!("Panic in metrics sidecar: {panic_reason:?}");
+            }
+        }
+    }
+}
+
+/// Records DFIR metrics.
+async fn record_metrics_dfir<W>(
+    namespace: &str,
+    location_name: &str,
+    timestamp: SystemTime,
+    metrics: DfirMetrics,
+    writer: &mut W,
+) -> Result<(), std::io::Error>
+where
+    W: AsyncWrite + Unpin,
+{
+    let ts_millis = timestamp
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_millis();
+
+    // Handoffs
+    for (hoff_id, hoff_metrics) in metrics.handoffs.iter() {
+        let emf = json!({
+            "_aws": {
+                "Timestamp": ts_millis,
+                "CloudWatchMetrics": [
+                    {
+                        "Namespace": namespace,
+                        "Dimensions": [["LocationName"], ["LocationName", "HandoffId"]],
+                        "Metrics": [
+                            {"Name": "CurrItemsCount", "Unit": Unit::Count},
+                            {"Name": "TotalItemsCount", "Unit": Unit::Count},
+                        ]
+                    }
+                ]
+            },
+            "LocationName": location_name,
+            "HandoffId": hoff_id.to_string(),
+            "CurrItemsCount": hoff_metrics.curr_items_count(),
+            "TotalItemsCount": hoff_metrics.total_items_count(),
+        })
+        .to_string();
+        writer.write_all(emf.as_bytes()).await?;
+        writer.write_u8(b'\n').await?;
+    }
+
+    // Subgraphs
+    for (sg_id, sg_metrics) in metrics.subgraphs.iter() {
+        let emf = json!({
+            "_aws": {
+                "Timestamp": ts_millis,
+                "CloudWatchMetrics": [
+                    {
+                        "Namespace": namespace,
+                        "Dimensions": [["LocationName"], ["LocationName", "SubgraphId"]],
+                        "Metrics": [
+                            {"Name": "TotalRunCount", "Unit": Unit::Count},
+                            {"Name": "TotalPollDuration", "Unit": Unit::Microseconds},
+                            {"Name": "TotalPollCount", "Unit": Unit::Count},
+                            {"Name": "TotalIdleDuration", "Unit": Unit::Microseconds},
+                            {"Name": "TotalIdleCount", "Unit": Unit::Count},
+                        ]
+                    }
+                ]
+            },
+            "LocationName": location_name,
+            "SubgraphId": sg_id.to_string(),
+            "TotalRunCount": sg_metrics.total_run_count(),
+            "TotalPollDuration": sg_metrics.total_poll_duration().as_micros(),
+            "TotalPollCount": sg_metrics.total_poll_count(),
+            "TotalIdleDuration": sg_metrics.total_idle_duration().as_micros(),
+            "TotalIdleCount": sg_metrics.total_idle_count(),
+        })
+        .to_string();
+        writer.write_all(emf.as_bytes()).await?;
+        writer.write_u8(b'\n').await?;
+    }
+
+    Ok(())
+}
+
+/// Records tokio runtime metrics.
+async fn record_metrics_tokio<W>(
+    namespace: &str,
+    location_name: &str,
+    timestamp: SystemTime,
+    rt_metrics: RuntimeMetrics,
+    writer: &mut W,
+) -> Result<(), std::io::Error>
+where
+    W: AsyncWrite + Unpin,
+{
+    let ts_millis = timestamp
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_millis();
+
+    // Tokio RuntimeMetrics
+    let emf = json!({
+        "_aws": {
+            "Timestamp": ts_millis,
+            "CloudWatchMetrics": [
+                {
+                    "Namespace": namespace,
+                    "Dimensions": [["LocationName"]],
+                    "Metrics": [
+                        // {"Name": "LiveTasksCount", "Unit": Unit::Count}, // https://github.com/tokio-rs/tokio-metrics/pull/108
+                        {"Name": "TotalBusyDuration", "Unit": Unit::Microseconds},
+                        {"Name": "GlobalQueueDepth", "Unit": Unit::Count},
+                    ]
+                }
+            ]
+        },
+        "LocationName": location_name,
+        // "LiveTasksCount": rt_metrics.live_tasks_count, // https://github.com/tokio-rs/tokio-metrics/pull/108
+        "TotalBusyDuration": rt_metrics.total_busy_duration.as_micros(),
+        "GlobalQueueDepth": rt_metrics.global_queue_depth,
+        // The rest of the tokio runtime metrics are `cfg(tokio_unstable)`
+    })
+    .to_string();
+    writer.write_all(emf.as_bytes()).await?;
+    writer.write_u8(b'\n').await?;
+
+    Ok(())
+}
+
+/// AWS CloudWatch EMF units.
+///
+/// <https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDatum.html#ACW-Type-MetricDatum-Unit>
+#[expect(missing_docs, reason = "self-explanatory")]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+pub enum Unit {
+    /// None
+    #[default]
+    None,
+    Seconds,
+    Microseconds,
+    Milliseconds,
+    Bytes,
+    Kilobytes,
+    Megabytes,
+    Gigabytes,
+    Terabytes,
+    Bits,
+    Kilobits,
+    Megabits,
+    Gigabits,
+    Terabits,
+    Percent,
+    Count,
+    #[serde(rename = "Bytes/Second")]
+    BytesPerSecond,
+    #[serde(rename = "Kilobytes/Second")]
+    KilobytesPerSecond,
+    #[serde(rename = "Megabytes/Second")]
+    MegabytesPerSecond,
+    #[serde(rename = "Gigabytes/Second")]
+    GigabytesPerSecond,
+    #[serde(rename = "Terabytes/Second")]
+    TerabytesPerSecond,
+    #[serde(rename = "Bits/Second")]
+    BitsPerSecond,
+    #[serde(rename = "Kilobits/Second")]
+    KilobitsPerSecond,
+    #[serde(rename = "Megabits/Second")]
+    MegabitsPerSecond,
+    #[serde(rename = "Gigabits/Second")]
+    GigabitsPerSecond,
+    #[serde(rename = "Terabits/Second")]
+    TerabitsPerSecond,
+    #[serde(rename = "Count/Second")]
+    CountPerSecond,
+}

--- a/hydro_lang/src/telemetry/mod.rs
+++ b/hydro_lang/src/telemetry/mod.rs
@@ -6,6 +6,8 @@ use tracing_subscriber::registry::LookupSpan;
 
 use crate::location::{LocationKey, LocationType};
 
+pub mod emf;
+
 struct Formatter;
 
 impl<S, N> FormatEvent<S, N> for Formatter


### PR DESCRIPTION
Tracking issue: https://github.com/hydro-project/hydro/issues/2228

This enabled automatic reporting of DFIR, Tokio, and CloudWatch Agent metrics/integrations (cpu, mem, netstat, disk, many other things) to AWS CloudWatch for AWS deployments. (For available CWA built-in metrics/integrations see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-Configuration-File-Details.html#CloudWatch-Agent-Configuration-File-Metricssection _Metrics section_ -> _Linux section_)

To use, you need to provide a `hydro_deploy` `iam_instance_profile` and `cloudwatch_log_group` to your deployment instances, see `perf_compute_pi` for usage example. In the future this may be done in CDK instead.

A `user_data` script installs and starts the CloudWatch Agent daemon. A sidecar logs metrics in EMF JSON format into a file which is read by the CloudWatch Agent and uploaded to AWS CloudWatch.

---

Also change the `perf_compute_pi` example to require the `--tracing` flag if CPU tracing is to enabled, for testing. The perf files are large and may fill up the disk or take a long time to download.