### PR TITLE
refactor(hydro_lang,hydro_test): use `sliced!` in more places

### DIFF
--- a/hydro_lang/src/live_collections/sliced.rs
+++ b/hydro_lang/src/live_collections/sliced.rs
@@ -1,6 +1,7 @@
 //! Utilities for transforming live collections via slicing.
 
 use super::boundedness::{Bounded, Unbounded};
+use crate::live_collections::boundedness::Boundedness;
 use crate::live_collections::keyed_singleton::BoundedValue;
 use crate::live_collections::stream::{Ordering, Retries};
 use crate::location::{Location, NoTick, Tick};
@@ -385,8 +386,8 @@ impl_slicable_for_tuple!(
     S1, S1_bt, 0, S2, S2_bt, 1, S3, S3_bt, 2, S4, S4_bt, 3, S5, S5_bt, 4
 ); // 5 slices ought to be enough for anyone
 
-impl<'a, T, L: Location<'a>, O: Ordering, R: Retries> Slicable<'a, L>
-    for super::Stream<T, L, Unbounded, O, R>
+impl<'a, T, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries> Slicable<'a, L>
+    for super::Stream<T, L, B, O, R>
 {
     type Slice = super::Stream<T, Tick<L>, Bounded, O, R>;
     type Backtrace = crate::compile::ir::backtrace::Backtrace;
@@ -416,7 +417,7 @@ impl<'a, T, L: Location<'a>, O: Ordering, R: Retries> Unslicable
     }
 }
 
-impl<'a, T, L: Location<'a>> Slicable<'a, L> for super::Singleton<T, L, Unbounded> {
+impl<'a, T, L: Location<'a>, B: Boundedness> Slicable<'a, L> for super::Singleton<T, L, B> {
     type Slice = super::Singleton<T, Tick<L>, Bounded>;
     type Backtrace = crate::compile::ir::backtrace::Backtrace;
 

--- a/hydro_test/src/cluster/paxos_bench.rs
+++ b/hydro_test/src/cluster/paxos_bench.rs
@@ -53,7 +53,6 @@ pub fn paxos_bench<'a>(
             kv_replica(replicas, sequenced_to_replicas, checkpoint_frequency);
 
         // Get the latest checkpoint sequence per replica
-        let checkpoint_tick = acceptors.tick();
         let a_checkpoint = {
             let a_checkpoint_largest_seqs = replica_checkpoint
                 .broadcast_bincode(&acceptors, nondet!(/** TODO */))
@@ -61,31 +60,30 @@ pub fn paxos_bench<'a>(
                     if seq > *curr_seq {
                         *curr_seq = seq;
                     }
-                }))
-                .snapshot(
-                    &checkpoint_tick,
-                    nondet!(
-                        /// even though we batch the checkpoint messages, because we reduce over the entire history,
-                        /// the final min checkpoint is deterministic
-                    ),
-                );
-
-            let a_checkpoints_quorum_reached = a_checkpoint_largest_seqs
-                .clone()
-                .key_count()
-                .filter_map(q!(move |num_received| if num_received == f + 1 {
-                    Some(true)
-                } else {
-                    None
                 }));
 
-            // Find the smallest checkpoint seq that everyone agrees to
-            a_checkpoint_largest_seqs
-                .entries()
-                .filter_if_some(a_checkpoints_quorum_reached)
-                .map(q!(|(_sender, seq)| seq))
-                .min()
-                .latest()
+            sliced! {
+                let snapshot = use(a_checkpoint_largest_seqs, nondet!(
+                    /// even though we batch the checkpoint messages, because we reduce over the entire history,
+                    /// the final min checkpoint is deterministic
+                ));
+
+                let a_checkpoints_quorum_reached = snapshot
+                    .clone()
+                    .key_count()
+                    .filter_map(q!(move |num_received| if num_received == f + 1 {
+                        Some(true)
+                    } else {
+                        None
+                    }));
+
+                // Find the smallest checkpoint seq that everyone agrees to
+                snapshot
+                    .entries()
+                    .filter_if_some(a_checkpoints_quorum_reached)
+                    .map(q!(|(_sender, seq)| seq))
+                    .min()
+            }
         };
 
         acceptor_checkpoint_complete.complete(a_checkpoint);

