### PR TITLE
fix(hydro_deploy): Remove musl compiler for performance and perf

### DIFF
--- a/hydro_deploy/core/src/rust_crate/build.rs
+++ b/hydro_deploy/core/src/rust_crate/build.rs
@@ -117,13 +117,6 @@ pub async fn build_crate_memoized(params: BuildParams) -> Result<&'static BuildO
                         command.args(["--example", example]);
                     }
 
-                    match params.target_type {
-                        HostTargetType::Local => {}
-                        HostTargetType::Linux => {
-                            command.args(["--target", "x86_64-unknown-linux-musl"]);
-                        }
-                    }
-
                     if params.no_default_features {
                         command.arg("--no-default-features");
                     }


### PR DESCRIPTION
Note: Will break hydro_deploy if the binary runs on a different architecture.