### PR TITLE
refactor(hydro_lang): eliminate use of `Persist` node from non-`persist` APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4791,9 +4791,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stageleft"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66d8913fd77d6b4819c5ce6e82eee9944d92a23d8c7cb879d990ff5789c2f1a"
+checksum = "cdd71b6d790b59ee72e41ebd70153649a0128ef56a527b101363d8cbe267d898"
 dependencies = [
  "ctor 0.4.3",
  "proc-macro-crate 3.3.0",
@@ -4805,9 +4805,9 @@ dependencies = [
 
 [[package]]
 name = "stageleft_macro"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c9cc63171ddf4b9380f8a974b4d3be585e4d7d083986345e52efafd9b702c2"
+checksum = "25dc7818feca1549fbcbc1afb9a7a1205fb3c1a55aebaa8c2c345f1984e2cc45"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -4818,9 +4818,9 @@ dependencies = [
 
 [[package]]
 name = "stageleft_tool"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0580927a70ee83c137c7275e348f8a2116cd7e64f00fe6f0635fc8cb32748ded"
+checksum = "6e929617fca91fd5c9db588f39212b1c80fac1524136f46aa42afb894a8fdc3c"
 dependencies = [
  "prettyplease",
  "proc-macro-crate 3.3.0",

--- a/hydro_lang/src/live_collections/singleton.rs
+++ b/hydro_lang/src/live_collections/singleton.rs
@@ -954,20 +954,11 @@ where
 
     #[deprecated(note = "use .into_stream().persist()")]
     #[expect(missing_docs, reason = "deprecated")]
-    pub fn persist(self) -> Stream<T, Tick<L>, Bounded, TotalOrder, ExactlyOnce> {
-        Stream::new(
-            self.location.clone(),
-            HydroNode::Persist {
-                inner: Box::new(self.ir_node.into_inner()),
-                metadata: self.location.new_node_metadata(Stream::<
-                    T,
-                    Tick<L>,
-                    Bounded,
-                    TotalOrder,
-                    ExactlyOnce,
-                >::collection_kind()),
-            },
-        )
+    pub fn persist(self) -> Stream<T, Tick<L>, Bounded, TotalOrder, ExactlyOnce>
+    where
+        T: Clone,
+    {
+        self.into_stream().persist()
     }
 
     /// Converts this singleton into a [`Stream`] containing a single element, the value.

--- a/hydro_test/src/cluster/snapshots/paxos_ir.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir.snap
@@ -243,20 +243,20 @@ expression: built.ir()
                                                                 },
                                                             },
                                                         },
-                                                        trusted: false,
+                                                        trusted: true,
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Cluster(
                                                                 0,
                                                             ),
                                                             collection_kind: Stream {
                                                                 bound: Unbounded,
-                                                                order: TotalOrder,
-                                                                retry: AtLeastOnce,
+                                                                order: NoOrder,
+                                                                retry: ExactlyOnce,
                                                                 element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                             },
                                                         },
                                                     },
