### PR TITLE
fix(hydro_lang): work around Windows stack overflow in doctests [ci-full]

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,5 +1,5 @@
 [profile.default]
-slow-timeout = { terminate-after = 5 } # terminate after 5 intervals of (default: `period = "60s"`).
+slow-timeout = { terminate-after = 10 } # terminate after 10 intervals of (default: `period = "60s"`).
 
 [test-groups]
 serial-integration = { max-threads = 1 }

--- a/hydro_lang/src/live_collections/stream/networking.rs
+++ b/hydro_lang/src/live_collections/stream/networking.rs
@@ -432,6 +432,7 @@ impl<'a, T, L, B: Boundedness> Stream<T, Cluster<'a, L>, B, TotalOrder, ExactlyO
     /// # use hydro_lang::live_collections::stream::{TotalOrder, ExactlyOnce, NoOrder};
     /// # use hydro_lang::location::MemberId;
     /// # use futures::StreamExt;
+    /// # std::thread::spawn(|| {
     /// # tokio_test::block_on(hydro_lang::test_util::multi_location_test(|flow, p2| {
     /// let p1 = flow.process::<()>();
     /// let workers1: Cluster<()> = flow.cluster::<()>();
@@ -454,6 +455,7 @@ impl<'a, T, L, B: Boundedness> Stream<T, Cluster<'a, L>, B, TotalOrder, ExactlyO
     /// # assert_eq!(results, (0..=16).collect::<Vec<_>>());
     /// # assert_eq!(locations.len(), 16);
     /// # }));
+    /// # }).join().unwrap();
     /// # }
     /// ```
     pub fn round_robin_bincode<L2: 'a>(


### PR DESCRIPTION

The main thread in Windows has a smaller stack size than spanwed threads. This is a hack, will create an issue for reducing stack blowup in IR traversals.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydro-project/hydro/pull/2363).
* #2366
* __->__ #2363