### PR TITLE
feat!: compile envs are now specifiable and plumbed throughout hydrolang/hydro deploy

### DIFF
--- a/hydro_lang/src/compile/builder.rs
+++ b/hydro_lang/src/compile/builder.rs
@@ -251,15 +251,21 @@ impl<'a> FlowBuilder<'a> {
         self.with_default_optimize::<D>().compile(env)
     }
 
-    pub fn compile_no_network<D: Deploy<'a>>(self) -> CompiledFlow<'a, D::GraphId> {
-        self.with_default_optimize::<D>().compile_no_network()
+    pub fn compile_no_network<D: Deploy<'a>>(
+        self,
+        compile_env: &D::CompileEnv,
+    ) -> CompiledFlow<'a, D::GraphId> {
+        self.with_default_optimize::<D>()
+            .compile_no_network(compile_env)
     }
 
-    pub fn deploy<D: Deploy<'a, CompileEnv = ()>>(
+    pub fn deploy<D: Deploy<'a>>(
         self,
-        env: &mut D::InstantiateEnv,
+        compile_env: &D::CompileEnv,
+        instantiate_env: &mut D::InstantiateEnv,
     ) -> DeployResult<'a, D> {
-        self.with_default_optimize().deploy(env)
+        self.with_default_optimize()
+            .deploy(compile_env, instantiate_env)
     }
 
     #[cfg(feature = "sim")]

--- a/hydro_lang/src/compile/built.rs
+++ b/hydro_lang/src/compile/built.rs
@@ -27,8 +27,9 @@ pub struct BuiltFlow<'a> {
 
 pub(crate) fn build_inner<'a, D: Deploy<'a>>(
     ir: &mut Vec<HydroRoot>,
+    compile_env: &D::CompileEnv,
 ) -> BTreeMap<usize, DfirGraph> {
-    emit::<D>(ir)
+    emit::<D>(ir, compile_env)
         .into_iter()
         .map(|(k, v)| {
             let (mut flat_graph, _, _) = v.build();
@@ -372,15 +373,19 @@ impl<'a> BuiltFlow<'a> {
         self.into_deploy::<D>().compile(env)
     }
 
-    pub fn compile_no_network<D: Deploy<'a>>(self) -> CompiledFlow<'a, D::GraphId> {
-        self.into_deploy::<D>().compile_no_network()
+    pub fn compile_no_network<D: Deploy<'a>>(
+        self,
+        compile_env: &D::CompileEnv,
+    ) -> CompiledFlow<'a, D::GraphId> {
+        self.into_deploy::<D>().compile_no_network(compile_env)
     }
 
-    pub fn deploy<D: Deploy<'a, CompileEnv = ()>>(
+    pub fn deploy<D: Deploy<'a>>(
         self,
-        env: &mut D::InstantiateEnv,
+        compile_env: &D::CompileEnv,
+        instantiate_env: &mut D::InstantiateEnv,
     ) -> DeployResult<'a, D> {
-        self.into_deploy::<D>().deploy(env)
+        self.into_deploy::<D>().deploy(compile_env, instantiate_env)
     }
 
     #[cfg(feature = "viz")]

--- a/hydro_lang/src/compile/deploy_provider.rs
+++ b/hydro_lang/src/compile/deploy_provider.rs
@@ -152,6 +152,7 @@ pub trait Deploy<'a> {
     ) -> impl QuotedWithContext<'a, TaglessMemberId, ()> + Clone + 'a;
 
     fn cluster_membership_stream(
+        env: &Self::CompileEnv,
         location_id: &LocationId,
     ) -> impl QuotedWithContext<'a, Box<dyn Stream<Item = (TaglessMemberId, MembershipEvent)> + Unpin>, ()>;
 }

