### PR TITLE
feat(hydro_lang): add `KeyedStream` APIs for compound keys and sending with keys

### DIFF
--- a/hydro_lang/src/live_collections/keyed_stream/networking.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/networking.rs
@@ -2,7 +2,7 @@
 
 use serde::Serialize;
 use serde::de::DeserializeOwned;
-use stageleft::quote_type;
+use stageleft::{q, quote_type};
 
 use super::KeyedStream;
 use crate::compile::ir::{DebugInstantiate, HydroNode};
@@ -74,6 +74,79 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
                 metadata: other.new_node_metadata(
                     Stream::<T, Cluster<'a, L2>, Unbounded, O, R>::collection_kind(),
                 ),
+            },
+        )
+    }
+}
+
+impl<'a, K, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
+    KeyedStream<(MemberId<L2>, K), T, Process<'a, L>, B, O, R>
+{
+    /// Sends each group of this stream to a specific member of a cluster. The input stream has a
+    /// compound key where the first element is the recipient's [`MemberId`] and the second element
+    /// is a key that will be sent along with the value, using [`bincode`] to serialize/deserialize
+    /// messages.
+    ///
+    /// # Example
+    /// ```rust
+    /// # #[cfg(feature = "deploy")] {
+    /// # use hydro_lang::prelude::*;
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(hydro_lang::test_util::multi_location_test(|flow, p2| {
+    /// let p1 = flow.process::<()>();
+    /// let workers: Cluster<()> = flow.cluster::<()>();
+    /// let to_send: KeyedStream<_, _, Process<_>, _> = p1
+    ///     .source_iter(q!(vec![0, 1, 2, 3]))
+    ///     .map(q!(|x| ((hydro_lang::location::MemberId::from_raw_id(x), x), x + 123)))
+    ///     .into_keyed();
+    /// let on_worker: KeyedStream<_, _, Cluster<_>, _> = to_send.demux_bincode(&workers);
+    /// # on_worker.entries().send_bincode(&p2).entries()
+    /// // if there are 4 members in the cluster, each receives one element
+    /// // - MemberId::<()>(0): { 0: [123] }
+    /// // - MemberId::<()>(1): { 1: [124] }
+    /// // - ...
+    /// # }, |mut stream| async move {
+    /// # let mut results = Vec::new();
+    /// # for w in 0..4 {
+    /// #     results.push(format!("{:?}", stream.next().await.unwrap()));
+    /// # }
+    /// # results.sort();
+    /// # assert_eq!(results, vec!["(MemberId::<()>(0), (0, 123))", "(MemberId::<()>(1), (1, 124))", "(MemberId::<()>(2), (2, 125))", "(MemberId::<()>(3), (3, 126))"]);
+    /// # }));
+    /// # }
+    /// ```
+    pub fn demux_bincode(
+        self,
+        other: &Cluster<'a, L2>,
+    ) -> KeyedStream<K, T, Cluster<'a, L2>, Unbounded, O, R>
+    where
+        K: Serialize + DeserializeOwned,
+        T: Serialize + DeserializeOwned,
+    {
+        let serialize_pipeline = Some(serialize_bincode::<(K, T)>(true));
+
+        let deserialize_pipeline = Some(deserialize_bincode::<(K, T)>(None));
+
+        KeyedStream::new(
+            other.clone(),
+            HydroNode::Network {
+                serialize_fn: serialize_pipeline.map(|e| e.into()),
+                instantiate_fn: DebugInstantiate::Building,
+                deserialize_fn: deserialize_pipeline.map(|e| e.into()),
+                input: Box::new(
+                    self.entries()
+                        .map(q!(|((id, k), v)| (id, (k, v))))
+                        .ir_node
+                        .into_inner(),
+                ),
+                metadata: other.new_node_metadata(KeyedStream::<
+                    K,
+                    T,
+                    Cluster<'a, L2>,
+                    Unbounded,
+                    O,
+                    R,
+                >::collection_kind()),
             },
         )
     }
@@ -158,5 +231,99 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
         );
 
         raw_stream.into_keyed()
+    }
+}
+
+impl<'a, K, V, L, B: Boundedness, O: Ordering, R: Retries>
+    KeyedStream<K, V, Cluster<'a, L>, B, O, R>
+{
+    #[expect(clippy::type_complexity, reason = "compound key types with ordering")]
+    /// "Moves" elements of this keyed stream from a cluster to a process by sending them over the
+    /// network, using [`bincode`] to serialize/deserialize messages. The resulting [`KeyedStream`]
+    /// has a compound key where the first element is the sender's [`MemberId`] and the second
+    /// element is the original key.
+    ///
+    /// # Example
+    /// ```rust
+    /// # #[cfg(feature = "deploy")] {
+    /// # use hydro_lang::prelude::*;
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(hydro_lang::test_util::multi_location_test(|flow, p2| {
+    /// # type Source = ();
+    /// # type Destination = ();
+    /// let source: Cluster<Source> = flow.cluster::<Source>();
+    /// let to_send: KeyedStream<_, _, Cluster<_>, _> = source
+    ///     .source_iter(q!(vec![0, 1, 2, 3]))
+    ///     .map(q!(|x| (x, x + 123)))
+    ///     .into_keyed();
+    /// let destination_process = flow.process::<Destination>();
+    /// let all_received = to_send.send_bincode(&destination_process); // KeyedStream<(MemberId<Source>, i32), i32, ...>
+    /// # all_received.entries().send_bincode(&p2)
+    /// # }, |mut stream| async move {
+    /// // if there are 4 members in the source cluster, the destination process receives four messages from each source member
+    /// // {
+    /// //     (MemberId<Source>(0), 0): [123], (MemberId<Source>(1), 0): [123], ...,
+    /// //     (MemberId<Source>(0), 1): [124], (MemberId<Source>(1), 1): [124], ...,
+    /// //     ...
+    /// // }
+    /// # let mut results = Vec::new();
+    /// # for w in 0..16 {
+    /// #     results.push(format!("{:?}", stream.next().await.unwrap()));
+    /// # }
+    /// # results.sort();
+    /// # assert_eq!(results, vec![
+    /// #   "((MemberId::<()>(0), 0), 123)",
+    /// #   "((MemberId::<()>(0), 1), 124)",
+    /// #   "((MemberId::<()>(0), 2), 125)",
+    /// #   "((MemberId::<()>(0), 3), 126)",
+    /// #   "((MemberId::<()>(1), 0), 123)",
+    /// #   "((MemberId::<()>(1), 1), 124)",
+    /// #   "((MemberId::<()>(1), 2), 125)",
+    /// #   "((MemberId::<()>(1), 3), 126)",
+    /// #   "((MemberId::<()>(2), 0), 123)",
+    /// #   "((MemberId::<()>(2), 1), 124)",
+    /// #   "((MemberId::<()>(2), 2), 125)",
+    /// #   "((MemberId::<()>(2), 3), 126)",
+    /// #   "((MemberId::<()>(3), 0), 123)",
+    /// #   "((MemberId::<()>(3), 1), 124)",
+    /// #   "((MemberId::<()>(3), 2), 125)",
+    /// #   "((MemberId::<()>(3), 3), 126)",
+    /// # ]);
+    /// # }));
+    /// # }
+    /// ```
+    pub fn send_bincode<L2>(
+        self,
+        other: &Process<'a, L2>,
+    ) -> KeyedStream<(MemberId<L>, K), V, Process<'a, L2>, Unbounded, O, R>
+    where
+        K: Serialize + DeserializeOwned,
+        V: Serialize + DeserializeOwned,
+    {
+        let serialize_pipeline = Some(serialize_bincode::<(K, V)>(false));
+
+        let deserialize_pipeline = Some(deserialize_bincode::<(K, V)>(Some(&quote_type::<L>())));
+
+        let raw_stream: Stream<(MemberId<L>, (K, V)), Process<'a, L2>, Unbounded, O, R> =
+            Stream::new(
+                other.clone(),
+                HydroNode::Network {
+                    serialize_fn: serialize_pipeline.map(|e| e.into()),
+                    instantiate_fn: DebugInstantiate::Building,
+                    deserialize_fn: deserialize_pipeline.map(|e| e.into()),
+                    input: Box::new(self.ir_node.into_inner()),
+                    metadata: other.new_node_metadata(Stream::<
+                        (MemberId<L>, (K, V)),
+                        Cluster<'a, L2>,
+                        Unbounded,
+                        O,
+                        R,
+                    >::collection_kind()),
+                },
+            );
+
+        raw_stream
+            .map(q!(|(sender, (k, v))| ((sender, k), v)))
+            .into_keyed()
     }
 }

--- a/hydro_test/src/tutorials/keyed_counter.rs
+++ b/hydro_test/src/tutorials/keyed_counter.rs
@@ -1,15 +1,15 @@
-use hydro_lang::live_collections::stream::{NoOrder, Ordering};
+use hydro_lang::live_collections::stream::NoOrder;
 use hydro_lang::location::{Location, NoTick};
 use hydro_lang::prelude::*;
 
 pub struct CounterServer;
 
 #[expect(clippy::type_complexity, reason = "output types with orderings")]
-pub fn keyed_counter_service<'a, L: Location<'a> + NoTick, O: Ordering>(
-    increment_requests: KeyedStream<u32, String, L, Unbounded, O>,
-    get_requests: KeyedStream<u32, String, L, Unbounded, O>,
+pub fn keyed_counter_service<'a, L: Location<'a> + NoTick>(
+    increment_requests: KeyedStream<u32, String, L, Unbounded>,
+    get_requests: KeyedStream<u32, String, L, Unbounded>,
 ) -> (
-    KeyedStream<u32, String, L, Unbounded, O>,
+    KeyedStream<u32, String, L, Unbounded>,
     KeyedStream<u32, (String, usize), L, Unbounded, NoOrder>,
 ) {
     let atomic_tick = increment_requests.location().tick();

--- a/template/prompts/challenge-keyed-counter.md.template
+++ b/template/prompts/challenge-keyed-counter.md.template
@@ -3,9 +3,8 @@
 ## Challenge Description
 You are helping the developer build a keyed counter service where a single server store counters for several keys. Here is the reference solution, but there are some tweaks:
 - instead of a generic location, keep things simple and just use `Process<'a, CounterServer>`
-- instead of a generic ordering, just omit it everywhere (also omit the `Unbounded` type parameter)
 - the reason the input and output streams are keyed on `u32` is because we are receiving and sending messages to multiple clients, and the streams for each are independent which is why they are grouped that way at the edges. internally, we will re-group by the counter keys but on the inputs and outputs it is important that the key is the client ID
-  - note that the get responses will still be unordered because `get_many_if_present` returns an unordered stream because it uses a hash join
+- note that the get responses will be unordered because `get_many_if_present` returns an unordered stream because it uses a hash join
 - ignore the `clippy` annotations in the reference
 - at first don't tell the developer about `atomic` at all, maybe hint that there's a consistency issue that we'll address later, but wait until the developer writes the simulation test and it fails before introducing `atomic` and consistency
 


### PR DESCRIPTION

Previously, the only way to send a `KeyedStream` _including_ the keys was to get the entries (which would erase the order).

Now, we add APIs to prefix/unprefix the key (prepend a tuple element), and then add a `KeyedStream::send_bincode` API that sends the entire set of entries with the sender ID prefixed in the return type. We also add an inverse `KeyedStream::demux_bincode` where the input keys are a compound of `(MemberId, Key)` and the recipient gets a `KeyedStream<Key>`.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydro-project/hydro/pull/2298).
* #2304
* #2302
* #2301
* __->__ #2298