### PR TITLE
refactor(hydro_deploy)!: fix `&self, self_arc: &Arc<Self>` methods, `RustCratePortConfig::merge`

### DIFF
--- a/hydro_deploy/core/src/custom_service.rs
+++ b/hydro_deploy/core/src/custom_service.rs
@@ -36,12 +36,12 @@ impl CustomService {
         }
     }
 
-    pub fn declare_client(&self, self_arc: &Arc<Self>) -> CustomClientPort {
-        CustomClientPort::new(Arc::downgrade(self_arc), false)
+    pub fn declare_client(self: &Arc<Self>) -> CustomClientPort {
+        CustomClientPort::new(Arc::downgrade(self), false)
     }
 
-    pub fn declare_many_client(&self, self_arc: &Arc<Self>) -> CustomClientPort {
-        CustomClientPort::new(Arc::downgrade(self_arc), true)
+    pub fn declare_many_client(self: &Arc<Self>) -> CustomClientPort {
+        CustomClientPort::new(Arc::downgrade(self), true)
     }
 }
 

--- a/hydro_deploy/core/src/rust_crate/ports.rs
+++ b/hydro_deploy/core/src/rust_crate/ports.rs
@@ -192,15 +192,9 @@ pub struct RustCratePortConfig {
 }
 
 impl RustCratePortConfig {
-    pub fn merge(&self) -> Self {
-        Self {
-            service: self.service.clone(),
-            service_host: self.service_host.clone(),
-            service_server_defns: self.service_server_defns.clone(),
-            network_hint: self.network_hint,
-            port: self.port.clone(),
-            merge: true,
-        }
+    pub fn merge(mut self) -> Self {
+        self.merge = true;
+        self
     }
 }
 

--- a/hydro_deploy/core/src/rust_crate/service.rs
+++ b/hydro_deploy/core/src/rust_crate/service.rs
@@ -83,9 +83,9 @@ impl RustCrateService {
             .expect("Cannot set meta twice.");
     }
 
-    pub fn get_port(&self, name: String, self_arc: &Arc<RustCrateService>) -> RustCratePortConfig {
+    pub fn get_port(self: &Arc<Self>, name: String) -> RustCratePortConfig {
         RustCratePortConfig {
-            service: Arc::downgrade(self_arc),
+            service: Arc::downgrade(self),
             service_host: self.on.clone(),
             service_server_defns: self.server_defns.clone(),
             network_hint: PortNetworkHint::Auto,
@@ -95,13 +95,12 @@ impl RustCrateService {
     }
 
     pub fn get_port_with_hint(
-        &self,
+        self: &Arc<Self>,
         name: String,
         network_hint: PortNetworkHint,
-        self_arc: &Arc<RustCrateService>,
     ) -> RustCratePortConfig {
         RustCratePortConfig {
-            service: Arc::downgrade(self_arc),
+            service: Arc::downgrade(self),
             service_host: self.on.clone(),
             service_server_defns: self.server_defns.clone(),
             network_hint,

--- a/hydro_lang/src/deploy/deploy_graph.rs
+++ b/hydro_lang/src/deploy/deploy_graph.rs
@@ -91,11 +91,11 @@ impl<'a> Deploy<'a> for HydroDeploy {
         Box::new(move || {
             let self_underlying_borrow = p1.underlying.borrow();
             let self_underlying = self_underlying_borrow.as_ref().unwrap();
-            let source_port = self_underlying.get_port(p1_port.clone(), self_underlying);
+            let source_port = self_underlying.get_port(p1_port.clone());
 
             let other_underlying_borrow = p2.underlying.borrow();
             let other_underlying = other_underlying_borrow.as_ref().unwrap();
-            let recipient_port = other_underlying.get_port(p2_port.clone(), other_underlying);
+            let recipient_port = other_underlying.get_port(p2_port.clone());
 
             source_port.send_to(&recipient_port)
         })
@@ -130,7 +130,7 @@ impl<'a> Deploy<'a> for HydroDeploy {
         Box::new(move || {
             let self_underlying_borrow = p1.underlying.borrow();
             let self_underlying = self_underlying_borrow.as_ref().unwrap();
-            let source_port = self_underlying.get_port(p1_port.clone(), self_underlying);
+            let source_port = self_underlying.get_port(p1_port.clone());
 
             let recipient_port = DemuxSink {
                 demux: c2
@@ -141,7 +141,7 @@ impl<'a> Deploy<'a> for HydroDeploy {
                     .map(|(id, c)| {
                         (
                             id as u32,
-                            Arc::new(c.underlying.get_port(c2_port.clone(), &c.underlying))
+                            Arc::new(c.underlying.get_port(c2_port.clone()))
                                 as Arc<dyn RustCrateSink + 'static>,
                         )
                     })
@@ -181,12 +181,10 @@ impl<'a> Deploy<'a> for HydroDeploy {
         Box::new(move || {
             let other_underlying_borrow = p2.underlying.borrow();
             let other_underlying = other_underlying_borrow.as_ref().unwrap();
-            let recipient_port = other_underlying
-                .get_port(p2_port.clone(), other_underlying)
-                .merge();
+            let recipient_port = other_underlying.get_port(p2_port.clone()).merge();
 
             for (i, node) in c1.members.borrow().iter().enumerate() {
-                let source_port = node.underlying.get_port(c1_port.clone(), &node.underlying);
+                let source_port = node.underlying.get_port(c1_port.clone());
 
                 TaggedSource {
                     source: Arc::new(source_port),
@@ -225,9 +223,7 @@ impl<'a> Deploy<'a> for HydroDeploy {
 
         Box::new(move || {
             for (i, sender) in c1.members.borrow().iter().enumerate() {
-                let source_port = sender
-                    .underlying
-                    .get_port(c1_port.clone(), &sender.underlying);
+                let source_port = sender.underlying.get_port(c1_port.clone());
 
                 let recipient_port = DemuxSink {
                     demux: c2
@@ -238,11 +234,7 @@ impl<'a> Deploy<'a> for HydroDeploy {
                         .map(|(id, c)| {
                             (
                                 id as u32,
-                                Arc::new(
-                                    c.underlying
-                                        .get_port(c2_port.clone(), &c.underlying)
-                                        .merge(),
-                                )
+                                Arc::new(c.underlying.get_port(c2_port.clone()).merge())
                                     as Arc<dyn RustCrateSink + 'static>,
                             )
                         })
@@ -370,7 +362,7 @@ impl<'a> Deploy<'a> for HydroDeploy {
         Box::new(move || {
             let self_underlying_borrow = p1.underlying.borrow();
             let self_underlying = self_underlying_borrow.as_ref().unwrap();
-            let source_port = self_underlying.declare_many_client(self_underlying);
+            let source_port = self_underlying.declare_many_client();
 
             let other_underlying_borrow = p2.underlying.borrow();
             let other_underlying = other_underlying_borrow.as_ref().unwrap();
@@ -380,7 +372,6 @@ impl<'a> Deploy<'a> for HydroDeploy {
                     NetworkHint::Auto => hydro_deploy::PortNetworkHint::Auto,
                     NetworkHint::TcpPort(p) => hydro_deploy::PortNetworkHint::TcpPort(p),
                 },
-                other_underlying,
             );
 
             source_port.send_to(&recipient_port);


### PR DESCRIPTION
Previous stack: #2372