### PR TITLE
test: include Hydro template sources into workspace tree and test example

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -19,6 +19,10 @@ filter = 'binary(kvs_replicated)'
 test-group = 'serial-integration'
 
 [[profile.default.overrides]]
+filter = 'binary(echo_local)'
+test-group = 'serial-integration'
+
+[[profile.default.overrides]]
 filter = 'package(hydro_lang)'
 test-group = 'hydro-trybuild-group'
 
@@ -28,4 +32,8 @@ test-group = 'hydro-trybuild-group'
 
 [[profile.default.overrides]]
 filter = 'package(hydro_test)'
+test-group = 'hydro-trybuild-group'
+
+[[profile.default.overrides]]
+filter = 'package(hydro_test_template)'
 test-group = 'hydro-trybuild-group'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2290,6 +2290,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "hydro_test_template"
+version = "0.0.0"
+dependencies = [
+ "ctor 0.2.9",
+ "example_test",
+ "futures",
+ "hydro_deploy",
+ "hydro_lang",
+ "hydro_std",
+ "stageleft",
+ "stageleft_tool",
+ "tokio",
+ "tokio-test",
+ "tokio-util",
+]
+
+[[package]]
 name = "hyper"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4744,9 +4761,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stageleft"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b92cb4d28ec3c2b3aba8ee05487f10c3aa00d7a369a3fe9d4d89e8719f28ca4f"
+checksum = "101469d4cf8d54ac88b735ecd1dcc5e11da859e191a1dd0e28e71a298ffae1b9"
 dependencies = [
  "ctor 0.4.3",
  "proc-macro-crate 3.3.0",
@@ -4758,9 +4775,9 @@ dependencies = [
 
 [[package]]
 name = "stageleft_macro"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05624677c37d2abebe0c3e50fa7722f99936d26de2a8a23ac5d2a397be596c0"
+checksum = "e1dc19da279ba29d00ae49363841037bd7c933130d0c4476899e1d7f8f04dab5"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -4771,9 +4788,9 @@ dependencies = [
 
 [[package]]
 name = "stageleft_tool"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da14207006ed0031a24197e0a2d3bc84b2a7ecf3a2ca70b70f1886cf1a37b464"
+checksum = "977b4e22d5233ef274f43a02d9946dd4ee66c1957eac8a5f031450ab97bfa834"
 dependencies = [
  "prettyplease",
  "proc-macro-crate 3.3.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "hydro_lang",
     "hydro_std",
     "hydro_test",
+    "hydro_test_template",
     "include_mdtests",
     "lattices_macro",
     "lattices",
@@ -67,5 +68,5 @@ uninlined_format_args = "allow"
 upper_case_acronyms = "warn"
 
 [workspace.dependencies]
-stageleft = "0.10.0"
-stageleft_tool = "0.10.0"
+stageleft = "0.10.1"
+stageleft_tool = "0.10.1"

--- a/hydro_lang/src/sim/graph.rs
+++ b/hydro_lang/src/sim/graph.rs
@@ -512,8 +512,20 @@ pub(super) fn create_sim_graph_trybuild(
     );
 
     let inlined_staged = if is_test {
+        let raw_toml_manifest = toml::from_str::<toml::Value>(
+            &fs::read_to_string(path!(source_dir / "Cargo.toml")).unwrap(),
+        )
+        .unwrap();
+
+        let maybe_custom_lib_path = raw_toml_manifest
+            .get("lib")
+            .and_then(|lib| lib.get("path"))
+            .and_then(|path| path.as_str());
+
         let gen_staged = stageleft_tool::gen_staged_trybuild(
-            &path!(source_dir / "src" / "lib.rs"),
+            &maybe_custom_lib_path
+                .map(|s| path!(source_dir / s))
+                .unwrap_or_else(|| path!(source_dir / "src" / "lib.rs")),
             &path!(source_dir / "Cargo.toml"),
             crate_name.clone(),
             Some("hydro___test".to_string()),

--- a/hydro_test_template/Cargo.toml
+++ b/hydro_test_template/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "hydro_test_template"
+publish = false
+version = "0.0.0"
+edition = "2024"
+
+[lib]
+path = "../template/hydro/src/lib.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+hydro_lang = { path = "../hydro_lang", version = "^0.14.0" }
+hydro_std = { path = "../hydro_std", version = "^0.14.0" }
+stageleft.workspace = true
+
+[build-dependencies]
+stageleft_tool.workspace = true
+
+[dev-dependencies]
+ctor = "0.2"
+hydro_deploy = { path = "../hydro_deploy/core", version = "^0.14.0" }
+hydro_lang = { path = "../hydro_lang", version = "^0.14.0", features = [
+    "deploy",
+    "sim",
+    "viz",
+] }
+tokio = { version = "1.29.0", features = ["full"] }
+tokio-util = { version = "0.7.5", features = [ "codec" ] }
+tokio-test = "0.4.4"
+futures = "0.3.0"
+example_test = { path = "../example_test", version = "^0.0.0" }

--- a/hydro_test_template/build.rs
+++ b/hydro_test_template/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    stageleft_tool::gen_final!();
+}

--- a/hydro_test_template/examples/echo_local.rs
+++ b/hydro_test_template/examples/echo_local.rs
@@ -1,0 +1,22 @@
+use hydro_test_template as hydro_template;
+
+include!("../../template/hydro/examples/echo_local.rs");
+
+#[test]
+fn test() {
+    use std::io::{BufRead, BufReader, Write};
+    use std::net::TcpStream;
+
+    use example_test::run_current_example;
+
+    let mut run = run_current_example!();
+    run.read_regex(r"Launched Echo Server");
+
+    let mut tcp_conn = TcpStream::connect("127.0.0.1:4000").unwrap();
+    tcp_conn
+        .write_all(b"Hello, Hydro!\n")
+        .expect("Failed to write to TCP stream");
+
+    let mut lines = BufReader::new(&tcp_conn).lines();
+    assert_eq!(lines.next().unwrap().unwrap(), "HELLO, HYDRO!");
+}

--- a/template/hydro/Cargo.toml
+++ b/template/hydro/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2024"
 [dependencies]
 hydro_lang = { git = "{{ hydro_git | default: 'https://github.com/hydro-project/hydro.git' }}", branch = "{{ hydro_branch | default: 'main' }}" }
 hydro_std = { git = "{{ hydro_git | default: 'https://github.com/hydro-project/hydro.git' }}", branch = "{{ hydro_branch | default: 'main' }}" }
-stageleft = "0.10.0"
+stageleft = "0.10.1"
 
 [build-dependencies]
-stageleft_tool = "0.10.0"
+stageleft_tool = "0.10.1"
 
 [dev-dependencies]
 ctor = "0.2"


### PR DESCRIPTION

Since none of the template sources rely on the template variables, we can include them as-is into the workspace tree so that we get code completion and can run tests without having to manually generate the template.

Also fixes a bug with Hydro not supporting custom `lib.path` (with accompanying Stageleft fix).
