### PR TITLE
refactor(hydro_deploy)!: use `&self` to avoid `RwLock` where possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,22 +170,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -196,6 +196,12 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 dependencies = [
  "backtrace",
 ]
+
+[[package]]
+name = "append-only-vec"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2114736faba96bcd79595c700d03183f61357b9fbce14852515e59f3bee4ed4a"
 
 [[package]]
 name = "approx"
@@ -244,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.32"
+version = "0.4.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a89bce6054c720275ac2432fbba080a66a2106a44a1b804553930ca6909f4e0"
+checksum = "98ec5f6c2f8bc326c994cb9e241cc257ddaba9afa8555a43cffbb5dd86efaa37"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -305,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "async-promise"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ec425ee5fc50a9920787f4b3f221d41c68bacb4fb9257a078b89c81cac5e1e"
+checksum = "b681c58ec6001e5385fb80647299e8a5f796d17ab33ffe81a17408899f008208"
 dependencies = [
  "thiserror 2.0.17",
 ]
@@ -320,7 +326,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -343,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "async-ssh2-russh"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b31fb71a813ca189ad1145e2603e2729e652cfe12622dc4427fb577ad417dd"
+checksum = "72b9a4b26c003caa9827163f79a0d29e58103fc3a5c762d15633cc90ed780b27"
 dependencies = [
  "async-promise",
  "russh",
@@ -374,7 +380,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -391,7 +397,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -408,7 +414,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -452,9 +458,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+checksum = "0e050f626429857a27ddccb31e0aca21356bfa709c04041aefddac081a8f068a"
 
 [[package]]
 name = "bcrypt-pbkdf"
@@ -627,7 +633,7 @@ dependencies = [
  "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -699,7 +705,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hex",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body-util",
  "hyper",
  "hyper-named-pipe",
@@ -762,7 +768,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "str_inflector",
- "syn 2.0.108",
+ "syn 2.0.111",
  "try_match",
 ]
 
@@ -792,9 +798,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 dependencies = [
  "serde",
 ]
@@ -813,9 +819,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276a59bf2b2c967788139340c9f0c5b12d7fd6630315c15c217e559de85d2609"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
 dependencies = [
  "serde_core",
 ]
@@ -860,9 +866,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.43"
+version = "1.2.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739eb0f94557554b3ca9a86d2d37bebd49c5e6d0c1d2bda35ba5bdac830befc2"
+checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -956,9 +962,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.51"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c26d721170e0295f191a69bd9a1f93efcdb0aff38684b61ab5750468972e5f5"
+checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -966,9 +972,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.51"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75835f0c7bf681bfd05abe44e965760fea999a5286c6eb2d59883634fd02011a"
+checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
 dependencies = [
  "anstream",
  "anstyle",
@@ -985,7 +991,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1040,9 +1046,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.31"
+version = "0.4.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef8a506ec4b81c460798f572caead636d57d3d7e940f998160f52bd254bf2d23"
+checksum = "b0f7ac3e5b97fdce45e8922fb05cae2c37f7bbd63d30dd94821dacfd8f3f2bf2"
 dependencies = [
  "brotli",
  "compression-core",
@@ -1052,9 +1058,9 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.29"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e47641d3deaf41fb1538ac1f54735925e275eaf3bf4d55c81b137fba797e5cbb"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "concurrent-queue"
@@ -1134,7 +1140,7 @@ name = "copy_span"
 version = "0.1.0"
 dependencies = [
  "proc-macro2",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1173,9 +1179,9 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
 dependencies = [
  "crc-catalog",
 ]
@@ -1287,9 +1293,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
@@ -1303,7 +1309,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1355,7 +1361,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1389,13 +1395,13 @@ dependencies = [
 
 [[package]]
 name = "delegate"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6178a82cf56c836a3ba61a7935cdb1c49bfaa6fa4327cd5bf554a503087de26b"
+checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1435,7 +1441,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slotmap",
- "syn 2.0.108",
+ "syn 2.0.111",
  "webbrowser",
 ]
 
@@ -1449,7 +1455,7 @@ dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1554,7 +1560,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1580,7 +1586,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strum",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1700,7 +1706,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1818,9 +1824,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
 name = "flate2"
@@ -1945,7 +1951,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1980,9 +1986,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.9"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -2097,9 +2103,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hdrhistogram"
@@ -2179,12 +2185,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -2195,7 +2200,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.3.1",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -2206,7 +2211,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body",
  "pin-project-lite",
 ]
@@ -2249,6 +2254,7 @@ name = "hydro_deploy"
 version = "0.15.0"
 dependencies = [
  "anyhow",
+ "append-only-vec",
  "async-process",
  "async-recursion",
  "async-ssh2-russh",
@@ -2341,7 +2347,7 @@ dependencies = [
  "sinktools",
  "stageleft",
  "stageleft_tool",
- "syn 2.0.108",
+ "syn 2.0.111",
  "tar",
  "tempfile",
  "tokio",
@@ -2417,15 +2423,15 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body",
  "httparse",
  "httpdate",
@@ -2458,7 +2464,7 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http 1.3.1",
+ "http 1.4.0",
  "hyper",
  "hyper-util",
  "rustls",
@@ -2471,16 +2477,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
+checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body",
  "hyper",
  "ipnet",
@@ -2580,9 +2586,9 @@ checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -2594,9 +2600,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
@@ -2641,7 +2647,7 @@ dependencies = [
  "glob",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2663,12 +2669,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
  "serde",
  "serde_core",
 ]
@@ -2698,7 +2704,7 @@ dependencies = [
  "crossbeam-utils",
  "dashmap",
  "env_logger",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "is-terminal",
  "itoa",
  "log",
@@ -2730,9 +2736,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.43.2"
+version = "1.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fdb647ebde000f43b5b53f773c30cf9b0cb4300453208713fa38b2c70935a0"
+checksum = "b5c943d4415edd8153251b6f197de5eb1640e56d84e8d9159bea190421c73698"
 dependencies = [
  "console",
  "once_cell",
@@ -2775,9 +2781,9 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "iri-string"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
 dependencies = [
  "memchr",
  "serde",
@@ -2835,26 +2841,26 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+checksum = "49cce2b81f2098e7e3efc35bc2e0a6b7abec9d34128283d7a26fa8f32a6dbb35"
 dependencies = [
  "jiff-static",
  "log",
  "portable-atomic",
  "portable-atomic-util",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+checksum = "980af8b43c3ad5d8d349ace167ec8170839f753a42d233ba19e08afe1850fa69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2881,9 +2887,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "js-sys"
-version = "0.3.82"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2915,7 +2921,7 @@ dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2929,9 +2935,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "libloading"
@@ -2962,9 +2968,9 @@ dependencies = [
 
 [[package]]
 name = "libz-rs-sys"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "840db8cf39d9ec4dd794376f38acc40d0fc65eec2a8f484f7fd375b84602becd"
+checksum = "15413ef615ad868d4d65dce091cb233b229419c7c0c4bcaa746c0901c49ff39c"
 dependencies = [
  "zlib-rs",
 ]
@@ -3031,9 +3037,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru-slab"
@@ -3076,7 +3082,7 @@ checksum = "c33c1d4fa92364abfc42bcc58c201cfbb63ae80f5e471aac5c051db48dab6843"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3123,9 +3129,9 @@ checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
 
 [[package]]
 name = "minicov"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27fe9f1cc3c22e1687f9446c2083c4c5fc7f0bcf1c7a86bdbded14985895b4b"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
 dependencies = [
  "cc",
  "walkdir",
@@ -3149,9 +3155,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi",
@@ -3246,11 +3252,10 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
 dependencies = [
- "byteorder",
  "lazy_static",
  "libm",
  "num-integer",
@@ -3400,7 +3405,7 @@ checksum = "969ccca8ffc4fb105bd131a228107d5c9dd89d9d627edf3295cbe979156f9712"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3484,7 +3489,7 @@ dependencies = [
  "by_address",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3633,7 +3638,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3646,7 +3651,7 @@ dependencies = [
  "phf_shared 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3845,7 +3850,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3872,7 +3877,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit 0.23.7",
+ "toml_edit 0.23.9",
 ]
 
 [[package]]
@@ -3928,7 +3933,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3997,9 +4002,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
@@ -4102,9 +4107,9 @@ dependencies = [
 
 [[package]]
 name = "rangemap"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93e7e49bb0bf967717f7bd674458b3d6b0c5f48ec7e3038166026a69fc22223"
+checksum = "acbbbbea733ec66275512d0b9694f34102e7d5406fdbe2ad8d21b28dce92887c"
 
 [[package]]
 name = "rayon"
@@ -4163,7 +4168,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4197,16 +4202,15 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
-version = "0.12.24"
+version = "0.12.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
+checksum = "3b4c14b2d9afca6a60277086b0cc6a6ae0b568f6f7916c943a8cdc79f8be240f"
 dependencies = [
- "async-compression",
  "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -4282,9 +4286,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
+checksum = "40a0376c50d0358279d9d643e4bf7b7be212f1f4ff1da9070a7b54d22ef75c88"
 dependencies = [
  "const-oid",
  "digest",
@@ -4462,9 +4466,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.34"
+version = "0.23.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9586e9ee2b4f8fab52a0048ca7334d7024eef48e2cb9407e3497bb7cab7fa7"
+checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
  "once_cell",
  "ring",
@@ -4476,9 +4480,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
+checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
 dependencies = [
  "web-time",
  "zeroize",
@@ -4588,9 +4592,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+checksum = "9558e172d4e8533736ba97870c4b2cd63f84b382a3d6eb063da41b91cce17289"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -4629,7 +4633,7 @@ checksum = "22f968c5ea23d555e670b449c1c5e7b2fc399fdaec1d304a17cd48e288abc107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4706,7 +4710,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4741,7 +4745,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4776,17 +4780,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.15.1"
+version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa66c845eee442168b2c8134fec70ac50dc20e760769c8ba0ad1319ca1959b04"
+checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "schemars 0.9.0",
- "schemars 1.0.4",
+ "schemars 1.1.0",
  "serde_core",
  "serde_json",
  "time",
@@ -4837,9 +4841,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.6"
+version = "1.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
 dependencies = [
  "libc",
 ]
@@ -4856,9 +4860,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "similar"
@@ -4895,9 +4899,9 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slotmap"
-version = "1.0.7"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
 dependencies = [
  "serde",
  "version_check",
@@ -4991,7 +4995,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "stageleft_macro",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5004,7 +5008,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha2",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5018,7 +5022,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha2",
- "syn 2.0.108",
+ "syn 2.0.111",
  "syn-inline-mod",
  "toml_edit 0.22.27",
 ]
@@ -5069,7 +5073,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5089,7 +5093,7 @@ dependencies = [
  "dirs",
  "fs4",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "reqwest",
  "scopeguard",
  "thiserror 2.0.17",
@@ -5109,9 +5113,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.108"
+version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da58917d35242480a05c2897064da0a80589a2a0476c9a3f2fdc83b53502e917"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5125,7 +5129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fa6dca1fdb7b2ed46dd534a326725419d4fb10f23d8c85a8b2860e5eb25d0f9"
 dependencies = [
  "proc-macro2",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5157,7 +5161,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5225,7 +5229,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5236,7 +5240,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5405,7 +5409,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5456,9 +5460,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.16"
+version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
 dependencies = [
  "bytes",
  "futures-core",
@@ -5486,13 +5490,13 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "serde_core",
  "serde_spanned 1.0.3",
  "toml_datetime 0.7.3",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.13",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -5519,7 +5523,7 @@ version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "toml_datetime 0.6.11",
  "winnow 0.5.40",
 ]
@@ -5530,24 +5534,24 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow 0.7.13",
+ "winnow 0.7.14",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.7"
+version = "0.23.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
+checksum = "5d7cbc3b4b49633d57a0509303158ca50de80ae32c265093b24c414705807832"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "toml_datetime 0.7.3",
  "toml_parser",
- "winnow 0.7.13",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -5556,7 +5560,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
 dependencies = [
- "winnow 0.7.13",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -5588,17 +5592,22 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -5618,9 +5627,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -5629,20 +5638,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -5661,9 +5670,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -5700,14 +5709,14 @@ checksum = "b9c81686f7ab4065ccac3df7a910c4249f8c0f3fb70421d6ddec19b9311f63f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "trybuild"
-version = "1.0.113"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "559b6a626c0815c942ac98d434746138b4f89ddd6a1b8cbb168c6845fb3376c5"
+checksum = "3e17e807bff86d2a06b52bca4276746584a78375055b6e45843925ce2802b335"
 dependencies = [
  "glob",
  "serde",
@@ -5845,9 +5854,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5877,7 +5886,7 @@ dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
  "variadics",
 ]
 
@@ -5923,9 +5932,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5936,9 +5945,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.55"
+version = "0.4.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
+checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -5949,9 +5958,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5959,34 +5968,42 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc379bfb624eb59050b509c13e77b4eb53150c350db69628141abce842f2373"
+checksum = "25e90e66d265d3a1efc0e72a54809ab90b9c0c515915c67cdf658689d2c22c6c"
 dependencies = [
+ "async-trait",
+ "cast",
  "js-sys",
+ "libm",
  "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test-macro",
@@ -5994,13 +6011,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "085b2df989e1e6f9620c1311df6c996e83fe16f57792b272ce1e024ac16a90f1"
+checksum = "7150335716dce6028bead2b848e72f47b45e7b9422f64cccdc23bedca89affc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6018,9 +6035,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.82"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
+checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6054,9 +6071,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b130c0d2d49f8b6889abc456e795e82525204f27c42cf767cf0d7734e089b8"
+checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6074,7 +6091,7 @@ dependencies = [
  "quote",
  "serde",
  "serde-wasm-bindgen",
- "syn 2.0.108",
+ "syn 2.0.111",
  "tokio",
  "wasm-bindgen",
  "wasm-bindgen-test",
@@ -6095,7 +6112,7 @@ dependencies = [
  "flate2",
  "fs4",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "libc",
  "memmap2",
  "reqwest",
@@ -6184,7 +6201,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6195,7 +6212,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6206,7 +6223,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6217,7 +6234,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6505,9 +6522,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
@@ -6553,28 +6570,28 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
  "synstructure 0.13.2",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.27"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.27"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6594,7 +6611,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
  "synstructure 0.13.2",
 ]
 
@@ -6634,7 +6651,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6648,6 +6665,6 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f06ae92f42f5e5c42443fd094f245eb656abf56dd7cce9b8b263236565e00f2"
+checksum = "51f936044d677be1a1168fae1d03b583a285a5dd9d8cbf7b24c23aa1fc775235"

--- a/hydro_deploy/core/Cargo.toml
+++ b/hydro_deploy/core/Cargo.toml
@@ -13,7 +13,8 @@ workspace = true
 
 [dependencies]
 anyhow = { version = "1.0.82", features = ["backtrace"] }
-async-ssh2-russh = { version = "0.1.0", features = [ "sftp" ] }
+append-only-vec = "0.1.8"
+async-ssh2-russh = { version = "0.2.0", features = [ "sftp" ] }
 async-process = "2.0.0"
 async-recursion = "1.0.0"
 async-trait = "0.1.54"

--- a/hydro_deploy/core/src/custom_service.rs
+++ b/hydro_deploy/core/src/custom_service.rs
@@ -6,7 +6,6 @@ use anyhow::{Result, bail};
 use async_trait::async_trait;
 use hydro_deploy_integration::ConnectedDirect;
 pub use hydro_deploy_integration::ServerPort;
-use tokio::sync::RwLock;
 
 use crate::rust_crate::ports::{
     ReverseSinkInstantiator, RustCrateServer, RustCrateSink, RustCrateSource, ServerConfig,
@@ -24,7 +23,7 @@ pub struct CustomService {
     /// The ports that the service wishes to expose to the public internet.
     external_ports: Vec<u16>,
 
-    launched_host: Option<Arc<dyn LaunchedHost>>,
+    launched_host: OnceLock<Arc<dyn LaunchedHost>>,
 }
 
 impl CustomService {
@@ -33,15 +32,15 @@ impl CustomService {
             _id: id,
             on,
             external_ports,
-            launched_host: None,
+            launched_host: OnceLock::new(),
         }
     }
 
-    pub fn declare_client(&self, self_arc: &Arc<RwLock<Self>>) -> CustomClientPort {
+    pub fn declare_client(&self, self_arc: &Arc<Self>) -> CustomClientPort {
         CustomClientPort::new(Arc::downgrade(self_arc), false)
     }
 
-    pub fn declare_many_client(&self, self_arc: &Arc<RwLock<Self>>) -> CustomClientPort {
+    pub fn declare_many_client(&self, self_arc: &Arc<Self>) -> CustomClientPort {
         CustomClientPort::new(Arc::downgrade(self_arc), true)
     }
 }
@@ -49,7 +48,7 @@ impl CustomService {
 #[async_trait]
 impl Service for CustomService {
     fn collect_resources(&self, _resource_batch: &mut ResourceBatch) {
-        if self.launched_host.is_some() {
+        if self.launched_host.get().is_some() {
             return;
         }
 
@@ -60,39 +59,38 @@ impl Service for CustomService {
         }
     }
 
-    async fn deploy(&mut self, resource_result: &Arc<ResourceResult>) -> Result<()> {
-        if self.launched_host.is_some() {
-            return Ok(());
-        }
+    async fn deploy(&self, resource_result: &Arc<ResourceResult>) -> Result<()> {
+        self.launched_host.get_or_init(|| {
+            let host = &self.on;
+            let launched = host.provision(resource_result);
+            launched
+        });
 
-        let host = &self.on;
-        let launched = host.provision(resource_result);
-        self.launched_host = Some(launched);
         Ok(())
     }
 
-    async fn ready(&mut self) -> Result<()> {
+    async fn ready(&self) -> Result<()> {
         Ok(())
     }
 
-    async fn start(&mut self) -> Result<()> {
+    async fn start(&self) -> Result<()> {
         Ok(())
     }
 
-    async fn stop(&mut self) -> Result<()> {
+    async fn stop(&self) -> Result<()> {
         Ok(())
     }
 }
 
 #[derive(Clone)]
 pub struct CustomClientPort {
-    pub on: Weak<RwLock<CustomService>>,
+    pub on: Weak<CustomService>,
     many: bool,
     client_port: OnceLock<ServerConfig>,
 }
 
 impl CustomClientPort {
-    fn new(on: Weak<RwLock<CustomService>>, many: bool) -> Self {
+    fn new(on: Weak<CustomService>, many: bool) -> Self {
         Self {
             on,
             many,
@@ -123,9 +121,9 @@ impl CustomClientPort {
 impl RustCrateSource for CustomClientPort {
     fn source_path(&self) -> SourcePath {
         if self.many {
-            SourcePath::Many(self.on.upgrade().unwrap().try_read().unwrap().on.clone())
+            SourcePath::Many(self.on.upgrade().unwrap().on.clone())
         } else {
-            SourcePath::Direct(self.on.upgrade().unwrap().try_read().unwrap().on.clone())
+            SourcePath::Direct(self.on.upgrade().unwrap().on.clone())
         }
     }
 
@@ -161,12 +159,11 @@ impl RustCrateSink for CustomClientPort {
         wrap_client_port: &dyn Fn(ServerConfig) -> ServerConfig,
     ) -> Result<ReverseSinkInstantiator> {
         let client = self.on.upgrade().unwrap();
-        let client_read = client.try_read().unwrap();
 
         let server_host = server_host.clone();
 
         let (conn_type, bind_type) =
-            server_host.strategy_as_server(client_read.on.deref(), crate::PortNetworkHint::Auto)?;
+            server_host.strategy_as_server(client.on.deref(), crate::PortNetworkHint::Auto)?;
 
         let client_port = wrap_client_port(ServerConfig::from_strategy(&conn_type, server_sink));
 

--- a/hydro_deploy/core/src/lib.rs
+++ b/hydro_deploy/core/src/lib.rs
@@ -5,6 +5,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use anyhow::Result;
+use append_only_vec::AppendOnlyVec;
 use async_trait::async_trait;
 use hydro_deploy_integration::ServerBindConfig;
 use rust_crate::build::BuildOutput;
@@ -74,7 +75,7 @@ pub struct ResourceResult {
     _last_result: Option<Arc<ResourceResult>>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct TracingResults {
     pub folded_data: Vec<u8>,
 }
@@ -99,9 +100,9 @@ pub trait LaunchedBinary: Send + Sync {
     fn exit_code(&self) -> Option<i32>;
 
     /// Wait for the process to stop on its own. Returns the exit code.
-    async fn wait(&mut self) -> Result<i32>;
+    async fn wait(&self) -> Result<i32>;
     /// If the process is still running, force stop it. Then run post-run tasks.
-    async fn stop(&mut self) -> Result<()>;
+    async fn stop(&self) -> Result<()>;
 }
 
 #[async_trait]
@@ -116,22 +117,18 @@ pub trait LaunchedHost: Send + Sync {
             ServerStrategy::Many(b) => {
                 ServerBindConfig::MultiConnection(Box::new(self.base_server_config(b)))
             }
-            ServerStrategy::Demux(demux) => {
-                let mut config_map = HashMap::new();
-                for (key, underlying) in demux {
-                    config_map.insert(*key, self.server_config(underlying));
-                }
-
-                ServerBindConfig::Demux(config_map)
-            }
-            ServerStrategy::Merge(merge) => {
-                let mut configs = vec![];
-                for underlying in merge {
-                    configs.push(self.server_config(underlying));
-                }
-
-                ServerBindConfig::Merge(configs)
-            }
+            ServerStrategy::Demux(demux) => ServerBindConfig::Demux(
+                demux
+                    .iter()
+                    .map(|(key, underlying)| (*key, self.server_config(underlying)))
+                    .collect::<HashMap<_, _>>(),
+            ),
+            ServerStrategy::Merge(merge) => ServerBindConfig::Merge(
+                merge
+                    .iter()
+                    .map(|underlying| self.server_config(underlying))
+                    .collect(),
+            ),
             ServerStrategy::Tagged(underlying, id) => {
                 ServerBindConfig::Tagged(Box::new(self.server_config(underlying)), *id)
             }
@@ -166,7 +163,8 @@ pub enum ServerStrategy {
     Direct(BaseServerStrategy),
     Many(BaseServerStrategy),
     Demux(HashMap<u32, ServerStrategy>),
-    Merge(Vec<ServerStrategy>),
+    /// AppendOnlyVec has a quite large inline array, so we box it.
+    Merge(Box<AppendOnlyVec<ServerStrategy>>),
     Tagged(Box<ServerStrategy>, u32),
     Null,
 }
@@ -222,7 +220,7 @@ pub trait Host: Any + Send + Sync + Debug {
                 }
             }
             ServerStrategy::Merge(merge) => {
-                for bind_type in merge {
+                for bind_type in merge.iter() {
                     self.request_port(bind_type);
                 }
             }
@@ -274,17 +272,17 @@ pub trait Service: Send + Sync {
     fn collect_resources(&self, resource_batch: &mut ResourceBatch);
 
     /// Connects to the acquired resources and prepares the service to be launched.
-    async fn deploy(&mut self, resource_result: &Arc<ResourceResult>) -> Result<()>;
+    async fn deploy(&self, resource_result: &Arc<ResourceResult>) -> Result<()>;
 
     /// Launches the service, which should start listening for incoming network
     /// connections. The service should not start computing at this point.
-    async fn ready(&mut self) -> Result<()>;
+    async fn ready(&self) -> Result<()>;
 
     /// Starts the service by having it connect to other services and start computations.
-    async fn start(&mut self) -> Result<()>;
+    async fn start(&self) -> Result<()>;
 
     /// Stops the service by having it disconnect from other services and stop computations.
-    async fn stop(&mut self) -> Result<()>;
+    async fn stop(&self) -> Result<()>;
 }
 
 pub trait ServiceBuilder {

--- a/hydro_deploy/core/src/localhost/launched_binary.rs
+++ b/hydro_deploy/core/src/localhost/launched_binary.rs
@@ -1,7 +1,7 @@
 #[cfg(unix)]
 use std::os::unix::process::ExitStatusExt;
 use std::process::{ExitStatus, Stdio};
-use std::sync::Mutex;
+use std::sync::OnceLock;
 
 use anyhow::{Result, bail};
 use async_process::Command;
@@ -29,10 +29,11 @@ pub(super) struct TracingDataLocal {
 }
 
 pub struct LaunchedLocalhostBinary {
-    child: Mutex<async_process::Child>,
+    /// Must use async mutex -- we will .await methods within the child (while holding lock).
+    child: tokio::sync::Mutex<async_process::Child>,
     tracing_config: Option<TracingOptions>,
-    tracing_data_local: Option<TracingDataLocal>,
-    tracing_results: Option<TracingResults>,
+    tracing_data_local: std::sync::Mutex<Option<TracingDataLocal>>,
+    tracing_results: OnceLock<TracingResults>,
     stdin_sender: mpsc::UnboundedSender<String>,
     stdout_broadcast: PriorityBroadcast,
     stderr_broadcast: PriorityBroadcast,
@@ -41,7 +42,7 @@ pub struct LaunchedLocalhostBinary {
 #[cfg(unix)]
 impl Drop for LaunchedLocalhostBinary {
     fn drop(&mut self) {
-        let mut child = self.child.lock().unwrap();
+        let child = self.child.get_mut();
 
         if let Ok(Some(_)) = child.try_status() {
             return;
@@ -87,10 +88,10 @@ impl LaunchedLocalhostBinary {
         );
 
         Self {
-            child: Mutex::new(child),
+            child: tokio::sync::Mutex::new(child),
             tracing_config,
-            tracing_data_local,
-            tracing_results: None,
+            tracing_data_local: std::sync::Mutex::new(tracing_data_local),
+            tracing_results: OnceLock::new(),
             stdin_sender,
             stdout_broadcast,
             stderr_broadcast,
@@ -125,35 +126,41 @@ impl LaunchedBinary for LaunchedLocalhostBinary {
     }
 
     fn tracing_results(&self) -> Option<&TracingResults> {
-        self.tracing_results.as_ref()
+        self.tracing_results.get()
     }
 
     fn exit_code(&self) -> Option<i32> {
         self.child
-            .lock()
-            .unwrap()
-            .try_status()
+            .try_lock()
             .ok()
+            .and_then(|mut child| child.try_status().ok())
             .flatten()
             .map(exit_code)
     }
 
-    async fn wait(&mut self) -> Result<i32> {
-        Ok(exit_code(self.child.get_mut().unwrap().status().await?))
+    async fn wait(&self) -> Result<i32> {
+        Ok(exit_code(self.child.lock().await.status().await?))
     }
 
-    async fn stop(&mut self) -> Result<()> {
-        if let Err(err) = self.child.get_mut().unwrap().kill()
+    async fn stop(&self) -> Result<()> {
+        if let Err(err) = { self.child.lock().await.kill() }
             && !matches!(err.kind(), std::io::ErrorKind::InvalidInput)
         {
             Err(err)?;
         }
 
         // Run perf post-processing and download perf output.
-        if let Some(tracing_config) = self.tracing_config.as_ref()
-            && self.tracing_results.is_none()
-        {
-            let tracing_data = self.tracing_data_local.take().unwrap();
+        if let Some(tracing_config) = self.tracing_config.as_ref() {
+            assert!(
+                self.tracing_results.get().is_none(),
+                "`tracing_results` already set! Was `stop()` called twice? This is a bug."
+            );
+            let tracing_data =
+                {
+                    self.tracing_data_local.lock().unwrap().take().expect(
+                        "`tracing_data_local` empty, was `stop()` called twice? This is a bug.",
+                    )
+                };
 
             if cfg!(any(target_os = "macos", target_family = "windows")) {
                 if let Some(samply_outfile) = tracing_config.samply_outfile.as_ref() {
@@ -235,9 +242,11 @@ impl LaunchedBinary for LaunchedLocalhostBinary {
 
             handle_fold_data(tracing_config, fold_data.clone()).await?;
 
-            self.tracing_results = Some(TracingResults {
-                folded_data: fold_data,
-            });
+            self.tracing_results
+                .set(TracingResults {
+                    folded_data: fold_data,
+                })
+                .expect("`tracing_results` already set! This is a bug.");
         };
 
         Ok(())

--- a/hydro_deploy/core/src/rust_crate/mod.rs
+++ b/hydro_deploy/core/src/rust_crate/mod.rs
@@ -229,7 +229,7 @@ mod tests {
 
         deployment.deploy().await.unwrap();
 
-        let mut stdout = service.try_read().unwrap().stdout();
+        let mut stdout = service.stdout();
 
         deployment.start().await.unwrap();
 

--- a/hydro_deploy/core/src/rust_crate/ports.rs
+++ b/hydro_deploy/core/src/rust_crate/ports.rs
@@ -5,6 +5,7 @@ use std::ops::Deref;
 use std::sync::{Arc, Weak};
 
 use anyhow::{Result, bail};
+use append_only_vec::AppendOnlyVec;
 use async_recursion::async_recursion;
 use dyn_clone::DynClone;
 use hydro_deploy_integration::ServerPort;
@@ -142,7 +143,7 @@ impl RustCrateSink for DemuxSink {
         Ok(Box::new(move || {
             let instantiated_map = thunk_map
                 .into_iter()
-                .map(|(key, thunk)| (key, thunk()))
+                .map(|(key, thunk)| (key, (thunk)()))
                 .collect();
 
             ServerConfig::Demux(instantiated_map)
@@ -182,7 +183,7 @@ impl RustCrateSink for DemuxSink {
 
 #[derive(Clone, Debug)]
 pub struct RustCratePortConfig {
-    pub service: Weak<RwLock<RustCrateService>>,
+    pub service: Weak<RustCrateService>,
     pub service_host: Arc<dyn Host>,
     pub service_server_defns: Arc<RwLock<HashMap<String, ServerPort>>>,
     pub network_hint: PortNetworkHint,
@@ -205,15 +206,7 @@ impl RustCratePortConfig {
 
 impl RustCrateSource for RustCratePortConfig {
     fn source_path(&self) -> SourcePath {
-        SourcePath::Direct(
-            self.service
-                .upgrade()
-                .unwrap()
-                .try_read()
-                .unwrap()
-                .on
-                .clone(),
-        )
+        SourcePath::Direct(self.service.upgrade().unwrap().on.clone())
     }
 
     fn host(&self) -> Arc<dyn Host> {
@@ -222,12 +215,11 @@ impl RustCrateSource for RustCratePortConfig {
 
     fn server(&self) -> Arc<dyn RustCrateServer> {
         let from = self.service.upgrade().unwrap();
-        let from_read = from.try_read().unwrap();
 
         Arc::new(RustCratePortConfig {
             service: Arc::downgrade(&from),
-            service_host: from_read.on.clone(),
-            service_server_defns: from_read.server_defns.clone(),
+            service_host: from.on.clone(),
+            service_server_defns: from.server_defns.clone(),
             network_hint: self.network_hint,
             port: self.port.clone(),
             merge: false,
@@ -236,22 +228,19 @@ impl RustCrateSource for RustCratePortConfig {
 
     fn record_server_config(&self, config: ServerConfig) {
         let from = self.service.upgrade().unwrap();
-        let mut from_write = from.try_write().unwrap();
-
         // TODO(shadaj): if already in this map, we want to broadcast
         assert!(
-            !from_write.port_to_server.contains_key(&self.port),
+            from.port_to_server.insert(self.port.clone(), config),
             "The port configuration is incorrect, for example, are you using a ConnectedDirect instead of a ConnectedDemux?"
         );
-        from_write.port_to_server.insert(self.port.clone(), config);
     }
 
     fn record_server_strategy(&self, config: ServerStrategy) {
         let from = self.service.upgrade().unwrap();
-        let mut from_write = from.try_write().unwrap();
-
-        assert!(!from_write.port_to_bind.contains_key(&self.port));
-        from_write.port_to_bind.insert(self.port.clone(), config);
+        assert!(
+            from.port_to_bind.insert(self.port.clone(), config),
+            "port already set!"
+        );
     }
 }
 
@@ -324,9 +313,8 @@ impl SourcePath {
 impl RustCrateSink for RustCratePortConfig {
     fn instantiate(&self, client_path: &SourcePath) -> Result<Box<dyn FnOnce() -> ServerConfig>> {
         let server = self.service.upgrade().unwrap();
-        let server_read = server.try_read().unwrap();
 
-        let server_host = server_read.on.clone();
+        let server_host = server.on.clone();
 
         let (bind_type, base_config) =
             client_path.plan(self, server_host.deref(), self.network_hint)?;
@@ -335,25 +323,22 @@ impl RustCrateSink for RustCratePortConfig {
         let merge = self.merge;
         let port = self.port.clone();
         Ok(Box::new(move || {
-            let mut server_write = server.try_write().unwrap();
-            let bind_type = (bind_type)(&*server_write.on);
+            let bind_type = (bind_type)(&*server.on);
 
             if merge {
-                let merge_config = server_write
+                let merge_config = server
                     .port_to_bind
-                    .entry(port.clone())
-                    .or_insert(ServerStrategy::Merge(vec![]));
-                let merge_index = if let ServerStrategy::Merge(merge) = merge_config {
-                    merge.push(bind_type);
-                    merge.len() - 1
-                } else {
+                    .get_or_insert_owned(port, || ServerStrategy::Merge(Default::default()));
+                let ServerStrategy::Merge(merge) = merge_config else {
                     panic!("Expected a merge connection definition")
                 };
-
-                ServerConfig::MergeSelect(Box::new(base_config), merge_index)
+                merge.push(bind_type);
+                ServerConfig::MergeSelect(Box::new(base_config), merge.len() - 1)
             } else {
-                assert!(!server_write.port_to_bind.contains_key(&port));
-                server_write.port_to_bind.insert(port.clone(), bind_type);
+                assert!(
+                    server.port_to_bind.insert(port.clone(), bind_type),
+                    "port already set!"
+                );
                 base_config
             }
         }))
@@ -370,39 +355,33 @@ impl RustCrateSink for RustCratePortConfig {
         }
 
         let client = self.service.upgrade().unwrap();
-        let client_read = client.try_read().unwrap();
 
         let server_host = server_host.clone();
 
         let (conn_type, bind_type) =
-            server_host.strategy_as_server(client_read.on.deref(), PortNetworkHint::Auto)?;
+            server_host.strategy_as_server(&*client.on, PortNetworkHint::Auto)?;
         let client_port = wrap_client_port(ServerConfig::from_strategy(&conn_type, server_sink));
 
         let client = client.clone();
         let merge = self.merge;
         let port = self.port.clone();
         Ok(Box::new(move |_| {
-            let mut client_write = client.try_write().unwrap();
-
             if merge {
-                let merge_config = client_write
+                let merge_config = client
                     .port_to_server
-                    .entry(port.clone())
-                    .or_insert(ServerConfig::Merge(vec![]));
-
-                if let ServerConfig::Merge(merge) = merge_config {
-                    merge.push(client_port);
-                } else {
+                    .get_or_insert_owned(port, || ServerConfig::Merge(Default::default()));
+                let ServerConfig::Merge(merge) = merge_config else {
                     panic!()
                 };
+                merge.push(client_port);
             } else {
-                assert!(!client_write.port_to_server.contains_key(&port));
-                client_write
-                    .port_to_server
-                    .insert(port.clone(), client_port);
+                assert!(
+                    client.port_to_server.insert(port.clone(), client_port),
+                    "port already set!"
+                );
             };
 
-            ServerStrategy::Direct((bind_type)(&*client_write.on))
+            ServerStrategy::Direct((bind_type)(&*client.on))
         }))
     }
 }
@@ -416,7 +395,8 @@ pub enum ServerConfig {
     /// The other side of a demux, with a port to extract the appropriate connection.
     DemuxSelect(Box<ServerConfig>, u32),
     /// A merge that will be used at runtime to combine many connections.
-    Merge(Vec<ServerConfig>),
+    /// AppendOnlyVec has a quite large inline array, so we box it.
+    Merge(Box<AppendOnlyVec<ServerConfig>>),
     /// The other side of a merge, with a port to extract the appropriate connection.
     MergeSelect(Box<ServerConfig>, usize),
     Tagged(Box<ServerConfig>, u32),
@@ -503,7 +483,7 @@ impl ServerConfig {
 
             ServerConfig::Merge(merge) => {
                 let mut merge_vec = Vec::new();
-                for conn in merge {
+                for conn in merge.iter() {
                     merge_vec.push(conn.load_instantiated(select).await);
                 }
                 ServerPort::Merge(merge_vec)

--- a/hydro_deploy/core/src/rust_crate/service.rs
+++ b/hydro_deploy/core/src/rust_crate/service.rs
@@ -1,13 +1,14 @@
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
 use async_trait::async_trait;
 use futures::Future;
 use hydro_deploy_integration::{InitConfig, ServerPort};
+use memo_map::MemoMap;
 use serde::Serialize;
-use tokio::sync::{RwLock, mpsc};
+use tokio::sync::{OnceCell, RwLock, mpsc};
 
 use super::build::{BuildError, BuildOutput, BuildParams, build_crate_memoized};
 use super::ports::{self, RustCratePortConfig};
@@ -27,23 +28,22 @@ pub struct RustCrateService {
     display_id: Option<String>,
     external_ports: Vec<u16>,
 
-    meta: Option<String>,
+    meta: OnceLock<String>,
 
     /// Configuration for the ports this service will connect to as a client.
-    pub(super) port_to_server: HashMap<String, ports::ServerConfig>,
-
+    pub(super) port_to_server: MemoMap<String, ports::ServerConfig>,
     /// Configuration for the ports that this service will listen on a port for.
-    pub(super) port_to_bind: HashMap<String, ServerStrategy>,
+    pub(super) port_to_bind: MemoMap<String, ServerStrategy>,
 
-    launched_host: Option<Arc<dyn LaunchedHost>>,
+    launched_host: OnceCell<Arc<dyn LaunchedHost>>,
 
     /// A map of port names to config for how other services can connect to this one.
     /// Only valid after `ready` has been called, only contains ports that are configured
     /// in `server_ports`.
     pub(super) server_defns: Arc<RwLock<HashMap<String, ServerPort>>>,
 
-    launched_binary: Option<Box<dyn LaunchedBinary>>,
-    started: bool,
+    launched_binary: OnceCell<Box<dyn LaunchedBinary>>,
+    started: OnceCell<()>,
 }
 
 impl RustCrateService {
@@ -64,29 +64,26 @@ impl RustCrateService {
             args,
             display_id,
             external_ports,
-            meta: None,
-            port_to_server: HashMap::new(),
-            port_to_bind: HashMap::new(),
-            launched_host: None,
+            meta: OnceLock::new(),
+            port_to_server: MemoMap::new(),
+            port_to_bind: MemoMap::new(),
+            launched_host: OnceCell::new(),
             server_defns: Arc::new(RwLock::new(HashMap::new())),
-            launched_binary: None,
-            started: false,
+            launched_binary: OnceCell::new(),
+            started: OnceCell::new(),
         }
     }
 
-    pub fn update_meta<T: Serialize>(&mut self, meta: T) {
-        if self.launched_binary.is_some() {
+    pub fn update_meta<T: Serialize>(&self, meta: T) {
+        if self.launched_binary.get().is_some() {
             panic!("Cannot update meta after binary has been launched")
         }
-
-        self.meta = Some(serde_json::to_string(&meta).unwrap());
+        self.meta
+            .set(serde_json::to_string(&meta).unwrap())
+            .expect("Cannot set meta twice.");
     }
 
-    pub fn get_port(
-        &self,
-        name: String,
-        self_arc: &Arc<RwLock<RustCrateService>>,
-    ) -> RustCratePortConfig {
+    pub fn get_port(&self, name: String, self_arc: &Arc<RustCrateService>) -> RustCratePortConfig {
         RustCratePortConfig {
             service: Arc::downgrade(self_arc),
             service_host: self.on.clone(),
@@ -101,7 +98,7 @@ impl RustCrateService {
         &self,
         name: String,
         network_hint: PortNetworkHint,
-        self_arc: &Arc<RwLock<RustCrateService>>,
+        self_arc: &Arc<RustCrateService>,
     ) -> RustCratePortConfig {
         RustCratePortConfig {
             service: Arc::downgrade(self_arc),
@@ -114,27 +111,27 @@ impl RustCrateService {
     }
 
     pub fn stdout(&self) -> mpsc::UnboundedReceiver<String> {
-        self.launched_binary.as_ref().unwrap().stdout()
+        self.launched_binary.get().unwrap().stdout()
     }
 
     pub fn stderr(&self) -> mpsc::UnboundedReceiver<String> {
-        self.launched_binary.as_ref().unwrap().stderr()
+        self.launched_binary.get().unwrap().stderr()
     }
 
     pub fn stdout_filter(&self, prefix: String) -> mpsc::UnboundedReceiver<String> {
-        self.launched_binary.as_ref().unwrap().stdout_filter(prefix)
+        self.launched_binary.get().unwrap().stdout_filter(prefix)
     }
 
     pub fn stderr_filter(&self, prefix: String) -> mpsc::UnboundedReceiver<String> {
-        self.launched_binary.as_ref().unwrap().stderr_filter(prefix)
+        self.launched_binary.get().unwrap().stderr_filter(prefix)
     }
 
     pub fn tracing_results(&self) -> Option<&TracingResults> {
-        self.launched_binary.as_ref().unwrap().tracing_results()
+        self.launched_binary.get().unwrap().tracing_results()
     }
 
     pub fn exit_code(&self) -> Option<i32> {
-        self.launched_binary.as_ref().unwrap().exit_code()
+        self.launched_binary.get().unwrap().exit_code()
     }
 
     fn build(
@@ -148,7 +145,7 @@ impl RustCrateService {
 #[async_trait]
 impl Service for RustCrateService {
     fn collect_resources(&self, _resource_batch: &mut ResourceBatch) {
-        if self.launched_host.is_some() {
+        if self.launched_host.get().is_some() {
             return;
         }
 
@@ -166,138 +163,146 @@ impl Service for RustCrateService {
         }
     }
 
-    async fn deploy(&mut self, resource_result: &Arc<ResourceResult>) -> Result<()> {
-        if self.launched_host.is_some() {
-            return Ok(());
-        }
+    async fn deploy(&self, resource_result: &Arc<ResourceResult>) -> Result<()> {
+        self.launched_host
+            .get_or_try_init::<anyhow::Error, _, _>(|| {
+                ProgressTracker::with_group(
+                    self.display_id
+                        .clone()
+                        .unwrap_or_else(|| format!("service/{}", self.id)),
+                    None,
+                    || async {
+                        let built = self.build().await?;
 
-        ProgressTracker::with_group(
-            self.display_id
-                .clone()
-                .unwrap_or_else(|| format!("service/{}", self.id)),
-            None,
-            || async {
-                let built = self.build().await?;
+                        let host = &self.on;
+                        let launched = host.provision(resource_result);
 
-                let host = &self.on;
-                let launched = host.provision(resource_result);
-
-                launched.copy_binary(built).await?;
-
-                self.launched_host = Some(launched);
-                Ok(())
-            },
-        )
-        .await
-    }
-
-    async fn ready(&mut self) -> Result<()> {
-        if self.launched_binary.is_some() {
-            return Ok(());
-        }
-
-        ProgressTracker::with_group(
-            self.display_id
-                .clone()
-                .unwrap_or_else(|| format!("service/{}", self.id)),
-            None,
-            || async {
-                let launched_host = self.launched_host.as_ref().unwrap();
-
-                let built = self.build().await?;
-                let args = self.args.as_ref().cloned().unwrap_or_default();
-
-                let binary = launched_host
-                    .launch_binary(
-                        self.display_id
-                            .clone()
-                            .unwrap_or_else(|| format!("service/{}", self.id)),
-                        built,
-                        &args,
-                        self.tracing.clone(),
-                    )
-                    .await?;
-
-                let mut bind_config = HashMap::new();
-                for (port_name, bind_type) in self.port_to_bind.iter() {
-                    bind_config.insert(port_name.clone(), launched_host.server_config(bind_type));
-                }
-
-                let formatted_bind_config =
-                    serde_json::to_string::<InitConfig>(&(bind_config, self.meta.clone())).unwrap();
-
-                // request stdout before sending config so we don't miss the "ready" response
-                let stdout_receiver = binary.deploy_stdout();
-
-                binary.stdin().send(format!("{formatted_bind_config}\n"))?;
-
-                let ready_line = ProgressTracker::leaf(
-                    "waiting for ready",
-                    tokio::time::timeout(Duration::from_secs(60), stdout_receiver),
+                        launched.copy_binary(built).await?;
+                        Ok(launched)
+                    },
                 )
-                .await
-                .context("Timed out waiting for ready")?
-                .context("Program unexpectedly quit")?;
-                if let Some(line_rest) = ready_line.strip_prefix("ready: ") {
-                    *self.server_defns.try_write().unwrap() =
-                        serde_json::from_str(line_rest).unwrap();
-                } else {
-                    bail!("expected ready");
-                }
-
-                self.launched_binary = Some(binary);
-
-                Ok(())
-            },
-        )
-        .await
-    }
-
-    async fn start(&mut self) -> Result<()> {
-        if self.started {
-            return Ok(());
-        }
-
-        let mut sink_ports = HashMap::new();
-        for (port_name, outgoing) in self.port_to_server.drain() {
-            sink_ports.insert(port_name.clone(), outgoing.load_instantiated(&|p| p).await);
-        }
-
-        let formatted_defns = serde_json::to_string(&sink_ports).unwrap();
-
-        let stdout_receiver = self.launched_binary.as_ref().unwrap().deploy_stdout();
-
-        self.launched_binary
-            .as_ref()
-            .unwrap()
-            .stdin()
-            .send(format!("start: {formatted_defns}\n"))
-            .unwrap();
-
-        let start_ack_line = ProgressTracker::leaf(
-            self.display_id
-                .clone()
-                .unwrap_or_else(|| format!("service/{}", self.id))
-                + " / waiting for ack start",
-            tokio::time::timeout(Duration::from_secs(60), stdout_receiver),
-        )
-        .await??;
-        if !start_ack_line.starts_with("ack start") {
-            bail!("expected ack start");
-        }
-
-        self.started = true;
+            })
+            .await?;
         Ok(())
     }
 
-    async fn stop(&mut self) -> Result<()> {
+    async fn ready(&self) -> Result<()> {
+        self.launched_binary
+            .get_or_try_init(|| {
+                ProgressTracker::with_group(
+                    self.display_id
+                        .clone()
+                        .unwrap_or_else(|| format!("service/{}", self.id)),
+                    None,
+                    || async {
+                        let launched_host = self.launched_host.get().unwrap();
+
+                        let built = self.build().await?;
+                        let args = self.args.as_ref().cloned().unwrap_or_default();
+
+                        let binary = launched_host
+                            .launch_binary(
+                                self.display_id
+                                    .clone()
+                                    .unwrap_or_else(|| format!("service/{}", self.id)),
+                                built,
+                                &args,
+                                self.tracing.clone(),
+                            )
+                            .await?;
+
+                        let bind_config = self
+                            .port_to_bind
+                            .iter()
+                            .map(|(port_name, bind_type)| {
+                                (port_name.clone(), launched_host.server_config(bind_type))
+                            })
+                            .collect::<HashMap<_, _>>();
+
+                        let formatted_bind_config = serde_json::to_string::<InitConfig>(&(
+                            bind_config,
+                            self.meta.get().map(|s| s.as_str().into()),
+                        ))
+                        .unwrap();
+
+                        // request stdout before sending config so we don't miss the "ready" response
+                        let stdout_receiver = binary.deploy_stdout();
+
+                        binary.stdin().send(format!("{formatted_bind_config}\n"))?;
+
+                        let ready_line = ProgressTracker::leaf(
+                            "waiting for ready",
+                            tokio::time::timeout(Duration::from_secs(60), stdout_receiver),
+                        )
+                        .await
+                        .context("Timed out waiting for ready")?
+                        .context("Program unexpectedly quit")?;
+                        if let Some(line_rest) = ready_line.strip_prefix("ready: ") {
+                            *self.server_defns.try_write().unwrap() =
+                                serde_json::from_str(line_rest).unwrap();
+                        } else {
+                            bail!("expected ready");
+                        }
+                        Ok(binary)
+                    },
+                )
+            })
+            .await?;
+        Ok(())
+    }
+
+    async fn start(&self) -> Result<()> {
+        self.started
+            .get_or_try_init(|| async {
+                let sink_ports_futures =
+                    self.port_to_server
+                        .iter()
+                        .map(|(port_name, outgoing)| async {
+                            (&**port_name, outgoing.load_instantiated(&|p| p).await)
+                        });
+                let sink_ports = futures::future::join_all(sink_ports_futures)
+                    .await
+                    .into_iter()
+                    .collect::<HashMap<_, _>>();
+
+                let formatted_defns = serde_json::to_string(&sink_ports).unwrap();
+
+                let stdout_receiver = self.launched_binary.get().unwrap().deploy_stdout();
+
+                self.launched_binary
+                    .get()
+                    .unwrap()
+                    .stdin()
+                    .send(format!("start: {formatted_defns}\n"))
+                    .unwrap();
+
+                let start_ack_line = ProgressTracker::leaf(
+                    self.display_id
+                        .clone()
+                        .unwrap_or_else(|| format!("service/{}", self.id))
+                        + " / waiting for ack start",
+                    tokio::time::timeout(Duration::from_secs(60), stdout_receiver),
+                )
+                .await??;
+                if !start_ack_line.starts_with("ack start") {
+                    bail!("expected ack start");
+                }
+
+                Ok(())
+            })
+            .await?;
+
+        Ok(())
+    }
+
+    async fn stop(&self) -> Result<()> {
         ProgressTracker::with_group(
             self.display_id
                 .clone()
                 .unwrap_or_else(|| format!("service/{}", self.id)),
             None,
             || async {
-                let launched_binary = self.launched_binary.as_mut().unwrap();
+                let launched_binary = self.launched_binary.get().unwrap();
                 launched_binary.stdin().send("stop\n".to_string())?;
 
                 let timeout_result = ProgressTracker::leaf(

--- a/hydro_deploy/hydro_deploy_integration/src/lib.rs
+++ b/hydro_deploy/hydro_deploy_integration/src/lib.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::marker::PhantomData;
@@ -24,7 +25,7 @@ use tokio_util::codec::{Framed, LengthDelimitedCodec};
 pub mod multi_connection;
 pub mod single_connection;
 
-pub type InitConfig = (HashMap<String, ServerBindConfig>, Option<String>);
+pub type InitConfig<'a> = (HashMap<String, ServerBindConfig>, Option<Cow<'a, str>>);
 
 /// Contains runtime information passed by Hydro Deploy to a program,
 /// describing how to connect to other services and metadata about them.

--- a/hydro_lang/src/compile/deploy_provider.rs
+++ b/hydro_lang/src/compile/deploy_provider.rs
@@ -191,7 +191,7 @@ pub trait Node {
 
     fn next_port(&self) -> Self::Port;
 
-    fn update_meta(&mut self, meta: &Self::Meta);
+    fn update_meta(&self, meta: &Self::Meta);
 
     fn instantiate(
         &self,

--- a/hydro_lang/src/deploy/deploy_graph.rs
+++ b/hydro_lang/src/deploy/deploy_graph.rs
@@ -23,7 +23,6 @@ use serde::Serialize;
 use serde::de::DeserializeOwned;
 use stageleft::{QuotedWithContext, RuntimeData};
 use syn::parse_quote;
-use tokio::sync::RwLock;
 
 use super::deploy_runtime::*;
 use crate::compile::deploy_provider::{
@@ -92,17 +91,11 @@ impl<'a> Deploy<'a> for HydroDeploy {
         Box::new(move || {
             let self_underlying_borrow = p1.underlying.borrow();
             let self_underlying = self_underlying_borrow.as_ref().unwrap();
-            let source_port = self_underlying
-                .try_read()
-                .unwrap()
-                .get_port(p1_port.clone(), self_underlying);
+            let source_port = self_underlying.get_port(p1_port.clone(), self_underlying);
 
             let other_underlying_borrow = p2.underlying.borrow();
             let other_underlying = other_underlying_borrow.as_ref().unwrap();
-            let recipient_port = other_underlying
-                .try_read()
-                .unwrap()
-                .get_port(p2_port.clone(), other_underlying);
+            let recipient_port = other_underlying.get_port(p2_port.clone(), other_underlying);
 
             source_port.send_to(&recipient_port)
         })
@@ -137,10 +130,7 @@ impl<'a> Deploy<'a> for HydroDeploy {
         Box::new(move || {
             let self_underlying_borrow = p1.underlying.borrow();
             let self_underlying = self_underlying_borrow.as_ref().unwrap();
-            let source_port = self_underlying
-                .try_read()
-                .unwrap()
-                .get_port(p1_port.clone(), self_underlying);
+            let source_port = self_underlying.get_port(p1_port.clone(), self_underlying);
 
             let recipient_port = DemuxSink {
                 demux: c2
@@ -149,10 +139,9 @@ impl<'a> Deploy<'a> for HydroDeploy {
                     .iter()
                     .enumerate()
                     .map(|(id, c)| {
-                        let n = c.underlying.try_read().unwrap();
                         (
                             id as u32,
-                            Arc::new(n.get_port(c2_port.clone(), &c.underlying))
+                            Arc::new(c.underlying.get_port(c2_port.clone(), &c.underlying))
                                 as Arc<dyn RustCrateSink + 'static>,
                         )
                     })
@@ -193,17 +182,11 @@ impl<'a> Deploy<'a> for HydroDeploy {
             let other_underlying_borrow = p2.underlying.borrow();
             let other_underlying = other_underlying_borrow.as_ref().unwrap();
             let recipient_port = other_underlying
-                .try_read()
-                .unwrap()
                 .get_port(p2_port.clone(), other_underlying)
                 .merge();
 
             for (i, node) in c1.members.borrow().iter().enumerate() {
-                let source_port = node
-                    .underlying
-                    .try_read()
-                    .unwrap()
-                    .get_port(c1_port.clone(), &node.underlying);
+                let source_port = node.underlying.get_port(c1_port.clone(), &node.underlying);
 
                 TaggedSource {
                     source: Arc::new(source_port),
@@ -244,8 +227,6 @@ impl<'a> Deploy<'a> for HydroDeploy {
             for (i, sender) in c1.members.borrow().iter().enumerate() {
                 let source_port = sender
                     .underlying
-                    .try_read()
-                    .unwrap()
                     .get_port(c1_port.clone(), &sender.underlying);
 
                 let recipient_port = DemuxSink {
@@ -255,10 +236,13 @@ impl<'a> Deploy<'a> for HydroDeploy {
                         .iter()
                         .enumerate()
                         .map(|(id, c)| {
-                            let n = c.underlying.try_read().unwrap();
                             (
                                 id as u32,
-                                Arc::new(n.get_port(c2_port.clone(), &c.underlying).merge())
+                                Arc::new(
+                                    c.underlying
+                                        .get_port(c2_port.clone(), &c.underlying)
+                                        .merge(),
+                                )
                                     as Arc<dyn RustCrateSink + 'static>,
                             )
                         })
@@ -386,14 +370,11 @@ impl<'a> Deploy<'a> for HydroDeploy {
         Box::new(move || {
             let self_underlying_borrow = p1.underlying.borrow();
             let self_underlying = self_underlying_borrow.as_ref().unwrap();
-            let source_port = self_underlying
-                .try_read()
-                .unwrap()
-                .declare_many_client(self_underlying);
+            let source_port = self_underlying.declare_many_client(self_underlying);
 
             let other_underlying_borrow = p2.underlying.borrow();
             let other_underlying = other_underlying_borrow.as_ref().unwrap();
-            let recipient_port = other_underlying.try_read().unwrap().get_port_with_hint(
+            let recipient_port = other_underlying.get_port_with_hint(
                 p2_port.clone(),
                 match server_hint {
                     NetworkHint::Auto => hydro_deploy::PortNetworkHint::Auto,
@@ -444,37 +425,32 @@ impl<'a> Deploy<'a> for HydroDeploy {
 
 #[expect(missing_docs, reason = "TODO")]
 pub trait DeployCrateWrapper {
-    fn underlying(&self) -> Arc<RwLock<RustCrateService>>;
+    fn underlying(&self) -> Arc<RustCrateService>;
 
-    #[expect(async_fn_in_trait, reason = "no auto trait bounds needed")]
-    async fn stdout(&self) -> tokio::sync::mpsc::UnboundedReceiver<String> {
-        self.underlying().read().await.stdout()
+    fn stdout(&self) -> tokio::sync::mpsc::UnboundedReceiver<String> {
+        self.underlying().stdout()
     }
 
-    #[expect(async_fn_in_trait, reason = "no auto trait bounds needed")]
-    async fn stderr(&self) -> tokio::sync::mpsc::UnboundedReceiver<String> {
-        self.underlying().read().await.stderr()
+    fn stderr(&self) -> tokio::sync::mpsc::UnboundedReceiver<String> {
+        self.underlying().stderr()
     }
 
-    #[expect(async_fn_in_trait, reason = "no auto trait bounds needed")]
-    async fn stdout_filter(
+    fn stdout_filter(
         &self,
         prefix: impl Into<String>,
     ) -> tokio::sync::mpsc::UnboundedReceiver<String> {
-        self.underlying().read().await.stdout_filter(prefix.into())
+        self.underlying().stdout_filter(prefix.into())
     }
 
-    #[expect(async_fn_in_trait, reason = "no auto trait bounds needed")]
-    async fn stderr_filter(
+    fn stderr_filter(
         &self,
         prefix: impl Into<String>,
     ) -> tokio::sync::mpsc::UnboundedReceiver<String> {
-        self.underlying().read().await.stderr_filter(prefix.into())
+        self.underlying().stderr_filter(prefix.into())
     }
 
-    #[expect(async_fn_in_trait, reason = "no auto trait bounds needed")]
-    async fn tracing_results(&self) -> Option<TracingResults> {
-        self.underlying().read().await.tracing_results().cloned()
+    fn tracing_results(&self) -> Option<TracingResults> {
+        self.underlying().tracing_results().cloned()
     }
 }
 
@@ -638,7 +614,7 @@ impl<H: Host + 'static> IntoProcessSpec<'_, HydroDeploy> for Arc<H> {
 pub struct DeployExternal {
     next_port: Rc<RefCell<usize>>,
     host: Arc<dyn Host>,
-    underlying: Rc<RefCell<Option<Arc<RwLock<CustomService>>>>>,
+    underlying: Rc<RefCell<Option<Arc<CustomService>>>>,
     client_ports: Rc<RefCell<HashMap<String, CustomClientPort>>>,
     allocated_ports: Rc<RefCell<HashMap<usize, String>>>,
 }
@@ -755,7 +731,7 @@ impl Node for DeployExternal {
         *self.underlying.borrow_mut() = Some(service);
     }
 
-    fn update_meta(&mut self, _meta: &Self::Meta) {}
+    fn update_meta(&self, _meta: &Self::Meta) {}
 }
 
 impl ExternalSpec<'_, HydroDeploy> for Arc<dyn Host> {
@@ -793,12 +769,12 @@ pub struct DeployNode {
     id: usize,
     next_port: Rc<RefCell<usize>>,
     service_spec: Rc<RefCell<Option<CrateOrTrybuild>>>,
-    underlying: Rc<RefCell<Option<Arc<RwLock<RustCrateService>>>>>,
+    underlying: Rc<RefCell<Option<Arc<RustCrateService>>>>,
 }
 
 impl DeployCrateWrapper for DeployNode {
-    fn underlying(&self) -> Arc<RwLock<RustCrateService>> {
-        self.underlying.borrow().as_ref().unwrap().clone()
+    fn underlying(&self) -> Arc<RustCrateService> {
+        Arc::clone(self.underlying.borrow().as_ref().unwrap())
     }
 }
 
@@ -814,10 +790,9 @@ impl Node for DeployNode {
         format!("port_{}", next_port)
     }
 
-    fn update_meta(&mut self, meta: &Self::Meta) {
+    fn update_meta(&self, meta: &Self::Meta) {
         let underlying_node = self.underlying.borrow();
-        let mut n = underlying_node.as_ref().unwrap().try_write().unwrap();
-        n.update_meta(HydroMeta {
+        underlying_node.as_ref().unwrap().update_meta(HydroMeta {
             clusters: meta.clone(),
             cluster_id: None,
             subgraph_id: self.id,
@@ -857,11 +832,11 @@ impl Node for DeployNode {
 #[expect(missing_docs, reason = "TODO")]
 #[derive(Clone)]
 pub struct DeployClusterNode {
-    underlying: Arc<RwLock<RustCrateService>>,
+    underlying: Arc<RustCrateService>,
 }
 
 impl DeployCrateWrapper for DeployClusterNode {
-    fn underlying(&self) -> Arc<RwLock<RustCrateService>> {
+    fn underlying(&self) -> Arc<RustCrateService> {
         self.underlying.clone()
     }
 }
@@ -960,10 +935,9 @@ impl Node for DeployCluster {
             .collect();
     }
 
-    fn update_meta(&mut self, meta: &Self::Meta) {
+    fn update_meta(&self, meta: &Self::Meta) {
         for (cluster_id, node) in self.members.borrow().iter().enumerate() {
-            let mut n = node.underlying.try_write().unwrap();
-            n.update_meta(HydroMeta {
+            node.underlying.update_meta(HydroMeta {
                 clusters: meta.clone(),
                 cluster_id: Some(TaglessMemberId::from_raw_id(cluster_id as u32)),
                 subgraph_id: self.id,

--- a/hydro_lang/src/deploy/deploy_graph_containerized.rs
+++ b/hydro_lang/src/deploy/deploy_graph_containerized.rs
@@ -90,7 +90,7 @@ impl Node for DockerDeployProcess {
     }
 
     #[instrument(level = "trace", skip_all, fields(id = self.id, name = self.name))]
-    fn update_meta(&mut self, _meta: &Self::Meta) {}
+    fn update_meta(&self, _meta: &Self::Meta) {}
 
     #[instrument(level = "trace", skip_all, fields(id = self.id, name = self.name, ?meta, extra_stmts = extra_stmts.len()))]
     fn instantiate(
@@ -158,7 +158,7 @@ impl Node for DockerDeployCluster {
     }
 
     #[instrument(level = "trace", skip_all, fields(id = self.id, name = self.name))]
-    fn update_meta(&mut self, _meta: &Self::Meta) {}
+    fn update_meta(&self, _meta: &Self::Meta) {}
 
     #[instrument(level = "trace", skip_all, fields(id = self.id, name = self.name, extra_stmts = extra_stmts.len()))]
     fn instantiate(
@@ -221,7 +221,7 @@ impl Node for DockerDeployExternal {
     }
 
     #[instrument(level = "trace", skip_all, fields(name = self.name))]
-    fn update_meta(&mut self, _meta: &Self::Meta) {}
+    fn update_meta(&self, _meta: &Self::Meta) {}
 
     #[instrument(level = "trace", skip_all, fields(name = self.name, ?meta, extra_stmts = extra_stmts.len()))]
     fn instantiate(

--- a/hydro_lang/src/sim/graph.rs
+++ b/hydro_lang/src/sim/graph.rs
@@ -38,7 +38,7 @@ impl Node for SimNode {
         todo!()
     }
 
-    fn update_meta(&mut self, _meta: &Self::Meta) {}
+    fn update_meta(&self, _meta: &Self::Meta) {}
 
     fn instantiate(
         &self,
@@ -65,7 +65,7 @@ impl Node for SimExternal {
         todo!()
     }
 
-    fn update_meta(&mut self, _meta: &Self::Meta) {
+    fn update_meta(&self, _meta: &Self::Meta) {
         todo!()
     }
 

--- a/hydro_test/src/cluster/many_to_many.rs
+++ b/hydro_test/src/cluster/many_to_many.rs
@@ -40,14 +40,12 @@ mod tests {
 
         deployment.deploy().await.unwrap();
 
-        let cluster_stdouts = futures::future::join_all(
-            nodes
-                .get_cluster(&cluster)
-                .members()
-                .iter()
-                .map(|node| node.stdout()),
-        )
-        .await;
+        let cluster_stdouts = nodes
+            .get_cluster(&cluster)
+            .members()
+            .iter()
+            .map(|node| node.stdout())
+            .collect::<Vec<_>>();
 
         deployment.start().await.unwrap();
 

--- a/hydro_test/src/cluster/paxos_bench.rs
+++ b/hydro_test/src/cluster/paxos_bench.rs
@@ -257,7 +257,7 @@ mod tests {
         deployment.deploy().await.unwrap();
 
         let client_node = &nodes.get_process(&client_aggregator);
-        let client_out = client_node.stdout_filter("Throughput:").await;
+        let client_out = client_node.stdout_filter("Throughput:");
 
         deployment.start().await.unwrap();
 

--- a/hydro_test/src/cluster/simple_cluster.rs
+++ b/hydro_test/src/cluster/simple_cluster.rs
@@ -105,15 +105,13 @@ mod tests {
 
         deployment.deploy().await.unwrap();
 
-        let mut node_stdout = nodes.get_process(&node).stdout().await;
-        let cluster_stdouts = futures::future::join_all(
-            nodes
-                .get_cluster(&cluster)
-                .members()
-                .iter()
-                .map(|node| node.stdout()),
-        )
-        .await;
+        let mut node_stdout = nodes.get_process(&node).stdout();
+        let cluster_stdouts = nodes
+            .get_cluster(&cluster)
+            .members()
+            .iter()
+            .map(|node| node.stdout())
+            .collect::<Vec<_>>();
 
         deployment.start().await.unwrap();
 
@@ -162,7 +160,7 @@ mod tests {
             .deploy(&mut deployment);
 
         deployment.deploy().await.unwrap();
-        let mut process2_stdout = nodes.get_process(&process2).stdout().await;
+        let mut process2_stdout = nodes.get_process(&process2).stdout();
         deployment.start().await.unwrap();
         for i in 0..3 {
             let expected_message = format!("I received message is {}", i);
@@ -185,14 +183,12 @@ mod tests {
 
         deployment.deploy().await.unwrap();
 
-        let cluster2_stdouts = futures::future::join_all(
-            nodes
-                .get_cluster(&cluster2)
-                .members()
-                .iter()
-                .map(|node| node.stdout()),
-        )
-        .await;
+        let cluster2_stdouts = nodes
+            .get_cluster(&cluster2)
+            .members()
+            .iter()
+            .map(|node| node.stdout())
+            .collect::<Vec<_>>();
 
         deployment.start().await.unwrap();
 
@@ -234,14 +230,12 @@ mod tests {
 
         deployment.deploy().await.unwrap();
 
-        let cluster2_stdouts = futures::future::join_all(
-            nodes
-                .get_cluster(&cluster2)
-                .members()
-                .iter()
-                .map(|node| node.stdout()),
-        )
-        .await;
+        let cluster2_stdouts = nodes
+            .get_cluster(&cluster2)
+            .members()
+            .iter()
+            .map(|node| node.stdout())
+            .collect::<Vec<_>>();
 
         deployment.start().await.unwrap();
 

--- a/hydro_test/src/cluster/two_pc_bench.rs
+++ b/hydro_test/src/cluster/two_pc_bench.rs
@@ -142,7 +142,7 @@ mod tests {
         deployment.deploy().await.unwrap();
 
         let client_node = &nodes.get_process(&client_aggregator);
-        let client_out = client_node.stdout_filter("Throughput:").await;
+        let client_out = client_node.stdout_filter("Throughput:");
 
         deployment.start().await.unwrap();
 

--- a/hydro_test/src/distributed/first_ten.rs
+++ b/hydro_test/src/distributed/first_ten.rs
@@ -65,8 +65,8 @@ mod tests {
 
         let mut external_port = nodes.connect(external_port).await;
 
-        let mut first_node_stdout = nodes.get_process(&p1).stdout().await;
-        let mut second_node_stdout = nodes.get_process(&p2).stdout().await;
+        let mut first_node_stdout = nodes.get_process(&p1).stdout();
+        let mut second_node_stdout = nodes.get_process(&p2).stdout();
 
         deployment.start().await.unwrap();
 


### PR DESCRIPTION
* Updates the `async-ssh2-russh` dependency.
* Use `&self` in `Service`, `LaunchedBinary` traits to avoid needing to wrap in locks
* Removed `async` from `DeployCrateWrapper`
* Other stuff (below)

Waiting on #2179 before merging

BREAKING CHANGE: Changes many trait and API signatures in `hydro_deploy`

# Summary: Breaking Changes in Traits and Public APIs

## 🔴 **Trait Method Signature Changes**

### Service Trait (`hydro_deploy/core/src/lib.rs`)
All methods changed from `&mut self` to `&self`:
- `deploy(&mut self, ...) -> Result<()>` → `deploy(&self, ...) -> Result<()>`
- `ready(&mut self, ...) -> Result<()>` → `ready(&self, ...) -> Result<()>`
- `start(&mut self, ...) -> Result<()>` → `start(&self, ...) -> Result<()>`
- `stop(&mut self, ...) -> Result<()>` → `stop(&self, ...) -> Result<()>`

### LaunchedBinary Trait (`hydro_deploy/core/src/lib.rs`)
- `wait(&mut self) -> Result<i32>` → `wait(&self) -> Result<i32>`
- `stop(&mut self) -> Result<()>` → `stop(&self) -> Result<()>`

### Node Trait (`hydro_lang/src/compile/deploy_provider.rs`)
- `update_meta(&mut self, meta: &Self::Meta)` → `update_meta(&self, meta: &Self::Meta)`

## 🔴 **DeployCrateWrapper Trait Changes** (`hydro_lang/src/deploy/deploy_graph.rs`)

**Return Type Change:**
- `underlying(&self) -> Arc<RwLock<RustCrateService>>` → `underlying(&self) -> Arc<RustCrateService>`

**Method Conversions from async to sync (removed async):**
- `async fn stdout()` → `fn stdout()`
- `async fn stderr()` → `fn stderr()`
- `async fn stdout_filter()` → `fn stdout_filter()`
- `async fn stderr_filter()` → `fn stderr_filter()`
- `async fn tracing_results()` → `fn tracing_results()`

## 🔴 **Public API Return Type Changes**

**Deployment Methods:**
- `add_custom_service()`: `Arc<RwLock<CustomService>>` → `Arc<CustomService>`
- `add_service()`: `Arc<RwLock<T>>` → `Arc<T>`
- `services`: `Vec<Weak<RwLock<dyn Service>>>` → `Vec<Weak<dyn Service>>`

**RustCrateService Methods:**
- `get_port(&self, ..., self_arc: &Arc<RwLock<RustCrateService>>)` → `get_port(&self, ..., self_arc: &Arc<RustCrateService>)`
- `get_port_with_hint(&self, ..., self_arc: &Arc<RwLock<RustCrateService>>)` → `get_port_with_hint(&self, ..., self_arc: &Arc<RustCrateService>)`

**CustomService Methods:**
- `declare_client(&self, self_arc: &Arc<RwLock<Self>>)` → `declare_client(&self, self_arc: &Arc<Self>)`
- `declare_many_client(&self, self_arc: &Arc<RwLock<Self>>)` → `declare_many_client(&self, self_arc: &Arc<Self>)`

## 🔴 **Generic Type Signature Changes**

**InitConfig Type** (`hydro_deploy_integration/src/lib.rs`):
- `InitConfig = (HashMap<String, ServerBindConfig>, Option<String>)`
- → `InitConfig<'a> = (HashMap<String, ServerBindConfig>, Option<Cow<'a, str>>)`
  (Now generic with a lifetime parameter)

## 🔴 **Collection Type Changes**

**ServerStrategy enum:**
- `Merge(Vec<ServerStrategy>)` → `Merge(Box<AppendOnlyVec<ServerStrategy>>)`

**ServerConfig enum:**
- `Merge(Vec<ServerConfig>)` → `Merge(Box<AppendOnlyVec<ServerConfig>>)`

## 📝 **Key Theme**

This refactor eliminates the need for `RwLock` wrapping around services by:
1. Changing mutable methods to use `&self` with interior mutability patterns
2. Using `OnceLock`, `OnceCell`, and `MemoMap` for state management instead of `Option<T>` and `HashMap`
3. Removing unnecessary `async` from methods that don't need it
4. Making trait objects simpler and more efficient (no more `RwLock` wrappers)

All these changes are marked as `BREAKING CHANGE` in the commit, meaning any code depending on `hydro_deploy`'s public APIs will need to be updated!