--- a/hydro_lang/src/deploy/deploy_graph.rs
+++ b/hydro_lang/src/deploy/deploy_graph.rs
@@ -446,6 +446,7 @@ impl<'a> Deploy<'a> for HydroDeploy {
     }
 
     fn cluster_membership_stream(
+        _env: &Self::CompileEnv,
         location_id: &LocationId,
     ) -> impl QuotedWithContext<'a, Box<dyn Stream<Item = (TaglessMemberId, MembershipEvent)> + Unpin>, ()>
     {

--- a/hydro_lang/src/live_collections/keyed_singleton.rs
+++ b/hydro_lang/src/live_collections/keyed_singleton.rs
@@ -1410,7 +1410,7 @@ mod tests {
         let nodes = flow
             .with_process(&node, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 
@@ -1448,7 +1448,7 @@ mod tests {
         let nodes = flow
             .with_process(&node, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 
@@ -1495,7 +1495,7 @@ mod tests {
         let nodes = flow
             .with_process(&node, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 
@@ -1542,7 +1542,7 @@ mod tests {
         let nodes = flow
             .with_process(&node, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 
@@ -1643,7 +1643,7 @@ mod tests {
         let nodes = flow
             .with_process(&node, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 

--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -2405,7 +2405,7 @@ mod tests {
         let nodes = flow
             .with_process(&node, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 
@@ -2463,7 +2463,7 @@ mod tests {
             .with_default_optimize()
             .with_process(&node, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 

--- a/hydro_lang/src/live_collections/optional.rs
+++ b/hydro_lang/src/live_collections/optional.rs
@@ -1308,7 +1308,7 @@ mod tests {
         let nodes = flow
             .with_process(&node, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 

--- a/hydro_lang/src/live_collections/singleton.rs
+++ b/hydro_lang/src/live_collections/singleton.rs
@@ -1130,7 +1130,7 @@ mod tests {
         let nodes = flow
             .with_process(&node, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -2994,7 +2994,7 @@ mod tests {
             .with_process(&first_node, deployment.Localhost())
             .with_process(&second_node, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 
@@ -3030,7 +3030,7 @@ mod tests {
         let nodes = flow
             .with_process(&node, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 
@@ -3059,7 +3059,7 @@ mod tests {
         let nodes = flow
             .with_process(&node, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 
@@ -3102,7 +3102,7 @@ mod tests {
         let nodes = flow
             .with_process(&node, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 
@@ -3141,7 +3141,7 @@ mod tests {
         let nodes = flow
             .with_process(&node, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 
@@ -3172,7 +3172,7 @@ mod tests {
         let nodes = flow
             .with_process(&node, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 
@@ -3204,7 +3204,7 @@ mod tests {
         let nodes = flow
             .with_process(&node, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 

--- a/hydro_lang/src/live_collections/stream/networking.rs
+++ b/hydro_lang/src/live_collections/stream/networking.rs
@@ -220,7 +220,7 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Process<'a, L>
     /// let nodes = flow
     ///     .with_process(&process, deployment.Localhost())
     ///     .with_external(&external, deployment.Localhost())
-    ///     .deploy(&mut deployment);
+    ///     .deploy(&(), &mut deployment);
     ///
     /// deployment.deploy().await.unwrap();
     /// // establish the TCP connection

--- a/hydro_lang/src/location/mod.rs
+++ b/hydro_lang/src/location/mod.rs
@@ -313,7 +313,7 @@ pub trait Location<'a>: dynamic::DynLocation {
     /// let nodes = flow // ... with_process and with_external
     /// #     .with_process(&node, deployment.Localhost())
     /// #     .with_external(&external, deployment.Localhost())
-    /// #     .deploy(&mut deployment);
+    /// #     .deploy(&(), &mut deployment);
     ///
     /// deployment.deploy().await.unwrap();
     /// deployment.start().await.unwrap();
@@ -862,7 +862,7 @@ mod tests {
         let nodes = flow
             .with_process(&node, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 
@@ -900,7 +900,7 @@ mod tests {
         let nodes = flow
             .with_process(&node, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 
@@ -930,7 +930,7 @@ mod tests {
         let nodes = flow
             .with_process(&first_node, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 
@@ -960,7 +960,7 @@ mod tests {
         let nodes = flow
             .with_process(&first_node, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 
@@ -995,7 +995,7 @@ mod tests {
         let nodes = flow
             .with_process(&first_node, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 
@@ -1027,7 +1027,7 @@ mod tests {
         let nodes = flow
             .with_process(&first_node, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 
@@ -1068,7 +1068,7 @@ mod tests {
         let nodes = flow
             .with_process(&first_node, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
         deployment.start().await.unwrap();
@@ -1098,7 +1098,7 @@ mod tests {
         let nodes = flow
             .with_process(&first_node, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 
@@ -1129,7 +1129,7 @@ mod tests {
         let nodes = flow
             .with_process(&first_node, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 

--- a/hydro_lang/src/runtime_context.rs
+++ b/hydro_lang/src/runtime_context.rs
@@ -59,7 +59,7 @@ mod tests {
         let nodes = flow
             .with_process(&node, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 

--- a/hydro_lang/src/sim/flow.rs
+++ b/hydro_lang/src/sim/flow.rs
@@ -120,7 +120,7 @@ impl<'a> SimFlow<'a> {
         let mut built_tees = HashMap::new();
         let mut next_stmt_id = 0;
         for leaf in &mut self.ir {
-            leaf.emit::<SimDeploy>(&mut sim_emit, &mut built_tees, &mut next_stmt_id);
+            leaf.emit::<SimDeploy>(&mut sim_emit, &mut built_tees, &mut next_stmt_id, &());
         }
 
         let process_graphs = sim_emit

--- a/hydro_lang/src/sim/graph.rs
+++ b/hydro_lang/src/sim/graph.rs
@@ -362,6 +362,7 @@ impl<'a> Deploy<'a> for SimDeploy {
     }
 
     fn cluster_membership_stream(
+        _env: &Self::CompileEnv,
         location_id: &LocationId,
     ) -> impl QuotedWithContext<
         'a,

--- a/hydro_lang/src/test_util.rs
+++ b/hydro_lang/src/test_util.rs
@@ -33,7 +33,7 @@ pub async fn multi_location_test<'a, T, C, O: Ordering, R: Retries>(
         .with_remaining_processes(|| deployment.Localhost())
         .with_remaining_clusters(|| vec![deployment.Localhost(); 4])
         .with_external(&external, deployment.Localhost())
-        .deploy(&mut deployment);
+        .deploy(&(), &mut deployment);
 
     deployment.deploy().await.unwrap();
 
@@ -61,7 +61,7 @@ pub async fn stream_transform_test<'a, T, C, O: Ordering, R: Retries>(
     let nodes = flow
         .with_process(&process, deployment.Localhost())
         .with_external(&external, deployment.Localhost())
-        .deploy(&mut deployment);
+        .deploy(&(), &mut deployment);
 
     deployment.deploy().await.unwrap();
 

--- a/hydro_test/examples/chat.rs
+++ b/hydro_test/examples/chat.rs
@@ -46,7 +46,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_default_optimize()
         .with_process(&process, TrybuildHost::new(deployment.Localhost()))
         .with_external(&external, deployment.Localhost())
-        .deploy(&mut deployment);
+        .deploy(&(), &mut deployment);
 
     deployment.deploy().await.unwrap();
 

--- a/hydro_test/examples/compartmentalized_paxos.rs
+++ b/hydro_test/examples/compartmentalized_paxos.rs
@@ -143,7 +143,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             (0..num_replicas)
                 .map(|_| TrybuildHost::new(create_host(&mut deployment)).rustflags(rustflags)),
         )
-        .deploy(&mut deployment);
+        .deploy(&(), &mut deployment);
 
     deployment.deploy().await.unwrap();
 

--- a/hydro_test/examples/compute_pi.rs
+++ b/hydro_test/examples/compute_pi.rs
@@ -75,7 +75,7 @@ async fn main() {
             &cluster,
             (0..8).map(|_| TrybuildHost::new(create_host(&mut deployment)).rustflags(rustflags)),
         )
-        .deploy(&mut deployment);
+        .deploy(&(), &mut deployment);
 
     deployment.run_ctrl_c().await.unwrap();
 }

--- a/hydro_test/examples/echo.rs
+++ b/hydro_test/examples/echo.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_default_optimize()
         .with_process(&process, TrybuildHost::new(deployment.Localhost()))
         .with_external(&external, deployment.Localhost())
-        .deploy(&mut deployment);
+        .deploy(&(), &mut deployment);
 
     deployment.deploy().await.unwrap();
 

--- a/hydro_test/examples/first_ten_distributed.rs
+++ b/hydro_test/examples/first_ten_distributed.rs
@@ -115,7 +115,7 @@ async fn main() {
             TrybuildHost::new(create_host(&mut deployment)).rustflags(rustflags),
         )
         .with_external(&external, deployment.Localhost())
-        .deploy(&mut deployment);
+        .deploy(&(), &mut deployment);
 
     deployment.deploy().await.unwrap();
 

--- a/hydro_test/examples/http_counter.rs
+++ b/hydro_test/examples/http_counter.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_default_optimize()
         .with_process(&process, TrybuildHost::new(deployment.Localhost()))
         .with_external(&external, deployment.Localhost())
-        .deploy(&mut deployment);
+        .deploy(&(), &mut deployment);
 
     deployment.deploy().await.unwrap();
 

--- a/hydro_test/examples/http_hello.rs
+++ b/hydro_test/examples/http_hello.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_default_optimize()
         .with_process(&process, TrybuildHost::new(deployment.Localhost()))
         .with_external(&external, deployment.Localhost())
-        .deploy(&mut deployment);
+        .deploy(&(), &mut deployment);
 
     deployment.deploy().await.unwrap();
 

--- a/hydro_test/examples/map_reduce.rs
+++ b/hydro_test/examples/map_reduce.rs
@@ -77,7 +77,7 @@ async fn main() {
             &cluster,
             (0..2).map(|_| TrybuildHost::new(create_host(&mut deployment)).rustflags(rustflags)),
         )
-        .deploy(&mut deployment);
+        .deploy(&(), &mut deployment);
 
     deployment.run_ctrl_c().await.unwrap();
 }

--- a/hydro_test/examples/paxos.rs
+++ b/hydro_test/examples/paxos.rs
@@ -119,7 +119,7 @@ async fn main() {
             (0..f + 1)
                 .map(|_| TrybuildHost::new(create_host(&mut deployment)).rustflags(rustflags)),
         )
-        .deploy(&mut deployment);
+        .deploy(&(), &mut deployment);
 
     deployment.deploy().await.unwrap();
 

--- a/hydro_test/examples/perf_compute_pi.rs
+++ b/hydro_test/examples/perf_compute_pi.rs
@@ -127,7 +127,7 @@ async fn main() {
                     )
             }),
         )
-        .deploy(&mut deployment);
+        .deploy(&(), &mut deployment);
 
     deployment.deploy().await.unwrap();
 

--- a/hydro_test/examples/simple_cluster.rs
+++ b/hydro_test/examples/simple_cluster.rs
@@ -75,6 +75,6 @@ async fn main() {
             &cluster,
             (0..2).map(|_| TrybuildHost::new(create_host(&mut deployment)).rustflags(rustflags)),
         )
-        .deploy(&mut deployment);
+        .deploy(&(), &mut deployment);
     deployment.run_ctrl_c().await.unwrap();
 }

--- a/hydro_test/examples/two_pc.rs
+++ b/hydro_test/examples/two_pc.rs
@@ -98,7 +98,7 @@ async fn main() {
             &client_aggregator,
             TrybuildHost::new(create_host(&mut deployment)).rustflags(rustflags),
         )
-        .deploy(&mut deployment);
+        .deploy(&(), &mut deployment);
 
     deployment.deploy().await.unwrap();
 

--- a/hydro_test/src/cluster/compute_pi.rs
+++ b/hydro_test/src/cluster/compute_pi.rs
@@ -66,7 +66,7 @@ mod tests {
 
         hydro_build_utils::assert_debug_snapshot!(built.ir());
 
-        for (id, ir) in built.preview_compile().all_dfir() {
+        for (id, ir) in built.preview_compile(&()).all_dfir() {
             hydro_build_utils::insta::with_settings!({
                 snapshot_suffix => format!("surface_graph_{id}"),
             }, {

--- a/hydro_test/src/cluster/many_to_many.rs
+++ b/hydro_test/src/cluster/many_to_many.rs
@@ -36,7 +36,7 @@ mod tests {
         let nodes = builder
             .with_default_optimize()
             .with_cluster(&cluster, (0..2).map(|_| deployment.Localhost()))
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 

--- a/hydro_test/src/cluster/map_reduce.rs
+++ b/hydro_test/src/cluster/map_reduce.rs
@@ -57,7 +57,7 @@ mod tests {
 
         hydro_build_utils::assert_debug_snapshot!(built.ir());
 
-        for (id, ir) in built.preview_compile().all_dfir() {
+        for (id, ir) in built.preview_compile(&()).all_dfir() {
             hydro_build_utils::insta::with_settings!({
                 snapshot_suffix => format!("surface_graph_{id}")
             }, {

--- a/hydro_test/src/cluster/paxos_bench.rs
+++ b/hydro_test/src/cluster/paxos_bench.rs
@@ -189,7 +189,7 @@ mod tests {
             hydro_build_utils::assert_debug_snapshot!(built.ir());
         });
 
-        let preview = built.preview_compile();
+        let preview = built.preview_compile(&());
         hydro_build_utils::insta::with_settings!({
             snapshot_suffix => "proposer_mermaid"
         }, {
@@ -254,7 +254,7 @@ mod tests {
                 &replicas,
                 (0..PAXOS_F + 1).map(|_| TrybuildHost::new(deployment.Localhost())),
             )
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 

--- a/hydro_test/src/cluster/simple_cluster.rs
+++ b/hydro_test/src/cluster/simple_cluster.rs
@@ -101,7 +101,7 @@ mod tests {
             .with_default_optimize()
             .with_process(&node, deployment.Localhost())
             .with_cluster(&cluster, (0..2).map(|_| deployment.Localhost()))
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 
@@ -159,7 +159,7 @@ mod tests {
         let nodes = built
             .with_process(&process1, deployment.Localhost())
             .with_process(&process2, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
         let mut process2_stdout = nodes.get_process(&process2).stdout().await;
@@ -181,7 +181,7 @@ mod tests {
         let nodes = built
             .with_cluster(&cluster1, (0..3).map(|_| deployment.Localhost()))
             .with_cluster(&cluster2, (0..3).map(|_| deployment.Localhost()))
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 
@@ -230,7 +230,7 @@ mod tests {
                 &cluster2,
                 (0..num_nodes * num_partitions).map(|_| deployment.Localhost()),
             )
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 

--- a/hydro_test/src/cluster/two_pc_bench.rs
+++ b/hydro_test/src/cluster/two_pc_bench.rs
@@ -84,7 +84,7 @@ mod tests {
             hydro_build_utils::assert_debug_snapshot!(built.ir());
         });
 
-        let preview = built.preview_compile();
+        let preview = built.preview_compile(&());
         hydro_build_utils::insta::with_settings!({
             snapshot_suffix => "coordinator_mermaid"
         }, {
@@ -99,7 +99,7 @@ mod tests {
             );
         });
 
-        let preview = built.preview_compile();
+        let preview = built.preview_compile(&());
         hydro_build_utils::insta::with_settings!({
             snapshot_suffix => "participants_mermaid"
         }, {
@@ -137,7 +137,7 @@ mod tests {
                 &client_aggregator,
                 TrybuildHost::new(deployment.Localhost()),
             )
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 

--- a/hydro_test/src/distributed/first_ten.rs
+++ b/hydro_test/src/distributed/first_ten.rs
@@ -59,7 +59,7 @@ mod tests {
             .with_process(&p1, deployment.Localhost())
             .with_process(&p2, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 

--- a/hydro_test/src/local/chat_app.rs
+++ b/hydro_test/src/local/chat_app.rs
@@ -62,7 +62,7 @@ mod tests {
 
         hydro_build_utils::assert_snapshot!(
             built
-                .preview_compile()
+                .preview_compile(&())
                 .dfir_for(&p1)
                 .to_mermaid(&Default::default())
         );
@@ -70,7 +70,7 @@ mod tests {
         let nodes = built
             .with_process(&p1, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 
@@ -127,7 +127,7 @@ mod tests {
 
         hydro_build_utils::assert_snapshot!(
             built
-                .preview_compile()
+                .preview_compile(&())
                 .dfir_for(&p1)
                 .to_mermaid(&Default::default())
         );
@@ -135,7 +135,7 @@ mod tests {
         let nodes = built
             .with_process(&p1, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 

--- a/hydro_test/src/local/count_elems.rs
+++ b/hydro_test/src/local/count_elems.rs
@@ -37,7 +37,7 @@ mod tests {
         let nodes = built
             .with_process(&p1, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 

--- a/hydro_test/src/local/futures.rs
+++ b/hydro_test/src/local/futures.rs
@@ -46,7 +46,7 @@ mod tests {
         let nodes = built
             .with_process(&p1, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 
@@ -78,7 +78,7 @@ mod tests {
         let nodes = built
             .with_process(&p1, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 

--- a/hydro_test/src/local/graph_reachability.rs
+++ b/hydro_test/src/local/graph_reachability.rs
@@ -57,7 +57,7 @@ mod tests {
         println!(
             "{}",
             built
-                .preview_compile()
+                .preview_compile(&())
                 .dfir_for(&p1)
                 .surface_syntax_string()
         );
@@ -65,7 +65,7 @@ mod tests {
         let nodes = built
             .with_process(&p1, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 

--- a/hydro_test/src/local/negation.rs
+++ b/hydro_test/src/local/negation.rs
@@ -117,7 +117,7 @@ mod tests {
         let nodes = built
             .with_process(&p1, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 
@@ -148,7 +148,7 @@ mod tests {
         let nodes = built
             .with_process(&p1, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 
@@ -179,7 +179,7 @@ mod tests {
         let nodes = built
             .with_process(&p1, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 
@@ -214,7 +214,7 @@ mod tests {
         let nodes = built
             .with_process(&p1, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 
@@ -249,7 +249,7 @@ mod tests {
         let nodes = built
             .with_process(&p1, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 
@@ -280,7 +280,7 @@ mod tests {
         let nodes = built
             .with_process(&p1, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 
@@ -311,7 +311,7 @@ mod tests {
         let nodes = built
             .with_process(&p1, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 
@@ -346,7 +346,7 @@ mod tests {
         let nodes = built
             .with_process(&p1, deployment.Localhost())
             .with_external(&external, deployment.Localhost())
-            .deploy(&mut deployment);
+            .deploy(&(), &mut deployment);
 
         deployment.deploy().await.unwrap();
 

--- a/template/hydro/examples/echo_gcp.rs
+++ b/template/hydro/examples/echo_gcp.rs
@@ -36,7 +36,7 @@ async fn main() {
                 .add(),
         )
         .with_external(&external, deployment.Localhost())
-        .deploy(&mut deployment);
+        .deploy(&(), &mut deployment);
 
     deployment.deploy().await.unwrap();
 

--- a/template/hydro/examples/echo_local.rs
+++ b/template/hydro/examples/echo_local.rs
@@ -17,7 +17,7 @@ async fn main() {
     let _nodes = flow
         .with_process(&process, deployment.Localhost())
         .with_external(&external, deployment.Localhost())
-        .deploy(&mut deployment);
+        .deploy(&(), &mut deployment);
 
     deployment.deploy().await.unwrap();
 


### PR DESCRIPTION
this change is driven by the upcoming docker deployment code. The docker code, specifically the membership-id stream needs to know what the container names are going to be called in order to listen to them. This change seemed like the right way to to achieve that. It's kind of a huge change and changes the public API which is a little suspect. Arguments in favor of this change would be that CompileEnv is currently hardcoded to "&()" everywhere which is even more suspect.