--- a/hydro_test/src/cluster/snapshots/paxos_ir.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir.snap
@@ -8799,7 +8799,7 @@ expression: built.ir()
                                                                                                 },
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_kind: Tick(
-                                                                                                        16,
+                                                                                                        15,
                                                                                                         Cluster(
                                                                                                             4,
                                                                                                         ),
@@ -8813,7 +8813,7 @@ expression: built.ir()
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_kind: Tick(
-                                                                                                    16,
+                                                                                                    15,
                                                                                                     Cluster(
                                                                                                         4,
                                                                                                     ),
@@ -8827,7 +8827,7 @@ expression: built.ir()
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
                                                                                             location_kind: Tick(
-                                                                                                16,
+                                                                                                15,
                                                                                                 Cluster(
                                                                                                     4,
                                                                                                 ),
@@ -8843,7 +8843,7 @@ expression: built.ir()
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_kind: Tick(
-                                                                                            16,
+                                                                                            15,
                                                                                             Cluster(
                                                                                                 4,
                                                                                             ),
@@ -8858,7 +8858,7 @@ expression: built.ir()
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_kind: Tick(
-                                                                                        16,
+                                                                                        15,
                                                                                         Cluster(
                                                                                             4,
                                                                                         ),
@@ -8874,7 +8874,7 @@ expression: built.ir()
                                                                             trusted: true,
                                                                             metadata: HydroIrMetadata {
                                                                                 location_kind: Tick(
-                                                                                    16,
+                                                                                    15,
                                                                                     Cluster(
                                                                                         4,
                                                                                     ),
@@ -8934,7 +8934,7 @@ expression: built.ir()
                                                                             },
                                                                             metadata: HydroIrMetadata {
                                                                                 location_kind: Tick(
-                                                                                    16,
+                                                                                    15,
                                                                                     Cluster(
                                                                                         4,
                                                                                     ),
@@ -8949,7 +8949,7 @@ expression: built.ir()
                                                                         },
                                                                         metadata: HydroIrMetadata {
                                                                             location_kind: Tick(
-                                                                                16,
+                                                                                15,
                                                                                 Cluster(
                                                                                     4,
                                                                                 ),
@@ -8964,7 +8964,7 @@ expression: built.ir()
                                                                     },
                                                                     metadata: HydroIrMetadata {
                                                                         location_kind: Tick(
-                                                                            16,
+                                                                            15,
                                                                             Cluster(
                                                                                 4,
                                                                             ),
@@ -9029,7 +9029,7 @@ expression: built.ir()
                                                 },
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
-                                                        15,
+                                                        16,
                                                         Cluster(
                                                             1,
                                                         ),
@@ -9043,7 +9043,7 @@ expression: built.ir()
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    15,
+                                                    16,
                                                     Cluster(
                                                         1,
                                                     ),
@@ -9057,7 +9057,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                15,
+                                                16,
                                                 Cluster(
                                                     1,
                                                 ),
@@ -9073,7 +9073,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            15,
+                                            16,
                                             Cluster(
                                                 1,
                                             ),
@@ -9100,7 +9100,7 @@ expression: built.ir()
                                                             inner: <tee 41>,
                                                             metadata: HydroIrMetadata {
                                                                 location_kind: Tick(
-                                                                    15,
+                                                                    16,
                                                                     Cluster(
                                                                         1,
                                                                     ),
@@ -9114,7 +9114,7 @@ expression: built.ir()
                                                         },
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Tick(
-                                                                15,
+                                                                16,
                                                                 Cluster(
                                                                     1,
                                                                 ),
@@ -9130,7 +9130,7 @@ expression: built.ir()
                                                     },
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Tick(
-                                                            15,
+                                                            16,
                                                             Cluster(
                                                                 1,
                                                             ),
@@ -9146,7 +9146,7 @@ expression: built.ir()
                                                 trusted: true,
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
-                                                        15,
+                                                        16,
                                                         Cluster(
                                                             1,
                                                         ),
@@ -9161,7 +9161,7 @@ expression: built.ir()
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    15,
+                                                    16,
                                                     Cluster(
                                                         1,
                                                     ),
@@ -9174,7 +9174,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                15,
+                                                16,
                                                 Cluster(
                                                     1,
                                                 ),
@@ -9187,7 +9187,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            15,
+                                            16,
                                             Cluster(
                                                 1,
                                             ),
@@ -9200,7 +9200,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        15,
+                                        16,
                                         Cluster(
                                             1,
                                         ),
@@ -9215,7 +9215,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    15,
+                                    16,
                                     Cluster(
                                         1,
                                     ),
@@ -9230,7 +9230,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                15,
+                                16,
                                 Cluster(
                                     1,
                                 ),
@@ -9246,7 +9246,7 @@ expression: built.ir()
                     trusted: true,
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            15,
+                            16,
                             Cluster(
                                 1,
                             ),
@@ -9261,7 +9261,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        15,
+                        16,
                         Cluster(
                             1,
                         ),

--- a/hydro_test/src/local/count_elems.rs
+++ b/hydro_test/src/local/count_elems.rs
@@ -1,18 +1,12 @@
 use hydro_lang::prelude::*;
 
 pub fn count_elems<'a, T: 'a>(
-    process: &Process<'a>,
     input_stream: Stream<T, Process<'a>, Unbounded>,
 ) -> Stream<u32, Process<'a>, Unbounded> {
-    let tick = process.tick();
-
-    let count = input_stream
-        .map(q!(|_| 1))
-        .batch(&tick, nondet!(/** test */))
-        .fold(q!(|| 0), q!(|a, b| *a += b))
-        .all_ticks();
-
-    count
+    sliced! {
+        let batch = use(input_stream.map(q!(|_| 1)), nondet!(/** test */));
+        batch.fold(q!(|| 0), q!(|a, b| *a += b)).into_stream()
+    }
 }
 
 #[cfg(test)]
@@ -30,7 +24,7 @@ mod tests {
         let p1 = builder.process();
 
         let (input_send, input) = p1.source_external_bincode(&external);
-        let out = super::count_elems(&p1, input);
+        let out = super::count_elems(input);
         let out_recv = out.send_bincode_external(&external);
 
         let built = builder.with_default_optimize();


### PR DESCRIPTION

Asked Kiro to search for use of ticks without cycles / atomics and rewrite them to `sliced!`.