-                                                    trusted: true,
+                                                    trusted: false,
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Cluster(
                                                             0,
@@ -1568,10 +1568,8 @@ expression: built.ir()
                                                                                                                                                                                                         },
                                                                                                                                                                                                     },
                                                                                                                                                                                                     second: Cast {
-                                                                                                                                                                                                        inner: Source {
-                                                                                                                                                                                                            source: Iter(
-                                                                                                                                                                                                                [:: std :: option :: Option :: None],
-                                                                                                                                                                                                            ),
+                                                                                                                                                                                                        inner: SingletonSource {
+                                                                                                                                                                                                            value: :: std :: option :: Option :: None,
                                                                                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                                                                                 location_kind: Tick(
                                                                                                                                                                                                                     1,
@@ -3713,10 +3711,8 @@ expression: built.ir()
                                                                                                                                                     },
                                                                                                                                                 },
                                                                                                                                                 second: Cast {
-                                                                                                                                                    inner: Source {
-                                                                                                                                                        source: Iter(
-                                                                                                                                                            [:: std :: option :: Option :: None],
-                                                                                                                                                        ),
+                                                                                                                                                    inner: SingletonSource {
+                                                                                                                                                        value: :: std :: option :: Option :: None,
                                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                                             location_kind: Tick(
                                                                                                                                                                 1,
@@ -4106,10 +4102,8 @@ expression: built.ir()
                                     },
                                 },
                                 second: Cast {
-                                    inner: Source {
-                                        source: Iter(
-                                            [:: std :: option :: Option :: None],
-                                        ),
+                                    inner: SingletonSource {
+                                        value: :: std :: option :: Option :: None,
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
                                                 10,
@@ -5576,10 +5570,8 @@ expression: built.ir()
                                                                                                                                                                                                 },
                                                                                                                                                                                             },
                                                                                                                                                                                             second: Cast {
-                                                                                                                                                                                                inner: Source {
-                                                                                                                                                                                                    source: Iter(
-                                                                                                                                                                                                        [:: std :: option :: Option :: None],
-                                                                                                                                                                                                    ),
+                                                                                                                                                                                                inner: SingletonSource {
+                                                                                                                                                                                                    value: :: std :: option :: Option :: None,
                                                                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                                                                         location_kind: Tick(
                                                                                                                                                                                                             1,
@@ -7012,10 +7004,8 @@ expression: built.ir()
                                     },
                                 },
                                 second: Cast {
-                                    inner: Source {
-                                        source: Iter(
-                                            [:: std :: option :: Option :: None],
-                                        ),
+                                    inner: SingletonSource {
+                                        value: :: std :: option :: Option :: None,
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
                                                 2,
@@ -8444,10 +8434,8 @@ expression: built.ir()
                                     },
                                 },
                                 second: Cast {
-                                    inner: Source {
-                                        source: Iter(
-                                            [:: std :: option :: Option :: None],
-                                        ),
+                                    inner: SingletonSource {
+                                        value: :: std :: option :: Option :: None,
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
                                                 14,
@@ -10484,10 +10472,8 @@ expression: built.ir()
                                                                                                                                                                                 },
                                                                                                                                                                             },
                                                                                                                                                                             second: Cast {
-                                                                                                                                                                                inner: Source {
-                                                                                                                                                                                    source: Iter(
-                                                                                                                                                                                        [:: std :: option :: Option :: None],
-                                                                                                                                                                                    ),
+                                                                                                                                                                                inner: SingletonSource {
+                                                                                                                                                                                    value: :: std :: option :: Option :: None,
                                                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                                                         location_kind: Tick(
                                                                                                                                                                                             0,
@@ -11596,10 +11582,8 @@ expression: built.ir()
                                             },
                                         },
                                         second: Cast {
-                                            inner: Source {
-                                                source: Iter(
-                                                    [:: std :: option :: Option :: None],
-                                                ),
+                                            inner: SingletonSource {
+                                                value: :: std :: option :: Option :: None,
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
                                                         18,
@@ -12377,10 +12361,8 @@ expression: built.ir()
                                             },
                                         },
                                         second: Cast {
-                                            inner: Source {
-                                                source: Iter(
-                                                    [:: std :: option :: Option :: None],
-                                                ),
+                                            inner: SingletonSource {
+                                                value: :: std :: option :: Option :: None,
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
                                                         18,

--- a/hydro_test/src/cluster/snapshots/two_pc_ir.snap
+++ b/hydro_test/src/cluster/snapshots/two_pc_ir.snap
@@ -2246,10 +2246,8 @@ expression: built.ir()
                                                                                                                                                                                 },
                                                                                                                                                                             },
                                                                                                                                                                             second: Cast {
-                                                                                                                                                                                inner: Source {
-                                                                                                                                                                                    source: Iter(
-                                                                                                                                                                                        [:: std :: option :: Option :: None],
-                                                                                                                                                                                    ),
+                                                                                                                                                                                inner: SingletonSource {
+                                                                                                                                                                                    value: :: std :: option :: Option :: None,
                                                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                                                         location_kind: Tick(
                                                                                                                                                                                             0,
@@ -3358,10 +3356,8 @@ expression: built.ir()
                                             },
                                         },
                                         second: Cast {
-                                            inner: Source {
-                                                source: Iter(
-                                                    [:: std :: option :: Option :: None],
-                                                ),
+                                            inner: SingletonSource {
+                                                value: :: std :: option :: Option :: None,
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
                                                         5,
@@ -4139,10 +4135,8 @@ expression: built.ir()
                                             },
                                         },
                                         second: Cast {
-                                            inner: Source {
-                                                source: Iter(
-                                                    [:: std :: option :: Option :: None],
-                                                ),
+                                            inner: SingletonSource {
+                                                value: :: std :: option :: Option :: None,
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
                                                         5,


### PR DESCRIPTION

Towards eventually eliminating the IR node altogether.
