### PR TITLE
refactor(hydro_std): port `bench_client` to use sliced!, introduce `Stream::merge_ordered`

### DIFF
--- a/hydro_std/src/bench_client/mod.rs
+++ b/hydro_std/src/bench_client/mod.rs
@@ -67,108 +67,104 @@ pub fn bench_client<'a, Client, Payload>(
 where
     Payload: Clone,
 {
-    let client_tick = clients.tick();
-
-    // Set up an initial set of payloads on the first tick
-    let initial_virtual_client = client_tick.optional_first_tick(q!(0u32));
-    let (next_virtual_client_complete_cycle, next_virtual_client) = client_tick.cycle();
-    let new_virtual_client = initial_virtual_client.or(next_virtual_client);
-    next_virtual_client_complete_cycle.complete_next_tick(new_virtual_client.clone().filter_map(
-        q!(move |virtual_id| {
-            if virtual_id < num_clients_per_node as u32 {
-                Some(virtual_id + 1)
-            } else {
-                None
-            }
-        }),
-    ));
-
-    let new_virtual_client_stream = new_virtual_client.into_stream();
-
-    let c_new_payloads_on_start = new_virtual_client_stream
-        .clone()
-        .map(q!(|virtual_id| (virtual_id, None)));
-
     let (c_to_proposers_complete_cycle, c_to_proposers) =
         clients.forward_ref::<Stream<_, _, _, TotalOrder>>();
 
-    // Whenever all replicas confirm that a payload was committed, send another payload
-    let c_received_quorum_payloads = transaction_cycle(c_to_proposers)
-        .batch(
-            &client_tick,
-            nondet!(
-                /// because the transaction processor is required to handle arbitrary reordering
-                /// across *different* keys, we are safe because delaying a transaction result for a key
-                /// will only affect when the next request for that key is emitted with respect to other keys
-            ),
-        )
-        .map(q!(|(virtual_id, payload)| (virtual_id, Some(payload))));
+    let (c_latencies, c_throughput_batches, c_new_payloads) = sliced! {
+        let mut next_virtual_client = use::state(|l| Optional::from(l.singleton(q!(0u32))));
+        let mut timers = use::state_null::<KeyedSingleton<u32, Instant, _, _>>();
 
-    let c_new_payloads = workload_generator(
-        clients,
-        c_new_payloads_on_start
-            .chain(c_received_quorum_payloads.clone())
-            .all_ticks(),
-    );
+        let transaction_results = use(transaction_cycle(c_to_proposers).into_keyed(), nondet!(
+            /// because the transaction processor is required to handle arbitrary reordering
+            /// across *different* keys, we are safe because delaying a transaction result for a key
+            /// will only affect when the next request for that key is emitted with respect to other keys
+        ));
+
+        // Set up virtual clients - spawn new ones each tick until we reach the limit
+        let new_virtual_client = next_virtual_client.clone();
+        next_virtual_client = new_virtual_client.clone().filter_map(
+            q!(move |virtual_id| {
+                if virtual_id < num_clients_per_node as u32 {
+                    Some(virtual_id + 1)
+                } else {
+                    None
+                }
+            }),
+        );
+
+        let new_virtual_client_stream = new_virtual_client.into_stream();
+
+        let c_new_payloads_on_start = new_virtual_client_stream
+            .clone()
+            .map(q!(|virtual_id| (virtual_id, None)))
+            .into_keyed();
+
+        let c_received_quorum_payloads = transaction_results
+            .map(q!(|payload| Some(payload)));
+
+        // Track statistics - timers for latency measurement
+        let c_new_timers_when_leader_elected =
+            new_virtual_client_stream.map(q!(|virtual_id| (virtual_id, Instant::now()))).into_keyed();
+        let c_updated_timers = c_received_quorum_payloads
+            .clone()
+            .map(q!(|_payload| Instant::now()));
+
+        let c_latencies = timers
+            .clone()
+            .get_many_if_present(c_updated_timers.clone())
+            .values()
+            .map(q!(
+                |(prev_time, curr_time)| curr_time.duration_since(prev_time)
+            ));
+
+        timers = timers // Update timers in tick+1 so we can record differences during this tick (to track latency)
+            .into_keyed_stream()
+            .chain(c_new_timers_when_leader_elected)
+            .chain(c_updated_timers)
+            .reduce_commutative(q!(|curr_time, new_time| {
+                if new_time > *curr_time {
+                    *curr_time = new_time;
+                }
+            }));
+
+        // Throughput tracking
+        let c_throughput_new_batch = c_received_quorum_payloads
+            .clone()
+            .values()
+            .count();
+
+        let c_new_payloads = c_new_payloads_on_start.chain(c_received_quorum_payloads);
+
+        (c_latencies, c_throughput_new_batch.into_stream(), c_new_payloads)
+    };
+
+    let c_new_payloads = workload_generator(clients, c_new_payloads.entries());
     c_to_proposers_complete_cycle.complete(c_new_payloads.assume_ordering::<TotalOrder>(nondet!(
         /// We don't send a new write for the same key until the previous one is committed,
         /// so this contains only a single write per key, and we don't care about order
         /// across keys.
     )));
 
-    // Track statistics
-    let (c_timers_complete_cycle, c_timers) =
-        client_tick.cycle::<Stream<(u32, Instant), _, _, NoOrder>>();
-    let c_new_timers_when_leader_elected =
-        new_virtual_client_stream.map(q!(|virtual_id| (virtual_id, Instant::now())));
-    let c_updated_timers = c_received_quorum_payloads
-        .clone()
-        .map(q!(|(key, _payload)| (key, Instant::now())));
-    let c_new_timers = c_timers
-        .clone() // Update c_timers in tick+1 so we can record differences during this tick (to track latency)
-        .chain(c_new_timers_when_leader_elected)
-        .chain(c_updated_timers.clone())
-        .into_keyed()
-        .reduce_commutative(q!(|curr_time, new_time| {
-            if new_time > *curr_time {
-                *curr_time = new_time;
-            }
-        }))
-        .entries();
-    c_timers_complete_cycle.complete_next_tick(c_new_timers);
+    let c_latencies = c_latencies.fold_commutative(
+        q!(move || Rc::new(RefCell::new(Histogram::<u64>::new(3).unwrap()))),
+        q!(move |latencies, latency| {
+            latencies
+                .borrow_mut()
+                .record(latency.as_nanos() as u64)
+                .unwrap();
+        }),
+    );
 
-    let c_latencies = c_timers
-        .join(c_updated_timers)
-        .map(q!(
-            |(_virtual_id, (prev_time, curr_time))| curr_time.duration_since(prev_time)
-        ))
-        .all_ticks()
-        .fold_commutative(
-            q!(move || Rc::new(RefCell::new(Histogram::<u64>::new(3).unwrap()))),
-            q!(move |latencies, latency| {
-                latencies
-                    .borrow_mut()
-                    .record(latency.as_nanos() as u64)
-                    .unwrap();
-            }),
+    let throughput_with_timers = c_throughput_batches
+        .map(q!(|batch_size| (batch_size, false)))
+        .merge_ordered(
+            clients
+                .source_interval(q!(Duration::from_secs(1)), nondet_throughput_window)
+                .map(q!(|_| (0, true))),
+            nondet_throughput_window,
         );
 
-    let c_stats_output_timer = clients
-        .source_interval(q!(Duration::from_secs(1)), nondet_throughput_window)
-        .batch(&client_tick, nondet_throughput_window)
-        .first();
-
-    let c_throughput_new_batch = c_received_quorum_payloads
-        .count()
-        .filter_if_none(c_stats_output_timer.clone())
-        .map(q!(|batch_size| (batch_size, false)));
-
-    let c_throughput_reset = c_stats_output_timer.map(q!(|_| (0, true))).defer_tick();
-
-    let c_throughput = c_throughput_new_batch
-        .into_stream()
-        .chain(c_throughput_reset.into_stream())
-        .all_ticks()
+    let c_throughput = throughput_with_timers
         .fold(
             q!(|| (0, { RollingAverage::new() })),
             q!(|(total, stats), (batch_size, reset)| {
@@ -183,7 +179,7 @@ where
                 }
             }),
         )
-        .map(q!(|(_, stats)| { stats }));
+        .map(q!(|(_, stats)| stats));
 
     BenchResult {
         latency_histogram: c_latencies,

--- a/hydro_test/src/cluster/snapshots/paxos_ir.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir.snap
@@ -3,114 +3,6 @@ source: hydro_test/src/cluster/paxos_bench.rs
 expression: built.ir()
 ---
 [
-    CycleSink {
-        ident: Ident {
-            sym: cycle_0,
-        },
-        input: FilterMap {
-            f: stageleft :: runtime_support :: fn1_type_hint :: < u32 , core :: option :: Option < u32 > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; let num_clients_per_node__free = 100usize ; move | virtual_id | { if virtual_id < num_clients_per_node__free as u32 { Some (virtual_id + 1) } else { None } } }),
-            input: Tee {
-                inner: <tee 0>: ChainFirst {
-                    first: Batch {
-                        inner: Source {
-                            source: Iter(
-                                { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: tick :: * ; let e__free = { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; 0u32 } ; [e__free] },
-                            ),
-                            metadata: HydroIrMetadata {
-                                location_kind: Cluster(
-                                    2,
-                                ),
-                                collection_kind: Optional {
-                                    bound: Unbounded,
-                                    element_type: u32,
-                                },
-                            },
-                        },
-                        metadata: HydroIrMetadata {
-                            location_kind: Tick(
-                                0,
-                                Cluster(
-                                    2,
-                                ),
-                            ),
-                            collection_kind: Optional {
-                                bound: Bounded,
-                                element_type: u32,
-                            },
-                        },
-                    },
-                    second: DeferTick {
-                        input: CycleSource {
-                            ident: Ident {
-                                sym: cycle_0,
-                            },
-                            metadata: HydroIrMetadata {
-                                location_kind: Tick(
-                                    0,
-                                    Cluster(
-                                        2,
-                                    ),
-                                ),
-                                collection_kind: Optional {
-                                    bound: Bounded,
-                                    element_type: u32,
-                                },
-                            },
-                        },
-                        metadata: HydroIrMetadata {
-                            location_kind: Tick(
-                                0,
-                                Cluster(
-                                    2,
-                                ),
-                            ),
-                            collection_kind: Optional {
-                                bound: Bounded,
-                                element_type: u32,
-                            },
-                        },
-                    },
-                    metadata: HydroIrMetadata {
-                        location_kind: Tick(
-                            0,
-                            Cluster(
-                                2,
-                            ),
-                        ),
-                        collection_kind: Optional {
-                            bound: Bounded,
-                            element_type: u32,
-                        },
-                    },
-                },
-                metadata: HydroIrMetadata {
-                    location_kind: Tick(
-                        0,
-                        Cluster(
-                            2,
-                        ),
-                    ),
-                    collection_kind: Optional {
-                        bound: Bounded,
-                        element_type: u32,
-                    },
-                },
-            },
-            metadata: HydroIrMetadata {
-                location_kind: Tick(
-                    0,
-                    Cluster(
-                        2,
-                    ),
-                ),
-                collection_kind: Optional {
-                    bound: Bounded,
-                    element_type: u32,
-                },
-            },
-        },
-        op_metadata: HydroIrOpMetadata,
-    },
     ForEach {
         f: stageleft :: runtime_support :: fn1_type_hint :: < & str , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | s | println ! ("{}" , s) }),
         input: Source {
@@ -153,15 +45,15 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_8,
+            sym: cycle_7,
         },
         input: Tee {
-            inner: <tee 1>: Map {
+            inner: <tee 0>: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , u32) , u32 > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless ((__hydro_lang_cluster_self_id_0) . clone ()) ; move | (received_max_ballot , ballot_num) | { if received_max_ballot > (Ballot { num : ballot_num , proposer_id : CLUSTER_SELF_ID__free . clone () , }) { received_max_ballot . num + 1 } else { ballot_num } } }),
                 input: Cast {
                     inner: CrossSingleton {
                         left: Tee {
-                            inner: <tee 2>: Batch {
+                            inner: <tee 1>: Batch {
                                 inner: YieldConcat {
                                     inner: Batch {
                                         inner: Cast {
@@ -176,7 +68,7 @@ expression: built.ir()
                                                                         first: Chain {
                                                                             first: CycleSource {
                                                                                 ident: Ident {
-                                                                                    sym: cycle_5,
+                                                                                    sym: cycle_4,
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_kind: Cluster(
@@ -192,7 +84,7 @@ expression: built.ir()
                                                                             },
                                                                             second: CycleSource {
                                                                                 ident: Ident {
-                                                                                    sym: cycle_3,
+                                                                                    sym: cycle_2,
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_kind: Cluster(
@@ -220,7 +112,7 @@ expression: built.ir()
                                                                         },
                                                                         second: CycleSource {
                                                                             ident: Ident {
-                                                                                sym: cycle_6,
+                                                                                sym: cycle_5,
                                                                             },
                                                                             metadata: HydroIrMetadata {
                                                                                 location_kind: Cluster(
@@ -284,7 +176,7 @@ expression: built.ir()
                                                         },
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Tick(
-                                                                3,
+                                                                2,
                                                                 Cluster(
                                                                     0,
                                                                 ),
@@ -321,7 +213,7 @@ expression: built.ir()
                                                         },
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Tick(
-                                                                3,
+                                                                2,
                                                                 Cluster(
                                                                     0,
                                                                 ),
@@ -334,7 +226,7 @@ expression: built.ir()
                                                     },
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Tick(
-                                                            3,
+                                                            2,
                                                             Cluster(
                                                                 0,
                                                             ),
@@ -367,7 +259,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                1,
+                                                0,
                                                 Cluster(
                                                     0,
                                                 ),
@@ -381,7 +273,7 @@ expression: built.ir()
                                     metadata: HydroIrMetadata {
                                         location_kind: Atomic(
                                             Tick(
-                                                1,
+                                                0,
                                                 Cluster(
                                                     0,
                                                 ),
@@ -395,7 +287,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        1,
+                                        0,
                                         Cluster(
                                             0,
                                         ),
@@ -408,7 +300,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    1,
+                                    0,
                                     Cluster(
                                         0,
                                     ),
@@ -424,11 +316,11 @@ expression: built.ir()
                                 first: DeferTick {
                                     input: CycleSource {
                                         ident: Ident {
-                                            sym: cycle_8,
+                                            sym: cycle_7,
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                1,
+                                                0,
                                                 Cluster(
                                                     0,
                                                 ),
@@ -441,7 +333,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            1,
+                                            0,
                                             Cluster(
                                                 0,
                                             ),
@@ -457,7 +349,7 @@ expression: built.ir()
                                         value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; 0 },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                1,
+                                                0,
                                                 Cluster(
                                                     0,
                                                 ),
@@ -470,7 +362,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            1,
+                                            0,
                                             Cluster(
                                                 0,
                                             ),
@@ -483,7 +375,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        1,
+                                        0,
                                         Cluster(
                                             0,
                                         ),
@@ -496,7 +388,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    1,
+                                    0,
                                     Cluster(
                                         0,
                                     ),
@@ -509,7 +401,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                1,
+                                0,
                                 Cluster(
                                     0,
                                 ),
@@ -522,7 +414,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            1,
+                            0,
                             Cluster(
                                 0,
                             ),
@@ -535,7 +427,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        1,
+                        0,
                         Cluster(
                             0,
                         ),
@@ -548,7 +440,7 @@ expression: built.ir()
             },
             metadata: HydroIrMetadata {
                 location_kind: Tick(
-                    1,
+                    0,
                     Cluster(
                         0,
                     ),
@@ -563,10 +455,10 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_6,
+            sym: cycle_5,
         },
         input: Tee {
-            inner: <tee 3>: Map {
+            inner: <tee 2>: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
                 input: Cast {
                     inner: Cast {
@@ -652,7 +544,7 @@ expression: built.ir()
                                                                     },
                                                                     metadata: HydroIrMetadata {
                                                                         location_kind: Tick(
-                                                                            5,
+                                                                            4,
                                                                             Cluster(
                                                                                 0,
                                                                             ),
@@ -666,7 +558,7 @@ expression: built.ir()
                                                                 },
                                                                 metadata: HydroIrMetadata {
                                                                     location_kind: Tick(
-                                                                        5,
+                                                                        4,
                                                                         Cluster(
                                                                             0,
                                                                         ),
@@ -680,7 +572,7 @@ expression: built.ir()
                                                             },
                                                             metadata: HydroIrMetadata {
                                                                 location_kind: Tick(
-                                                                    5,
+                                                                    4,
                                                                     Cluster(
                                                                         0,
                                                                     ),
@@ -696,7 +588,7 @@ expression: built.ir()
                                                         },
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Tick(
-                                                                5,
+                                                                4,
                                                                 Cluster(
                                                                     0,
                                                                 ),
@@ -711,7 +603,7 @@ expression: built.ir()
                                                     },
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Tick(
-                                                            5,
+                                                            4,
                                                             Cluster(
                                                                 0,
                                                             ),
@@ -726,7 +618,7 @@ expression: built.ir()
                                                 },
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
-                                                        5,
+                                                        4,
                                                         Cluster(
                                                             0,
                                                         ),
@@ -742,7 +634,7 @@ expression: built.ir()
                                             trusted: true,
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    5,
+                                                    4,
                                                     Cluster(
                                                         0,
                                                     ),
@@ -768,16 +660,16 @@ expression: built.ir()
                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , ()) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _signal) | d }),
                                                                             input: CrossSingleton {
                                                                                 left: Tee {
-                                                                                    inner: <tee 4>: Batch {
+                                                                                    inner: <tee 3>: Batch {
                                                                                         inner: YieldConcat {
                                                                                             inner: Tee {
-                                                                                                inner: <tee 5>: Map {
+                                                                                                inner: <tee 4>: Map {
                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < u32 , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless ((__hydro_lang_cluster_self_id_0) . clone ()) ; move | num | Ballot { num , proposer_id : CLUSTER_SELF_ID__free . clone () } }),
                                                                                                     input: Tee {
-                                                                                                        inner: <tee 1>,
+                                                                                                        inner: <tee 0>,
                                                                                                         metadata: HydroIrMetadata {
                                                                                                             location_kind: Tick(
-                                                                                                                1,
+                                                                                                                0,
                                                                                                                 Cluster(
                                                                                                                     0,
                                                                                                                 ),
@@ -790,7 +682,7 @@ expression: built.ir()
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
                                                                                                         location_kind: Tick(
-                                                                                                            1,
+                                                                                                            0,
                                                                                                             Cluster(
                                                                                                                 0,
                                                                                                             ),
@@ -803,7 +695,7 @@ expression: built.ir()
                                                                                                 },
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_kind: Tick(
-                                                                                                        1,
+                                                                                                        0,
                                                                                                         Cluster(
                                                                                                             0,
                                                                                                         ),
@@ -817,7 +709,7 @@ expression: built.ir()
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_kind: Atomic(
                                                                                                     Tick(
-                                                                                                        1,
+                                                                                                        0,
                                                                                                         Cluster(
                                                                                                             0,
                                                                                                         ),
@@ -831,7 +723,7 @@ expression: built.ir()
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
                                                                                             location_kind: Tick(
-                                                                                                1,
+                                                                                                0,
                                                                                                 Cluster(
                                                                                                     0,
                                                                                                 ),
@@ -844,7 +736,7 @@ expression: built.ir()
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_kind: Tick(
-                                                                                            1,
+                                                                                            0,
                                                                                             Cluster(
                                                                                                 0,
                                                                                             ),
@@ -858,13 +750,13 @@ expression: built.ir()
                                                                                 right: Map {
                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _u | () }),
                                                                                     input: Tee {
-                                                                                        inner: <tee 6>: CycleSource {
+                                                                                        inner: <tee 5>: CycleSource {
                                                                                             ident: Ident {
-                                                                                                sym: cycle_7,
+                                                                                                sym: cycle_6,
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_kind: Tick(
-                                                                                                    1,
+                                                                                                    0,
                                                                                                     Cluster(
                                                                                                         0,
                                                                                                     ),
@@ -877,7 +769,7 @@ expression: built.ir()
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
                                                                                             location_kind: Tick(
-                                                                                                1,
+                                                                                                0,
                                                                                                 Cluster(
                                                                                                     0,
                                                                                                 ),
@@ -890,7 +782,7 @@ expression: built.ir()
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_kind: Tick(
-                                                                                            1,
+                                                                                            0,
                                                                                             Cluster(
                                                                                                 0,
                                                                                             ),
@@ -903,7 +795,7 @@ expression: built.ir()
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_kind: Tick(
-                                                                                        1,
+                                                                                        0,
                                                                                         Cluster(
                                                                                             0,
                                                                                         ),
@@ -916,7 +808,7 @@ expression: built.ir()
                                                                             },
                                                                             metadata: HydroIrMetadata {
                                                                                 location_kind: Tick(
-                                                                                    1,
+                                                                                    0,
                                                                                     Cluster(
                                                                                         0,
                                                                                     ),
@@ -939,7 +831,7 @@ expression: built.ir()
                                                                     },
                                                                     metadata: HydroIrMetadata {
                                                                         location_kind: Tick(
-                                                                            4,
+                                                                            3,
                                                                             Cluster(
                                                                                 0,
                                                                             ),
@@ -973,7 +865,7 @@ expression: built.ir()
                                                                             },
                                                                             metadata: HydroIrMetadata {
                                                                                 location_kind: Tick(
-                                                                                    4,
+                                                                                    3,
                                                                                     Cluster(
                                                                                         0,
                                                                                     ),
@@ -988,7 +880,7 @@ expression: built.ir()
                                                                         },
                                                                         metadata: HydroIrMetadata {
                                                                             location_kind: Tick(
-                                                                                4,
+                                                                                3,
                                                                                 Cluster(
                                                                                     0,
                                                                                 ),
@@ -1001,7 +893,7 @@ expression: built.ir()
                                                                     },
                                                                     metadata: HydroIrMetadata {
                                                                         location_kind: Tick(
-                                                                            4,
+                                                                            3,
                                                                             Cluster(
                                                                                 0,
                                                                             ),
@@ -1014,7 +906,7 @@ expression: built.ir()
                                                                 },
                                                                 metadata: HydroIrMetadata {
                                                                     location_kind: Tick(
-                                                                        4,
+                                                                        3,
                                                                         Cluster(
                                                                             0,
                                                                         ),
@@ -1027,7 +919,7 @@ expression: built.ir()
                                                             },
                                                             metadata: HydroIrMetadata {
                                                                 location_kind: Tick(
-                                                                    4,
+                                                                    3,
                                                                     Cluster(
                                                                         0,
                                                                     ),
@@ -1040,7 +932,7 @@ expression: built.ir()
                                                         },
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Tick(
-                                                                4,
+                                                                3,
                                                                 Cluster(
                                                                     0,
                                                                 ),
@@ -1079,7 +971,7 @@ expression: built.ir()
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    5,
+                                                    4,
                                                     Cluster(
                                                         0,
                                                     ),
@@ -1094,7 +986,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                5,
+                                                4,
                                                 Cluster(
                                                     0,
                                                 ),
@@ -1109,7 +1001,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            5,
+                                            4,
                                             Cluster(
                                                 0,
                                             ),
@@ -1201,19 +1093,19 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_9,
+            sym: cycle_8,
         },
         input: AntiJoin {
             pos: Tee {
-                inner: <tee 7>: Chain {
+                inner: <tee 6>: Chain {
                     first: DeferTick {
                         input: CycleSource {
                             ident: Ident {
-                                sym: cycle_9,
+                                sym: cycle_8,
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    8,
+                                    7,
                                     Cluster(
                                         0,
                                     ),
@@ -1228,7 +1120,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                8,
+                                7,
                                 Cluster(
                                     0,
                                 ),
@@ -1243,7 +1135,7 @@ expression: built.ir()
                     },
                     second: Batch {
                         inner: Tee {
-                            inner: <tee 8>: Inspect {
+                            inner: <tee 7>: Inspect {
                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | p1b | println ! ("Proposer received P1b: {:?}" , p1b) }),
                                 input: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
@@ -1264,7 +1156,7 @@ expression: built.ir()
                                                             input: CrossSingleton {
                                                                 left: CrossSingleton {
                                                                     left: Tee {
-                                                                        inner: <tee 9>: Batch {
+                                                                        inner: <tee 8>: Batch {
                                                                             inner: Map {
                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
                                                                                 input: Cast {
@@ -1350,7 +1242,7 @@ expression: built.ir()
                                                                                                                                 },
                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                     location_kind: Tick(
-                                                                                                                                        7,
+                                                                                                                                        6,
                                                                                                                                         Cluster(
                                                                                                                                             0,
                                                                                                                                         ),
@@ -1364,7 +1256,7 @@ expression: built.ir()
                                                                                                                             },
                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                 location_kind: Tick(
-                                                                                                                                    7,
+                                                                                                                                    6,
                                                                                                                                     Cluster(
                                                                                                                                         0,
                                                                                                                                     ),
@@ -1378,7 +1270,7 @@ expression: built.ir()
                                                                                                                         },
                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                             location_kind: Tick(
-                                                                                                                                7,
+                                                                                                                                6,
                                                                                                                                 Cluster(
                                                                                                                                     0,
                                                                                                                                 ),
@@ -1394,7 +1286,7 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                         location_kind: Tick(
-                                                                                                                            7,
+                                                                                                                            6,
                                                                                                                             Cluster(
                                                                                                                                 0,
                                                                                                                             ),
@@ -1409,7 +1301,7 @@ expression: built.ir()
                                                                                                                 },
                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                     location_kind: Tick(
-                                                                                                                        7,
+                                                                                                                        6,
                                                                                                                         Cluster(
                                                                                                                             0,
                                                                                                                         ),
@@ -1425,7 +1317,7 @@ expression: built.ir()
                                                                                                             trusted: true,
                                                                                                             metadata: HydroIrMetadata {
                                                                                                                 location_kind: Tick(
-                                                                                                                    7,
+                                                                                                                    6,
                                                                                                                     Cluster(
                                                                                                                         0,
                                                                                                                     ),
@@ -1447,10 +1339,10 @@ expression: built.ir()
                                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , ()) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _signal) | d }),
                                                                                                                             input: CrossSingleton {
                                                                                                                                 left: Tee {
-                                                                                                                                    inner: <tee 4>,
+                                                                                                                                    inner: <tee 3>,
                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                         location_kind: Tick(
-                                                                                                                                            1,
+                                                                                                                                            0,
                                                                                                                                             Cluster(
                                                                                                                                                 0,
                                                                                                                                             ),
@@ -1480,7 +1372,7 @@ expression: built.ir()
                                                                                                                                                                         input: ObserveNonDet {
                                                                                                                                                                             inner: ObserveNonDet {
                                                                                                                                                                                 inner: Tee {
-                                                                                                                                                                                    inner: <tee 3>,
+                                                                                                                                                                                    inner: <tee 2>,
                                                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                                                         location_kind: Cluster(
                                                                                                                                                                                             0,
@@ -1531,7 +1423,7 @@ expression: built.ir()
                                                                                                                                                                     },
                                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                                         location_kind: Tick(
-                                                                                                                                                                            6,
+                                                                                                                                                                            5,
                                                                                                                                                                             Cluster(
                                                                                                                                                                                 0,
                                                                                                                                                                             ),
@@ -1544,7 +1436,7 @@ expression: built.ir()
                                                                                                                                                                 },
                                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                                     location_kind: Tick(
-                                                                                                                                                                        6,
+                                                                                                                                                                        5,
                                                                                                                                                                         Cluster(
                                                                                                                                                                             0,
                                                                                                                                                                         ),
@@ -1567,7 +1459,7 @@ expression: built.ir()
                                                                                                                                                         },
                                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                                             location_kind: Tick(
-                                                                                                                                                                1,
+                                                                                                                                                                0,
                                                                                                                                                                 Cluster(
                                                                                                                                                                     0,
                                                                                                                                                                 ),
@@ -1589,10 +1481,10 @@ expression: built.ir()
                                                                                                                                                                         input: Map {
                                                                                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                                                                                                                                             input: Tee {
-                                                                                                                                                                                inner: <tee 6>,
+                                                                                                                                                                                inner: <tee 5>,
                                                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                                                     location_kind: Tick(
-                                                                                                                                                                                        1,
+                                                                                                                                                                                        0,
                                                                                                                                                                                         Cluster(
                                                                                                                                                                                             0,
                                                                                                                                                                                         ),
@@ -1605,7 +1497,7 @@ expression: built.ir()
                                                                                                                                                                             },
                                                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                                                 location_kind: Tick(
-                                                                                                                                                                                    1,
+                                                                                                                                                                                    0,
                                                                                                                                                                                     Cluster(
                                                                                                                                                                                         0,
                                                                                                                                                                                     ),
@@ -1618,7 +1510,7 @@ expression: built.ir()
                                                                                                                                                                         },
                                                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                                                             location_kind: Tick(
-                                                                                                                                                                                1,
+                                                                                                                                                                                0,
                                                                                                                                                                                 Cluster(
                                                                                                                                                                                     0,
                                                                                                                                                                                 ),
@@ -1634,7 +1526,7 @@ expression: built.ir()
                                                                                                                                                                             value: :: std :: option :: Option :: None,
                                                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                                                 location_kind: Tick(
-                                                                                                                                                                                    1,
+                                                                                                                                                                                    0,
                                                                                                                                                                                     Cluster(
                                                                                                                                                                                         0,
                                                                                                                                                                                     ),
@@ -1647,7 +1539,7 @@ expression: built.ir()
                                                                                                                                                                         },
                                                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                                                             location_kind: Tick(
-                                                                                                                                                                                1,
+                                                                                                                                                                                0,
                                                                                                                                                                                 Cluster(
                                                                                                                                                                                     0,
                                                                                                                                                                                 ),
@@ -1660,7 +1552,7 @@ expression: built.ir()
                                                                                                                                                                     },
                                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                                         location_kind: Tick(
-                                                                                                                                                                            1,
+                                                                                                                                                                            0,
                                                                                                                                                                             Cluster(
                                                                                                                                                                                 0,
                                                                                                                                                                             ),
@@ -1673,7 +1565,7 @@ expression: built.ir()
                                                                                                                                                                 },
                                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                                     location_kind: Tick(
-                                                                                                                                                                        1,
+                                                                                                                                                                        0,
                                                                                                                                                                         Cluster(
                                                                                                                                                                             0,
                                                                                                                                                                         ),
@@ -1686,7 +1578,7 @@ expression: built.ir()
                                                                                                                                                             },
                                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                                 location_kind: Tick(
-                                                                                                                                                                    1,
+                                                                                                                                                                    0,
                                                                                                                                                                     Cluster(
                                                                                                                                                                         0,
                                                                                                                                                                     ),
@@ -1699,7 +1591,7 @@ expression: built.ir()
                                                                                                                                                         },
                                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                                             location_kind: Tick(
-                                                                                                                                                                1,
+                                                                                                                                                                0,
                                                                                                                                                                 Cluster(
                                                                                                                                                                     0,
                                                                                                                                                                 ),
@@ -1712,7 +1604,7 @@ expression: built.ir()
                                                                                                                                                     },
                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                         location_kind: Tick(
-                                                                                                                                                            1,
+                                                                                                                                                            0,
                                                                                                                                                             Cluster(
                                                                                                                                                                 0,
                                                                                                                                                             ),
@@ -1725,7 +1617,7 @@ expression: built.ir()
                                                                                                                                                 },
                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                     location_kind: Tick(
-                                                                                                                                                        1,
+                                                                                                                                                        0,
                                                                                                                                                         Cluster(
                                                                                                                                                             0,
                                                                                                                                                         ),
@@ -1759,7 +1651,7 @@ expression: built.ir()
                                                                                                                                                         },
                                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                                             location_kind: Tick(
-                                                                                                                                                                1,
+                                                                                                                                                                0,
                                                                                                                                                                 Cluster(
                                                                                                                                                                     0,
                                                                                                                                                                 ),
@@ -1774,7 +1666,7 @@ expression: built.ir()
                                                                                                                                                     },
                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                         location_kind: Tick(
-                                                                                                                                                            1,
+                                                                                                                                                            0,
                                                                                                                                                             Cluster(
                                                                                                                                                                 0,
                                                                                                                                                             ),
@@ -1787,7 +1679,7 @@ expression: built.ir()
                                                                                                                                                 },
                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                     location_kind: Tick(
-                                                                                                                                                        1,
+                                                                                                                                                        0,
                                                                                                                                                         Cluster(
                                                                                                                                                             0,
                                                                                                                                                         ),
@@ -1800,7 +1692,7 @@ expression: built.ir()
                                                                                                                                             },
                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                 location_kind: Tick(
-                                                                                                                                                    1,
+                                                                                                                                                    0,
                                                                                                                                                     Cluster(
                                                                                                                                                         0,
                                                                                                                                                     ),
@@ -1813,7 +1705,7 @@ expression: built.ir()
                                                                                                                                         },
                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                             location_kind: Tick(
-                                                                                                                                                1,
+                                                                                                                                                0,
                                                                                                                                                 Cluster(
                                                                                                                                                     0,
                                                                                                                                                 ),
@@ -1826,7 +1718,7 @@ expression: built.ir()
                                                                                                                                     },
                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                         location_kind: Tick(
-                                                                                                                                            1,
+                                                                                                                                            0,
                                                                                                                                             Cluster(
                                                                                                                                                 0,
                                                                                                                                             ),
@@ -1839,7 +1731,7 @@ expression: built.ir()
                                                                                                                                 },
                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                     location_kind: Tick(
-                                                                                                                                        1,
+                                                                                                                                        0,
                                                                                                                                         Cluster(
                                                                                                                                             0,
                                                                                                                                         ),
@@ -1852,7 +1744,7 @@ expression: built.ir()
                                                                                                                             },
                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                 location_kind: Tick(
-                                                                                                                                    1,
+                                                                                                                                    0,
                                                                                                                                     Cluster(
                                                                                                                                         0,
                                                                                                                                     ),
@@ -1865,7 +1757,7 @@ expression: built.ir()
                                                                                                                         },
                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                             location_kind: Tick(
-                                                                                                                                1,
+                                                                                                                                0,
                                                                                                                                 Cluster(
                                                                                                                                     0,
                                                                                                                                 ),
@@ -1904,7 +1796,7 @@ expression: built.ir()
                                                                                                             },
                                                                                                             metadata: HydroIrMetadata {
                                                                                                                 location_kind: Tick(
-                                                                                                                    7,
+                                                                                                                    6,
                                                                                                                     Cluster(
                                                                                                                         0,
                                                                                                                     ),
@@ -1919,7 +1811,7 @@ expression: built.ir()
                                                                                                         },
                                                                                                         metadata: HydroIrMetadata {
                                                                                                             location_kind: Tick(
-                                                                                                                7,
+                                                                                                                6,
                                                                                                                 Cluster(
                                                                                                                     0,
                                                                                                                 ),
@@ -1934,7 +1826,7 @@ expression: built.ir()
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
                                                                                                         location_kind: Tick(
-                                                                                                            7,
+                                                                                                            6,
                                                                                                             Cluster(
                                                                                                                 0,
                                                                                                             ),
@@ -2012,7 +1904,7 @@ expression: built.ir()
                                                                             },
                                                                             metadata: HydroIrMetadata {
                                                                                 location_kind: Tick(
-                                                                                    2,
+                                                                                    1,
                                                                                     Cluster(
                                                                                         1,
                                                                                     ),
@@ -2027,7 +1919,7 @@ expression: built.ir()
                                                                         },
                                                                         metadata: HydroIrMetadata {
                                                                             location_kind: Tick(
-                                                                                2,
+                                                                                1,
                                                                                 Cluster(
                                                                                     1,
                                                                                 ),
@@ -2042,7 +1934,7 @@ expression: built.ir()
                                                                     },
                                                                     right: Cast {
                                                                         inner: Tee {
-                                                                            inner: <tee 10>: Cast {
+                                                                            inner: <tee 9>: Cast {
                                                                                 inner: ChainFirst {
                                                                                     first: Batch {
                                                                                         inner: Reduce {
@@ -2052,10 +1944,10 @@ expression: built.ir()
                                                                                                     inner: Inspect {
                                                                                                         f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | p1a | println ! ("Acceptor received P1a: {:?}" , p1a) }),
                                                                                                         input: Tee {
-                                                                                                            inner: <tee 9>,
+                                                                                                            inner: <tee 8>,
                                                                                                             metadata: HydroIrMetadata {
                                                                                                                 location_kind: Tick(
-                                                                                                                    2,
+                                                                                                                    1,
                                                                                                                     Cluster(
                                                                                                                         1,
                                                                                                                     ),
@@ -2070,7 +1962,7 @@ expression: built.ir()
                                                                                                         },
                                                                                                         metadata: HydroIrMetadata {
                                                                                                             location_kind: Tick(
-                                                                                                                2,
+                                                                                                                1,
                                                                                                                 Cluster(
                                                                                                                     1,
                                                                                                                 ),
@@ -2086,7 +1978,7 @@ expression: built.ir()
                                                                                                     metadata: HydroIrMetadata {
                                                                                                         location_kind: Atomic(
                                                                                                             Tick(
-                                                                                                                2,
+                                                                                                                1,
                                                                                                                 Cluster(
                                                                                                                     1,
                                                                                                                 ),
@@ -2104,7 +1996,7 @@ expression: built.ir()
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_kind: Atomic(
                                                                                                         Tick(
-                                                                                                            2,
+                                                                                                            1,
                                                                                                             Cluster(
                                                                                                                 1,
                                                                                                             ),
@@ -2121,7 +2013,7 @@ expression: built.ir()
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_kind: Atomic(
                                                                                                     Tick(
-                                                                                                        2,
+                                                                                                        1,
                                                                                                         Cluster(
                                                                                                             1,
                                                                                                         ),
@@ -2135,7 +2027,7 @@ expression: built.ir()
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
                                                                                             location_kind: Tick(
-                                                                                                2,
+                                                                                                1,
                                                                                                 Cluster(
                                                                                                     1,
                                                                                                 ),
@@ -2151,7 +2043,7 @@ expression: built.ir()
                                                                                             value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; Ballot { num : 0 , proposer_id : MemberId :: from_raw_id (0) } },
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_kind: Tick(
-                                                                                                    2,
+                                                                                                    1,
                                                                                                     Cluster(
                                                                                                         1,
                                                                                                     ),
@@ -2164,7 +2056,7 @@ expression: built.ir()
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
                                                                                             location_kind: Tick(
-                                                                                                2,
+                                                                                                1,
                                                                                                 Cluster(
                                                                                                     1,
                                                                                                 ),
@@ -2177,7 +2069,7 @@ expression: built.ir()
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_kind: Tick(
-                                                                                            2,
+                                                                                            1,
                                                                                             Cluster(
                                                                                                 1,
                                                                                             ),
@@ -2190,7 +2082,7 @@ expression: built.ir()
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_kind: Tick(
-                                                                                        2,
+                                                                                        1,
                                                                                         Cluster(
                                                                                             1,
                                                                                         ),
@@ -2203,7 +2095,7 @@ expression: built.ir()
                                                                             },
                                                                             metadata: HydroIrMetadata {
                                                                                 location_kind: Tick(
-                                                                                    2,
+                                                                                    1,
                                                                                     Cluster(
                                                                                         1,
                                                                                     ),
@@ -2216,7 +2108,7 @@ expression: built.ir()
                                                                         },
                                                                         metadata: HydroIrMetadata {
                                                                             location_kind: Tick(
-                                                                                2,
+                                                                                1,
                                                                                 Cluster(
                                                                                     1,
                                                                                 ),
@@ -2229,7 +2121,7 @@ expression: built.ir()
                                                                     },
                                                                     metadata: HydroIrMetadata {
                                                                         location_kind: Tick(
-                                                                            2,
+                                                                            1,
                                                                             Cluster(
                                                                                 1,
                                                                             ),
@@ -2245,11 +2137,11 @@ expression: built.ir()
                                                                 right: Cast {
                                                                     inner: CycleSource {
                                                                         ident: Ident {
-                                                                            sym: cycle_4,
+                                                                            sym: cycle_3,
                                                                         },
                                                                         metadata: HydroIrMetadata {
                                                                             location_kind: Tick(
-                                                                                2,
+                                                                                1,
                                                                                 Cluster(
                                                                                     1,
                                                                                 ),
@@ -2262,7 +2154,7 @@ expression: built.ir()
                                                                     },
                                                                     metadata: HydroIrMetadata {
                                                                         location_kind: Tick(
-                                                                            2,
+                                                                            1,
                                                                             Cluster(
                                                                                 1,
                                                                             ),
@@ -2275,7 +2167,7 @@ expression: built.ir()
                                                                 },
                                                                 metadata: HydroIrMetadata {
                                                                     location_kind: Tick(
-                                                                        2,
+                                                                        1,
                                                                         Cluster(
                                                                             1,
                                                                         ),
@@ -2290,7 +2182,7 @@ expression: built.ir()
                                                             },
                                                             metadata: HydroIrMetadata {
                                                                 location_kind: Tick(
-                                                                    2,
+                                                                    1,
                                                                     Cluster(
                                                                         1,
                                                                     ),
@@ -2403,7 +2295,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                8,
+                                7,
                                 Cluster(
                                     0,
                                 ),
@@ -2418,7 +2310,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            8,
+                            7,
                             Cluster(
                                 0,
                             ),
@@ -2433,7 +2325,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        8,
+                        7,
                         Cluster(
                             0,
                         ),
@@ -2447,23 +2339,23 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <tee 11>: Map {
+                inner: <tee 10>: Map {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
                     input: Cast {
                         inner: Cast {
                             inner: Filter {
                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < (usize , usize) , bool > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; let max__free = 3usize ; move | (success , error) | (success + error) >= max__free }) ; { let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) } }),
                                 input: Tee {
-                                    inner: <tee 12>: FoldKeyed {
+                                    inner: <tee 11>: FoldKeyed {
                                         init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | | (0 , 0) }),
                                         acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } } }),
                                         input: ObserveNonDet {
                                             inner: Cast {
                                                 inner: Tee {
-                                                    inner: <tee 7>,
+                                                    inner: <tee 6>,
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Tick(
-                                                            8,
+                                                            7,
                                                             Cluster(
                                                                 0,
                                                             ),
@@ -2478,7 +2370,7 @@ expression: built.ir()
                                                 },
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
-                                                        8,
+                                                        7,
                                                         Cluster(
                                                             0,
                                                         ),
@@ -2495,7 +2387,7 @@ expression: built.ir()
                                             trusted: false,
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    8,
+                                                    7,
                                                     Cluster(
                                                         0,
                                                     ),
@@ -2511,7 +2403,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                8,
+                                                7,
                                                 Cluster(
                                                     0,
                                                 ),
@@ -2525,7 +2417,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            8,
+                                            7,
                                             Cluster(
                                                 0,
                                             ),
@@ -2539,7 +2431,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        8,
+                                        7,
                                         Cluster(
                                             0,
                                         ),
@@ -2553,7 +2445,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    8,
+                                    7,
                                     Cluster(
                                         0,
                                     ),
@@ -2569,7 +2461,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                8,
+                                7,
                                 Cluster(
                                     0,
                                 ),
@@ -2584,7 +2476,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            8,
+                            7,
                             Cluster(
                                 0,
                             ),
@@ -2599,7 +2491,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        8,
+                        7,
                         Cluster(
                             0,
                         ),
@@ -2614,7 +2506,7 @@ expression: built.ir()
             },
             metadata: HydroIrMetadata {
                 location_kind: Tick(
-                    8,
+                    7,
                     Cluster(
                         0,
                     ),
@@ -2631,7 +2523,7 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_10,
+            sym: cycle_9,
         },
         input: Difference {
             pos: Map {
@@ -2641,10 +2533,10 @@ expression: built.ir()
                         inner: Filter {
                             f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < (usize , usize) , bool > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; let min__free = 2usize ; move | (success , _error) | success >= & min__free }) ; { let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) } }),
                             input: Tee {
-                                inner: <tee 12>,
+                                inner: <tee 11>,
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        8,
+                                        7,
                                         Cluster(
                                             0,
                                         ),
@@ -2658,7 +2550,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    8,
+                                    7,
                                     Cluster(
                                         0,
                                     ),
@@ -2672,7 +2564,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                8,
+                                7,
                                 Cluster(
                                     0,
                                 ),
@@ -2688,7 +2580,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            8,
+                            7,
                             Cluster(
                                 0,
                             ),
@@ -2703,7 +2595,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        8,
+                        7,
                         Cluster(
                             0,
                         ),
@@ -2717,10 +2609,10 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <tee 11>,
+                inner: <tee 10>,
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        8,
+                        7,
                         Cluster(
                             0,
                         ),
@@ -2735,7 +2627,7 @@ expression: built.ir()
             },
             metadata: HydroIrMetadata {
                 location_kind: Tick(
-                    8,
+                    7,
                     Cluster(
                         0,
                     ),
@@ -2752,16 +2644,16 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_7,
+            sym: cycle_6,
         },
         input: Tee {
-            inner: <tee 13>: Map {
+            inner: <tee 12>: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (() , ()) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | (d , _signal) | d }),
                 input: CrossSingleton {
                     left: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | _ | () }),
                         input: Tee {
-                            inner: <tee 14>: FilterMap {
+                            inner: <tee 13>: FilterMap {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < ((hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) >) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; move | ((quorum_ballot , quorum_accepted) , my_ballot) | if quorum_ballot == my_ballot { Some (quorum_accepted) } else { None } }),
                                 input: CrossSingleton {
                                     left: Batch {
@@ -2784,10 +2676,10 @@ expression: built.ir()
                                                                                     input: AntiJoin {
                                                                                         pos: AntiJoin {
                                                                                             pos: Tee {
-                                                                                                inner: <tee 7>,
+                                                                                                inner: <tee 6>,
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_kind: Tick(
-                                                                                                        8,
+                                                                                                        7,
                                                                                                         Cluster(
                                                                                                             0,
                                                                                                         ),
@@ -2807,10 +2699,10 @@ expression: built.ir()
                                                                                                         inner: Filter {
                                                                                                             f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < (usize , usize) , bool > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; let min__free = 2usize ; move | (success , _error) | success < & min__free }) ; { let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) } }),
                                                                                                             input: Tee {
-                                                                                                                inner: <tee 12>,
+                                                                                                                inner: <tee 11>,
                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                     location_kind: Tick(
-                                                                                                                        8,
+                                                                                                                        7,
                                                                                                                         Cluster(
                                                                                                                             0,
                                                                                                                         ),
@@ -2824,7 +2716,7 @@ expression: built.ir()
                                                                                                             },
                                                                                                             metadata: HydroIrMetadata {
                                                                                                                 location_kind: Tick(
-                                                                                                                    8,
+                                                                                                                    7,
                                                                                                                     Cluster(
                                                                                                                         0,
                                                                                                                     ),
@@ -2838,7 +2730,7 @@ expression: built.ir()
                                                                                                         },
                                                                                                         metadata: HydroIrMetadata {
                                                                                                             location_kind: Tick(
-                                                                                                                8,
+                                                                                                                7,
                                                                                                                 Cluster(
                                                                                                                     0,
                                                                                                                 ),
@@ -2854,7 +2746,7 @@ expression: built.ir()
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
                                                                                                         location_kind: Tick(
-                                                                                                            8,
+                                                                                                            7,
                                                                                                             Cluster(
                                                                                                                 0,
                                                                                                             ),
@@ -2869,7 +2761,7 @@ expression: built.ir()
                                                                                                 },
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_kind: Tick(
-                                                                                                        8,
+                                                                                                        7,
                                                                                                         Cluster(
                                                                                                             0,
                                                                                                         ),
@@ -2884,7 +2776,7 @@ expression: built.ir()
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_kind: Tick(
-                                                                                                    8,
+                                                                                                    7,
                                                                                                     Cluster(
                                                                                                         0,
                                                                                                     ),
@@ -2900,11 +2792,11 @@ expression: built.ir()
                                                                                         neg: DeferTick {
                                                                                             input: CycleSource {
                                                                                                 ident: Ident {
-                                                                                                    sym: cycle_10,
+                                                                                                    sym: cycle_9,
                                                                                                 },
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_kind: Tick(
-                                                                                                        8,
+                                                                                                        7,
                                                                                                         Cluster(
                                                                                                             0,
                                                                                                         ),
@@ -2919,7 +2811,7 @@ expression: built.ir()
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_kind: Tick(
-                                                                                                    8,
+                                                                                                    7,
                                                                                                     Cluster(
                                                                                                         0,
                                                                                                     ),
@@ -2934,7 +2826,7 @@ expression: built.ir()
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
                                                                                             location_kind: Tick(
-                                                                                                8,
+                                                                                                7,
                                                                                                 Cluster(
                                                                                                     0,
                                                                                                 ),
@@ -2949,7 +2841,7 @@ expression: built.ir()
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_kind: Tick(
-                                                                                            8,
+                                                                                            7,
                                                                                             Cluster(
                                                                                                 0,
                                                                                             ),
@@ -3087,7 +2979,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                1,
+                                                0,
                                                 Cluster(
                                                     0,
                                                 ),
@@ -3100,10 +2992,10 @@ expression: built.ir()
                                     },
                                     right: Cast {
                                         inner: Tee {
-                                            inner: <tee 4>,
+                                            inner: <tee 3>,
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    1,
+                                                    0,
                                                     Cluster(
                                                         0,
                                                     ),
@@ -3116,7 +3008,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                1,
+                                                0,
                                                 Cluster(
                                                     0,
                                                 ),
@@ -3129,7 +3021,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            1,
+                                            0,
                                             Cluster(
                                                 0,
                                             ),
@@ -3142,7 +3034,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        1,
+                                        0,
                                         Cluster(
                                             0,
                                         ),
@@ -3155,7 +3047,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    1,
+                                    0,
                                     Cluster(
                                         0,
                                     ),
@@ -3168,7 +3060,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                1,
+                                0,
                                 Cluster(
                                     0,
                                 ),
@@ -3182,7 +3074,7 @@ expression: built.ir()
                     right: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _u | () }),
                         input: Tee {
-                            inner: <tee 15>: Batch {
+                            inner: <tee 14>: Batch {
                                 inner: YieldConcat {
                                     inner: Map {
                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | _ | () }),
@@ -3191,10 +3083,10 @@ expression: built.ir()
                                             input: Cast {
                                                 inner: CrossSingleton {
                                                     left: Tee {
-                                                        inner: <tee 2>,
+                                                        inner: <tee 1>,
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Tick(
-                                                                1,
+                                                                0,
                                                                 Cluster(
                                                                     0,
                                                                 ),
@@ -3206,10 +3098,10 @@ expression: built.ir()
                                                         },
                                                     },
                                                     right: Tee {
-                                                        inner: <tee 5>,
+                                                        inner: <tee 4>,
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Tick(
-                                                                1,
+                                                                0,
                                                                 Cluster(
                                                                     0,
                                                                 ),
@@ -3222,7 +3114,7 @@ expression: built.ir()
                                                     },
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Tick(
-                                                            1,
+                                                            0,
                                                             Cluster(
                                                                 0,
                                                             ),
@@ -3235,7 +3127,7 @@ expression: built.ir()
                                                 },
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
-                                                        1,
+                                                        0,
                                                         Cluster(
                                                             0,
                                                         ),
@@ -3248,7 +3140,7 @@ expression: built.ir()
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    1,
+                                                    0,
                                                     Cluster(
                                                         0,
                                                     ),
@@ -3261,7 +3153,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                1,
+                                                0,
                                                 Cluster(
                                                     0,
                                                 ),
@@ -3275,7 +3167,7 @@ expression: built.ir()
                                     metadata: HydroIrMetadata {
                                         location_kind: Atomic(
                                             Tick(
-                                                1,
+                                                0,
                                                 Cluster(
                                                     0,
                                                 ),
@@ -3289,7 +3181,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        1,
+                                        0,
                                         Cluster(
                                             0,
                                         ),
@@ -3302,7 +3194,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    1,
+                                    0,
                                     Cluster(
                                         0,
                                     ),
@@ -3315,7 +3207,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                1,
+                                0,
                                 Cluster(
                                     0,
                                 ),
@@ -3328,7 +3220,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            1,
+                            0,
                             Cluster(
                                 0,
                             ),
@@ -3341,7 +3233,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        1,
+                        0,
                         Cluster(
                             0,
                         ),
@@ -3354,7 +3246,7 @@ expression: built.ir()
             },
             metadata: HydroIrMetadata {
                 location_kind: Tick(
-                    1,
+                    0,
                     Cluster(
                         0,
                     ),
@@ -3369,14 +3261,14 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_5,
+            sym: cycle_4,
         },
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (_ , ballot) | ballot }),
             input: FilterMap {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | (key , res) | match res { Ok (_) => None , Err (e) => Some ((key , e)) , } }),
                 input: Tee {
-                    inner: <tee 8>,
+                    inner: <tee 7>,
                     metadata: HydroIrMetadata {
                         location_kind: Cluster(
                             0,
@@ -3417,21 +3309,21 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_11,
+            sym: cycle_10,
         },
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , ()) , hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | (d , _signal) | d }),
             input: CrossSingleton {
                 left: Tee {
-                    inner: <tee 16>: Chain {
+                    inner: <tee 15>: Chain {
                         first: DeferTick {
                             input: CycleSource {
                                 ident: Ident {
-                                    sym: cycle_11,
+                                    sym: cycle_10,
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        10,
+                                        9,
                                         Cluster(
                                             2,
                                         ),
@@ -3446,7 +3338,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    10,
+                                    9,
                                     Cluster(
                                         2,
                                     ),
@@ -3464,7 +3356,7 @@ expression: built.ir()
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , u32) , hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos_bench :: Client > :: from_tagless ((__hydro_lang_cluster_self_id_2) . clone ()) ; move | (key , value) | KvPayload { key , value : (CLUSTER_SELF_ID__free . clone () , value) } }),
                                 input: CycleSource {
                                     ident: Ident {
-                                        sym: cycle_1,
+                                        sym: cycle_0,
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Cluster(
@@ -3492,7 +3384,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    10,
+                                    9,
                                     Cluster(
                                         2,
                                     ),
@@ -3507,7 +3399,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                10,
+                                9,
                                 Cluster(
                                     2,
                                 ),
@@ -3522,7 +3414,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            10,
+                            9,
                             Cluster(
                                 2,
                             ),
@@ -3546,7 +3438,7 @@ expression: built.ir()
                                     input: Map {
                                         f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ | () }),
                                         input: Tee {
-                                            inner: <tee 17>: Batch {
+                                            inner: <tee 16>: Batch {
                                                 inner: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | ballot | ballot . proposer_id }),
                                                     input: Reduce {
@@ -3639,7 +3531,7 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                         location_kind: Tick(
-                                                                                                                            9,
+                                                                                                                            8,
                                                                                                                             Cluster(
                                                                                                                                 0,
                                                                                                                             ),
@@ -3653,7 +3545,7 @@ expression: built.ir()
                                                                                                                 },
                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                     location_kind: Tick(
-                                                                                                                        9,
+                                                                                                                        8,
                                                                                                                         Cluster(
                                                                                                                             0,
                                                                                                                         ),
@@ -3667,7 +3559,7 @@ expression: built.ir()
                                                                                                             },
                                                                                                             metadata: HydroIrMetadata {
                                                                                                                 location_kind: Tick(
-                                                                                                                    9,
+                                                                                                                    8,
                                                                                                                     Cluster(
                                                                                                                         0,
                                                                                                                     ),
@@ -3683,7 +3575,7 @@ expression: built.ir()
                                                                                                         },
                                                                                                         metadata: HydroIrMetadata {
                                                                                                             location_kind: Tick(
-                                                                                                                9,
+                                                                                                                8,
                                                                                                                 Cluster(
                                                                                                                     0,
                                                                                                                 ),
@@ -3698,7 +3590,7 @@ expression: built.ir()
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
                                                                                                         location_kind: Tick(
-                                                                                                            9,
+                                                                                                            8,
                                                                                                             Cluster(
                                                                                                                 0,
                                                                                                             ),
@@ -3714,7 +3606,7 @@ expression: built.ir()
                                                                                                 trusted: true,
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_kind: Tick(
-                                                                                                        9,
+                                                                                                        8,
                                                                                                         Cluster(
                                                                                                             0,
                                                                                                         ),
@@ -3734,10 +3626,10 @@ expression: built.ir()
                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , ()) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _signal) | d }),
                                                                                                             input: CrossSingleton {
                                                                                                                 left: Tee {
-                                                                                                                    inner: <tee 4>,
+                                                                                                                    inner: <tee 3>,
                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                         location_kind: Tick(
-                                                                                                                            1,
+                                                                                                                            0,
                                                                                                                             Cluster(
                                                                                                                                 0,
                                                                                                                             ),
@@ -3751,14 +3643,14 @@ expression: built.ir()
                                                                                                                 right: Map {
                                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _u | () }),
                                                                                                                     input: Tee {
-                                                                                                                        inner: <tee 18>: Map {
+                                                                                                                        inner: <tee 17>: Map {
                                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (() , ()) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | (d , _signal) | d }),
                                                                                                                             input: CrossSingleton {
                                                                                                                                 left: Tee {
-                                                                                                                                    inner: <tee 13>,
+                                                                                                                                    inner: <tee 12>,
                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                         location_kind: Tick(
-                                                                                                                                            1,
+                                                                                                                                            0,
                                                                                                                                             Cluster(
                                                                                                                                                 0,
                                                                                                                                             ),
@@ -3781,10 +3673,10 @@ expression: built.ir()
                                                                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                                                                                                                         input: DeferTick {
                                                                                                                                                             input: Tee {
-                                                                                                                                                                inner: <tee 13>,
+                                                                                                                                                                inner: <tee 12>,
                                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                                     location_kind: Tick(
-                                                                                                                                                                        1,
+                                                                                                                                                                        0,
                                                                                                                                                                         Cluster(
                                                                                                                                                                             0,
                                                                                                                                                                         ),
@@ -3797,7 +3689,7 @@ expression: built.ir()
                                                                                                                                                             },
                                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                                 location_kind: Tick(
-                                                                                                                                                                    1,
+                                                                                                                                                                    0,
                                                                                                                                                                     Cluster(
                                                                                                                                                                         0,
                                                                                                                                                                     ),
@@ -3810,7 +3702,7 @@ expression: built.ir()
                                                                                                                                                         },
                                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                                             location_kind: Tick(
-                                                                                                                                                                1,
+                                                                                                                                                                0,
                                                                                                                                                                 Cluster(
                                                                                                                                                                     0,
                                                                                                                                                                 ),
@@ -3823,7 +3715,7 @@ expression: built.ir()
                                                                                                                                                     },
                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                         location_kind: Tick(
-                                                                                                                                                            1,
+                                                                                                                                                            0,
                                                                                                                                                             Cluster(
                                                                                                                                                                 0,
                                                                                                                                                             ),
@@ -3839,7 +3731,7 @@ expression: built.ir()
                                                                                                                                                         value: :: std :: option :: Option :: None,
                                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                                             location_kind: Tick(
-                                                                                                                                                                1,
+                                                                                                                                                                0,
                                                                                                                                                                 Cluster(
                                                                                                                                                                     0,
                                                                                                                                                                 ),
@@ -3852,7 +3744,7 @@ expression: built.ir()
                                                                                                                                                     },
                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                         location_kind: Tick(
-                                                                                                                                                            1,
+                                                                                                                                                            0,
                                                                                                                                                             Cluster(
                                                                                                                                                                 0,
                                                                                                                                                             ),
@@ -3865,7 +3757,7 @@ expression: built.ir()
                                                                                                                                                 },
                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                     location_kind: Tick(
-                                                                                                                                                        1,
+                                                                                                                                                        0,
                                                                                                                                                         Cluster(
                                                                                                                                                             0,
                                                                                                                                                         ),
@@ -3878,7 +3770,7 @@ expression: built.ir()
                                                                                                                                             },
                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                 location_kind: Tick(
-                                                                                                                                                    1,
+                                                                                                                                                    0,
                                                                                                                                                     Cluster(
                                                                                                                                                         0,
                                                                                                                                                     ),
@@ -3891,7 +3783,7 @@ expression: built.ir()
                                                                                                                                         },
                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                             location_kind: Tick(
-                                                                                                                                                1,
+                                                                                                                                                0,
                                                                                                                                                 Cluster(
                                                                                                                                                     0,
                                                                                                                                                 ),
@@ -3904,7 +3796,7 @@ expression: built.ir()
                                                                                                                                     },
                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                         location_kind: Tick(
-                                                                                                                                            1,
+                                                                                                                                            0,
                                                                                                                                             Cluster(
                                                                                                                                                 0,
                                                                                                                                             ),
@@ -3917,7 +3809,7 @@ expression: built.ir()
                                                                                                                                 },
                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                     location_kind: Tick(
-                                                                                                                                        1,
+                                                                                                                                        0,
                                                                                                                                         Cluster(
                                                                                                                                             0,
                                                                                                                                         ),
@@ -3930,7 +3822,7 @@ expression: built.ir()
                                                                                                                             },
                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                 location_kind: Tick(
-                                                                                                                                    1,
+                                                                                                                                    0,
                                                                                                                                     Cluster(
                                                                                                                                         0,
                                                                                                                                     ),
@@ -3943,7 +3835,7 @@ expression: built.ir()
                                                                                                                         },
                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                             location_kind: Tick(
-                                                                                                                                1,
+                                                                                                                                0,
                                                                                                                                 Cluster(
                                                                                                                                     0,
                                                                                                                                 ),
@@ -3956,7 +3848,7 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                         location_kind: Tick(
-                                                                                                                            1,
+                                                                                                                            0,
                                                                                                                             Cluster(
                                                                                                                                 0,
                                                                                                                             ),
@@ -3969,7 +3861,7 @@ expression: built.ir()
                                                                                                                 },
                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                     location_kind: Tick(
-                                                                                                                        1,
+                                                                                                                        0,
                                                                                                                         Cluster(
                                                                                                                             0,
                                                                                                                         ),
@@ -3982,7 +3874,7 @@ expression: built.ir()
                                                                                                             },
                                                                                                             metadata: HydroIrMetadata {
                                                                                                                 location_kind: Tick(
-                                                                                                                    1,
+                                                                                                                    0,
                                                                                                                     Cluster(
                                                                                                                         0,
                                                                                                                     ),
@@ -3995,7 +3887,7 @@ expression: built.ir()
                                                                                                         },
                                                                                                         metadata: HydroIrMetadata {
                                                                                                             location_kind: Tick(
-                                                                                                                1,
+                                                                                                                0,
                                                                                                                 Cluster(
                                                                                                                     0,
                                                                                                                 ),
@@ -4022,7 +3914,7 @@ expression: built.ir()
                                                                                                 },
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_kind: Tick(
-                                                                                                        9,
+                                                                                                        8,
                                                                                                         Cluster(
                                                                                                             0,
                                                                                                         ),
@@ -4037,7 +3929,7 @@ expression: built.ir()
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_kind: Tick(
-                                                                                                    9,
+                                                                                                    8,
                                                                                                     Cluster(
                                                                                                         0,
                                                                                                     ),
@@ -4052,7 +3944,7 @@ expression: built.ir()
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
                                                                                             location_kind: Tick(
-                                                                                                9,
+                                                                                                8,
                                                                                                 Cluster(
                                                                                                     0,
                                                                                                 ),
@@ -4175,7 +4067,7 @@ expression: built.ir()
                                                 },
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
-                                                        10,
+                                                        9,
                                                         Cluster(
                                                             2,
                                                         ),
@@ -4188,7 +4080,7 @@ expression: built.ir()
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    10,
+                                                    9,
                                                     Cluster(
                                                         2,
                                                     ),
@@ -4201,7 +4093,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                10,
+                                                9,
                                                 Cluster(
                                                     2,
                                                 ),
@@ -4214,7 +4106,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            10,
+                                            9,
                                             Cluster(
                                                 2,
                                             ),
@@ -4230,7 +4122,7 @@ expression: built.ir()
                                         value: :: std :: option :: Option :: None,
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                10,
+                                                9,
                                                 Cluster(
                                                     2,
                                                 ),
@@ -4243,7 +4135,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            10,
+                                            9,
                                             Cluster(
                                                 2,
                                             ),
@@ -4256,7 +4148,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        10,
+                                        9,
                                         Cluster(
                                             2,
                                         ),
@@ -4269,7 +4161,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    10,
+                                    9,
                                     Cluster(
                                         2,
                                     ),
@@ -4282,7 +4174,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                10,
+                                9,
                                 Cluster(
                                     2,
                                 ),
@@ -4295,7 +4187,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            10,
+                            9,
                             Cluster(
                                 2,
                             ),
@@ -4308,7 +4200,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        10,
+                        9,
                         Cluster(
                             2,
                         ),
@@ -4323,7 +4215,7 @@ expression: built.ir()
             },
             metadata: HydroIrMetadata {
                 location_kind: Tick(
-                    10,
+                    9,
                     Cluster(
                         2,
                     ),
@@ -4340,18 +4232,18 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_12,
+            sym: cycle_11,
         },
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , usize) , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (num_payloads , base_slot) | base_slot + num_payloads }),
             input: Cast {
                 inner: CrossSingleton {
                     left: Tee {
-                        inner: <tee 19>: Fold {
+                        inner: <tee 18>: Fold {
                             init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | | 0usize }),
                             acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , (usize , hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) >) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | count , _ | * count += 1 }),
                             input: Tee {
-                                inner: <tee 20>: Map {
+                                inner: <tee 19>: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) >) , usize) , (usize , hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | ((index , payload) , base_slot) | (base_slot + index , payload) }),
                                     input: CrossSingleton {
                                         left: Enumerate {
@@ -4380,10 +4272,10 @@ expression: built.ir()
                                                                                             input: YieldConcat {
                                                                                                 inner: CrossSingleton {
                                                                                                     left: Tee {
-                                                                                                        inner: <tee 16>,
+                                                                                                        inner: <tee 15>,
                                                                                                         metadata: HydroIrMetadata {
                                                                                                             location_kind: Tick(
-                                                                                                                10,
+                                                                                                                9,
                                                                                                                 Cluster(
                                                                                                                     2,
                                                                                                                 ),
@@ -4397,10 +4289,10 @@ expression: built.ir()
                                                                                                         },
                                                                                                     },
                                                                                                     right: Tee {
-                                                                                                        inner: <tee 17>,
+                                                                                                        inner: <tee 16>,
                                                                                                         metadata: HydroIrMetadata {
                                                                                                             location_kind: Tick(
-                                                                                                                10,
+                                                                                                                9,
                                                                                                                 Cluster(
                                                                                                                     2,
                                                                                                                 ),
@@ -4413,7 +4305,7 @@ expression: built.ir()
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
                                                                                                         location_kind: Tick(
-                                                                                                            10,
+                                                                                                            9,
                                                                                                             Cluster(
                                                                                                                 2,
                                                                                                             ),
@@ -4527,7 +4419,7 @@ expression: built.ir()
                                                                 },
                                                                 metadata: HydroIrMetadata {
                                                                     location_kind: Tick(
-                                                                        1,
+                                                                        0,
                                                                         Cluster(
                                                                             0,
                                                                         ),
@@ -4543,10 +4435,10 @@ expression: built.ir()
                                                             right: Map {
                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _u | () }),
                                                                 input: Tee {
-                                                                    inner: <tee 13>,
+                                                                    inner: <tee 12>,
                                                                     metadata: HydroIrMetadata {
                                                                         location_kind: Tick(
-                                                                            1,
+                                                                            0,
                                                                             Cluster(
                                                                                 0,
                                                                             ),
@@ -4559,7 +4451,7 @@ expression: built.ir()
                                                                 },
                                                                 metadata: HydroIrMetadata {
                                                                     location_kind: Tick(
-                                                                        1,
+                                                                        0,
                                                                         Cluster(
                                                                             0,
                                                                         ),
@@ -4572,7 +4464,7 @@ expression: built.ir()
                                                             },
                                                             metadata: HydroIrMetadata {
                                                                 location_kind: Tick(
-                                                                    1,
+                                                                    0,
                                                                     Cluster(
                                                                         0,
                                                                     ),
@@ -4587,7 +4479,7 @@ expression: built.ir()
                                                         },
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Tick(
-                                                                1,
+                                                                0,
                                                                 Cluster(
                                                                     0,
                                                                 ),
@@ -4603,7 +4495,7 @@ expression: built.ir()
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Atomic(
                                                             Tick(
-                                                                1,
+                                                                0,
                                                                 Cluster(
                                                                     0,
                                                                 ),
@@ -4619,7 +4511,7 @@ expression: built.ir()
                                                 },
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
-                                                        1,
+                                                        0,
                                                         Cluster(
                                                             0,
                                                         ),
@@ -4634,7 +4526,7 @@ expression: built.ir()
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    1,
+                                                    0,
                                                     Cluster(
                                                         0,
                                                     ),
@@ -4649,14 +4541,14 @@ expression: built.ir()
                                         },
                                         right: Cast {
                                             inner: Tee {
-                                                inner: <tee 21>: Cast {
+                                                inner: <tee 20>: Cast {
                                                     inner: ChainFirst {
                                                         first: Map {
                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < usize , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | s | s + 1 }),
                                                             input: Batch {
                                                                 inner: YieldConcat {
                                                                     inner: Tee {
-                                                                        inner: <tee 22>: Reduce {
+                                                                        inner: <tee 21>: Reduce {
                                                                             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | curr , new | { if new > * curr { * curr = new ; } } }),
                                                                             input: ObserveNonDet {
                                                                                 inner: Map {
@@ -4664,7 +4556,7 @@ expression: built.ir()
                                                                                     input: Cast {
                                                                                         inner: Cast {
                                                                                             inner: Tee {
-                                                                                                inner: <tee 23>: Map {
+                                                                                                inner: <tee 22>: Map {
                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >)) , (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (count , entry) | (count , entry . unwrap ()) }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
                                                                                                     input: FoldKeyed {
                                                                                                         init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | | (0 , None) }),
@@ -4676,13 +4568,13 @@ expression: built.ir()
                                                                                                                     input: Map {
                                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (_checkpoint , log) | log }),
                                                                                                                         input: Tee {
-                                                                                                                            inner: <tee 24>: FlatMap {
+                                                                                                                            inner: <tee 23>: FlatMap {
                                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) > , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | v }),
                                                                                                                                 input: Tee {
-                                                                                                                                    inner: <tee 14>,
+                                                                                                                                    inner: <tee 13>,
                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                         location_kind: Tick(
-                                                                                                                                            1,
+                                                                                                                                            0,
                                                                                                                                             Cluster(
                                                                                                                                                 0,
                                                                                                                                             ),
@@ -4695,7 +4587,7 @@ expression: built.ir()
                                                                                                                                 },
                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                     location_kind: Tick(
-                                                                                                                                        1,
+                                                                                                                                        0,
                                                                                                                                         Cluster(
                                                                                                                                             0,
                                                                                                                                         ),
@@ -4710,7 +4602,7 @@ expression: built.ir()
                                                                                                                             },
                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                 location_kind: Tick(
-                                                                                                                                    1,
+                                                                                                                                    0,
                                                                                                                                     Cluster(
                                                                                                                                         0,
                                                                                                                                     ),
@@ -4725,7 +4617,7 @@ expression: built.ir()
                                                                                                                         },
                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                             location_kind: Tick(
-                                                                                                                                1,
+                                                                                                                                0,
                                                                                                                                 Cluster(
                                                                                                                                     0,
                                                                                                                                 ),
@@ -4740,7 +4632,7 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                         location_kind: Tick(
-                                                                                                                            1,
+                                                                                                                            0,
                                                                                                                             Cluster(
                                                                                                                                 0,
                                                                                                                             ),
@@ -4755,7 +4647,7 @@ expression: built.ir()
                                                                                                                 },
                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                     location_kind: Tick(
-                                                                                                                        1,
+                                                                                                                        0,
                                                                                                                         Cluster(
                                                                                                                             0,
                                                                                                                         ),
@@ -4772,7 +4664,7 @@ expression: built.ir()
                                                                                                             trusted: false,
                                                                                                             metadata: HydroIrMetadata {
                                                                                                                 location_kind: Tick(
-                                                                                                                    1,
+                                                                                                                    0,
                                                                                                                     Cluster(
                                                                                                                         0,
                                                                                                                     ),
@@ -4788,7 +4680,7 @@ expression: built.ir()
                                                                                                         },
                                                                                                         metadata: HydroIrMetadata {
                                                                                                             location_kind: Tick(
-                                                                                                                1,
+                                                                                                                0,
                                                                                                                 Cluster(
                                                                                                                     0,
                                                                                                                 ),
@@ -4802,7 +4694,7 @@ expression: built.ir()
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
                                                                                                         location_kind: Tick(
-                                                                                                            1,
+                                                                                                            0,
                                                                                                             Cluster(
                                                                                                                 0,
                                                                                                             ),
@@ -4816,7 +4708,7 @@ expression: built.ir()
                                                                                                 },
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_kind: Tick(
-                                                                                                        1,
+                                                                                                        0,
                                                                                                         Cluster(
                                                                                                             0,
                                                                                                         ),
@@ -4830,7 +4722,7 @@ expression: built.ir()
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_kind: Tick(
-                                                                                                    1,
+                                                                                                    0,
                                                                                                     Cluster(
                                                                                                         0,
                                                                                                     ),
@@ -4846,7 +4738,7 @@ expression: built.ir()
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
                                                                                             location_kind: Tick(
-                                                                                                1,
+                                                                                                0,
                                                                                                 Cluster(
                                                                                                     0,
                                                                                                 ),
@@ -4861,7 +4753,7 @@ expression: built.ir()
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_kind: Tick(
-                                                                                            1,
+                                                                                            0,
                                                                                             Cluster(
                                                                                                 0,
                                                                                             ),
@@ -4877,7 +4769,7 @@ expression: built.ir()
                                                                                 trusted: true,
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_kind: Tick(
-                                                                                        1,
+                                                                                        0,
                                                                                         Cluster(
                                                                                             0,
                                                                                         ),
@@ -4892,7 +4784,7 @@ expression: built.ir()
                                                                             },
                                                                             metadata: HydroIrMetadata {
                                                                                 location_kind: Tick(
-                                                                                    1,
+                                                                                    0,
                                                                                     Cluster(
                                                                                         0,
                                                                                     ),
@@ -4905,7 +4797,7 @@ expression: built.ir()
                                                                         },
                                                                         metadata: HydroIrMetadata {
                                                                             location_kind: Tick(
-                                                                                1,
+                                                                                0,
                                                                                 Cluster(
                                                                                     0,
                                                                                 ),
@@ -4919,7 +4811,7 @@ expression: built.ir()
                                                                     metadata: HydroIrMetadata {
                                                                         location_kind: Atomic(
                                                                             Tick(
-                                                                                1,
+                                                                                0,
                                                                                 Cluster(
                                                                                     0,
                                                                                 ),
@@ -4933,7 +4825,7 @@ expression: built.ir()
                                                                 },
                                                                 metadata: HydroIrMetadata {
                                                                     location_kind: Tick(
-                                                                        1,
+                                                                        0,
                                                                         Cluster(
                                                                             0,
                                                                         ),
@@ -4946,7 +4838,7 @@ expression: built.ir()
                                                             },
                                                             metadata: HydroIrMetadata {
                                                                 location_kind: Tick(
-                                                                    1,
+                                                                    0,
                                                                     Cluster(
                                                                         0,
                                                                     ),
@@ -4963,11 +4855,11 @@ expression: built.ir()
                                                                     first: DeferTick {
                                                                         input: CycleSource {
                                                                             ident: Ident {
-                                                                                sym: cycle_12,
+                                                                                sym: cycle_11,
                                                                             },
                                                                             metadata: HydroIrMetadata {
                                                                                 location_kind: Tick(
-                                                                                    1,
+                                                                                    0,
                                                                                     Cluster(
                                                                                         0,
                                                                                     ),
@@ -4980,7 +4872,7 @@ expression: built.ir()
                                                                         },
                                                                         metadata: HydroIrMetadata {
                                                                             location_kind: Tick(
-                                                                                1,
+                                                                                0,
                                                                                 Cluster(
                                                                                     0,
                                                                                 ),
@@ -4996,7 +4888,7 @@ expression: built.ir()
                                                                             value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; 0 },
                                                                             metadata: HydroIrMetadata {
                                                                                 location_kind: Tick(
-                                                                                    1,
+                                                                                    0,
                                                                                     Cluster(
                                                                                         0,
                                                                                     ),
@@ -5009,7 +4901,7 @@ expression: built.ir()
                                                                         },
                                                                         metadata: HydroIrMetadata {
                                                                             location_kind: Tick(
-                                                                                1,
+                                                                                0,
                                                                                 Cluster(
                                                                                     0,
                                                                                 ),
@@ -5022,7 +4914,7 @@ expression: built.ir()
                                                                     },
                                                                     metadata: HydroIrMetadata {
                                                                         location_kind: Tick(
-                                                                            1,
+                                                                            0,
                                                                             Cluster(
                                                                                 0,
                                                                             ),
@@ -5035,7 +4927,7 @@ expression: built.ir()
                                                                 },
                                                                 metadata: HydroIrMetadata {
                                                                     location_kind: Tick(
-                                                                        1,
+                                                                        0,
                                                                         Cluster(
                                                                             0,
                                                                         ),
@@ -5048,7 +4940,7 @@ expression: built.ir()
                                                             },
                                                             metadata: HydroIrMetadata {
                                                                 location_kind: Tick(
-                                                                    1,
+                                                                    0,
                                                                     Cluster(
                                                                         0,
                                                                     ),
@@ -5061,7 +4953,7 @@ expression: built.ir()
                                                         },
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Tick(
-                                                                1,
+                                                                0,
                                                                 Cluster(
                                                                     0,
                                                                 ),
@@ -5074,7 +4966,7 @@ expression: built.ir()
                                                     },
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Tick(
-                                                            1,
+                                                            0,
                                                             Cluster(
                                                                 0,
                                                             ),
@@ -5087,7 +4979,7 @@ expression: built.ir()
                                                 },
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
-                                                        1,
+                                                        0,
                                                         Cluster(
                                                             0,
                                                         ),
@@ -5100,7 +4992,7 @@ expression: built.ir()
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    1,
+                                                    0,
                                                     Cluster(
                                                         0,
                                                     ),
@@ -5113,7 +5005,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                1,
+                                                0,
                                                 Cluster(
                                                     0,
                                                 ),
@@ -5128,7 +5020,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            1,
+                                            0,
                                             Cluster(
                                                 0,
                                             ),
@@ -5143,7 +5035,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        1,
+                                        0,
                                         Cluster(
                                             0,
                                         ),
@@ -5158,7 +5050,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    1,
+                                    0,
                                     Cluster(
                                         0,
                                     ),
@@ -5171,7 +5063,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                1,
+                                0,
                                 Cluster(
                                     0,
                                 ),
@@ -5183,10 +5075,10 @@ expression: built.ir()
                         },
                     },
                     right: Tee {
-                        inner: <tee 21>,
+                        inner: <tee 20>,
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                1,
+                                0,
                                 Cluster(
                                     0,
                                 ),
@@ -5199,7 +5091,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            1,
+                            0,
                             Cluster(
                                 0,
                             ),
@@ -5212,7 +5104,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        1,
+                        0,
                         Cluster(
                             0,
                         ),
@@ -5225,7 +5117,7 @@ expression: built.ir()
             },
             metadata: HydroIrMetadata {
                 location_kind: Tick(
-                    1,
+                    0,
                     Cluster(
                         0,
                     ),
@@ -5240,19 +5132,19 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_13,
+            sym: cycle_12,
         },
         input: AntiJoin {
             pos: Tee {
-                inner: <tee 25>: Chain {
+                inner: <tee 24>: Chain {
                     first: DeferTick {
                         input: CycleSource {
                             ident: Ident {
-                                sym: cycle_13,
+                                sym: cycle_12,
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    12,
+                                    11,
                                     Cluster(
                                         0,
                                     ),
@@ -5267,7 +5159,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                12,
+                                11,
                                 Cluster(
                                     0,
                                 ),
@@ -5282,7 +5174,7 @@ expression: built.ir()
                     },
                     second: Batch {
                         inner: Tee {
-                            inner: <tee 26>: Map {
+                            inner: <tee 25>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
                                 input: Cast {
                                     inner: Cast {
@@ -5300,7 +5192,7 @@ expression: built.ir()
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (p2a , max_ballot) | (p2a . sender , ((p2a . slot , p2a . ballot . clone ()) , if p2a . ballot == max_ballot { Ok (()) } else { Err (max_ballot) })) }),
                                                         input: CrossSingleton {
                                                             left: Tee {
-                                                                inner: <tee 27>: Batch {
+                                                                inner: <tee 26>: Batch {
                                                                     inner: Map {
                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer >) , hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
                                                                         input: Cast {
@@ -5386,7 +5278,7 @@ expression: built.ir()
                                                                                                                         },
                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                             location_kind: Tick(
-                                                                                                                                11,
+                                                                                                                                10,
                                                                                                                                 Cluster(
                                                                                                                                     0,
                                                                                                                                 ),
@@ -5400,7 +5292,7 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                         location_kind: Tick(
-                                                                                                                            11,
+                                                                                                                            10,
                                                                                                                             Cluster(
                                                                                                                                 0,
                                                                                                                             ),
@@ -5414,7 +5306,7 @@ expression: built.ir()
                                                                                                                 },
                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                     location_kind: Tick(
-                                                                                                                        11,
+                                                                                                                        10,
                                                                                                                         Cluster(
                                                                                                                             0,
                                                                                                                         ),
@@ -5430,7 +5322,7 @@ expression: built.ir()
                                                                                                             },
                                                                                                             metadata: HydroIrMetadata {
                                                                                                                 location_kind: Tick(
-                                                                                                                    11,
+                                                                                                                    10,
                                                                                                                     Cluster(
                                                                                                                         0,
                                                                                                                     ),
@@ -5445,7 +5337,7 @@ expression: built.ir()
                                                                                                         },
                                                                                                         metadata: HydroIrMetadata {
                                                                                                             location_kind: Tick(
-                                                                                                                11,
+                                                                                                                10,
                                                                                                                 Cluster(
                                                                                                                     0,
                                                                                                                 ),
@@ -5461,7 +5353,7 @@ expression: built.ir()
                                                                                                     trusted: true,
                                                                                                     metadata: HydroIrMetadata {
                                                                                                         location_kind: Tick(
-                                                                                                            11,
+                                                                                                            10,
                                                                                                             Cluster(
                                                                                                                 0,
                                                                                                             ),
@@ -5479,7 +5371,7 @@ expression: built.ir()
                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >) , hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless ((__hydro_lang_cluster_self_id_0) . clone ()) ; move | ((slot , ballot) , value) | P2a { sender : CLUSTER_SELF_ID__free . clone () , ballot , slot , value } }),
                                                                                                         input: EndAtomic {
                                                                                                             inner: Tee {
-                                                                                                                inner: <tee 28>: YieldConcat {
+                                                                                                                inner: <tee 27>: YieldConcat {
                                                                                                                     inner: Map {
                                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >) , ()) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | (d , _signal) | d }),
                                                                                                                         input: CrossSingleton {
@@ -5490,10 +5382,10 @@ expression: built.ir()
                                                                                                                                         left: Batch {
                                                                                                                                             inner: YieldConcat {
                                                                                                                                                 inner: Tee {
-                                                                                                                                                    inner: <tee 20>,
+                                                                                                                                                    inner: <tee 19>,
                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                         location_kind: Tick(
-                                                                                                                                                            1,
+                                                                                                                                                            0,
                                                                                                                                                             Cluster(
                                                                                                                                                                 0,
                                                                                                                                                             ),
@@ -5509,7 +5401,7 @@ expression: built.ir()
                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                     location_kind: Atomic(
                                                                                                                                                         Tick(
-                                                                                                                                                            1,
+                                                                                                                                                            0,
                                                                                                                                                             Cluster(
                                                                                                                                                                 0,
                                                                                                                                                             ),
@@ -5525,7 +5417,7 @@ expression: built.ir()
                                                                                                                                             },
                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                 location_kind: Tick(
-                                                                                                                                                    1,
+                                                                                                                                                    0,
                                                                                                                                                     Cluster(
                                                                                                                                                         0,
                                                                                                                                                     ),
@@ -5540,10 +5432,10 @@ expression: built.ir()
                                                                                                                                         },
                                                                                                                                         right: Cast {
                                                                                                                                             inner: Tee {
-                                                                                                                                                inner: <tee 4>,
+                                                                                                                                                inner: <tee 3>,
                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                     location_kind: Tick(
-                                                                                                                                                        1,
+                                                                                                                                                        0,
                                                                                                                                                         Cluster(
                                                                                                                                                             0,
                                                                                                                                                         ),
@@ -5556,7 +5448,7 @@ expression: built.ir()
                                                                                                                                             },
                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                 location_kind: Tick(
-                                                                                                                                                    1,
+                                                                                                                                                    0,
                                                                                                                                                     Cluster(
                                                                                                                                                         0,
                                                                                                                                                     ),
@@ -5569,7 +5461,7 @@ expression: built.ir()
                                                                                                                                         },
                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                             location_kind: Tick(
-                                                                                                                                                1,
+                                                                                                                                                0,
                                                                                                                                                 Cluster(
                                                                                                                                                     0,
                                                                                                                                                 ),
@@ -5584,7 +5476,7 @@ expression: built.ir()
                                                                                                                                     },
                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                         location_kind: Tick(
-                                                                                                                                            1,
+                                                                                                                                            0,
                                                                                                                                             Cluster(
                                                                                                                                                 0,
                                                                                                                                             ),
@@ -5605,10 +5497,10 @@ expression: built.ir()
                                                                                                                                                 left: Cast {
                                                                                                                                                     inner: Cast {
                                                                                                                                                         inner: Tee {
-                                                                                                                                                            inner: <tee 23>,
+                                                                                                                                                            inner: <tee 22>,
                                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                                 location_kind: Tick(
-                                                                                                                                                                    1,
+                                                                                                                                                                    0,
                                                                                                                                                                     Cluster(
                                                                                                                                                                         0,
                                                                                                                                                                     ),
@@ -5622,7 +5514,7 @@ expression: built.ir()
                                                                                                                                                         },
                                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                                             location_kind: Tick(
-                                                                                                                                                                1,
+                                                                                                                                                                0,
                                                                                                                                                                 Cluster(
                                                                                                                                                                     0,
                                                                                                                                                                 ),
@@ -5638,7 +5530,7 @@ expression: built.ir()
                                                                                                                                                     },
                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                         location_kind: Tick(
-                                                                                                                                                            1,
+                                                                                                                                                            0,
                                                                                                                                                             Cluster(
                                                                                                                                                                 0,
                                                                                                                                                             ),
@@ -5653,10 +5545,10 @@ expression: built.ir()
                                                                                                                                                 },
                                                                                                                                                 right: Cast {
                                                                                                                                                     inner: Tee {
-                                                                                                                                                        inner: <tee 4>,
+                                                                                                                                                        inner: <tee 3>,
                                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                                             location_kind: Tick(
-                                                                                                                                                                1,
+                                                                                                                                                                0,
                                                                                                                                                                 Cluster(
                                                                                                                                                                     0,
                                                                                                                                                                 ),
@@ -5669,7 +5561,7 @@ expression: built.ir()
                                                                                                                                                     },
                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                         location_kind: Tick(
-                                                                                                                                                            1,
+                                                                                                                                                            0,
                                                                                                                                                             Cluster(
                                                                                                                                                                 0,
                                                                                                                                                             ),
@@ -5682,7 +5574,7 @@ expression: built.ir()
                                                                                                                                                 },
                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                     location_kind: Tick(
-                                                                                                                                                        1,
+                                                                                                                                                        0,
                                                                                                                                                         Cluster(
                                                                                                                                                             0,
                                                                                                                                                         ),
@@ -5697,7 +5589,7 @@ expression: built.ir()
                                                                                                                                             },
                                                                                                                                             right: Cast {
                                                                                                                                                 inner: Tee {
-                                                                                                                                                    inner: <tee 29>: Cast {
+                                                                                                                                                    inner: <tee 28>: Cast {
                                                                                                                                                         inner: ChainFirst {
                                                                                                                                                             first: Map {
                                                                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < usize , core :: option :: Option < usize > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
@@ -5707,10 +5599,10 @@ expression: built.ir()
                                                                                                                                                                         inner: FilterMap {
                                                                                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > >) , core :: option :: Option < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (checkpoint , _log) | checkpoint }),
                                                                                                                                                                             input: Tee {
-                                                                                                                                                                                inner: <tee 24>,
+                                                                                                                                                                                inner: <tee 23>,
                                                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                                                     location_kind: Tick(
-                                                                                                                                                                                        1,
+                                                                                                                                                                                        0,
                                                                                                                                                                                         Cluster(
                                                                                                                                                                                             0,
                                                                                                                                                                                         ),
@@ -5725,7 +5617,7 @@ expression: built.ir()
                                                                                                                                                                             },
                                                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                                                 location_kind: Tick(
-                                                                                                                                                                                    1,
+                                                                                                                                                                                    0,
                                                                                                                                                                                     Cluster(
                                                                                                                                                                                         0,
                                                                                                                                                                                     ),
@@ -5741,7 +5633,7 @@ expression: built.ir()
                                                                                                                                                                         trusted: true,
                                                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                                                             location_kind: Tick(
-                                                                                                                                                                                1,
+                                                                                                                                                                                0,
                                                                                                                                                                                 Cluster(
                                                                                                                                                                                     0,
                                                                                                                                                                                 ),
@@ -5756,7 +5648,7 @@ expression: built.ir()
                                                                                                                                                                     },
                                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                                         location_kind: Tick(
-                                                                                                                                                                            1,
+                                                                                                                                                                            0,
                                                                                                                                                                             Cluster(
                                                                                                                                                                                 0,
                                                                                                                                                                             ),
@@ -5769,7 +5661,7 @@ expression: built.ir()
                                                                                                                                                                 },
                                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                                     location_kind: Tick(
-                                                                                                                                                                        1,
+                                                                                                                                                                        0,
                                                                                                                                                                         Cluster(
                                                                                                                                                                             0,
                                                                                                                                                                         ),
@@ -5785,7 +5677,7 @@ expression: built.ir()
                                                                                                                                                                     value: :: std :: option :: Option :: None,
                                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                                         location_kind: Tick(
-                                                                                                                                                                            1,
+                                                                                                                                                                            0,
                                                                                                                                                                             Cluster(
                                                                                                                                                                                 0,
                                                                                                                                                                             ),
@@ -5798,7 +5690,7 @@ expression: built.ir()
                                                                                                                                                                 },
                                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                                     location_kind: Tick(
-                                                                                                                                                                        1,
+                                                                                                                                                                        0,
                                                                                                                                                                         Cluster(
                                                                                                                                                                             0,
                                                                                                                                                                         ),
@@ -5811,7 +5703,7 @@ expression: built.ir()
                                                                                                                                                             },
                                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                                 location_kind: Tick(
-                                                                                                                                                                    1,
+                                                                                                                                                                    0,
                                                                                                                                                                     Cluster(
                                                                                                                                                                         0,
                                                                                                                                                                     ),
@@ -5824,7 +5716,7 @@ expression: built.ir()
                                                                                                                                                         },
                                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                                             location_kind: Tick(
-                                                                                                                                                                1,
+                                                                                                                                                                0,
                                                                                                                                                                 Cluster(
                                                                                                                                                                     0,
                                                                                                                                                                 ),
@@ -5837,7 +5729,7 @@ expression: built.ir()
                                                                                                                                                     },
                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                         location_kind: Tick(
-                                                                                                                                                            1,
+                                                                                                                                                            0,
                                                                                                                                                             Cluster(
                                                                                                                                                                 0,
                                                                                                                                                             ),
@@ -5850,7 +5742,7 @@ expression: built.ir()
                                                                                                                                                 },
                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                     location_kind: Tick(
-                                                                                                                                                        1,
+                                                                                                                                                        0,
                                                                                                                                                         Cluster(
                                                                                                                                                             0,
                                                                                                                                                         ),
@@ -5863,7 +5755,7 @@ expression: built.ir()
                                                                                                                                             },
                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                 location_kind: Tick(
-                                                                                                                                                    1,
+                                                                                                                                                    0,
                                                                                                                                                     Cluster(
                                                                                                                                                         0,
                                                                                                                                                     ),
@@ -5878,7 +5770,7 @@ expression: built.ir()
                                                                                                                                         },
                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                             location_kind: Tick(
-                                                                                                                                                1,
+                                                                                                                                                0,
                                                                                                                                                 Cluster(
                                                                                                                                                     0,
                                                                                                                                                 ),
@@ -5899,10 +5791,10 @@ expression: built.ir()
                                                                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , core :: option :: Option < usize >) , std :: ops :: Range < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (max_slot , checkpoint) | { if let Some (checkpoint) = checkpoint { (checkpoint + 1) .. max_slot } else { 0 .. max_slot } } }),
                                                                                                                                                     input: CrossSingleton {
                                                                                                                                                         left: Tee {
-                                                                                                                                                            inner: <tee 22>,
+                                                                                                                                                            inner: <tee 21>,
                                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                                 location_kind: Tick(
-                                                                                                                                                                    1,
+                                                                                                                                                                    0,
                                                                                                                                                                     Cluster(
                                                                                                                                                                         0,
                                                                                                                                                                     ),
@@ -5915,10 +5807,10 @@ expression: built.ir()
                                                                                                                                                         },
                                                                                                                                                         right: Cast {
                                                                                                                                                             inner: Tee {
-                                                                                                                                                                inner: <tee 29>,
+                                                                                                                                                                inner: <tee 28>,
                                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                                     location_kind: Tick(
-                                                                                                                                                                        1,
+                                                                                                                                                                        0,
                                                                                                                                                                         Cluster(
                                                                                                                                                                             0,
                                                                                                                                                                         ),
@@ -5931,7 +5823,7 @@ expression: built.ir()
                                                                                                                                                             },
                                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                                 location_kind: Tick(
-                                                                                                                                                                    1,
+                                                                                                                                                                    0,
                                                                                                                                                                     Cluster(
                                                                                                                                                                         0,
                                                                                                                                                                     ),
@@ -5944,7 +5836,7 @@ expression: built.ir()
                                                                                                                                                         },
                                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                                             location_kind: Tick(
-                                                                                                                                                                1,
+                                                                                                                                                                0,
                                                                                                                                                                 Cluster(
                                                                                                                                                                     0,
                                                                                                                                                                 ),
@@ -5957,7 +5849,7 @@ expression: built.ir()
                                                                                                                                                     },
                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                         location_kind: Tick(
-                                                                                                                                                            1,
+                                                                                                                                                            0,
                                                                                                                                                             Cluster(
                                                                                                                                                                 0,
                                                                                                                                                             ),
@@ -5975,10 +5867,10 @@ expression: built.ir()
                                                                                                                                                     input: Cast {
                                                                                                                                                         inner: Cast {
                                                                                                                                                             inner: Tee {
-                                                                                                                                                                inner: <tee 23>,
+                                                                                                                                                                inner: <tee 22>,
                                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                                     location_kind: Tick(
-                                                                                                                                                                        1,
+                                                                                                                                                                        0,
                                                                                                                                                                         Cluster(
                                                                                                                                                                             0,
                                                                                                                                                                         ),
@@ -5992,7 +5884,7 @@ expression: built.ir()
                                                                                                                                                             },
                                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                                 location_kind: Tick(
-                                                                                                                                                                    1,
+                                                                                                                                                                    0,
                                                                                                                                                                     Cluster(
                                                                                                                                                                         0,
                                                                                                                                                                     ),
@@ -6008,7 +5900,7 @@ expression: built.ir()
                                                                                                                                                         },
                                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                                             location_kind: Tick(
-                                                                                                                                                                1,
+                                                                                                                                                                0,
                                                                                                                                                                 Cluster(
                                                                                                                                                                     0,
                                                                                                                                                                 ),
@@ -6023,7 +5915,7 @@ expression: built.ir()
                                                                                                                                                     },
                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                         location_kind: Tick(
-                                                                                                                                                            1,
+                                                                                                                                                            0,
                                                                                                                                                             Cluster(
                                                                                                                                                                 0,
                                                                                                                                                             ),
@@ -6038,7 +5930,7 @@ expression: built.ir()
                                                                                                                                                 },
                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                     location_kind: Tick(
-                                                                                                                                                        1,
+                                                                                                                                                        0,
                                                                                                                                                         Cluster(
                                                                                                                                                             0,
                                                                                                                                                         ),
@@ -6053,10 +5945,10 @@ expression: built.ir()
                                                                                                                                             },
                                                                                                                                             right: Cast {
                                                                                                                                                 inner: Tee {
-                                                                                                                                                    inner: <tee 4>,
+                                                                                                                                                    inner: <tee 3>,
                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                         location_kind: Tick(
-                                                                                                                                                            1,
+                                                                                                                                                            0,
                                                                                                                                                             Cluster(
                                                                                                                                                                 0,
                                                                                                                                                             ),
@@ -6069,7 +5961,7 @@ expression: built.ir()
                                                                                                                                                 },
                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                     location_kind: Tick(
-                                                                                                                                                        1,
+                                                                                                                                                        0,
                                                                                                                                                         Cluster(
                                                                                                                                                             0,
                                                                                                                                                         ),
@@ -6082,7 +5974,7 @@ expression: built.ir()
                                                                                                                                             },
                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                 location_kind: Tick(
-                                                                                                                                                    1,
+                                                                                                                                                    0,
                                                                                                                                                     Cluster(
                                                                                                                                                         0,
                                                                                                                                                     ),
@@ -6097,7 +5989,7 @@ expression: built.ir()
                                                                                                                                         },
                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                             location_kind: Tick(
-                                                                                                                                                1,
+                                                                                                                                                0,
                                                                                                                                                 Cluster(
                                                                                                                                                     0,
                                                                                                                                                 ),
@@ -6112,7 +6004,7 @@ expression: built.ir()
                                                                                                                                     },
                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                         location_kind: Tick(
-                                                                                                                                            1,
+                                                                                                                                            0,
                                                                                                                                             Cluster(
                                                                                                                                                 0,
                                                                                                                                             ),
@@ -6127,7 +6019,7 @@ expression: built.ir()
                                                                                                                                 },
                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                     location_kind: Tick(
-                                                                                                                                        1,
+                                                                                                                                        0,
                                                                                                                                         Cluster(
                                                                                                                                             0,
                                                                                                                                         ),
@@ -6143,10 +6035,10 @@ expression: built.ir()
                                                                                                                             right: Map {
                                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _u | () }),
                                                                                                                                 input: Tee {
-                                                                                                                                    inner: <tee 13>,
+                                                                                                                                    inner: <tee 12>,
                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                         location_kind: Tick(
-                                                                                                                                            1,
+                                                                                                                                            0,
                                                                                                                                             Cluster(
                                                                                                                                                 0,
                                                                                                                                             ),
@@ -6159,7 +6051,7 @@ expression: built.ir()
                                                                                                                                 },
                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                     location_kind: Tick(
-                                                                                                                                        1,
+                                                                                                                                        0,
                                                                                                                                         Cluster(
                                                                                                                                             0,
                                                                                                                                         ),
@@ -6172,7 +6064,7 @@ expression: built.ir()
                                                                                                                             },
                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                 location_kind: Tick(
-                                                                                                                                    1,
+                                                                                                                                    0,
                                                                                                                                     Cluster(
                                                                                                                                         0,
                                                                                                                                     ),
@@ -6187,7 +6079,7 @@ expression: built.ir()
                                                                                                                         },
                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                             location_kind: Tick(
-                                                                                                                                1,
+                                                                                                                                0,
                                                                                                                                 Cluster(
                                                                                                                                     0,
                                                                                                                                 ),
@@ -6203,7 +6095,7 @@ expression: built.ir()
                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                         location_kind: Atomic(
                                                                                                                             Tick(
-                                                                                                                                1,
+                                                                                                                                0,
                                                                                                                                 Cluster(
                                                                                                                                     0,
                                                                                                                                 ),
@@ -6220,7 +6112,7 @@ expression: built.ir()
                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                     location_kind: Atomic(
                                                                                                                         Tick(
-                                                                                                                            1,
+                                                                                                                            0,
                                                                                                                             Cluster(
                                                                                                                                 0,
                                                                                                                             ),
@@ -6260,7 +6152,7 @@ expression: built.ir()
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
                                                                                                         location_kind: Tick(
-                                                                                                            11,
+                                                                                                            10,
                                                                                                             Cluster(
                                                                                                                 0,
                                                                                                             ),
@@ -6275,7 +6167,7 @@ expression: built.ir()
                                                                                                 },
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_kind: Tick(
-                                                                                                        11,
+                                                                                                        10,
                                                                                                         Cluster(
                                                                                                             0,
                                                                                                         ),
@@ -6290,7 +6182,7 @@ expression: built.ir()
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_kind: Tick(
-                                                                                                    11,
+                                                                                                    10,
                                                                                                     Cluster(
                                                                                                         0,
                                                                                                     ),
@@ -6368,7 +6260,7 @@ expression: built.ir()
                                                                     },
                                                                     metadata: HydroIrMetadata {
                                                                         location_kind: Tick(
-                                                                            2,
+                                                                            1,
                                                                             Cluster(
                                                                                 1,
                                                                             ),
@@ -6383,7 +6275,7 @@ expression: built.ir()
                                                                 },
                                                                 metadata: HydroIrMetadata {
                                                                     location_kind: Tick(
-                                                                        2,
+                                                                        1,
                                                                         Cluster(
                                                                             1,
                                                                         ),
@@ -6398,10 +6290,10 @@ expression: built.ir()
                                                             },
                                                             right: Cast {
                                                                 inner: Tee {
-                                                                    inner: <tee 10>,
+                                                                    inner: <tee 9>,
                                                                     metadata: HydroIrMetadata {
                                                                         location_kind: Tick(
-                                                                            2,
+                                                                            1,
                                                                             Cluster(
                                                                                 1,
                                                                             ),
@@ -6414,7 +6306,7 @@ expression: built.ir()
                                                                 },
                                                                 metadata: HydroIrMetadata {
                                                                     location_kind: Tick(
-                                                                        2,
+                                                                        1,
                                                                         Cluster(
                                                                             1,
                                                                         ),
@@ -6427,7 +6319,7 @@ expression: built.ir()
                                                             },
                                                             metadata: HydroIrMetadata {
                                                                 location_kind: Tick(
-                                                                    2,
+                                                                    1,
                                                                     Cluster(
                                                                         1,
                                                                     ),
@@ -6442,7 +6334,7 @@ expression: built.ir()
                                                         },
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Tick(
-                                                                2,
+                                                                1,
                                                                 Cluster(
                                                                     1,
                                                                 ),
@@ -6543,7 +6435,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                12,
+                                11,
                                 Cluster(
                                     0,
                                 ),
@@ -6558,7 +6450,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            12,
+                            11,
                             Cluster(
                                 0,
                             ),
@@ -6573,7 +6465,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        12,
+                        11,
                         Cluster(
                             0,
                         ),
@@ -6587,23 +6479,23 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <tee 30>: Map {
+                inner: <tee 29>: Map {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (usize , usize)) , (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
                     input: Cast {
                         inner: Cast {
                             inner: Filter {
                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (usize , usize)) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < (usize , usize) , bool > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; let max__free = 3usize ; move | (success , error) | (success + error) >= max__free }) ; { let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) } }),
                                 input: Tee {
-                                    inner: <tee 31>: FoldKeyed {
+                                    inner: <tee 30>: FoldKeyed {
                                         init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | | (0 , 0) }),
                                         acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } } }),
                                         input: ObserveNonDet {
                                             inner: Cast {
                                                 inner: Tee {
-                                                    inner: <tee 25>,
+                                                    inner: <tee 24>,
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Tick(
-                                                            12,
+                                                            11,
                                                             Cluster(
                                                                 0,
                                                             ),
@@ -6618,7 +6510,7 @@ expression: built.ir()
                                                 },
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
-                                                        12,
+                                                        11,
                                                         Cluster(
                                                             0,
                                                         ),
@@ -6635,7 +6527,7 @@ expression: built.ir()
                                             trusted: false,
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    12,
+                                                    11,
                                                     Cluster(
                                                         0,
                                                     ),
@@ -6651,7 +6543,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                12,
+                                                11,
                                                 Cluster(
                                                     0,
                                                 ),
@@ -6665,7 +6557,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            12,
+                                            11,
                                             Cluster(
                                                 0,
                                             ),
@@ -6679,7 +6571,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        12,
+                                        11,
                                         Cluster(
                                             0,
                                         ),
@@ -6693,7 +6585,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    12,
+                                    11,
                                     Cluster(
                                         0,
                                     ),
@@ -6709,7 +6601,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                12,
+                                11,
                                 Cluster(
                                     0,
                                 ),
@@ -6724,7 +6616,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            12,
+                            11,
                             Cluster(
                                 0,
                             ),
@@ -6739,7 +6631,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        12,
+                        11,
                         Cluster(
                             0,
                         ),
@@ -6754,7 +6646,7 @@ expression: built.ir()
             },
             metadata: HydroIrMetadata {
                 location_kind: Tick(
-                    12,
+                    11,
                     Cluster(
                         0,
                     ),
@@ -6771,19 +6663,19 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_14,
+            sym: cycle_13,
         },
         input: Difference {
             pos: Tee {
-                inner: <tee 32>: FilterMap {
+                inner: <tee 31>: FilterMap {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (usize , usize)) , core :: option :: Option < (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; let min__free = 2usize ; move | (key , (success , _error)) | if success >= min__free { Some (key) } else { None } }),
                     input: Cast {
                         inner: Cast {
                             inner: Tee {
-                                inner: <tee 31>,
+                                inner: <tee 30>,
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        12,
+                                        11,
                                         Cluster(
                                             0,
                                         ),
@@ -6797,7 +6689,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    12,
+                                    11,
                                     Cluster(
                                         0,
                                     ),
@@ -6813,7 +6705,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                12,
+                                11,
                                 Cluster(
                                     0,
                                 ),
@@ -6828,7 +6720,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            12,
+                            11,
                             Cluster(
                                 0,
                             ),
@@ -6843,7 +6735,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        12,
+                        11,
                         Cluster(
                             0,
                         ),
@@ -6857,10 +6749,10 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <tee 30>,
+                inner: <tee 29>,
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        12,
+                        11,
                         Cluster(
                             0,
                         ),
@@ -6875,7 +6767,7 @@ expression: built.ir()
             },
             metadata: HydroIrMetadata {
                 location_kind: Tick(
-                    12,
+                    11,
                     Cluster(
                         0,
                     ),
@@ -6892,19 +6784,19 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_15,
+            sym: cycle_14,
         },
         input: AntiJoin {
             pos: Tee {
-                inner: <tee 33>: Chain {
+                inner: <tee 32>: Chain {
                     first: DeferTick {
                         input: CycleSource {
                             ident: Ident {
-                                sym: cycle_15,
+                                sym: cycle_14,
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    1,
+                                    0,
                                     Cluster(
                                         0,
                                     ),
@@ -6919,7 +6811,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                1,
+                                0,
                                 Cluster(
                                     0,
                                 ),
@@ -6936,11 +6828,11 @@ expression: built.ir()
                         inner: YieldConcat {
                             inner: Batch {
                                 inner: Tee {
-                                    inner: <tee 28>,
+                                    inner: <tee 27>,
                                     metadata: HydroIrMetadata {
                                         location_kind: Atomic(
                                             Tick(
-                                                1,
+                                                0,
                                                 Cluster(
                                                     0,
                                                 ),
@@ -6956,7 +6848,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        1,
+                                        0,
                                         Cluster(
                                             0,
                                         ),
@@ -6972,7 +6864,7 @@ expression: built.ir()
                             metadata: HydroIrMetadata {
                                 location_kind: Atomic(
                                     Tick(
-                                        1,
+                                        0,
                                         Cluster(
                                             0,
                                         ),
@@ -6988,7 +6880,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                1,
+                                0,
                                 Cluster(
                                     0,
                                 ),
@@ -7003,7 +6895,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            1,
+                            0,
                             Cluster(
                                 0,
                             ),
@@ -7018,7 +6910,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        1,
+                        0,
                         Cluster(
                             0,
                         ),
@@ -7034,16 +6926,16 @@ expression: built.ir()
             neg: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ()) , (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: request_response :: * ; | (key , _) | key }),
                 input: Tee {
-                    inner: <tee 34>: Batch {
+                    inner: <tee 33>: Batch {
                         inner: Map {
                             f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ()) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | k | (k , ()) }),
                             input: YieldConcat {
                                 inner: Difference {
                                     pos: Tee {
-                                        inner: <tee 32>,
+                                        inner: <tee 31>,
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                12,
+                                                11,
                                                 Cluster(
                                                     0,
                                                 ),
@@ -7059,11 +6951,11 @@ expression: built.ir()
                                     neg: DeferTick {
                                         input: CycleSource {
                                             ident: Ident {
-                                                sym: cycle_14,
+                                                sym: cycle_13,
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    12,
+                                                    11,
                                                     Cluster(
                                                         0,
                                                     ),
@@ -7078,7 +6970,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                12,
+                                                11,
                                                 Cluster(
                                                     0,
                                                 ),
@@ -7093,7 +6985,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            12,
+                                            11,
                                             Cluster(
                                                 0,
                                             ),
@@ -7132,7 +7024,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                1,
+                                0,
                                 Cluster(
                                     0,
                                 ),
@@ -7147,7 +7039,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            1,
+                            0,
                             Cluster(
                                 0,
                             ),
@@ -7162,7 +7054,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        1,
+                        0,
                         Cluster(
                             0,
                         ),
@@ -7177,7 +7069,7 @@ expression: built.ir()
             },
             metadata: HydroIrMetadata {
                 location_kind: Tick(
-                    1,
+                    0,
                     Cluster(
                         0,
                     ),
@@ -7194,7 +7086,7 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_4,
+            sym: cycle_3,
         },
         input: Batch {
             inner: YieldConcat {
@@ -7205,10 +7097,10 @@ expression: built.ir()
                                 first: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < usize , core :: option :: Option < usize > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                     input: Tee {
-                                        inner: <tee 35>: Batch {
+                                        inner: <tee 34>: Batch {
                                             inner: CycleSource {
                                                 ident: Ident {
-                                                    sym: cycle_2,
+                                                    sym: cycle_1,
                                                 },
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Cluster(
@@ -7222,7 +7114,7 @@ expression: built.ir()
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    2,
+                                                    1,
                                                     Cluster(
                                                         1,
                                                     ),
@@ -7235,7 +7127,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                2,
+                                                1,
                                                 Cluster(
                                                     1,
                                                 ),
@@ -7248,7 +7140,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            2,
+                                            1,
                                             Cluster(
                                                 1,
                                             ),
@@ -7264,7 +7156,7 @@ expression: built.ir()
                                         value: :: std :: option :: Option :: None,
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                2,
+                                                1,
                                                 Cluster(
                                                     1,
                                                 ),
@@ -7277,7 +7169,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            2,
+                                            1,
                                             Cluster(
                                                 1,
                                             ),
@@ -7290,7 +7182,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        2,
+                                        1,
                                         Cluster(
                                             1,
                                         ),
@@ -7303,7 +7195,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    2,
+                                    1,
                                     Cluster(
                                         1,
                                     ),
@@ -7330,10 +7222,10 @@ expression: built.ir()
                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: P2a < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (p2a , max_ballot) | if p2a . ballot >= max_ballot { Some ((p2a . slot , LogValue { ballot : p2a . ballot , value : p2a . value , })) } else { None } }),
                                                                 input: CrossSingleton {
                                                                     left: Tee {
-                                                                        inner: <tee 27>,
+                                                                        inner: <tee 26>,
                                                                         metadata: HydroIrMetadata {
                                                                             location_kind: Tick(
-                                                                                2,
+                                                                                1,
                                                                                 Cluster(
                                                                                     1,
                                                                                 ),
@@ -7348,10 +7240,10 @@ expression: built.ir()
                                                                     },
                                                                     right: Cast {
                                                                         inner: Tee {
-                                                                            inner: <tee 10>,
+                                                                            inner: <tee 9>,
                                                                             metadata: HydroIrMetadata {
                                                                                 location_kind: Tick(
-                                                                                    2,
+                                                                                    1,
                                                                                     Cluster(
                                                                                         1,
                                                                                     ),
@@ -7364,7 +7256,7 @@ expression: built.ir()
                                                                         },
                                                                         metadata: HydroIrMetadata {
                                                                             location_kind: Tick(
-                                                                                2,
+                                                                                1,
                                                                                 Cluster(
                                                                                     1,
                                                                                 ),
@@ -7377,7 +7269,7 @@ expression: built.ir()
                                                                     },
                                                                     metadata: HydroIrMetadata {
                                                                         location_kind: Tick(
-                                                                            2,
+                                                                            1,
                                                                             Cluster(
                                                                                 1,
                                                                             ),
@@ -7392,7 +7284,7 @@ expression: built.ir()
                                                                 },
                                                                 metadata: HydroIrMetadata {
                                                                     location_kind: Tick(
-                                                                        2,
+                                                                        1,
                                                                         Cluster(
                                                                             1,
                                                                         ),
@@ -7408,7 +7300,7 @@ expression: built.ir()
                                                             metadata: HydroIrMetadata {
                                                                 location_kind: Atomic(
                                                                     Tick(
-                                                                        2,
+                                                                        1,
                                                                         Cluster(
                                                                             1,
                                                                         ),
@@ -7425,7 +7317,7 @@ expression: built.ir()
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Atomic(
                                                                 Tick(
-                                                                    2,
+                                                                    1,
                                                                     Cluster(
                                                                         1,
                                                                     ),
@@ -7444,7 +7336,7 @@ expression: built.ir()
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Atomic(
                                                             Tick(
-                                                                2,
+                                                                1,
                                                                 Cluster(
                                                                     1,
                                                                 ),
@@ -7460,10 +7352,10 @@ expression: built.ir()
                                                     },
                                                 },
                                                 watermark: Tee {
-                                                    inner: <tee 35>,
+                                                    inner: <tee 34>,
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Tick(
-                                                            2,
+                                                            1,
                                                             Cluster(
                                                                 1,
                                                             ),
@@ -7477,7 +7369,7 @@ expression: built.ir()
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Atomic(
                                                         Tick(
-                                                            2,
+                                                            1,
                                                             Cluster(
                                                                 1,
                                                             ),
@@ -7492,7 +7384,7 @@ expression: built.ir()
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    2,
+                                                    1,
                                                     Cluster(
                                                         1,
                                                     ),
@@ -7506,7 +7398,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                2,
+                                                1,
                                                 Cluster(
                                                     1,
                                                 ),
@@ -7522,7 +7414,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            2,
+                                            1,
                                             Cluster(
                                                 1,
                                             ),
@@ -7538,7 +7430,7 @@ expression: built.ir()
                                 trusted: false,
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        2,
+                                        1,
                                         Cluster(
                                             1,
                                         ),
@@ -7553,7 +7445,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    2,
+                                    1,
                                     Cluster(
                                         1,
                                     ),
@@ -7566,7 +7458,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                2,
+                                1,
                                 Cluster(
                                     1,
                                 ),
@@ -7579,7 +7471,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            2,
+                            1,
                             Cluster(
                                 1,
                             ),
@@ -7593,7 +7485,7 @@ expression: built.ir()
                 metadata: HydroIrMetadata {
                     location_kind: Atomic(
                         Tick(
-                            2,
+                            1,
                             Cluster(
                                 1,
                             ),
@@ -7607,7 +7499,7 @@ expression: built.ir()
             },
             metadata: HydroIrMetadata {
                 location_kind: Tick(
-                    2,
+                    1,
                     Cluster(
                         1,
                     ),
@@ -7622,14 +7514,14 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_3,
+            sym: cycle_2,
         },
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (_ , ballot) | ballot }),
             input: FilterMap {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , core :: option :: Option < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | (key , res) | match res { Ok (_) => None , Err (e) => Some ((key , e)) , } }),
                 input: Tee {
-                    inner: <tee 26>,
+                    inner: <tee 25>,
                     metadata: HydroIrMetadata {
                         location_kind: Cluster(
                             0,
@@ -7670,7 +7562,7 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_16,
+            sym: cycle_15,
         },
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , usize) , hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; | (sorted_payload , _) | { sorted_payload } }),
@@ -7678,7 +7570,7 @@ expression: built.ir()
                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , usize) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; | (sorted_payload , highest_seq) | sorted_payload . seq > * highest_seq }),
                 input: CrossSingleton {
                     left: Tee {
-                        inner: <tee 36>: Sort {
+                        inner: <tee 35>: Sort {
                             input: Chain {
                                 first: Batch {
                                     inner: Map {
@@ -7768,7 +7660,7 @@ expression: built.ir()
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_kind: Tick(
-                                                                                                    13,
+                                                                                                    12,
                                                                                                     Cluster(
                                                                                                         0,
                                                                                                     ),
@@ -7782,7 +7674,7 @@ expression: built.ir()
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
                                                                                             location_kind: Tick(
-                                                                                                13,
+                                                                                                12,
                                                                                                 Cluster(
                                                                                                     0,
                                                                                                 ),
@@ -7796,7 +7688,7 @@ expression: built.ir()
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_kind: Tick(
-                                                                                            13,
+                                                                                            12,
                                                                                             Cluster(
                                                                                                 0,
                                                                                             ),
@@ -7812,7 +7704,7 @@ expression: built.ir()
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_kind: Tick(
-                                                                                        13,
+                                                                                        12,
                                                                                         Cluster(
                                                                                             0,
                                                                                         ),
@@ -7827,7 +7719,7 @@ expression: built.ir()
                                                                             },
                                                                             metadata: HydroIrMetadata {
                                                                                 location_kind: Tick(
-                                                                                    13,
+                                                                                    12,
                                                                                     Cluster(
                                                                                         0,
                                                                                     ),
@@ -7843,7 +7735,7 @@ expression: built.ir()
                                                                         trusted: true,
                                                                         metadata: HydroIrMetadata {
                                                                             location_kind: Tick(
-                                                                                13,
+                                                                                12,
                                                                                 Cluster(
                                                                                     0,
                                                                                 ),
@@ -7864,10 +7756,10 @@ expression: built.ir()
                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > , ())) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > , ())) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: request_response :: * ; | (key , (meta , resp)) | (key , (meta , resp)) }),
                                                                                     input: Join {
                                                                                         left: Tee {
-                                                                                            inner: <tee 33>,
+                                                                                            inner: <tee 32>,
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_kind: Tick(
-                                                                                                    1,
+                                                                                                    0,
                                                                                                     Cluster(
                                                                                                         0,
                                                                                                     ),
@@ -7881,10 +7773,10 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         right: Tee {
-                                                                                            inner: <tee 34>,
+                                                                                            inner: <tee 33>,
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_kind: Tick(
-                                                                                                    1,
+                                                                                                    0,
                                                                                                     Cluster(
                                                                                                         0,
                                                                                                     ),
@@ -7899,7 +7791,7 @@ expression: built.ir()
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
                                                                                             location_kind: Tick(
-                                                                                                1,
+                                                                                                0,
                                                                                                 Cluster(
                                                                                                     0,
                                                                                                 ),
@@ -7914,7 +7806,7 @@ expression: built.ir()
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_kind: Tick(
-                                                                                            1,
+                                                                                            0,
                                                                                             Cluster(
                                                                                                 0,
                                                                                             ),
@@ -7953,7 +7845,7 @@ expression: built.ir()
                                                                         },
                                                                         metadata: HydroIrMetadata {
                                                                             location_kind: Tick(
-                                                                                13,
+                                                                                12,
                                                                                 Cluster(
                                                                                     0,
                                                                                 ),
@@ -7968,7 +7860,7 @@ expression: built.ir()
                                                                     },
                                                                     metadata: HydroIrMetadata {
                                                                         location_kind: Tick(
-                                                                            13,
+                                                                            12,
                                                                             Cluster(
                                                                                 0,
                                                                             ),
@@ -7983,7 +7875,7 @@ expression: built.ir()
                                                                 },
                                                                 metadata: HydroIrMetadata {
                                                                     location_kind: Tick(
-                                                                        13,
+                                                                        12,
                                                                         Cluster(
                                                                             0,
                                                                         ),
@@ -8073,7 +7965,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            14,
+                                            13,
                                             Cluster(
                                                 4,
                                             ),
@@ -8089,11 +7981,11 @@ expression: built.ir()
                                 second: DeferTick {
                                     input: CycleSource {
                                         ident: Ident {
-                                            sym: cycle_16,
+                                            sym: cycle_15,
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                14,
+                                                13,
                                                 Cluster(
                                                     4,
                                                 ),
@@ -8108,7 +8000,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            14,
+                                            13,
                                             Cluster(
                                                 4,
                                             ),
@@ -8123,7 +8015,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        14,
+                                        13,
                                         Cluster(
                                             4,
                                         ),
@@ -8138,7 +8030,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    14,
+                                    13,
                                     Cluster(
                                         4,
                                     ),
@@ -8153,7 +8045,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                14,
+                                13,
                                 Cluster(
                                     4,
                                 ),
@@ -8168,15 +8060,15 @@ expression: built.ir()
                     },
                     right: Cast {
                         inner: Tee {
-                            inner: <tee 37>: Fold {
+                            inner: <tee 36>: Fold {
                                 init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; | | 0 }),
                                 acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , usize) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; | new_next_slot , (sorted_payload , next_slot) | { if sorted_payload . seq == std :: cmp :: max (* new_next_slot , next_slot) { * new_next_slot = sorted_payload . seq + 1 ; } } }),
                                 input: CrossSingleton {
                                     left: Tee {
-                                        inner: <tee 36>,
+                                        inner: <tee 35>,
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                14,
+                                                13,
                                                 Cluster(
                                                     4,
                                                 ),
@@ -8191,16 +8083,16 @@ expression: built.ir()
                                     },
                                     right: Cast {
                                         inner: Tee {
-                                            inner: <tee 38>: Cast {
+                                            inner: <tee 37>: Cast {
                                                 inner: ChainFirst {
                                                     first: DeferTick {
                                                         input: CycleSource {
                                                             ident: Ident {
-                                                                sym: cycle_17,
+                                                                sym: cycle_16,
                                                             },
                                                             metadata: HydroIrMetadata {
                                                                 location_kind: Tick(
-                                                                    14,
+                                                                    13,
                                                                     Cluster(
                                                                         4,
                                                                     ),
@@ -8213,7 +8105,7 @@ expression: built.ir()
                                                         },
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Tick(
-                                                                14,
+                                                                13,
                                                                 Cluster(
                                                                     4,
                                                                 ),
@@ -8229,7 +8121,7 @@ expression: built.ir()
                                                             value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; 0 },
                                                             metadata: HydroIrMetadata {
                                                                 location_kind: Tick(
-                                                                    14,
+                                                                    13,
                                                                     Cluster(
                                                                         4,
                                                                     ),
@@ -8242,7 +8134,7 @@ expression: built.ir()
                                                         },
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Tick(
-                                                                14,
+                                                                13,
                                                                 Cluster(
                                                                     4,
                                                                 ),
@@ -8255,7 +8147,7 @@ expression: built.ir()
                                                     },
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Tick(
-                                                            14,
+                                                            13,
                                                             Cluster(
                                                                 4,
                                                             ),
@@ -8268,7 +8160,7 @@ expression: built.ir()
                                                 },
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
-                                                        14,
+                                                        13,
                                                         Cluster(
                                                             4,
                                                         ),
@@ -8281,7 +8173,7 @@ expression: built.ir()
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    14,
+                                                    13,
                                                     Cluster(
                                                         4,
                                                     ),
@@ -8294,7 +8186,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                14,
+                                                13,
                                                 Cluster(
                                                     4,
                                                 ),
@@ -8307,7 +8199,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            14,
+                                            13,
                                             Cluster(
                                                 4,
                                             ),
@@ -8322,7 +8214,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        14,
+                                        13,
                                         Cluster(
                                             4,
                                         ),
@@ -8335,7 +8227,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    14,
+                                    13,
                                     Cluster(
                                         4,
                                     ),
@@ -8348,7 +8240,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                14,
+                                13,
                                 Cluster(
                                     4,
                                 ),
@@ -8361,7 +8253,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            14,
+                            13,
                             Cluster(
                                 4,
                             ),
@@ -8376,7 +8268,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        14,
+                        13,
                         Cluster(
                             4,
                         ),
@@ -8391,7 +8283,7 @@ expression: built.ir()
             },
             metadata: HydroIrMetadata {
                 location_kind: Tick(
-                    14,
+                    13,
                     Cluster(
                         4,
                     ),
@@ -8408,10 +8300,10 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_17,
+            sym: cycle_16,
         },
         input: Tee {
-            inner: <tee 39>: Map {
+            inner: <tee 38>: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: collections :: hash_map :: HashMap < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , usize) , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; | (_kv_store , next_slot) | next_slot }),
                 input: Batch {
                     inner: Fold {
@@ -8419,16 +8311,16 @@ expression: built.ir()
                         acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (std :: collections :: hash_map :: HashMap < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , usize) , hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; | (kv_store , next_slot) , payload | { if let Some (kv) = payload . kv { kv_store . insert (kv . key , kv . value) ; } * next_slot = payload . seq + 1 ; } }),
                         input: YieldConcat {
                             inner: Tee {
-                                inner: <tee 40>: Map {
+                                inner: <tee 39>: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , usize) , hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; | (sorted_payload , _) | { sorted_payload } }),
                                     input: Filter {
                                         f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , usize) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; | (sorted_payload , highest_seq) | sorted_payload . seq < * highest_seq }),
                                         input: CrossSingleton {
                                             left: Tee {
-                                                inner: <tee 36>,
+                                                inner: <tee 35>,
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
-                                                        14,
+                                                        13,
                                                         Cluster(
                                                             4,
                                                         ),
@@ -8443,10 +8335,10 @@ expression: built.ir()
                                             },
                                             right: Cast {
                                                 inner: Tee {
-                                                    inner: <tee 37>,
+                                                    inner: <tee 36>,
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Tick(
-                                                            14,
+                                                            13,
                                                             Cluster(
                                                                 4,
                                                             ),
@@ -8459,7 +8351,7 @@ expression: built.ir()
                                                 },
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
-                                                        14,
+                                                        13,
                                                         Cluster(
                                                             4,
                                                         ),
@@ -8472,7 +8364,7 @@ expression: built.ir()
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    14,
+                                                    13,
                                                     Cluster(
                                                         4,
                                                     ),
@@ -8487,7 +8379,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                14,
+                                                13,
                                                 Cluster(
                                                     4,
                                                 ),
@@ -8502,7 +8394,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            14,
+                                            13,
                                             Cluster(
                                                 4,
                                             ),
@@ -8517,7 +8409,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        14,
+                                        13,
                                         Cluster(
                                             4,
                                         ),
@@ -8533,7 +8425,7 @@ expression: built.ir()
                             metadata: HydroIrMetadata {
                                 location_kind: Atomic(
                                     Tick(
-                                        14,
+                                        13,
                                         Cluster(
                                             4,
                                         ),
@@ -8550,7 +8442,7 @@ expression: built.ir()
                         metadata: HydroIrMetadata {
                             location_kind: Atomic(
                                 Tick(
-                                    14,
+                                    13,
                                     Cluster(
                                         4,
                                     ),
@@ -8564,7 +8456,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            14,
+                            13,
                             Cluster(
                                 4,
                             ),
@@ -8577,7 +8469,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        14,
+                        13,
                         Cluster(
                             4,
                         ),
@@ -8590,7 +8482,7 @@ expression: built.ir()
             },
             metadata: HydroIrMetadata {
                 location_kind: Tick(
-                    14,
+                    13,
                     Cluster(
                         4,
                     ),
@@ -8605,10 +8497,10 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_18,
+            sym: cycle_17,
         },
         input: Tee {
-            inner: <tee 41>: FilterMap {
+            inner: <tee 40>: FilterMap {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (core :: option :: Option < usize > , usize) , core :: option :: Option < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; let checkpoint_frequency__free = 1000usize ; move | (max_checkpointed_seq , next_slot) | if max_checkpointed_seq . map (| m | next_slot - m >= checkpoint_frequency__free) . unwrap_or (true) { Some (next_slot) } else { None } }),
                 input: Cast {
                     inner: CrossSingleton {
@@ -8624,11 +8516,11 @@ expression: built.ir()
                                                     inner: DeferTick {
                                                         input: CycleSource {
                                                             ident: Ident {
-                                                                sym: cycle_18,
+                                                                sym: cycle_17,
                                                             },
                                                             metadata: HydroIrMetadata {
                                                                 location_kind: Tick(
-                                                                    14,
+                                                                    13,
                                                                     Cluster(
                                                                         4,
                                                                     ),
@@ -8641,7 +8533,7 @@ expression: built.ir()
                                                         },
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Tick(
-                                                                14,
+                                                                13,
                                                                 Cluster(
                                                                     4,
                                                                 ),
@@ -8654,7 +8546,7 @@ expression: built.ir()
                                                     },
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Tick(
-                                                            14,
+                                                            13,
                                                             Cluster(
                                                                 4,
                                                             ),
@@ -8670,7 +8562,7 @@ expression: built.ir()
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Atomic(
                                                         Tick(
-                                                            14,
+                                                            13,
                                                             Cluster(
                                                                 4,
                                                             ),
@@ -8687,7 +8579,7 @@ expression: built.ir()
                                             metadata: HydroIrMetadata {
                                                 location_kind: Atomic(
                                                     Tick(
-                                                        14,
+                                                        13,
                                                         Cluster(
                                                             4,
                                                         ),
@@ -8701,7 +8593,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                14,
+                                                13,
                                                 Cluster(
                                                     4,
                                                 ),
@@ -8714,7 +8606,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            14,
+                                            13,
                                             Cluster(
                                                 4,
                                             ),
@@ -8730,7 +8622,7 @@ expression: built.ir()
                                         value: :: std :: option :: Option :: None,
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                14,
+                                                13,
                                                 Cluster(
                                                     4,
                                                 ),
@@ -8743,7 +8635,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            14,
+                                            13,
                                             Cluster(
                                                 4,
                                             ),
@@ -8756,7 +8648,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        14,
+                                        13,
                                         Cluster(
                                             4,
                                         ),
@@ -8769,7 +8661,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    14,
+                                    13,
                                     Cluster(
                                         4,
                                     ),
@@ -8785,10 +8677,10 @@ expression: built.ir()
                                 first: DeferTick {
                                     input: Cast {
                                         inner: Tee {
-                                            inner: <tee 39>,
+                                            inner: <tee 38>,
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    14,
+                                                    13,
                                                     Cluster(
                                                         4,
                                                     ),
@@ -8801,7 +8693,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                14,
+                                                13,
                                                 Cluster(
                                                     4,
                                                 ),
@@ -8814,7 +8706,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            14,
+                                            13,
                                             Cluster(
                                                 4,
                                             ),
@@ -8830,7 +8722,7 @@ expression: built.ir()
                                         value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; 0 },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                14,
+                                                13,
                                                 Cluster(
                                                     4,
                                                 ),
@@ -8843,7 +8735,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            14,
+                                            13,
                                             Cluster(
                                                 4,
                                             ),
@@ -8856,7 +8748,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        14,
+                                        13,
                                         Cluster(
                                             4,
                                         ),
@@ -8869,7 +8761,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    14,
+                                    13,
                                     Cluster(
                                         4,
                                     ),
@@ -8882,7 +8774,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                14,
+                                13,
                                 Cluster(
                                     4,
                                 ),
@@ -8895,7 +8787,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            14,
+                            13,
                             Cluster(
                                 4,
                             ),
@@ -8908,7 +8800,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        14,
+                        13,
                         Cluster(
                             4,
                         ),
@@ -8921,7 +8813,7 @@ expression: built.ir()
             },
             metadata: HydroIrMetadata {
                 location_kind: Tick(
-                    14,
+                    13,
                     Cluster(
                         4,
                     ),
@@ -8936,7 +8828,7 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_2,
+            sym: cycle_1,
         },
         input: YieldConcat {
             inner: Reduce {
@@ -8950,7 +8842,7 @@ expression: built.ir()
                                 left: Cast {
                                     inner: Cast {
                                         inner: Tee {
-                                            inner: <tee 42>: Batch {
+                                            inner: <tee 41>: Batch {
                                                 inner: ReduceKeyed {
                                                     f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; | curr_seq , seq | { if seq > * curr_seq { * curr_seq = seq ; } } }),
                                                     input: Cast {
@@ -9035,7 +8927,7 @@ expression: built.ir()
                                                                                                 },
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_kind: Tick(
-                                                                                                        15,
+                                                                                                        14,
                                                                                                         Cluster(
                                                                                                             4,
                                                                                                         ),
@@ -9049,7 +8941,7 @@ expression: built.ir()
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_kind: Tick(
-                                                                                                    15,
+                                                                                                    14,
                                                                                                     Cluster(
                                                                                                         4,
                                                                                                     ),
@@ -9063,7 +8955,7 @@ expression: built.ir()
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
                                                                                             location_kind: Tick(
-                                                                                                15,
+                                                                                                14,
                                                                                                 Cluster(
                                                                                                     4,
                                                                                                 ),
@@ -9079,7 +8971,7 @@ expression: built.ir()
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_kind: Tick(
-                                                                                            15,
+                                                                                            14,
                                                                                             Cluster(
                                                                                                 4,
                                                                                             ),
@@ -9094,7 +8986,7 @@ expression: built.ir()
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_kind: Tick(
-                                                                                        15,
+                                                                                        14,
                                                                                         Cluster(
                                                                                             4,
                                                                                         ),
@@ -9110,7 +9002,7 @@ expression: built.ir()
                                                                             trusted: true,
                                                                             metadata: HydroIrMetadata {
                                                                                 location_kind: Tick(
-                                                                                    15,
+                                                                                    14,
                                                                                     Cluster(
                                                                                         4,
                                                                                     ),
@@ -9127,10 +9019,10 @@ expression: built.ir()
                                                                             inner: YieldConcat {
                                                                                 inner: Cast {
                                                                                     inner: Tee {
-                                                                                        inner: <tee 41>,
+                                                                                        inner: <tee 40>,
                                                                                         metadata: HydroIrMetadata {
                                                                                             location_kind: Tick(
-                                                                                                14,
+                                                                                                13,
                                                                                                 Cluster(
                                                                                                     4,
                                                                                                 ),
@@ -9143,7 +9035,7 @@ expression: built.ir()
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_kind: Tick(
-                                                                                            14,
+                                                                                            13,
                                                                                             Cluster(
                                                                                                 4,
                                                                                             ),
@@ -9170,7 +9062,7 @@ expression: built.ir()
                                                                             },
                                                                             metadata: HydroIrMetadata {
                                                                                 location_kind: Tick(
-                                                                                    15,
+                                                                                    14,
                                                                                     Cluster(
                                                                                         4,
                                                                                     ),
@@ -9185,7 +9077,7 @@ expression: built.ir()
                                                                         },
                                                                         metadata: HydroIrMetadata {
                                                                             location_kind: Tick(
-                                                                                15,
+                                                                                14,
                                                                                 Cluster(
                                                                                     4,
                                                                                 ),
@@ -9200,7 +9092,7 @@ expression: built.ir()
                                                                     },
                                                                     metadata: HydroIrMetadata {
                                                                         location_kind: Tick(
-                                                                            15,
+                                                                            14,
                                                                             Cluster(
                                                                                 4,
                                                                             ),
@@ -9265,7 +9157,7 @@ expression: built.ir()
                                                 },
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
-                                                        16,
+                                                        15,
                                                         Cluster(
                                                             1,
                                                         ),
@@ -9279,7 +9171,7 @@ expression: built.ir()
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    16,
+                                                    15,
                                                     Cluster(
                                                         1,
                                                     ),
@@ -9293,7 +9185,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                16,
+                                                15,
                                                 Cluster(
                                                     1,
                                                 ),
@@ -9309,7 +9201,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            16,
+                                            15,
                                             Cluster(
                                                 1,
                                             ),
@@ -9333,10 +9225,10 @@ expression: built.ir()
                                                 inner: Cast {
                                                     inner: Cast {
                                                         inner: Tee {
-                                                            inner: <tee 42>,
+                                                            inner: <tee 41>,
                                                             metadata: HydroIrMetadata {
                                                                 location_kind: Tick(
-                                                                    16,
+                                                                    15,
                                                                     Cluster(
                                                                         1,
                                                                     ),
@@ -9350,7 +9242,7 @@ expression: built.ir()
                                                         },
                                                         metadata: HydroIrMetadata {
                                                             location_kind: Tick(
-                                                                16,
+                                                                15,
                                                                 Cluster(
                                                                     1,
                                                                 ),
@@ -9366,7 +9258,7 @@ expression: built.ir()
                                                     },
                                                     metadata: HydroIrMetadata {
                                                         location_kind: Tick(
-                                                            16,
+                                                            15,
                                                             Cluster(
                                                                 1,
                                                             ),
@@ -9382,7 +9274,7 @@ expression: built.ir()
                                                 trusted: true,
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
-                                                        16,
+                                                        15,
                                                         Cluster(
                                                             1,
                                                         ),
@@ -9397,7 +9289,7 @@ expression: built.ir()
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    16,
+                                                    15,
                                                     Cluster(
                                                         1,
                                                     ),
@@ -9410,7 +9302,7 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                16,
+                                                15,
                                                 Cluster(
                                                     1,
                                                 ),
@@ -9423,7 +9315,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            16,
+                                            15,
                                             Cluster(
                                                 1,
                                             ),
@@ -9436,7 +9328,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        16,
+                                        15,
                                         Cluster(
                                             1,
                                         ),
@@ -9451,7 +9343,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    16,
+                                    15,
                                     Cluster(
                                         1,
                                     ),
@@ -9466,7 +9358,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                16,
+                                15,
                                 Cluster(
                                     1,
                                 ),
@@ -9482,7 +9374,7 @@ expression: built.ir()
                     trusted: true,
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            16,
+                            15,
                             Cluster(
                                 1,
                             ),
@@ -9497,7 +9389,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        16,
+                        15,
                         Cluster(
                             1,
                         ),
@@ -9522,19 +9414,19 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_19,
+            sym: cycle_18,
         },
         input: AntiJoin {
             pos: Tee {
-                inner: <tee 43>: Chain {
+                inner: <tee 42>: Chain {
                     first: DeferTick {
                         input: CycleSource {
                             ident: Ident {
-                                sym: cycle_19,
+                                sym: cycle_18,
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    17,
+                                    16,
                                     Cluster(
                                         2,
                                     ),
@@ -9549,7 +9441,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                17,
+                                16,
                                 Cluster(
                                     2,
                                 ),
@@ -9564,7 +9456,7 @@ expression: built.ir()
                     },
                     second: Batch {
                         inner: Tee {
-                            inner: <tee 44>: Map {
+                            inner: <tee 43>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica > , ((u32 , u32) , core :: result :: Result < () , () >)) , ((u32 , u32) , core :: result :: Result < () , () >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
                                 input: Cast {
                                     inner: Cast {
@@ -9583,10 +9475,10 @@ expression: built.ir()
                                                         inner: FilterMap {
                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , u32) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; | payload | payload . kv }),
                                                             input: Tee {
-                                                                inner: <tee 40>,
+                                                                inner: <tee 39>,
                                                                 metadata: HydroIrMetadata {
                                                                     location_kind: Tick(
-                                                                        14,
+                                                                        13,
                                                                         Cluster(
                                                                             4,
                                                                         ),
@@ -9601,7 +9493,7 @@ expression: built.ir()
                                                             },
                                                             metadata: HydroIrMetadata {
                                                                 location_kind: Tick(
-                                                                    14,
+                                                                    13,
                                                                     Cluster(
                                                                         4,
                                                                     ),
@@ -9714,7 +9606,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                17,
+                                16,
                                 Cluster(
                                     2,
                                 ),
@@ -9729,7 +9621,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            17,
+                            16,
                             Cluster(
                                 2,
                             ),
@@ -9744,7 +9636,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        17,
+                        16,
                         Cluster(
                             2,
                         ),
@@ -9758,21 +9650,21 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <tee 45>: FilterMap {
+                inner: <tee 44>: FilterMap {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < ((u32 , u32) , (usize , usize)) , core :: option :: Option < (u32 , u32) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; let min__free = 2usize ; move | (key , (success , _error)) | if success >= min__free { Some (key) } else { None } }),
                     input: Cast {
                         inner: Cast {
                             inner: Tee {
-                                inner: <tee 46>: FoldKeyed {
+                                inner: <tee 45>: FoldKeyed {
                                     init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | | (0 , 0) }),
                                     acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < () , () > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } } }),
                                     input: ObserveNonDet {
                                         inner: Cast {
                                             inner: Tee {
-                                                inner: <tee 43>,
+                                                inner: <tee 42>,
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
-                                                        17,
+                                                        16,
                                                         Cluster(
                                                             2,
                                                         ),
@@ -9787,7 +9679,7 @@ expression: built.ir()
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    17,
+                                                    16,
                                                     Cluster(
                                                         2,
                                                     ),
@@ -9804,7 +9696,7 @@ expression: built.ir()
                                         trusted: false,
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                17,
+                                                16,
                                                 Cluster(
                                                     2,
                                                 ),
@@ -9820,7 +9712,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            17,
+                                            16,
                                             Cluster(
                                                 2,
                                             ),
@@ -9834,7 +9726,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        17,
+                                        16,
                                         Cluster(
                                             2,
                                         ),
@@ -9848,7 +9740,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    17,
+                                    16,
                                     Cluster(
                                         2,
                                     ),
@@ -9864,7 +9756,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                17,
+                                16,
                                 Cluster(
                                     2,
                                 ),
@@ -9879,7 +9771,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            17,
+                            16,
                             Cluster(
                                 2,
                             ),
@@ -9894,7 +9786,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        17,
+                        16,
                         Cluster(
                             2,
                         ),
@@ -9909,7 +9801,7 @@ expression: built.ir()
             },
             metadata: HydroIrMetadata {
                 location_kind: Tick(
-                    17,
+                    16,
                     Cluster(
                         2,
                     ),
@@ -9926,16 +9818,16 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_20,
+            sym: cycle_19,
         },
         input: DeferTick {
             input: CycleSource {
                 ident: Ident {
-                    sym: cycle_20,
+                    sym: cycle_19,
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        17,
+                        16,
                         Cluster(
                             2,
                         ),
@@ -9950,7 +9842,7 @@ expression: built.ir()
             },
             metadata: HydroIrMetadata {
                 location_kind: Tick(
-                    17,
+                    16,
                     Cluster(
                         2,
                     ),
@@ -9967,35 +9859,297 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_1,
+            sym: cycle_20,
         },
-        input: ObserveNonDet {
-            inner: Map {
-                f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , core :: option :: Option < u32 >) , (u32 , u32) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; move | (virtual_id , payload) | { let value = if let Some (payload) = payload { payload + 1 } else { 0 } ; (virtual_id , value) } }),
-                input: YieldConcat {
-                    inner: Chain {
-                        first: Map {
-                            f: stageleft :: runtime_support :: fn1_type_hint :: < u32 , (u32 , core :: option :: Option < u32 >) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | virtual_id | (virtual_id , None) }),
-                            input: Tee {
-                                inner: <tee 47>: Cast {
-                                    inner: Tee {
-                                        inner: <tee 0>,
+        input: FilterMap {
+            f: stageleft :: runtime_support :: fn1_type_hint :: < u32 , core :: option :: Option < u32 > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; let num_clients_per_node__free = 100usize ; move | virtual_id | { if virtual_id < num_clients_per_node__free as u32 { Some (virtual_id + 1) } else { None } } }),
+            input: Tee {
+                inner: <tee 46>: ChainFirst {
+                    first: DeferTick {
+                        input: CycleSource {
+                            ident: Ident {
+                                sym: cycle_20,
+                            },
+                            metadata: HydroIrMetadata {
+                                location_kind: Tick(
+                                    17,
+                                    Cluster(
+                                        2,
+                                    ),
+                                ),
+                                collection_kind: Optional {
+                                    bound: Bounded,
+                                    element_type: u32,
+                                },
+                            },
+                        },
+                        metadata: HydroIrMetadata {
+                            location_kind: Tick(
+                                17,
+                                Cluster(
+                                    2,
+                                ),
+                            ),
+                            collection_kind: Optional {
+                                bound: Bounded,
+                                element_type: u32,
+                            },
+                        },
+                    },
+                    second: Map {
+                        f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , ()) , u32 > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | (d , _signal) | d }),
+                        input: CrossSingleton {
+                            left: Cast {
+                                inner: SingletonSource {
+                                    value: { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; 0u32 },
+                                    metadata: HydroIrMetadata {
+                                        location_kind: Tick(
+                                            17,
+                                            Cluster(
+                                                2,
+                                            ),
+                                        ),
+                                        collection_kind: Singleton {
+                                            bound: Bounded,
+                                            element_type: u32,
+                                        },
+                                    },
+                                },
+                                metadata: HydroIrMetadata {
+                                    location_kind: Tick(
+                                        17,
+                                        Cluster(
+                                            2,
+                                        ),
+                                    ),
+                                    collection_kind: Optional {
+                                        bound: Bounded,
+                                        element_type: u32,
+                                    },
+                                },
+                            },
+                            right: Map {
+                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _u | () }),
+                                input: Batch {
+                                    inner: Source {
+                                        source: Iter(
+                                            { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: tick :: * ; let e__free = { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; () } ; [e__free] },
+                                        ),
+                                        metadata: HydroIrMetadata {
+                                            location_kind: Cluster(
+                                                2,
+                                            ),
+                                            collection_kind: Optional {
+                                                bound: Unbounded,
+                                                element_type: (),
+                                            },
+                                        },
+                                    },
+                                    metadata: HydroIrMetadata {
+                                        location_kind: Tick(
+                                            17,
+                                            Cluster(
+                                                2,
+                                            ),
+                                        ),
+                                        collection_kind: Optional {
+                                            bound: Bounded,
+                                            element_type: (),
+                                        },
+                                    },
+                                },
+                                metadata: HydroIrMetadata {
+                                    location_kind: Tick(
+                                        17,
+                                        Cluster(
+                                            2,
+                                        ),
+                                    ),
+                                    collection_kind: Optional {
+                                        bound: Bounded,
+                                        element_type: (),
+                                    },
+                                },
+                            },
+                            metadata: HydroIrMetadata {
+                                location_kind: Tick(
+                                    17,
+                                    Cluster(
+                                        2,
+                                    ),
+                                ),
+                                collection_kind: Optional {
+                                    bound: Bounded,
+                                    element_type: (u32 , ()),
+                                },
+                            },
+                        },
+                        metadata: HydroIrMetadata {
+                            location_kind: Tick(
+                                17,
+                                Cluster(
+                                    2,
+                                ),
+                            ),
+                            collection_kind: Optional {
+                                bound: Bounded,
+                                element_type: u32,
+                            },
+                        },
+                    },
+                    metadata: HydroIrMetadata {
+                        location_kind: Tick(
+                            17,
+                            Cluster(
+                                2,
+                            ),
+                        ),
+                        collection_kind: Optional {
+                            bound: Bounded,
+                            element_type: u32,
+                        },
+                    },
+                },
+                metadata: HydroIrMetadata {
+                    location_kind: Tick(
+                        17,
+                        Cluster(
+                            2,
+                        ),
+                    ),
+                    collection_kind: Optional {
+                        bound: Bounded,
+                        element_type: u32,
+                    },
+                },
+            },
+            metadata: HydroIrMetadata {
+                location_kind: Tick(
+                    17,
+                    Cluster(
+                        2,
+                    ),
+                ),
+                collection_kind: Optional {
+                    bound: Bounded,
+                    element_type: u32,
+                },
+            },
+        },
+        op_metadata: HydroIrOpMetadata,
+    },
+    CycleSink {
+        ident: Ident {
+            sym: cycle_21,
+        },
+        input: ReduceKeyed {
+            f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: time :: Instant , std :: time :: Instant , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | curr_time , new_time | { if new_time > * curr_time { * curr_time = new_time ; } } }),
+            input: ObserveNonDet {
+                inner: Chain {
+                    first: Chain {
+                        first: Cast {
+                            inner: Tee {
+                                inner: <tee 47>: DeferTick {
+                                    input: CycleSource {
+                                        ident: Ident {
+                                            sym: cycle_21,
+                                        },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                0,
+                                                17,
                                                 Cluster(
                                                     2,
                                                 ),
                                             ),
-                                            collection_kind: Optional {
+                                            collection_kind: KeyedSingleton {
                                                 bound: Bounded,
+                                                key_type: u32,
+                                                value_type: std :: time :: Instant,
+                                            },
+                                        },
+                                    },
+                                    metadata: HydroIrMetadata {
+                                        location_kind: Tick(
+                                            17,
+                                            Cluster(
+                                                2,
+                                            ),
+                                        ),
+                                        collection_kind: KeyedSingleton {
+                                            bound: Bounded,
+                                            key_type: u32,
+                                            value_type: std :: time :: Instant,
+                                        },
+                                    },
+                                },
+                                metadata: HydroIrMetadata {
+                                    location_kind: Tick(
+                                        17,
+                                        Cluster(
+                                            2,
+                                        ),
+                                    ),
+                                    collection_kind: KeyedSingleton {
+                                        bound: Bounded,
+                                        key_type: u32,
+                                        value_type: std :: time :: Instant,
+                                    },
+                                },
+                            },
+                            metadata: HydroIrMetadata {
+                                location_kind: Tick(
+                                    17,
+                                    Cluster(
+                                        2,
+                                    ),
+                                ),
+                                collection_kind: KeyedStream {
+                                    bound: Bounded,
+                                    value_order: TotalOrder,
+                                    value_retry: ExactlyOnce,
+                                    key_type: u32,
+                                    value_type: std :: time :: Instant,
+                                },
+                            },
+                        },
+                        second: Cast {
+                            inner: Map {
+                                f: stageleft :: runtime_support :: fn1_type_hint :: < u32 , (u32 , std :: time :: Instant) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | virtual_id | (virtual_id , Instant :: now ()) }),
+                                input: Tee {
+                                    inner: <tee 48>: Cast {
+                                        inner: Tee {
+                                            inner: <tee 46>,
+                                            metadata: HydroIrMetadata {
+                                                location_kind: Tick(
+                                                    17,
+                                                    Cluster(
+                                                        2,
+                                                    ),
+                                                ),
+                                                collection_kind: Optional {
+                                                    bound: Bounded,
+                                                    element_type: u32,
+                                                },
+                                            },
+                                        },
+                                        metadata: HydroIrMetadata {
+                                            location_kind: Tick(
+                                                17,
+                                                Cluster(
+                                                    2,
+                                                ),
+                                            ),
+                                            collection_kind: Stream {
+                                                bound: Bounded,
+                                                order: TotalOrder,
+                                                retry: ExactlyOnce,
                                                 element_type: u32,
                                             },
                                         },
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            0,
+                                            17,
                                             Cluster(
                                                 2,
                                             ),
@@ -10010,7 +10164,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        0,
+                                        17,
                                         Cluster(
                                             2,
                                         ),
@@ -10019,116 +10173,327 @@ expression: built.ir()
                                         bound: Bounded,
                                         order: TotalOrder,
                                         retry: ExactlyOnce,
-                                        element_type: u32,
+                                        element_type: (u32 , std :: time :: Instant),
                                     },
                                 },
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    0,
+                                    17,
                                     Cluster(
                                         2,
                                     ),
                                 ),
-                                collection_kind: Stream {
+                                collection_kind: KeyedStream {
                                     bound: Bounded,
-                                    order: TotalOrder,
-                                    retry: ExactlyOnce,
-                                    element_type: (u32 , core :: option :: Option < u32 >),
+                                    value_order: TotalOrder,
+                                    value_retry: ExactlyOnce,
+                                    key_type: u32,
+                                    value_type: std :: time :: Instant,
                                 },
                             },
                         },
-                        second: Tee {
-                            inner: <tee 48>: Map {
-                                f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , u32) , (u32 , core :: option :: Option < u32 >) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (virtual_id , payload) | (virtual_id , Some (payload)) }),
-                                input: Batch {
-                                    inner: YieldConcat {
-                                        inner: Tee {
-                                            inner: <tee 45>,
-                                            metadata: HydroIrMetadata {
-                                                location_kind: Tick(
-                                                    17,
-                                                    Cluster(
+                        metadata: HydroIrMetadata {
+                            location_kind: Tick(
+                                17,
+                                Cluster(
+                                    2,
+                                ),
+                            ),
+                            collection_kind: KeyedStream {
+                                bound: Bounded,
+                                value_order: TotalOrder,
+                                value_retry: ExactlyOnce,
+                                key_type: u32,
+                                value_type: std :: time :: Instant,
+                            },
+                        },
+                    },
+                    second: Tee {
+                        inner: <tee 49>: Map {
+                            f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , core :: option :: Option < u32 >) , (u32 , std :: time :: Instant) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < u32 > , std :: time :: Instant > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | _payload | Instant :: now () }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
+                            input: Tee {
+                                inner: <tee 50>: Map {
+                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , u32) , (u32 , core :: option :: Option < u32 >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < u32 , core :: option :: Option < u32 > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | payload | Some (payload) }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
+                                    input: Batch {
+                                        inner: Cast {
+                                            inner: YieldConcat {
+                                                inner: Tee {
+                                                    inner: <tee 44>,
+                                                    metadata: HydroIrMetadata {
+                                                        location_kind: Tick(
+                                                            16,
+                                                            Cluster(
+                                                                2,
+                                                            ),
+                                                        ),
+                                                        collection_kind: Stream {
+                                                            bound: Bounded,
+                                                            order: NoOrder,
+                                                            retry: ExactlyOnce,
+                                                            element_type: (u32 , u32),
+                                                        },
+                                                    },
+                                                },
+                                                metadata: HydroIrMetadata {
+                                                    location_kind: Cluster(
                                                         2,
                                                     ),
+                                                    collection_kind: Stream {
+                                                        bound: Unbounded,
+                                                        order: NoOrder,
+                                                        retry: ExactlyOnce,
+                                                        element_type: (u32 , u32),
+                                                    },
+                                                },
+                                            },
+                                            metadata: HydroIrMetadata {
+                                                location_kind: Cluster(
+                                                    2,
                                                 ),
-                                                collection_kind: Stream {
-                                                    bound: Bounded,
-                                                    order: NoOrder,
-                                                    retry: ExactlyOnce,
-                                                    element_type: (u32 , u32),
+                                                collection_kind: KeyedStream {
+                                                    bound: Unbounded,
+                                                    value_order: NoOrder,
+                                                    value_retry: ExactlyOnce,
+                                                    key_type: u32,
+                                                    value_type: u32,
                                                 },
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_kind: Cluster(
-                                                2,
+                                            location_kind: Tick(
+                                                17,
+                                                Cluster(
+                                                    2,
+                                                ),
                                             ),
-                                            collection_kind: Stream {
-                                                bound: Unbounded,
-                                                order: NoOrder,
-                                                retry: ExactlyOnce,
-                                                element_type: (u32 , u32),
+                                            collection_kind: KeyedStream {
+                                                bound: Bounded,
+                                                value_order: NoOrder,
+                                                value_retry: ExactlyOnce,
+                                                key_type: u32,
+                                                value_type: u32,
                                             },
                                         },
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            0,
+                                            17,
+                                            Cluster(
+                                                2,
+                                            ),
+                                        ),
+                                        collection_kind: KeyedStream {
+                                            bound: Bounded,
+                                            value_order: NoOrder,
+                                            value_retry: ExactlyOnce,
+                                            key_type: u32,
+                                            value_type: core :: option :: Option < u32 >,
+                                        },
+                                    },
+                                },
+                                metadata: HydroIrMetadata {
+                                    location_kind: Tick(
+                                        17,
+                                        Cluster(
+                                            2,
+                                        ),
+                                    ),
+                                    collection_kind: KeyedStream {
+                                        bound: Bounded,
+                                        value_order: NoOrder,
+                                        value_retry: ExactlyOnce,
+                                        key_type: u32,
+                                        value_type: core :: option :: Option < u32 >,
+                                    },
+                                },
+                            },
+                            metadata: HydroIrMetadata {
+                                location_kind: Tick(
+                                    17,
+                                    Cluster(
+                                        2,
+                                    ),
+                                ),
+                                collection_kind: KeyedStream {
+                                    bound: Bounded,
+                                    value_order: NoOrder,
+                                    value_retry: ExactlyOnce,
+                                    key_type: u32,
+                                    value_type: std :: time :: Instant,
+                                },
+                            },
+                        },
+                        metadata: HydroIrMetadata {
+                            location_kind: Tick(
+                                17,
+                                Cluster(
+                                    2,
+                                ),
+                            ),
+                            collection_kind: KeyedStream {
+                                bound: Bounded,
+                                value_order: NoOrder,
+                                value_retry: ExactlyOnce,
+                                key_type: u32,
+                                value_type: std :: time :: Instant,
+                            },
+                        },
+                    },
+                    metadata: HydroIrMetadata {
+                        location_kind: Tick(
+                            17,
+                            Cluster(
+                                2,
+                            ),
+                        ),
+                        collection_kind: KeyedStream {
+                            bound: Bounded,
+                            value_order: NoOrder,
+                            value_retry: ExactlyOnce,
+                            key_type: u32,
+                            value_type: std :: time :: Instant,
+                        },
+                    },
+                },
+                trusted: false,
+                metadata: HydroIrMetadata {
+                    location_kind: Tick(
+                        17,
+                        Cluster(
+                            2,
+                        ),
+                    ),
+                    collection_kind: KeyedStream {
+                        bound: Bounded,
+                        value_order: TotalOrder,
+                        value_retry: ExactlyOnce,
+                        key_type: u32,
+                        value_type: std :: time :: Instant,
+                    },
+                },
+            },
+            metadata: HydroIrMetadata {
+                location_kind: Tick(
+                    17,
+                    Cluster(
+                        2,
+                    ),
+                ),
+                collection_kind: KeyedSingleton {
+                    bound: Bounded,
+                    key_type: u32,
+                    value_type: std :: time :: Instant,
+                },
+            },
+        },
+        op_metadata: HydroIrOpMetadata,
+    },
+    CycleSink {
+        ident: Ident {
+            sym: cycle_0,
+        },
+        input: ObserveNonDet {
+            inner: Map {
+                f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , core :: option :: Option < u32 >) , (u32 , u32) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; move | (virtual_id , payload) | { let value = if let Some (payload) = payload { payload + 1 } else { 0 } ; (virtual_id , value) } }),
+                input: Cast {
+                    inner: YieldConcat {
+                        inner: Chain {
+                            first: Cast {
+                                inner: Map {
+                                    f: stageleft :: runtime_support :: fn1_type_hint :: < u32 , (u32 , core :: option :: Option < u32 >) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | virtual_id | (virtual_id , None) }),
+                                    input: Tee {
+                                        inner: <tee 48>,
+                                        metadata: HydroIrMetadata {
+                                            location_kind: Tick(
+                                                17,
+                                                Cluster(
+                                                    2,
+                                                ),
+                                            ),
+                                            collection_kind: Stream {
+                                                bound: Bounded,
+                                                order: TotalOrder,
+                                                retry: ExactlyOnce,
+                                                element_type: u32,
+                                            },
+                                        },
+                                    },
+                                    metadata: HydroIrMetadata {
+                                        location_kind: Tick(
+                                            17,
                                             Cluster(
                                                 2,
                                             ),
                                         ),
                                         collection_kind: Stream {
                                             bound: Bounded,
-                                            order: NoOrder,
+                                            order: TotalOrder,
                                             retry: ExactlyOnce,
-                                            element_type: (u32 , u32),
+                                            element_type: (u32 , core :: option :: Option < u32 >),
                                         },
                                     },
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        0,
+                                        17,
                                         Cluster(
                                             2,
                                         ),
                                     ),
-                                    collection_kind: Stream {
+                                    collection_kind: KeyedStream {
                                         bound: Bounded,
-                                        order: NoOrder,
-                                        retry: ExactlyOnce,
-                                        element_type: (u32 , core :: option :: Option < u32 >),
+                                        value_order: TotalOrder,
+                                        value_retry: ExactlyOnce,
+                                        key_type: u32,
+                                        value_type: core :: option :: Option < u32 >,
+                                    },
+                                },
+                            },
+                            second: Tee {
+                                inner: <tee 50>,
+                                metadata: HydroIrMetadata {
+                                    location_kind: Tick(
+                                        17,
+                                        Cluster(
+                                            2,
+                                        ),
+                                    ),
+                                    collection_kind: KeyedStream {
+                                        bound: Bounded,
+                                        value_order: NoOrder,
+                                        value_retry: ExactlyOnce,
+                                        key_type: u32,
+                                        value_type: core :: option :: Option < u32 >,
                                     },
                                 },
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    0,
+                                    17,
                                     Cluster(
                                         2,
                                     ),
                                 ),
-                                collection_kind: Stream {
+                                collection_kind: KeyedStream {
                                     bound: Bounded,
-                                    order: NoOrder,
-                                    retry: ExactlyOnce,
-                                    element_type: (u32 , core :: option :: Option < u32 >),
+                                    value_order: NoOrder,
+                                    value_retry: ExactlyOnce,
+                                    key_type: u32,
+                                    value_type: core :: option :: Option < u32 >,
                                 },
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_kind: Tick(
-                                0,
-                                Cluster(
-                                    2,
-                                ),
+                            location_kind: Cluster(
+                                2,
                             ),
-                            collection_kind: Stream {
-                                bound: Bounded,
-                                order: NoOrder,
-                                retry: ExactlyOnce,
-                                element_type: (u32 , core :: option :: Option < u32 >),
+                            collection_kind: KeyedStream {
+                                bound: Unbounded,
+                                value_order: NoOrder,
+                                value_retry: ExactlyOnce,
+                                key_type: u32,
+                                value_type: core :: option :: Option < u32 >,
                             },
                         },
                     },
@@ -10166,263 +10531,6 @@ expression: built.ir()
                     order: TotalOrder,
                     retry: ExactlyOnce,
                     element_type: (u32 , u32),
-                },
-            },
-        },
-        op_metadata: HydroIrOpMetadata,
-    },
-    CycleSink {
-        ident: Ident {
-            sym: cycle_21,
-        },
-        input: Cast {
-            inner: Cast {
-                inner: ReduceKeyed {
-                    f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: time :: Instant , std :: time :: Instant , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | curr_time , new_time | { if new_time > * curr_time { * curr_time = new_time ; } } }),
-                    input: ObserveNonDet {
-                        inner: Cast {
-                            inner: Chain {
-                                first: Chain {
-                                    first: Tee {
-                                        inner: <tee 49>: DeferTick {
-                                            input: CycleSource {
-                                                ident: Ident {
-                                                    sym: cycle_21,
-                                                },
-                                                metadata: HydroIrMetadata {
-                                                    location_kind: Tick(
-                                                        0,
-                                                        Cluster(
-                                                            2,
-                                                        ),
-                                                    ),
-                                                    collection_kind: Stream {
-                                                        bound: Bounded,
-                                                        order: NoOrder,
-                                                        retry: ExactlyOnce,
-                                                        element_type: (u32 , std :: time :: Instant),
-                                                    },
-                                                },
-                                            },
-                                            metadata: HydroIrMetadata {
-                                                location_kind: Tick(
-                                                    0,
-                                                    Cluster(
-                                                        2,
-                                                    ),
-                                                ),
-                                                collection_kind: Stream {
-                                                    bound: Bounded,
-                                                    order: NoOrder,
-                                                    retry: ExactlyOnce,
-                                                    element_type: (u32 , std :: time :: Instant),
-                                                },
-                                            },
-                                        },
-                                        metadata: HydroIrMetadata {
-                                            location_kind: Tick(
-                                                0,
-                                                Cluster(
-                                                    2,
-                                                ),
-                                            ),
-                                            collection_kind: Stream {
-                                                bound: Bounded,
-                                                order: NoOrder,
-                                                retry: ExactlyOnce,
-                                                element_type: (u32 , std :: time :: Instant),
-                                            },
-                                        },
-                                    },
-                                    second: Map {
-                                        f: stageleft :: runtime_support :: fn1_type_hint :: < u32 , (u32 , std :: time :: Instant) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | virtual_id | (virtual_id , Instant :: now ()) }),
-                                        input: Tee {
-                                            inner: <tee 47>,
-                                            metadata: HydroIrMetadata {
-                                                location_kind: Tick(
-                                                    0,
-                                                    Cluster(
-                                                        2,
-                                                    ),
-                                                ),
-                                                collection_kind: Stream {
-                                                    bound: Bounded,
-                                                    order: TotalOrder,
-                                                    retry: ExactlyOnce,
-                                                    element_type: u32,
-                                                },
-                                            },
-                                        },
-                                        metadata: HydroIrMetadata {
-                                            location_kind: Tick(
-                                                0,
-                                                Cluster(
-                                                    2,
-                                                ),
-                                            ),
-                                            collection_kind: Stream {
-                                                bound: Bounded,
-                                                order: TotalOrder,
-                                                retry: ExactlyOnce,
-                                                element_type: (u32 , std :: time :: Instant),
-                                            },
-                                        },
-                                    },
-                                    metadata: HydroIrMetadata {
-                                        location_kind: Tick(
-                                            0,
-                                            Cluster(
-                                                2,
-                                            ),
-                                        ),
-                                        collection_kind: Stream {
-                                            bound: Bounded,
-                                            order: NoOrder,
-                                            retry: ExactlyOnce,
-                                            element_type: (u32 , std :: time :: Instant),
-                                        },
-                                    },
-                                },
-                                second: Tee {
-                                    inner: <tee 50>: Map {
-                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , core :: option :: Option < u32 >) , (u32 , std :: time :: Instant) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (key , _payload) | (key , Instant :: now ()) }),
-                                        input: Tee {
-                                            inner: <tee 48>,
-                                            metadata: HydroIrMetadata {
-                                                location_kind: Tick(
-                                                    0,
-                                                    Cluster(
-                                                        2,
-                                                    ),
-                                                ),
-                                                collection_kind: Stream {
-                                                    bound: Bounded,
-                                                    order: NoOrder,
-                                                    retry: ExactlyOnce,
-                                                    element_type: (u32 , core :: option :: Option < u32 >),
-                                                },
-                                            },
-                                        },
-                                        metadata: HydroIrMetadata {
-                                            location_kind: Tick(
-                                                0,
-                                                Cluster(
-                                                    2,
-                                                ),
-                                            ),
-                                            collection_kind: Stream {
-                                                bound: Bounded,
-                                                order: NoOrder,
-                                                retry: ExactlyOnce,
-                                                element_type: (u32 , std :: time :: Instant),
-                                            },
-                                        },
-                                    },
-                                    metadata: HydroIrMetadata {
-                                        location_kind: Tick(
-                                            0,
-                                            Cluster(
-                                                2,
-                                            ),
-                                        ),
-                                        collection_kind: Stream {
-                                            bound: Bounded,
-                                            order: NoOrder,
-                                            retry: ExactlyOnce,
-                                            element_type: (u32 , std :: time :: Instant),
-                                        },
-                                    },
-                                },
-                                metadata: HydroIrMetadata {
-                                    location_kind: Tick(
-                                        0,
-                                        Cluster(
-                                            2,
-                                        ),
-                                    ),
-                                    collection_kind: Stream {
-                                        bound: Bounded,
-                                        order: NoOrder,
-                                        retry: ExactlyOnce,
-                                        element_type: (u32 , std :: time :: Instant),
-                                    },
-                                },
-                            },
-                            metadata: HydroIrMetadata {
-                                location_kind: Tick(
-                                    0,
-                                    Cluster(
-                                        2,
-                                    ),
-                                ),
-                                collection_kind: KeyedStream {
-                                    bound: Bounded,
-                                    value_order: NoOrder,
-                                    value_retry: ExactlyOnce,
-                                    key_type: u32,
-                                    value_type: std :: time :: Instant,
-                                },
-                            },
-                        },
-                        trusted: false,
-                        metadata: HydroIrMetadata {
-                            location_kind: Tick(
-                                0,
-                                Cluster(
-                                    2,
-                                ),
-                            ),
-                            collection_kind: KeyedStream {
-                                bound: Bounded,
-                                value_order: TotalOrder,
-                                value_retry: ExactlyOnce,
-                                key_type: u32,
-                                value_type: std :: time :: Instant,
-                            },
-                        },
-                    },
-                    metadata: HydroIrMetadata {
-                        location_kind: Tick(
-                            0,
-                            Cluster(
-                                2,
-                            ),
-                        ),
-                        collection_kind: KeyedSingleton {
-                            bound: Bounded,
-                            key_type: u32,
-                            value_type: std :: time :: Instant,
-                        },
-                    },
-                },
-                metadata: HydroIrMetadata {
-                    location_kind: Tick(
-                        0,
-                        Cluster(
-                            2,
-                        ),
-                    ),
-                    collection_kind: KeyedStream {
-                        bound: Bounded,
-                        value_order: TotalOrder,
-                        value_retry: ExactlyOnce,
-                        key_type: u32,
-                        value_type: std :: time :: Instant,
-                    },
-                },
-            },
-            metadata: HydroIrMetadata {
-                location_kind: Tick(
-                    0,
-                    Cluster(
-                        2,
-                    ),
-                ),
-                collection_kind: Stream {
-                    bound: Bounded,
-                    order: NoOrder,
-                    retry: ExactlyOnce,
-                    element_type: (u32 , std :: time :: Instant),
                 },
             },
         },
@@ -10645,50 +10753,50 @@ expression: built.ir()
                                                                                                                     input: CrossSingleton {
                                                                                                                         left: Batch {
                                                                                                                             inner: Map {
-                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage) , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (_ , stats) | { stats } }),
+                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage) , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (_ , stats) | stats }),
                                                                                                                                 input: Fold {
                                                                                                                                     init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | | (0 , { RollingAverage :: new () }) }),
                                                                                                                                     acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage) , (usize , bool) , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (total , stats) , (batch_size , reset) | { if reset { if * total > 0 { stats . add_sample (* total as f64) ; } * total = 0 ; } else { * total += batch_size ; } } }),
-                                                                                                                                    input: YieldConcat {
-                                                                                                                                        inner: Chain {
-                                                                                                                                            first: Cast {
-                                                                                                                                                inner: Map {
-                                                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < usize , (usize , bool) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | batch_size | (batch_size , false) }),
-                                                                                                                                                    input: Map {
-                                                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , ()) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _signal) | d }),
-                                                                                                                                                        input: CrossSingleton {
-                                                                                                                                                            left: Fold {
-                                                                                                                                                                init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | | 0usize }),
-                                                                                                                                                                acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , (u32 , core :: option :: Option < u32 >) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | count , _ | * count += 1 }),
-                                                                                                                                                                input: ObserveNonDet {
+                                                                                                                                    input: Chain {
+                                                                                                                                        first: Map {
+                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < usize , (usize , bool) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | batch_size | (batch_size , false) }),
+                                                                                                                                            input: YieldConcat {
+                                                                                                                                                inner: Cast {
+                                                                                                                                                    inner: Fold {
+                                                                                                                                                        init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | | 0usize }),
+                                                                                                                                                        acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , core :: option :: Option < u32 > , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | count , _ | * count += 1 }),
+                                                                                                                                                        input: ObserveNonDet {
+                                                                                                                                                            inner: Map {
+                                                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , core :: option :: Option < u32 >) , core :: option :: Option < u32 > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
+                                                                                                                                                                input: Cast {
                                                                                                                                                                     inner: Tee {
-                                                                                                                                                                        inner: <tee 48>,
+                                                                                                                                                                        inner: <tee 50>,
                                                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                                                             location_kind: Tick(
-                                                                                                                                                                                0,
+                                                                                                                                                                                17,
                                                                                                                                                                                 Cluster(
                                                                                                                                                                                     2,
                                                                                                                                                                                 ),
                                                                                                                                                                             ),
-                                                                                                                                                                            collection_kind: Stream {
+                                                                                                                                                                            collection_kind: KeyedStream {
                                                                                                                                                                                 bound: Bounded,
-                                                                                                                                                                                order: NoOrder,
-                                                                                                                                                                                retry: ExactlyOnce,
-                                                                                                                                                                                element_type: (u32 , core :: option :: Option < u32 >),
+                                                                                                                                                                                value_order: NoOrder,
+                                                                                                                                                                                value_retry: ExactlyOnce,
+                                                                                                                                                                                key_type: u32,
+                                                                                                                                                                                value_type: core :: option :: Option < u32 >,
                                                                                                                                                                             },
                                                                                                                                                                         },
                                                                                                                                                                     },
-                                                                                                                                                                    trusted: true,
                                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                                         location_kind: Tick(
-                                                                                                                                                                            0,
+                                                                                                                                                                            17,
                                                                                                                                                                             Cluster(
                                                                                                                                                                                 2,
                                                                                                                                                                             ),
                                                                                                                                                                         ),
                                                                                                                                                                         collection_kind: Stream {
                                                                                                                                                                             bound: Bounded,
-                                                                                                                                                                            order: TotalOrder,
+                                                                                                                                                                            order: NoOrder,
                                                                                                                                                                             retry: ExactlyOnce,
                                                                                                                                                                             element_type: (u32 , core :: option :: Option < u32 >),
                                                                                                                                                                         },
@@ -10696,216 +10804,43 @@ expression: built.ir()
                                                                                                                                                                 },
                                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                                     location_kind: Tick(
-                                                                                                                                                                        0,
+                                                                                                                                                                        17,
                                                                                                                                                                         Cluster(
                                                                                                                                                                             2,
                                                                                                                                                                         ),
                                                                                                                                                                     ),
-                                                                                                                                                                    collection_kind: Singleton {
+                                                                                                                                                                    collection_kind: Stream {
                                                                                                                                                                         bound: Bounded,
-                                                                                                                                                                        element_type: usize,
+                                                                                                                                                                        order: NoOrder,
+                                                                                                                                                                        retry: ExactlyOnce,
+                                                                                                                                                                        element_type: core :: option :: Option < u32 >,
                                                                                                                                                                     },
                                                                                                                                                                 },
                                                                                                                                                             },
-                                                                                                                                                            right: Map {
-                                                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _u | () }),
-                                                                                                                                                                input: Filter {
-                                                                                                                                                                    f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | o | o . is_none () }),
-                                                                                                                                                                    input: Cast {
-                                                                                                                                                                        inner: ChainFirst {
-                                                                                                                                                                            first: Map {
-                                                                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                                                                                                                                                input: Map {
-                                                                                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _ | () }),
-                                                                                                                                                                                    input: Tee {
-                                                                                                                                                                                        inner: <tee 54>: Reduce {
-                                                                                                                                                                                            f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
-                                                                                                                                                                                            input: Batch {
-                                                                                                                                                                                                inner: Source {
-                                                                                                                                                                                                    source: Stream(
-                                                                                                                                                                                                        { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let interval__free = { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; Duration :: from_secs (1) } ; tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval (interval__free)) },
-                                                                                                                                                                                                    ),
-                                                                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                                                                        location_kind: Cluster(
-                                                                                                                                                                                                            2,
-                                                                                                                                                                                                        ),
-                                                                                                                                                                                                        collection_kind: Stream {
-                                                                                                                                                                                                            bound: Unbounded,
-                                                                                                                                                                                                            order: TotalOrder,
-                                                                                                                                                                                                            retry: ExactlyOnce,
-                                                                                                                                                                                                            element_type: hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
-                                                                                                                                                                                                        },
-                                                                                                                                                                                                    },
-                                                                                                                                                                                                },
-                                                                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                                                                    location_kind: Tick(
-                                                                                                                                                                                                        0,
-                                                                                                                                                                                                        Cluster(
-                                                                                                                                                                                                            2,
-                                                                                                                                                                                                        ),
-                                                                                                                                                                                                    ),
-                                                                                                                                                                                                    collection_kind: Stream {
-                                                                                                                                                                                                        bound: Bounded,
-                                                                                                                                                                                                        order: TotalOrder,
-                                                                                                                                                                                                        retry: ExactlyOnce,
-                                                                                                                                                                                                        element_type: hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
-                                                                                                                                                                                                    },
-                                                                                                                                                                                                },
-                                                                                                                                                                                            },
-                                                                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                                                                location_kind: Tick(
-                                                                                                                                                                                                    0,
-                                                                                                                                                                                                    Cluster(
-                                                                                                                                                                                                        2,
-                                                                                                                                                                                                    ),
-                                                                                                                                                                                                ),
-                                                                                                                                                                                                collection_kind: Optional {
-                                                                                                                                                                                                    bound: Bounded,
-                                                                                                                                                                                                    element_type: hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
-                                                                                                                                                                                                },
-                                                                                                                                                                                            },
-                                                                                                                                                                                        },
-                                                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                                                            location_kind: Tick(
-                                                                                                                                                                                                0,
-                                                                                                                                                                                                Cluster(
-                                                                                                                                                                                                    2,
-                                                                                                                                                                                                ),
-                                                                                                                                                                                            ),
-                                                                                                                                                                                            collection_kind: Optional {
-                                                                                                                                                                                                bound: Bounded,
-                                                                                                                                                                                                element_type: hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
-                                                                                                                                                                                            },
-                                                                                                                                                                                        },
-                                                                                                                                                                                    },
-                                                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                                                        location_kind: Tick(
-                                                                                                                                                                                            0,
-                                                                                                                                                                                            Cluster(
-                                                                                                                                                                                                2,
-                                                                                                                                                                                            ),
-                                                                                                                                                                                        ),
-                                                                                                                                                                                        collection_kind: Optional {
-                                                                                                                                                                                            bound: Bounded,
-                                                                                                                                                                                            element_type: (),
-                                                                                                                                                                                        },
-                                                                                                                                                                                    },
-                                                                                                                                                                                },
-                                                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                                                    location_kind: Tick(
-                                                                                                                                                                                        0,
-                                                                                                                                                                                        Cluster(
-                                                                                                                                                                                            2,
-                                                                                                                                                                                        ),
-                                                                                                                                                                                    ),
-                                                                                                                                                                                    collection_kind: Optional {
-                                                                                                                                                                                        bound: Bounded,
-                                                                                                                                                                                        element_type: core :: option :: Option < () >,
-                                                                                                                                                                                    },
-                                                                                                                                                                                },
-                                                                                                                                                                            },
-                                                                                                                                                                            second: Cast {
-                                                                                                                                                                                inner: SingletonSource {
-                                                                                                                                                                                    value: :: std :: option :: Option :: None,
-                                                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                                                        location_kind: Tick(
-                                                                                                                                                                                            0,
-                                                                                                                                                                                            Cluster(
-                                                                                                                                                                                                2,
-                                                                                                                                                                                            ),
-                                                                                                                                                                                        ),
-                                                                                                                                                                                        collection_kind: Singleton {
-                                                                                                                                                                                            bound: Bounded,
-                                                                                                                                                                                            element_type: core :: option :: Option < () >,
-                                                                                                                                                                                        },
-                                                                                                                                                                                    },
-                                                                                                                                                                                },
-                                                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                                                    location_kind: Tick(
-                                                                                                                                                                                        0,
-                                                                                                                                                                                        Cluster(
-                                                                                                                                                                                            2,
-                                                                                                                                                                                        ),
-                                                                                                                                                                                    ),
-                                                                                                                                                                                    collection_kind: Optional {
-                                                                                                                                                                                        bound: Bounded,
-                                                                                                                                                                                        element_type: core :: option :: Option < () >,
-                                                                                                                                                                                    },
-                                                                                                                                                                                },
-                                                                                                                                                                            },
-                                                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                                                location_kind: Tick(
-                                                                                                                                                                                    0,
-                                                                                                                                                                                    Cluster(
-                                                                                                                                                                                        2,
-                                                                                                                                                                                    ),
-                                                                                                                                                                                ),
-                                                                                                                                                                                collection_kind: Optional {
-                                                                                                                                                                                    bound: Bounded,
-                                                                                                                                                                                    element_type: core :: option :: Option < () >,
-                                                                                                                                                                                },
-                                                                                                                                                                            },
-                                                                                                                                                                        },
-                                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                                            location_kind: Tick(
-                                                                                                                                                                                0,
-                                                                                                                                                                                Cluster(
-                                                                                                                                                                                    2,
-                                                                                                                                                                                ),
-                                                                                                                                                                            ),
-                                                                                                                                                                            collection_kind: Singleton {
-                                                                                                                                                                                bound: Bounded,
-                                                                                                                                                                                element_type: core :: option :: Option < () >,
-                                                                                                                                                                            },
-                                                                                                                                                                        },
-                                                                                                                                                                    },
-                                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                                        location_kind: Tick(
-                                                                                                                                                                            0,
-                                                                                                                                                                            Cluster(
-                                                                                                                                                                                2,
-                                                                                                                                                                            ),
-                                                                                                                                                                        ),
-                                                                                                                                                                        collection_kind: Optional {
-                                                                                                                                                                            bound: Bounded,
-                                                                                                                                                                            element_type: core :: option :: Option < () >,
-                                                                                                                                                                        },
-                                                                                                                                                                    },
-                                                                                                                                                                },
-                                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                                    location_kind: Tick(
-                                                                                                                                                                        0,
-                                                                                                                                                                        Cluster(
-                                                                                                                                                                            2,
-                                                                                                                                                                        ),
-                                                                                                                                                                    ),
-                                                                                                                                                                    collection_kind: Optional {
-                                                                                                                                                                        bound: Bounded,
-                                                                                                                                                                        element_type: (),
-                                                                                                                                                                    },
-                                                                                                                                                                },
-                                                                                                                                                            },
+                                                                                                                                                            trusted: true,
                                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                                 location_kind: Tick(
-                                                                                                                                                                    0,
+                                                                                                                                                                    17,
                                                                                                                                                                     Cluster(
                                                                                                                                                                         2,
                                                                                                                                                                     ),
                                                                                                                                                                 ),
-                                                                                                                                                                collection_kind: Optional {
+                                                                                                                                                                collection_kind: Stream {
                                                                                                                                                                     bound: Bounded,
-                                                                                                                                                                    element_type: (usize , ()),
+                                                                                                                                                                    order: TotalOrder,
+                                                                                                                                                                    retry: ExactlyOnce,
+                                                                                                                                                                    element_type: core :: option :: Option < u32 >,
                                                                                                                                                                 },
                                                                                                                                                             },
                                                                                                                                                         },
                                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                                             location_kind: Tick(
-                                                                                                                                                                0,
+                                                                                                                                                                17,
                                                                                                                                                                 Cluster(
                                                                                                                                                                     2,
                                                                                                                                                                 ),
                                                                                                                                                             ),
-                                                                                                                                                            collection_kind: Optional {
+                                                                                                                                                            collection_kind: Singleton {
                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                 element_type: usize,
                                                                                                                                                             },
@@ -10913,101 +10848,67 @@ expression: built.ir()
                                                                                                                                                     },
                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                         location_kind: Tick(
-                                                                                                                                                            0,
+                                                                                                                                                            17,
                                                                                                                                                             Cluster(
                                                                                                                                                                 2,
                                                                                                                                                             ),
                                                                                                                                                         ),
-                                                                                                                                                        collection_kind: Optional {
+                                                                                                                                                        collection_kind: Stream {
                                                                                                                                                             bound: Bounded,
-                                                                                                                                                            element_type: (usize , bool),
+                                                                                                                                                            order: TotalOrder,
+                                                                                                                                                            retry: ExactlyOnce,
+                                                                                                                                                            element_type: usize,
                                                                                                                                                         },
                                                                                                                                                     },
                                                                                                                                                 },
                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                    location_kind: Tick(
-                                                                                                                                                        0,
-                                                                                                                                                        Cluster(
-                                                                                                                                                            2,
-                                                                                                                                                        ),
+                                                                                                                                                    location_kind: Cluster(
+                                                                                                                                                        2,
                                                                                                                                                     ),
                                                                                                                                                     collection_kind: Stream {
-                                                                                                                                                        bound: Bounded,
+                                                                                                                                                        bound: Unbounded,
                                                                                                                                                         order: TotalOrder,
                                                                                                                                                         retry: ExactlyOnce,
-                                                                                                                                                        element_type: (usize , bool),
-                                                                                                                                                    },
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                            second: Cast {
-                                                                                                                                                inner: DeferTick {
-                                                                                                                                                    input: Map {
-                                                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , (usize , bool) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | _ | (0 , true) }),
-                                                                                                                                                        input: Tee {
-                                                                                                                                                            inner: <tee 54>,
-                                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                                location_kind: Tick(
-                                                                                                                                                                    0,
-                                                                                                                                                                    Cluster(
-                                                                                                                                                                        2,
-                                                                                                                                                                    ),
-                                                                                                                                                                ),
-                                                                                                                                                                collection_kind: Optional {
-                                                                                                                                                                    bound: Bounded,
-                                                                                                                                                                    element_type: hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
-                                                                                                                                                                },
-                                                                                                                                                            },
-                                                                                                                                                        },
-                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                            location_kind: Tick(
-                                                                                                                                                                0,
-                                                                                                                                                                Cluster(
-                                                                                                                                                                    2,
-                                                                                                                                                                ),
-                                                                                                                                                            ),
-                                                                                                                                                            collection_kind: Optional {
-                                                                                                                                                                bound: Bounded,
-                                                                                                                                                                element_type: (usize , bool),
-                                                                                                                                                            },
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                        location_kind: Tick(
-                                                                                                                                                            0,
-                                                                                                                                                            Cluster(
-                                                                                                                                                                2,
-                                                                                                                                                            ),
-                                                                                                                                                        ),
-                                                                                                                                                        collection_kind: Optional {
-                                                                                                                                                            bound: Bounded,
-                                                                                                                                                            element_type: (usize , bool),
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                },
-                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                    location_kind: Tick(
-                                                                                                                                                        0,
-                                                                                                                                                        Cluster(
-                                                                                                                                                            2,
-                                                                                                                                                        ),
-                                                                                                                                                    ),
-                                                                                                                                                    collection_kind: Stream {
-                                                                                                                                                        bound: Bounded,
-                                                                                                                                                        order: TotalOrder,
-                                                                                                                                                        retry: ExactlyOnce,
-                                                                                                                                                        element_type: (usize , bool),
+                                                                                                                                                        element_type: usize,
                                                                                                                                                     },
                                                                                                                                                 },
                                                                                                                                             },
                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                location_kind: Tick(
-                                                                                                                                                    0,
-                                                                                                                                                    Cluster(
-                                                                                                                                                        2,
-                                                                                                                                                    ),
+                                                                                                                                                location_kind: Cluster(
+                                                                                                                                                    2,
                                                                                                                                                 ),
                                                                                                                                                 collection_kind: Stream {
-                                                                                                                                                    bound: Bounded,
+                                                                                                                                                    bound: Unbounded,
+                                                                                                                                                    order: TotalOrder,
+                                                                                                                                                    retry: ExactlyOnce,
+                                                                                                                                                    element_type: (usize , bool),
+                                                                                                                                                },
+                                                                                                                                            },
+                                                                                                                                        },
+                                                                                                                                        second: Map {
+                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , (usize , bool) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | _ | (0 , true) }),
+                                                                                                                                            input: Source {
+                                                                                                                                                source: Stream(
+                                                                                                                                                    { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let interval__free = { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; Duration :: from_secs (1) } ; tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval (interval__free)) },
+                                                                                                                                                ),
+                                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                                    location_kind: Cluster(
+                                                                                                                                                        2,
+                                                                                                                                                    ),
+                                                                                                                                                    collection_kind: Stream {
+                                                                                                                                                        bound: Unbounded,
+                                                                                                                                                        order: TotalOrder,
+                                                                                                                                                        retry: ExactlyOnce,
+                                                                                                                                                        element_type: hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
+                                                                                                                                                    },
+                                                                                                                                                },
+                                                                                                                                            },
+                                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                                location_kind: Cluster(
+                                                                                                                                                    2,
+                                                                                                                                                ),
+                                                                                                                                                collection_kind: Stream {
+                                                                                                                                                    bound: Unbounded,
                                                                                                                                                     order: TotalOrder,
                                                                                                                                                     retry: ExactlyOnce,
                                                                                                                                                     element_type: (usize , bool),
@@ -12103,30 +12004,129 @@ expression: built.ir()
                                                                                                                             input: ObserveNonDet {
                                                                                                                                 inner: YieldConcat {
                                                                                                                                     inner: Map {
-                                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , (std :: time :: Instant , std :: time :: Instant)) , core :: time :: Duration > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (_virtual_id , (prev_time , curr_time)) | curr_time . duration_since (prev_time) }),
-                                                                                                                                        input: Join {
-                                                                                                                                            left: Tee {
-                                                                                                                                                inner: <tee 49>,
-                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                    location_kind: Tick(
-                                                                                                                                                        0,
-                                                                                                                                                        Cluster(
-                                                                                                                                                            2,
+                                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: time :: Instant , std :: time :: Instant) , core :: time :: Duration > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (prev_time , curr_time) | curr_time . duration_since (prev_time) }),
+                                                                                                                                        input: Map {
+                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , (std :: time :: Instant , std :: time :: Instant)) , (std :: time :: Instant , std :: time :: Instant) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
+                                                                                                                                            input: Cast {
+                                                                                                                                                inner: Cast {
+                                                                                                                                                    inner: Join {
+                                                                                                                                                        left: Cast {
+                                                                                                                                                            inner: Cast {
+                                                                                                                                                                inner: Tee {
+                                                                                                                                                                    inner: <tee 47>,
+                                                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                                                        location_kind: Tick(
+                                                                                                                                                                            17,
+                                                                                                                                                                            Cluster(
+                                                                                                                                                                                2,
+                                                                                                                                                                            ),
+                                                                                                                                                                        ),
+                                                                                                                                                                        collection_kind: KeyedSingleton {
+                                                                                                                                                                            bound: Bounded,
+                                                                                                                                                                            key_type: u32,
+                                                                                                                                                                            value_type: std :: time :: Instant,
+                                                                                                                                                                        },
+                                                                                                                                                                    },
+                                                                                                                                                                },
+                                                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                                                    location_kind: Tick(
+                                                                                                                                                                        17,
+                                                                                                                                                                        Cluster(
+                                                                                                                                                                            2,
+                                                                                                                                                                        ),
+                                                                                                                                                                    ),
+                                                                                                                                                                    collection_kind: KeyedStream {
+                                                                                                                                                                        bound: Bounded,
+                                                                                                                                                                        value_order: TotalOrder,
+                                                                                                                                                                        value_retry: ExactlyOnce,
+                                                                                                                                                                        key_type: u32,
+                                                                                                                                                                        value_type: std :: time :: Instant,
+                                                                                                                                                                    },
+                                                                                                                                                                },
+                                                                                                                                                            },
+                                                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                                                location_kind: Tick(
+                                                                                                                                                                    17,
+                                                                                                                                                                    Cluster(
+                                                                                                                                                                        2,
+                                                                                                                                                                    ),
+                                                                                                                                                                ),
+                                                                                                                                                                collection_kind: Stream {
+                                                                                                                                                                    bound: Bounded,
+                                                                                                                                                                    order: NoOrder,
+                                                                                                                                                                    retry: ExactlyOnce,
+                                                                                                                                                                    element_type: (u32 , std :: time :: Instant),
+                                                                                                                                                                },
+                                                                                                                                                            },
+                                                                                                                                                        },
+                                                                                                                                                        right: Cast {
+                                                                                                                                                            inner: Tee {
+                                                                                                                                                                inner: <tee 49>,
+                                                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                                                    location_kind: Tick(
+                                                                                                                                                                        17,
+                                                                                                                                                                        Cluster(
+                                                                                                                                                                            2,
+                                                                                                                                                                        ),
+                                                                                                                                                                    ),
+                                                                                                                                                                    collection_kind: KeyedStream {
+                                                                                                                                                                        bound: Bounded,
+                                                                                                                                                                        value_order: NoOrder,
+                                                                                                                                                                        value_retry: ExactlyOnce,
+                                                                                                                                                                        key_type: u32,
+                                                                                                                                                                        value_type: std :: time :: Instant,
+                                                                                                                                                                    },
+                                                                                                                                                                },
+                                                                                                                                                            },
+                                                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                                                location_kind: Tick(
+                                                                                                                                                                    17,
+                                                                                                                                                                    Cluster(
+                                                                                                                                                                        2,
+                                                                                                                                                                    ),
+                                                                                                                                                                ),
+                                                                                                                                                                collection_kind: Stream {
+                                                                                                                                                                    bound: Bounded,
+                                                                                                                                                                    order: NoOrder,
+                                                                                                                                                                    retry: ExactlyOnce,
+                                                                                                                                                                    element_type: (u32 , std :: time :: Instant),
+                                                                                                                                                                },
+                                                                                                                                                            },
+                                                                                                                                                        },
+                                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                                            location_kind: Tick(
+                                                                                                                                                                17,
+                                                                                                                                                                Cluster(
+                                                                                                                                                                    2,
+                                                                                                                                                                ),
+                                                                                                                                                            ),
+                                                                                                                                                            collection_kind: Stream {
+                                                                                                                                                                bound: Bounded,
+                                                                                                                                                                order: NoOrder,
+                                                                                                                                                                retry: ExactlyOnce,
+                                                                                                                                                                element_type: (u32 , (std :: time :: Instant , std :: time :: Instant)),
+                                                                                                                                                            },
+                                                                                                                                                        },
+                                                                                                                                                    },
+                                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                                        location_kind: Tick(
+                                                                                                                                                            17,
+                                                                                                                                                            Cluster(
+                                                                                                                                                                2,
+                                                                                                                                                            ),
                                                                                                                                                         ),
-                                                                                                                                                    ),
-                                                                                                                                                    collection_kind: Stream {
-                                                                                                                                                        bound: Bounded,
-                                                                                                                                                        order: NoOrder,
-                                                                                                                                                        retry: ExactlyOnce,
-                                                                                                                                                        element_type: (u32 , std :: time :: Instant),
+                                                                                                                                                        collection_kind: KeyedStream {
+                                                                                                                                                            bound: Bounded,
+                                                                                                                                                            value_order: NoOrder,
+                                                                                                                                                            value_retry: ExactlyOnce,
+                                                                                                                                                            key_type: u32,
+                                                                                                                                                            value_type: (std :: time :: Instant , std :: time :: Instant),
+                                                                                                                                                        },
                                                                                                                                                     },
                                                                                                                                                 },
-                                                                                                                                            },
-                                                                                                                                            right: Tee {
-                                                                                                                                                inner: <tee 50>,
                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                     location_kind: Tick(
-                                                                                                                                                        0,
+                                                                                                                                                        17,
                                                                                                                                                         Cluster(
                                                                                                                                                             2,
                                                                                                                                                         ),
@@ -12135,13 +12135,13 @@ expression: built.ir()
                                                                                                                                                         bound: Bounded,
                                                                                                                                                         order: NoOrder,
                                                                                                                                                         retry: ExactlyOnce,
-                                                                                                                                                        element_type: (u32 , std :: time :: Instant),
+                                                                                                                                                        element_type: (u32 , (std :: time :: Instant , std :: time :: Instant)),
                                                                                                                                                     },
                                                                                                                                                 },
                                                                                                                                             },
                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                 location_kind: Tick(
-                                                                                                                                                    0,
+                                                                                                                                                    17,
                                                                                                                                                     Cluster(
                                                                                                                                                         2,
                                                                                                                                                     ),
@@ -12150,13 +12150,13 @@ expression: built.ir()
                                                                                                                                                     bound: Bounded,
                                                                                                                                                     order: NoOrder,
                                                                                                                                                     retry: ExactlyOnce,
-                                                                                                                                                    element_type: (u32 , (std :: time :: Instant , std :: time :: Instant)),
+                                                                                                                                                    element_type: (std :: time :: Instant , std :: time :: Instant),
                                                                                                                                                 },
                                                                                                                                             },
                                                                                                                                         },
                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                             location_kind: Tick(
-                                                                                                                                                0,
+                                                                                                                                                17,
                                                                                                                                                 Cluster(
                                                                                                                                                     2,
                                                                                                                                                 ),

--- a/hydro_test/src/cluster/snapshots/paxos_ir@acceptor_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir@acceptor_mermaid.snap
@@ -122,165 +122,165 @@ linkStyle default stroke:#aaa
 25v1
 35v1
 34v1
-subgraph var_cycle_2 ["var <tt>cycle_2</tt>"]
-    style var_cycle_2 fill:transparent
+subgraph var_cycle_1 ["var <tt>cycle_1</tt>"]
+    style var_cycle_1 fill:transparent
     52v1
 end
-subgraph var_cycle_4 ["var <tt>cycle_4</tt>"]
-    style var_cycle_4 fill:transparent
+subgraph var_cycle_3 ["var <tt>cycle_3</tt>"]
+    style var_cycle_3 fill:transparent
     40v1
 end
-subgraph var_reduce_keyed_watermark_chain_484 ["var <tt>reduce_keyed_watermark_chain_484</tt>"]
-    style var_reduce_keyed_watermark_chain_484 fill:transparent
+subgraph var_reduce_keyed_watermark_chain_477 ["var <tt>reduce_keyed_watermark_chain_477</tt>"]
+    style var_reduce_keyed_watermark_chain_477 fill:transparent
     33v1
 end
-subgraph var_stream_130 ["var <tt>stream_130</tt>"]
-    style var_stream_130 fill:transparent
+subgraph var_stream_123 ["var <tt>stream_123</tt>"]
+    style var_stream_123 fill:transparent
     3v1
     4v1
 end
+subgraph var_stream_126 ["var <tt>stream_126</tt>"]
+    style var_stream_126 fill:transparent
+    5v1
+end
+subgraph var_stream_128 ["var <tt>stream_128</tt>"]
+    style var_stream_128 fill:transparent
+    6v1
+end
+subgraph var_stream_130 ["var <tt>stream_130</tt>"]
+    style var_stream_130 fill:transparent
+    7v1
+end
 subgraph var_stream_133 ["var <tt>stream_133</tt>"]
     style var_stream_133 fill:transparent
-    5v1
+    8v1
 end
 subgraph var_stream_135 ["var <tt>stream_135</tt>"]
     style var_stream_135 fill:transparent
-    6v1
-end
-subgraph var_stream_137 ["var <tt>stream_137</tt>"]
-    style var_stream_137 fill:transparent
-    7v1
-end
-subgraph var_stream_140 ["var <tt>stream_140</tt>"]
-    style var_stream_140 fill:transparent
-    8v1
-end
-subgraph var_stream_142 ["var <tt>stream_142</tt>"]
-    style var_stream_142 fill:transparent
     9v1
     10v1
 end
-subgraph var_stream_144 ["var <tt>stream_144</tt>"]
-    style var_stream_144 fill:transparent
+subgraph var_stream_137 ["var <tt>stream_137</tt>"]
+    style var_stream_137 fill:transparent
     11v1
 end
-subgraph var_stream_146 ["var <tt>stream_146</tt>"]
-    style var_stream_146 fill:transparent
+subgraph var_stream_139 ["var <tt>stream_139</tt>"]
+    style var_stream_139 fill:transparent
     12v1
 end
-subgraph var_stream_148 ["var <tt>stream_148</tt>"]
-    style var_stream_148 fill:transparent
+subgraph var_stream_141 ["var <tt>stream_141</tt>"]
+    style var_stream_141 fill:transparent
     13v1
 end
-subgraph var_stream_151 ["var <tt>stream_151</tt>"]
-    style var_stream_151 fill:transparent
+subgraph var_stream_144 ["var <tt>stream_144</tt>"]
+    style var_stream_144 fill:transparent
     14v1
 end
-subgraph var_stream_152 ["var <tt>stream_152</tt>"]
-    style var_stream_152 fill:transparent
+subgraph var_stream_145 ["var <tt>stream_145</tt>"]
+    style var_stream_145 fill:transparent
     15v1
 end
-subgraph var_stream_411 ["var <tt>stream_411</tt>"]
-    style var_stream_411 fill:transparent
+subgraph var_stream_2 ["var <tt>stream_2</tt>"]
+    style var_stream_2 fill:transparent
+    1v1
+end
+subgraph var_stream_404 ["var <tt>stream_404</tt>"]
+    style var_stream_404 fill:transparent
     18v1
     19v1
 end
-subgraph var_stream_414 ["var <tt>stream_414</tt>"]
-    style var_stream_414 fill:transparent
+subgraph var_stream_407 ["var <tt>stream_407</tt>"]
+    style var_stream_407 fill:transparent
     20v1
 end
-subgraph var_stream_416 ["var <tt>stream_416</tt>"]
-    style var_stream_416 fill:transparent
+subgraph var_stream_409 ["var <tt>stream_409</tt>"]
+    style var_stream_409 fill:transparent
     21v1
 end
-subgraph var_stream_419 ["var <tt>stream_419</tt>"]
-    style var_stream_419 fill:transparent
+subgraph var_stream_412 ["var <tt>stream_412</tt>"]
+    style var_stream_412 fill:transparent
     22v1
 end
-subgraph var_stream_420 ["var <tt>stream_420</tt>"]
-    style var_stream_420 fill:transparent
+subgraph var_stream_413 ["var <tt>stream_413</tt>"]
+    style var_stream_413 fill:transparent
     23v1
 end
-subgraph var_stream_469 ["var <tt>stream_469</tt>"]
-    style var_stream_469 fill:transparent
+subgraph var_stream_462 ["var <tt>stream_462</tt>"]
+    style var_stream_462 fill:transparent
     26v1
 end
-subgraph var_stream_470 ["var <tt>stream_470</tt>"]
-    style var_stream_470 fill:transparent
+subgraph var_stream_463 ["var <tt>stream_463</tt>"]
+    style var_stream_463 fill:transparent
     27v1
 end
-subgraph var_stream_471 ["var <tt>stream_471</tt>"]
-    style var_stream_471 fill:transparent
+subgraph var_stream_464 ["var <tt>stream_464</tt>"]
+    style var_stream_464 fill:transparent
     28v1
     29v1
 end
-subgraph var_stream_473 ["var <tt>stream_473</tt>"]
-    style var_stream_473 fill:transparent
+subgraph var_stream_466 ["var <tt>stream_466</tt>"]
+    style var_stream_466 fill:transparent
     30v1
 end
-subgraph var_stream_478 ["var <tt>stream_478</tt>"]
-    style var_stream_478 fill:transparent
+subgraph var_stream_471 ["var <tt>stream_471</tt>"]
+    style var_stream_471 fill:transparent
     31v1
 end
-subgraph var_stream_479 ["var <tt>stream_479</tt>"]
-    style var_stream_479 fill:transparent
+subgraph var_stream_472 ["var <tt>stream_472</tt>"]
+    style var_stream_472 fill:transparent
     32v1
 end
-subgraph var_stream_484 ["var <tt>stream_484</tt>"]
-    style var_stream_484 fill:transparent
+subgraph var_stream_477 ["var <tt>stream_477</tt>"]
+    style var_stream_477 fill:transparent
     36v1
     37v1
 end
-subgraph var_stream_489 ["var <tt>stream_489</tt>"]
-    style var_stream_489 fill:transparent
+subgraph var_stream_482 ["var <tt>stream_482</tt>"]
+    style var_stream_482 fill:transparent
     38v1
 end
-subgraph var_stream_490 ["var <tt>stream_490</tt>"]
-    style var_stream_490 fill:transparent
+subgraph var_stream_483 ["var <tt>stream_483</tt>"]
+    style var_stream_483 fill:transparent
     39v1
 end
-subgraph var_stream_595 ["var <tt>stream_595</tt>"]
-    style var_stream_595 fill:transparent
+subgraph var_stream_588 ["var <tt>stream_588</tt>"]
+    style var_stream_588 fill:transparent
     41v1
     42v1
 end
-subgraph var_stream_597 ["var <tt>stream_597</tt>"]
-    style var_stream_597 fill:transparent
+subgraph var_stream_590 ["var <tt>stream_590</tt>"]
+    style var_stream_590 fill:transparent
     43v1
+end
+subgraph var_stream_592 ["var <tt>stream_592</tt>"]
+    style var_stream_592 fill:transparent
+    44v1
 end
 subgraph var_stream_599 ["var <tt>stream_599</tt>"]
     style var_stream_599 fill:transparent
-    44v1
+    45v1
+end
+subgraph var_stream_600 ["var <tt>stream_600</tt>"]
+    style var_stream_600 fill:transparent
+    46v1
+end
+subgraph var_stream_601 ["var <tt>stream_601</tt>"]
+    style var_stream_601 fill:transparent
+    47v1
+end
+subgraph var_stream_602 ["var <tt>stream_602</tt>"]
+    style var_stream_602 fill:transparent
+    48v1
+end
+subgraph var_stream_603 ["var <tt>stream_603</tt>"]
+    style var_stream_603 fill:transparent
+    49v1
+end
+subgraph var_stream_604 ["var <tt>stream_604</tt>"]
+    style var_stream_604 fill:transparent
+    50v1
 end
 subgraph var_stream_606 ["var <tt>stream_606</tt>"]
     style var_stream_606 fill:transparent
-    45v1
-end
-subgraph var_stream_607 ["var <tt>stream_607</tt>"]
-    style var_stream_607 fill:transparent
-    46v1
-end
-subgraph var_stream_608 ["var <tt>stream_608</tt>"]
-    style var_stream_608 fill:transparent
-    47v1
-end
-subgraph var_stream_609 ["var <tt>stream_609</tt>"]
-    style var_stream_609 fill:transparent
-    48v1
-end
-subgraph var_stream_610 ["var <tt>stream_610</tt>"]
-    style var_stream_610 fill:transparent
-    49v1
-end
-subgraph var_stream_611 ["var <tt>stream_611</tt>"]
-    style var_stream_611 fill:transparent
-    50v1
-end
-subgraph var_stream_613 ["var <tt>stream_613</tt>"]
-    style var_stream_613 fill:transparent
     51v1
-end
-subgraph var_stream_9 ["var <tt>stream_9</tt>"]
-    style var_stream_9 fill:transparent
-    1v1
 end

--- a/hydro_test/src/cluster/snapshots/paxos_ir@proposer_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir@proposer_mermaid.snap
@@ -554,889 +554,889 @@ linkStyle default stroke:#aaa
 348v1
 350v1
 352v1
-subgraph var_cycle_10 ["var <tt>cycle_10</tt>"]
-    style var_cycle_10 fill:transparent
-    89v1
+subgraph var_cycle_11 ["var <tt>cycle_11</tt>"]
+    style var_cycle_11 fill:transparent
+    168v1
 end
 subgraph var_cycle_12 ["var <tt>cycle_12</tt>"]
     style var_cycle_12 fill:transparent
-    168v1
+    215v1
 end
 subgraph var_cycle_13 ["var <tt>cycle_13</tt>"]
     style var_cycle_13 fill:transparent
-    215v1
+    219v1
 end
 subgraph var_cycle_14 ["var <tt>cycle_14</tt>"]
     style var_cycle_14 fill:transparent
-    219v1
-end
-subgraph var_cycle_15 ["var <tt>cycle_15</tt>"]
-    style var_cycle_15 fill:transparent
     229v1
 end
-subgraph var_cycle_3 ["var <tt>cycle_3</tt>"]
-    style var_cycle_3 fill:transparent
+subgraph var_cycle_2 ["var <tt>cycle_2</tt>"]
+    style var_cycle_2 fill:transparent
     232v1
+end
+subgraph var_cycle_4 ["var <tt>cycle_4</tt>"]
+    style var_cycle_4 fill:transparent
+    114v1
 end
 subgraph var_cycle_5 ["var <tt>cycle_5</tt>"]
     style var_cycle_5 fill:transparent
-    114v1
+    42v1
 end
 subgraph var_cycle_6 ["var <tt>cycle_6</tt>"]
     style var_cycle_6 fill:transparent
-    42v1
+    111v1
 end
 subgraph var_cycle_7 ["var <tt>cycle_7</tt>"]
     style var_cycle_7 fill:transparent
-    111v1
+    17v1
 end
 subgraph var_cycle_8 ["var <tt>cycle_8</tt>"]
     style var_cycle_8 fill:transparent
-    17v1
+    85v1
 end
 subgraph var_cycle_9 ["var <tt>cycle_9</tt>"]
     style var_cycle_9 fill:transparent
-    85v1
+    89v1
 end
-subgraph var_stream_100 ["var <tt>stream_100</tt>"]
-    style var_stream_100 fill:transparent
-    50v1
+subgraph var_stream_0 ["var <tt>stream_0</tt>"]
+    style var_stream_0 fill:transparent
+    1v1
+end
+subgraph var_stream_101 ["var <tt>stream_101</tt>"]
+    style var_stream_101 fill:transparent
+    55v1
+end
+subgraph var_stream_103 ["var <tt>stream_103</tt>"]
+    style var_stream_103 fill:transparent
+    56v1
 end
 subgraph var_stream_104 ["var <tt>stream_104</tt>"]
     style var_stream_104 fill:transparent
-    51v1
+    57v1
 end
 subgraph var_stream_105 ["var <tt>stream_105</tt>"]
     style var_stream_105 fill:transparent
-    52v1
+    58v1
 end
 subgraph var_stream_106 ["var <tt>stream_106</tt>"]
     style var_stream_106 fill:transparent
-    53v1
-    54v1
+    59v1
 end
-subgraph var_stream_108 ["var <tt>stream_108</tt>"]
-    style var_stream_108 fill:transparent
-    55v1
+subgraph var_stream_107 ["var <tt>stream_107</tt>"]
+    style var_stream_107 fill:transparent
+    60v1
+end
+subgraph var_stream_109 ["var <tt>stream_109</tt>"]
+    style var_stream_109 fill:transparent
+    61v1
+end
+subgraph var_stream_11 ["var <tt>stream_11</tt>"]
+    style var_stream_11 fill:transparent
+    5v1
 end
 subgraph var_stream_110 ["var <tt>stream_110</tt>"]
     style var_stream_110 fill:transparent
-    56v1
+    62v1
 end
 subgraph var_stream_111 ["var <tt>stream_111</tt>"]
     style var_stream_111 fill:transparent
-    57v1
+    63v1
 end
 subgraph var_stream_112 ["var <tt>stream_112</tt>"]
     style var_stream_112 fill:transparent
-    58v1
+    64v1
 end
 subgraph var_stream_113 ["var <tt>stream_113</tt>"]
     style var_stream_113 fill:transparent
-    59v1
+    65v1
 end
 subgraph var_stream_114 ["var <tt>stream_114</tt>"]
     style var_stream_114 fill:transparent
-    60v1
+    66v1
 end
-subgraph var_stream_116 ["var <tt>stream_116</tt>"]
-    style var_stream_116 fill:transparent
-    61v1
-end
-subgraph var_stream_117 ["var <tt>stream_117</tt>"]
-    style var_stream_117 fill:transparent
-    62v1
+subgraph var_stream_115 ["var <tt>stream_115</tt>"]
+    style var_stream_115 fill:transparent
+    67v1
 end
 subgraph var_stream_118 ["var <tt>stream_118</tt>"]
     style var_stream_118 fill:transparent
-    63v1
-end
-subgraph var_stream_119 ["var <tt>stream_119</tt>"]
-    style var_stream_119 fill:transparent
-    64v1
+    68v1
 end
 subgraph var_stream_120 ["var <tt>stream_120</tt>"]
     style var_stream_120 fill:transparent
-    65v1
-end
-subgraph var_stream_121 ["var <tt>stream_121</tt>"]
-    style var_stream_121 fill:transparent
-    66v1
-end
-subgraph var_stream_122 ["var <tt>stream_122</tt>"]
-    style var_stream_122 fill:transparent
-    67v1
-end
-subgraph var_stream_125 ["var <tt>stream_125</tt>"]
-    style var_stream_125 fill:transparent
-    68v1
-end
-subgraph var_stream_127 ["var <tt>stream_127</tt>"]
-    style var_stream_127 fill:transparent
     69v1
 end
 subgraph var_stream_13 ["var <tt>stream_13</tt>"]
     style var_stream_13 fill:transparent
-    3v1
-end
-subgraph var_stream_15 ["var <tt>stream_15</tt>"]
-    style var_stream_15 fill:transparent
-    4v1
-end
-subgraph var_stream_155 ["var <tt>stream_155</tt>"]
-    style var_stream_155 fill:transparent
-    72v1
-    73v1
-end
-subgraph var_stream_158 ["var <tt>stream_158</tt>"]
-    style var_stream_158 fill:transparent
-    74v1
-end
-subgraph var_stream_159 ["var <tt>stream_159</tt>"]
-    style var_stream_159 fill:transparent
-    75v1
-end
-subgraph var_stream_160 ["var <tt>stream_160</tt>"]
-    style var_stream_160 fill:transparent
-    76v1
-end
-subgraph var_stream_162 ["var <tt>stream_162</tt>"]
-    style var_stream_162 fill:transparent
-    77v1
-end
-subgraph var_stream_163 ["var <tt>stream_163</tt>"]
-    style var_stream_163 fill:transparent
-    78v1
-end
-subgraph var_stream_167 ["var <tt>stream_167</tt>"]
-    style var_stream_167 fill:transparent
-    79v1
-end
-subgraph var_stream_168 ["var <tt>stream_168</tt>"]
-    style var_stream_168 fill:transparent
-    80v1
-end
-subgraph var_stream_169 ["var <tt>stream_169</tt>"]
-    style var_stream_169 fill:transparent
-    81v1
-end
-subgraph var_stream_172 ["var <tt>stream_172</tt>"]
-    style var_stream_172 fill:transparent
-    82v1
-end
-subgraph var_stream_173 ["var <tt>stream_173</tt>"]
-    style var_stream_173 fill:transparent
-    83v1
-end
-subgraph var_stream_174 ["var <tt>stream_174</tt>"]
-    style var_stream_174 fill:transparent
-    84v1
-end
-subgraph var_stream_176 ["var <tt>stream_176</tt>"]
-    style var_stream_176 fill:transparent
-    86v1
-end
-subgraph var_stream_179 ["var <tt>stream_179</tt>"]
-    style var_stream_179 fill:transparent
-    87v1
-end
-subgraph var_stream_18 ["var <tt>stream_18</tt>"]
-    style var_stream_18 fill:transparent
-    5v1
-end
-subgraph var_stream_181 ["var <tt>stream_181</tt>"]
-    style var_stream_181 fill:transparent
-    88v1
-end
-subgraph var_stream_184 ["var <tt>stream_184</tt>"]
-    style var_stream_184 fill:transparent
-    90v1
-end
-subgraph var_stream_187 ["var <tt>stream_187</tt>"]
-    style var_stream_187 fill:transparent
-    91v1
-end
-subgraph var_stream_188 ["var <tt>stream_188</tt>"]
-    style var_stream_188 fill:transparent
-    92v1
-end
-subgraph var_stream_190 ["var <tt>stream_190</tt>"]
-    style var_stream_190 fill:transparent
-    93v1
-end
-subgraph var_stream_191 ["var <tt>stream_191</tt>"]
-    style var_stream_191 fill:transparent
-    94v1
-end
-subgraph var_stream_192 ["var <tt>stream_192</tt>"]
-    style var_stream_192 fill:transparent
-    95v1
-end
-subgraph var_stream_196 ["var <tt>stream_196</tt>"]
-    style var_stream_196 fill:transparent
-    96v1
-end
-subgraph var_stream_197 ["var <tt>stream_197</tt>"]
-    style var_stream_197 fill:transparent
-    97v1
-end
-subgraph var_stream_20 ["var <tt>stream_20</tt>"]
-    style var_stream_20 fill:transparent
     6v1
     7v1
 end
-subgraph var_stream_202 ["var <tt>stream_202</tt>"]
-    style var_stream_202 fill:transparent
+subgraph var_stream_148 ["var <tt>stream_148</tt>"]
+    style var_stream_148 fill:transparent
+    72v1
+    73v1
+end
+subgraph var_stream_151 ["var <tt>stream_151</tt>"]
+    style var_stream_151 fill:transparent
+    74v1
+end
+subgraph var_stream_152 ["var <tt>stream_152</tt>"]
+    style var_stream_152 fill:transparent
+    75v1
+end
+subgraph var_stream_153 ["var <tt>stream_153</tt>"]
+    style var_stream_153 fill:transparent
+    76v1
+end
+subgraph var_stream_155 ["var <tt>stream_155</tt>"]
+    style var_stream_155 fill:transparent
+    77v1
+end
+subgraph var_stream_156 ["var <tt>stream_156</tt>"]
+    style var_stream_156 fill:transparent
+    78v1
+end
+subgraph var_stream_16 ["var <tt>stream_16</tt>"]
+    style var_stream_16 fill:transparent
+    8v1
+end
+subgraph var_stream_160 ["var <tt>stream_160</tt>"]
+    style var_stream_160 fill:transparent
+    79v1
+end
+subgraph var_stream_161 ["var <tt>stream_161</tt>"]
+    style var_stream_161 fill:transparent
+    80v1
+end
+subgraph var_stream_162 ["var <tt>stream_162</tt>"]
+    style var_stream_162 fill:transparent
+    81v1
+end
+subgraph var_stream_165 ["var <tt>stream_165</tt>"]
+    style var_stream_165 fill:transparent
+    82v1
+end
+subgraph var_stream_166 ["var <tt>stream_166</tt>"]
+    style var_stream_166 fill:transparent
+    83v1
+end
+subgraph var_stream_167 ["var <tt>stream_167</tt>"]
+    style var_stream_167 fill:transparent
+    84v1
+end
+subgraph var_stream_169 ["var <tt>stream_169</tt>"]
+    style var_stream_169 fill:transparent
+    86v1
+end
+subgraph var_stream_172 ["var <tt>stream_172</tt>"]
+    style var_stream_172 fill:transparent
+    87v1
+end
+subgraph var_stream_174 ["var <tt>stream_174</tt>"]
+    style var_stream_174 fill:transparent
+    88v1
+end
+subgraph var_stream_177 ["var <tt>stream_177</tt>"]
+    style var_stream_177 fill:transparent
+    90v1
+end
+subgraph var_stream_180 ["var <tt>stream_180</tt>"]
+    style var_stream_180 fill:transparent
+    91v1
+end
+subgraph var_stream_181 ["var <tt>stream_181</tt>"]
+    style var_stream_181 fill:transparent
+    92v1
+end
+subgraph var_stream_183 ["var <tt>stream_183</tt>"]
+    style var_stream_183 fill:transparent
+    93v1
+end
+subgraph var_stream_184 ["var <tt>stream_184</tt>"]
+    style var_stream_184 fill:transparent
+    94v1
+end
+subgraph var_stream_185 ["var <tt>stream_185</tt>"]
+    style var_stream_185 fill:transparent
+    95v1
+end
+subgraph var_stream_189 ["var <tt>stream_189</tt>"]
+    style var_stream_189 fill:transparent
+    96v1
+end
+subgraph var_stream_190 ["var <tt>stream_190</tt>"]
+    style var_stream_190 fill:transparent
+    97v1
+end
+subgraph var_stream_195 ["var <tt>stream_195</tt>"]
+    style var_stream_195 fill:transparent
     98v1
 end
-subgraph var_stream_206 ["var <tt>stream_206</tt>"]
-    style var_stream_206 fill:transparent
+subgraph var_stream_199 ["var <tt>stream_199</tt>"]
+    style var_stream_199 fill:transparent
     99v1
+end
+subgraph var_stream_200 ["var <tt>stream_200</tt>"]
+    style var_stream_200 fill:transparent
+    100v1
+end
+subgraph var_stream_201 ["var <tt>stream_201</tt>"]
+    style var_stream_201 fill:transparent
+    101v1
+end
+subgraph var_stream_202 ["var <tt>stream_202</tt>"]
+    style var_stream_202 fill:transparent
+    102v1
+end
+subgraph var_stream_205 ["var <tt>stream_205</tt>"]
+    style var_stream_205 fill:transparent
+    103v1
 end
 subgraph var_stream_207 ["var <tt>stream_207</tt>"]
     style var_stream_207 fill:transparent
-    100v1
+    104v1
 end
 subgraph var_stream_208 ["var <tt>stream_208</tt>"]
     style var_stream_208 fill:transparent
-    101v1
-end
-subgraph var_stream_209 ["var <tt>stream_209</tt>"]
-    style var_stream_209 fill:transparent
-    102v1
+    105v1
 end
 subgraph var_stream_212 ["var <tt>stream_212</tt>"]
     style var_stream_212 fill:transparent
-    103v1
+    107v1
+end
+subgraph var_stream_213 ["var <tt>stream_213</tt>"]
+    style var_stream_213 fill:transparent
+    108v1
 end
 subgraph var_stream_214 ["var <tt>stream_214</tt>"]
     style var_stream_214 fill:transparent
-    104v1
+    109v1
 end
 subgraph var_stream_215 ["var <tt>stream_215</tt>"]
     style var_stream_215 fill:transparent
-    105v1
-end
-subgraph var_stream_219 ["var <tt>stream_219</tt>"]
-    style var_stream_219 fill:transparent
-    107v1
-end
-subgraph var_stream_220 ["var <tt>stream_220</tt>"]
-    style var_stream_220 fill:transparent
-    108v1
-end
-subgraph var_stream_221 ["var <tt>stream_221</tt>"]
-    style var_stream_221 fill:transparent
-    109v1
-end
-subgraph var_stream_222 ["var <tt>stream_222</tt>"]
-    style var_stream_222 fill:transparent
     110v1
 end
-subgraph var_stream_224 ["var <tt>stream_224</tt>"]
-    style var_stream_224 fill:transparent
+subgraph var_stream_217 ["var <tt>stream_217</tt>"]
+    style var_stream_217 fill:transparent
     112v1
 end
-subgraph var_stream_225 ["var <tt>stream_225</tt>"]
-    style var_stream_225 fill:transparent
+subgraph var_stream_218 ["var <tt>stream_218</tt>"]
+    style var_stream_218 fill:transparent
     113v1
 end
-subgraph var_stream_23 ["var <tt>stream_23</tt>"]
-    style var_stream_23 fill:transparent
-    8v1
+subgraph var_stream_22 ["var <tt>stream_22</tt>"]
+    style var_stream_22 fill:transparent
+    9v1
 end
-subgraph var_stream_233 ["var <tt>stream_233</tt>"]
-    style var_stream_233 fill:transparent
+subgraph var_stream_226 ["var <tt>stream_226</tt>"]
+    style var_stream_226 fill:transparent
     115v1
+end
+subgraph var_stream_227 ["var <tt>stream_227</tt>"]
+    style var_stream_227 fill:transparent
+    116v1
+end
+subgraph var_stream_229 ["var <tt>stream_229</tt>"]
+    style var_stream_229 fill:transparent
+    117v1
+end
+subgraph var_stream_231 ["var <tt>stream_231</tt>"]
+    style var_stream_231 fill:transparent
+    118v1
 end
 subgraph var_stream_234 ["var <tt>stream_234</tt>"]
     style var_stream_234 fill:transparent
-    116v1
+    119v1
 end
-subgraph var_stream_236 ["var <tt>stream_236</tt>"]
-    style var_stream_236 fill:transparent
-    117v1
+subgraph var_stream_239 ["var <tt>stream_239</tt>"]
+    style var_stream_239 fill:transparent
+    120v1
 end
-subgraph var_stream_238 ["var <tt>stream_238</tt>"]
-    style var_stream_238 fill:transparent
-    118v1
+subgraph var_stream_24 ["var <tt>stream_24</tt>"]
+    style var_stream_24 fill:transparent
+    10v1
+end
+subgraph var_stream_240 ["var <tt>stream_240</tt>"]
+    style var_stream_240 fill:transparent
+    121v1
 end
 subgraph var_stream_241 ["var <tt>stream_241</tt>"]
     style var_stream_241 fill:transparent
-    119v1
-end
-subgraph var_stream_246 ["var <tt>stream_246</tt>"]
-    style var_stream_246 fill:transparent
-    120v1
-end
-subgraph var_stream_247 ["var <tt>stream_247</tt>"]
-    style var_stream_247 fill:transparent
-    121v1
-end
-subgraph var_stream_248 ["var <tt>stream_248</tt>"]
-    style var_stream_248 fill:transparent
     122v1
 end
-subgraph var_stream_249 ["var <tt>stream_249</tt>"]
-    style var_stream_249 fill:transparent
+subgraph var_stream_242 ["var <tt>stream_242</tt>"]
+    style var_stream_242 fill:transparent
     123v1
     124v1
 end
-subgraph var_stream_251 ["var <tt>stream_251</tt>"]
-    style var_stream_251 fill:transparent
+subgraph var_stream_244 ["var <tt>stream_244</tt>"]
+    style var_stream_244 fill:transparent
     125v1
 end
-subgraph var_stream_253 ["var <tt>stream_253</tt>"]
-    style var_stream_253 fill:transparent
+subgraph var_stream_246 ["var <tt>stream_246</tt>"]
+    style var_stream_246 fill:transparent
     126v1
 end
-subgraph var_stream_254 ["var <tt>stream_254</tt>"]
-    style var_stream_254 fill:transparent
+subgraph var_stream_247 ["var <tt>stream_247</tt>"]
+    style var_stream_247 fill:transparent
     127v1
 end
-subgraph var_stream_255 ["var <tt>stream_255</tt>"]
-    style var_stream_255 fill:transparent
+subgraph var_stream_248 ["var <tt>stream_248</tt>"]
+    style var_stream_248 fill:transparent
     128v1
 end
-subgraph var_stream_256 ["var <tt>stream_256</tt>"]
-    style var_stream_256 fill:transparent
+subgraph var_stream_249 ["var <tt>stream_249</tt>"]
+    style var_stream_249 fill:transparent
     129v1
 end
-subgraph var_stream_258 ["var <tt>stream_258</tt>"]
-    style var_stream_258 fill:transparent
-    131v1
-end
-subgraph var_stream_259 ["var <tt>stream_259</tt>"]
-    style var_stream_259 fill:transparent
-    132v1
-end
-subgraph var_stream_260 ["var <tt>stream_260</tt>"]
-    style var_stream_260 fill:transparent
-    133v1
-end
-subgraph var_stream_264 ["var <tt>stream_264</tt>"]
-    style var_stream_264 fill:transparent
-    134v1
-end
-subgraph var_stream_29 ["var <tt>stream_29</tt>"]
-    style var_stream_29 fill:transparent
-    9v1
-end
-subgraph var_stream_293 ["var <tt>stream_293</tt>"]
-    style var_stream_293 fill:transparent
-    138v1
-    137v1
-end
-subgraph var_stream_296 ["var <tt>stream_296</tt>"]
-    style var_stream_296 fill:transparent
-    139v1
-end
-subgraph var_stream_300 ["var <tt>stream_300</tt>"]
-    style var_stream_300 fill:transparent
-    140v1
-end
-subgraph var_stream_301 ["var <tt>stream_301</tt>"]
-    style var_stream_301 fill:transparent
-    141v1
-end
-subgraph var_stream_302 ["var <tt>stream_302</tt>"]
-    style var_stream_302 fill:transparent
-    142v1
-end
-subgraph var_stream_305 ["var <tt>stream_305</tt>"]
-    style var_stream_305 fill:transparent
-    143v1
-end
-subgraph var_stream_307 ["var <tt>stream_307</tt>"]
-    style var_stream_307 fill:transparent
-    144v1
-end
-subgraph var_stream_308 ["var <tt>stream_308</tt>"]
-    style var_stream_308 fill:transparent
-    145v1
-end
-subgraph var_stream_309 ["var <tt>stream_309</tt>"]
-    style var_stream_309 fill:transparent
-    146v1
-end
-subgraph var_stream_31 ["var <tt>stream_31</tt>"]
-    style var_stream_31 fill:transparent
-    10v1
-end
-subgraph var_stream_310 ["var <tt>stream_310</tt>"]
-    style var_stream_310 fill:transparent
-    147v1
-end
-subgraph var_stream_313 ["var <tt>stream_313</tt>"]
-    style var_stream_313 fill:transparent
-    148v1
-end
-subgraph var_stream_314 ["var <tt>stream_314</tt>"]
-    style var_stream_314 fill:transparent
-    149v1
-end
-subgraph var_stream_315 ["var <tt>stream_315</tt>"]
-    style var_stream_315 fill:transparent
-    150v1
-end
-subgraph var_stream_318 ["var <tt>stream_318</tt>"]
-    style var_stream_318 fill:transparent
-    151v1
-end
-subgraph var_stream_32 ["var <tt>stream_32</tt>"]
-    style var_stream_32 fill:transparent
+subgraph var_stream_25 ["var <tt>stream_25</tt>"]
+    style var_stream_25 fill:transparent
     11v1
     12v1
 end
-subgraph var_stream_320 ["var <tt>stream_320</tt>"]
-    style var_stream_320 fill:transparent
+subgraph var_stream_251 ["var <tt>stream_251</tt>"]
+    style var_stream_251 fill:transparent
+    131v1
+end
+subgraph var_stream_252 ["var <tt>stream_252</tt>"]
+    style var_stream_252 fill:transparent
+    132v1
+end
+subgraph var_stream_253 ["var <tt>stream_253</tt>"]
+    style var_stream_253 fill:transparent
+    133v1
+end
+subgraph var_stream_257 ["var <tt>stream_257</tt>"]
+    style var_stream_257 fill:transparent
+    134v1
+end
+subgraph var_stream_27 ["var <tt>stream_27</tt>"]
+    style var_stream_27 fill:transparent
+    13v1
+end
+subgraph var_stream_286 ["var <tt>stream_286</tt>"]
+    style var_stream_286 fill:transparent
+    138v1
+    137v1
+end
+subgraph var_stream_289 ["var <tt>stream_289</tt>"]
+    style var_stream_289 fill:transparent
+    139v1
+end
+subgraph var_stream_29 ["var <tt>stream_29</tt>"]
+    style var_stream_29 fill:transparent
+    14v1
+end
+subgraph var_stream_293 ["var <tt>stream_293</tt>"]
+    style var_stream_293 fill:transparent
+    140v1
+end
+subgraph var_stream_294 ["var <tt>stream_294</tt>"]
+    style var_stream_294 fill:transparent
+    141v1
+end
+subgraph var_stream_295 ["var <tt>stream_295</tt>"]
+    style var_stream_295 fill:transparent
+    142v1
+end
+subgraph var_stream_298 ["var <tt>stream_298</tt>"]
+    style var_stream_298 fill:transparent
+    143v1
+end
+subgraph var_stream_300 ["var <tt>stream_300</tt>"]
+    style var_stream_300 fill:transparent
+    144v1
+end
+subgraph var_stream_301 ["var <tt>stream_301</tt>"]
+    style var_stream_301 fill:transparent
+    145v1
+end
+subgraph var_stream_302 ["var <tt>stream_302</tt>"]
+    style var_stream_302 fill:transparent
+    146v1
+end
+subgraph var_stream_303 ["var <tt>stream_303</tt>"]
+    style var_stream_303 fill:transparent
+    147v1
+end
+subgraph var_stream_306 ["var <tt>stream_306</tt>"]
+    style var_stream_306 fill:transparent
+    148v1
+end
+subgraph var_stream_307 ["var <tt>stream_307</tt>"]
+    style var_stream_307 fill:transparent
+    149v1
+end
+subgraph var_stream_308 ["var <tt>stream_308</tt>"]
+    style var_stream_308 fill:transparent
+    150v1
+end
+subgraph var_stream_31 ["var <tt>stream_31</tt>"]
+    style var_stream_31 fill:transparent
+    15v1
+end
+subgraph var_stream_311 ["var <tt>stream_311</tt>"]
+    style var_stream_311 fill:transparent
+    151v1
+end
+subgraph var_stream_313 ["var <tt>stream_313</tt>"]
+    style var_stream_313 fill:transparent
     152v1
 end
-subgraph var_stream_321 ["var <tt>stream_321</tt>"]
-    style var_stream_321 fill:transparent
+subgraph var_stream_314 ["var <tt>stream_314</tt>"]
+    style var_stream_314 fill:transparent
     153v1
 end
-subgraph var_stream_324 ["var <tt>stream_324</tt>"]
-    style var_stream_324 fill:transparent
+subgraph var_stream_317 ["var <tt>stream_317</tt>"]
+    style var_stream_317 fill:transparent
     154v1
 end
-subgraph var_stream_326 ["var <tt>stream_326</tt>"]
-    style var_stream_326 fill:transparent
+subgraph var_stream_319 ["var <tt>stream_319</tt>"]
+    style var_stream_319 fill:transparent
     155v1
 end
-subgraph var_stream_327 ["var <tt>stream_327</tt>"]
-    style var_stream_327 fill:transparent
+subgraph var_stream_32 ["var <tt>stream_32</tt>"]
+    style var_stream_32 fill:transparent
+    16v1
+end
+subgraph var_stream_320 ["var <tt>stream_320</tt>"]
+    style var_stream_320 fill:transparent
     156v1
     157v1
 end
+subgraph var_stream_322 ["var <tt>stream_322</tt>"]
+    style var_stream_322 fill:transparent
+    158v1
+end
+subgraph var_stream_325 ["var <tt>stream_325</tt>"]
+    style var_stream_325 fill:transparent
+    159v1
+end
+subgraph var_stream_327 ["var <tt>stream_327</tt>"]
+    style var_stream_327 fill:transparent
+    160v1
+end
 subgraph var_stream_329 ["var <tt>stream_329</tt>"]
     style var_stream_329 fill:transparent
-    158v1
+    161v1
+end
+subgraph var_stream_33 ["var <tt>stream_33</tt>"]
+    style var_stream_33 fill:transparent
+    18v1
+end
+subgraph var_stream_330 ["var <tt>stream_330</tt>"]
+    style var_stream_330 fill:transparent
+    162v1
+end
+subgraph var_stream_331 ["var <tt>stream_331</tt>"]
+    style var_stream_331 fill:transparent
+    163v1
 end
 subgraph var_stream_332 ["var <tt>stream_332</tt>"]
     style var_stream_332 fill:transparent
-    159v1
+    164v1
 end
-subgraph var_stream_334 ["var <tt>stream_334</tt>"]
-    style var_stream_334 fill:transparent
-    160v1
-end
-subgraph var_stream_336 ["var <tt>stream_336</tt>"]
-    style var_stream_336 fill:transparent
-    161v1
+subgraph var_stream_335 ["var <tt>stream_335</tt>"]
+    style var_stream_335 fill:transparent
+    166v1
 end
 subgraph var_stream_337 ["var <tt>stream_337</tt>"]
     style var_stream_337 fill:transparent
-    162v1
-end
-subgraph var_stream_338 ["var <tt>stream_338</tt>"]
-    style var_stream_338 fill:transparent
-    163v1
+    167v1
 end
 subgraph var_stream_339 ["var <tt>stream_339</tt>"]
     style var_stream_339 fill:transparent
-    164v1
+    169v1
 end
 subgraph var_stream_34 ["var <tt>stream_34</tt>"]
     style var_stream_34 fill:transparent
-    13v1
+    19v1
 end
-subgraph var_stream_342 ["var <tt>stream_342</tt>"]
-    style var_stream_342 fill:transparent
-    166v1
-end
-subgraph var_stream_344 ["var <tt>stream_344</tt>"]
-    style var_stream_344 fill:transparent
-    167v1
-end
-subgraph var_stream_346 ["var <tt>stream_346</tt>"]
-    style var_stream_346 fill:transparent
-    169v1
-end
-subgraph var_stream_347 ["var <tt>stream_347</tt>"]
-    style var_stream_347 fill:transparent
+subgraph var_stream_340 ["var <tt>stream_340</tt>"]
+    style var_stream_340 fill:transparent
     170v1
+end
+subgraph var_stream_341 ["var <tt>stream_341</tt>"]
+    style var_stream_341 fill:transparent
+    171v1
+end
+subgraph var_stream_343 ["var <tt>stream_343</tt>"]
+    style var_stream_343 fill:transparent
+    172v1
+end
+subgraph var_stream_345 ["var <tt>stream_345</tt>"]
+    style var_stream_345 fill:transparent
+    173v1
 end
 subgraph var_stream_348 ["var <tt>stream_348</tt>"]
     style var_stream_348 fill:transparent
-    171v1
-end
-subgraph var_stream_350 ["var <tt>stream_350</tt>"]
-    style var_stream_350 fill:transparent
-    172v1
-end
-subgraph var_stream_352 ["var <tt>stream_352</tt>"]
-    style var_stream_352 fill:transparent
-    173v1
+    174v1
 end
 subgraph var_stream_355 ["var <tt>stream_355</tt>"]
     style var_stream_355 fill:transparent
-    174v1
+    175v1
+end
+subgraph var_stream_356 ["var <tt>stream_356</tt>"]
+    style var_stream_356 fill:transparent
+    176v1
 end
 subgraph var_stream_36 ["var <tt>stream_36</tt>"]
     style var_stream_36 fill:transparent
-    14v1
+    20v1
 end
 subgraph var_stream_362 ["var <tt>stream_362</tt>"]
     style var_stream_362 fill:transparent
-    175v1
-end
-subgraph var_stream_363 ["var <tt>stream_363</tt>"]
-    style var_stream_363 fill:transparent
-    176v1
-end
-subgraph var_stream_369 ["var <tt>stream_369</tt>"]
-    style var_stream_369 fill:transparent
     177v1
 end
-subgraph var_stream_371 ["var <tt>stream_371</tt>"]
-    style var_stream_371 fill:transparent
+subgraph var_stream_364 ["var <tt>stream_364</tt>"]
+    style var_stream_364 fill:transparent
     178v1
 end
-subgraph var_stream_373 ["var <tt>stream_373</tt>"]
-    style var_stream_373 fill:transparent
+subgraph var_stream_366 ["var <tt>stream_366</tt>"]
+    style var_stream_366 fill:transparent
     179v1
 end
-subgraph var_stream_374 ["var <tt>stream_374</tt>"]
-    style var_stream_374 fill:transparent
+subgraph var_stream_367 ["var <tt>stream_367</tt>"]
+    style var_stream_367 fill:transparent
     180v1
 end
-subgraph var_stream_375 ["var <tt>stream_375</tt>"]
-    style var_stream_375 fill:transparent
+subgraph var_stream_368 ["var <tt>stream_368</tt>"]
+    style var_stream_368 fill:transparent
     181v1
     182v1
 end
-subgraph var_stream_377 ["var <tt>stream_377</tt>"]
-    style var_stream_377 fill:transparent
+subgraph var_stream_370 ["var <tt>stream_370</tt>"]
+    style var_stream_370 fill:transparent
     183v1
+end
+subgraph var_stream_372 ["var <tt>stream_372</tt>"]
+    style var_stream_372 fill:transparent
+    184v1
+end
+subgraph var_stream_374 ["var <tt>stream_374</tt>"]
+    style var_stream_374 fill:transparent
+    185v1
+end
+subgraph var_stream_375 ["var <tt>stream_375</tt>"]
+    style var_stream_375 fill:transparent
+    186v1
 end
 subgraph var_stream_379 ["var <tt>stream_379</tt>"]
     style var_stream_379 fill:transparent
-    184v1
+    187v1
 end
 subgraph var_stream_38 ["var <tt>stream_38</tt>"]
     style var_stream_38 fill:transparent
-    15v1
+    21v1
 end
-subgraph var_stream_381 ["var <tt>stream_381</tt>"]
-    style var_stream_381 fill:transparent
-    185v1
-end
-subgraph var_stream_382 ["var <tt>stream_382</tt>"]
-    style var_stream_382 fill:transparent
-    186v1
-end
-subgraph var_stream_386 ["var <tt>stream_386</tt>"]
-    style var_stream_386 fill:transparent
-    187v1
-end
-subgraph var_stream_387 ["var <tt>stream_387</tt>"]
-    style var_stream_387 fill:transparent
+subgraph var_stream_380 ["var <tt>stream_380</tt>"]
+    style var_stream_380 fill:transparent
     188v1
 end
-subgraph var_stream_39 ["var <tt>stream_39</tt>"]
-    style var_stream_39 fill:transparent
-    16v1
+subgraph var_stream_384 ["var <tt>stream_384</tt>"]
+    style var_stream_384 fill:transparent
+    189v1
+end
+subgraph var_stream_385 ["var <tt>stream_385</tt>"]
+    style var_stream_385 fill:transparent
+    190v1
+end
+subgraph var_stream_388 ["var <tt>stream_388</tt>"]
+    style var_stream_388 fill:transparent
+    191v1
+end
+subgraph var_stream_389 ["var <tt>stream_389</tt>"]
+    style var_stream_389 fill:transparent
+    192v1
+end
+subgraph var_stream_390 ["var <tt>stream_390</tt>"]
+    style var_stream_390 fill:transparent
+    193v1
 end
 subgraph var_stream_391 ["var <tt>stream_391</tt>"]
     style var_stream_391 fill:transparent
-    189v1
+    194v1
 end
-subgraph var_stream_392 ["var <tt>stream_392</tt>"]
-    style var_stream_392 fill:transparent
-    190v1
+subgraph var_stream_393 ["var <tt>stream_393</tt>"]
+    style var_stream_393 fill:transparent
+    195v1
+end
+subgraph var_stream_394 ["var <tt>stream_394</tt>"]
+    style var_stream_394 fill:transparent
+    196v1
 end
 subgraph var_stream_395 ["var <tt>stream_395</tt>"]
     style var_stream_395 fill:transparent
-    191v1
-end
-subgraph var_stream_396 ["var <tt>stream_396</tt>"]
-    style var_stream_396 fill:transparent
-    192v1
+    197v1
 end
 subgraph var_stream_397 ["var <tt>stream_397</tt>"]
     style var_stream_397 fill:transparent
-    193v1
+    198v1
 end
-subgraph var_stream_398 ["var <tt>stream_398</tt>"]
-    style var_stream_398 fill:transparent
-    194v1
-end
-subgraph var_stream_40 ["var <tt>stream_40</tt>"]
-    style var_stream_40 fill:transparent
-    18v1
-end
-subgraph var_stream_400 ["var <tt>stream_400</tt>"]
-    style var_stream_400 fill:transparent
-    195v1
+subgraph var_stream_399 ["var <tt>stream_399</tt>"]
+    style var_stream_399 fill:transparent
+    199v1
 end
 subgraph var_stream_401 ["var <tt>stream_401</tt>"]
     style var_stream_401 fill:transparent
-    196v1
-end
-subgraph var_stream_402 ["var <tt>stream_402</tt>"]
-    style var_stream_402 fill:transparent
-    197v1
-end
-subgraph var_stream_404 ["var <tt>stream_404</tt>"]
-    style var_stream_404 fill:transparent
-    198v1
-end
-subgraph var_stream_406 ["var <tt>stream_406</tt>"]
-    style var_stream_406 fill:transparent
-    199v1
-end
-subgraph var_stream_408 ["var <tt>stream_408</tt>"]
-    style var_stream_408 fill:transparent
     200v1
 end
 subgraph var_stream_41 ["var <tt>stream_41</tt>"]
     style var_stream_41 fill:transparent
-    19v1
+    22v1
 end
-subgraph var_stream_423 ["var <tt>stream_423</tt>"]
-    style var_stream_423 fill:transparent
+subgraph var_stream_416 ["var <tt>stream_416</tt>"]
+    style var_stream_416 fill:transparent
     203v1
     204v1
 end
-subgraph var_stream_426 ["var <tt>stream_426</tt>"]
-    style var_stream_426 fill:transparent
+subgraph var_stream_419 ["var <tt>stream_419</tt>"]
+    style var_stream_419 fill:transparent
     205v1
+end
+subgraph var_stream_420 ["var <tt>stream_420</tt>"]
+    style var_stream_420 fill:transparent
+    206v1
+end
+subgraph var_stream_422 ["var <tt>stream_422</tt>"]
+    style var_stream_422 fill:transparent
+    207v1
+end
+subgraph var_stream_423 ["var <tt>stream_423</tt>"]
+    style var_stream_423 fill:transparent
+    208v1
 end
 subgraph var_stream_427 ["var <tt>stream_427</tt>"]
     style var_stream_427 fill:transparent
-    206v1
+    209v1
+end
+subgraph var_stream_428 ["var <tt>stream_428</tt>"]
+    style var_stream_428 fill:transparent
+    210v1
 end
 subgraph var_stream_429 ["var <tt>stream_429</tt>"]
     style var_stream_429 fill:transparent
-    207v1
+    211v1
 end
-subgraph var_stream_43 ["var <tt>stream_43</tt>"]
-    style var_stream_43 fill:transparent
-    20v1
+subgraph var_stream_432 ["var <tt>stream_432</tt>"]
+    style var_stream_432 fill:transparent
+    212v1
 end
-subgraph var_stream_430 ["var <tt>stream_430</tt>"]
-    style var_stream_430 fill:transparent
-    208v1
+subgraph var_stream_433 ["var <tt>stream_433</tt>"]
+    style var_stream_433 fill:transparent
+    213v1
 end
 subgraph var_stream_434 ["var <tt>stream_434</tt>"]
     style var_stream_434 fill:transparent
-    209v1
+    214v1
 end
-subgraph var_stream_435 ["var <tt>stream_435</tt>"]
-    style var_stream_435 fill:transparent
-    210v1
-end
-subgraph var_stream_436 ["var <tt>stream_436</tt>"]
-    style var_stream_436 fill:transparent
-    211v1
+subgraph var_stream_438 ["var <tt>stream_438</tt>"]
+    style var_stream_438 fill:transparent
+    216v1
 end
 subgraph var_stream_439 ["var <tt>stream_439</tt>"]
     style var_stream_439 fill:transparent
-    212v1
-end
-subgraph var_stream_440 ["var <tt>stream_440</tt>"]
-    style var_stream_440 fill:transparent
-    213v1
+    217v1
 end
 subgraph var_stream_441 ["var <tt>stream_441</tt>"]
     style var_stream_441 fill:transparent
-    214v1
+    218v1
 end
-subgraph var_stream_445 ["var <tt>stream_445</tt>"]
-    style var_stream_445 fill:transparent
-    216v1
-end
-subgraph var_stream_446 ["var <tt>stream_446</tt>"]
-    style var_stream_446 fill:transparent
-    217v1
+subgraph var_stream_443 ["var <tt>stream_443</tt>"]
+    style var_stream_443 fill:transparent
+    220v1
 end
 subgraph var_stream_448 ["var <tt>stream_448</tt>"]
     style var_stream_448 fill:transparent
-    218v1
+    221v1
+end
+subgraph var_stream_449 ["var <tt>stream_449</tt>"]
+    style var_stream_449 fill:transparent
+    222v1
 end
 subgraph var_stream_45 ["var <tt>stream_45</tt>"]
     style var_stream_45 fill:transparent
-    21v1
+    23v1
 end
-subgraph var_stream_450 ["var <tt>stream_450</tt>"]
-    style var_stream_450 fill:transparent
-    220v1
+subgraph var_stream_452 ["var <tt>stream_452</tt>"]
+    style var_stream_452 fill:transparent
+    223v1
+end
+subgraph var_stream_453 ["var <tt>stream_453</tt>"]
+    style var_stream_453 fill:transparent
+    224v1
 end
 subgraph var_stream_455 ["var <tt>stream_455</tt>"]
     style var_stream_455 fill:transparent
-    221v1
+    225v1
 end
-subgraph var_stream_456 ["var <tt>stream_456</tt>"]
-    style var_stream_456 fill:transparent
-    222v1
+subgraph var_stream_457 ["var <tt>stream_457</tt>"]
+    style var_stream_457 fill:transparent
+    226v1
+end
+subgraph var_stream_458 ["var <tt>stream_458</tt>"]
+    style var_stream_458 fill:transparent
+    227v1
 end
 subgraph var_stream_459 ["var <tt>stream_459</tt>"]
     style var_stream_459 fill:transparent
-    223v1
-end
-subgraph var_stream_460 ["var <tt>stream_460</tt>"]
-    style var_stream_460 fill:transparent
-    224v1
-end
-subgraph var_stream_462 ["var <tt>stream_462</tt>"]
-    style var_stream_462 fill:transparent
-    225v1
-end
-subgraph var_stream_464 ["var <tt>stream_464</tt>"]
-    style var_stream_464 fill:transparent
-    226v1
-end
-subgraph var_stream_465 ["var <tt>stream_465</tt>"]
-    style var_stream_465 fill:transparent
-    227v1
-end
-subgraph var_stream_466 ["var <tt>stream_466</tt>"]
-    style var_stream_466 fill:transparent
     228v1
 end
-subgraph var_stream_48 ["var <tt>stream_48</tt>"]
-    style var_stream_48 fill:transparent
-    22v1
+subgraph var_stream_46 ["var <tt>stream_46</tt>"]
+    style var_stream_46 fill:transparent
+    24v1
+end
+subgraph var_stream_488 ["var <tt>stream_488</tt>"]
+    style var_stream_488 fill:transparent
+    230v1
+end
+subgraph var_stream_489 ["var <tt>stream_489</tt>"]
+    style var_stream_489 fill:transparent
+    231v1
+end
+subgraph var_stream_49 ["var <tt>stream_49</tt>"]
+    style var_stream_49 fill:transparent
+    25v1
+end
+subgraph var_stream_490 ["var <tt>stream_490</tt>"]
+    style var_stream_490 fill:transparent
+    233v1
+end
+subgraph var_stream_491 ["var <tt>stream_491</tt>"]
+    style var_stream_491 fill:transparent
+    234v1
+end
+subgraph var_stream_493 ["var <tt>stream_493</tt>"]
+    style var_stream_493 fill:transparent
+    235v1
 end
 subgraph var_stream_495 ["var <tt>stream_495</tt>"]
     style var_stream_495 fill:transparent
-    230v1
-end
-subgraph var_stream_496 ["var <tt>stream_496</tt>"]
-    style var_stream_496 fill:transparent
-    231v1
-end
-subgraph var_stream_497 ["var <tt>stream_497</tt>"]
-    style var_stream_497 fill:transparent
-    233v1
+    236v1
 end
 subgraph var_stream_498 ["var <tt>stream_498</tt>"]
     style var_stream_498 fill:transparent
-    234v1
-end
-subgraph var_stream_500 ["var <tt>stream_500</tt>"]
-    style var_stream_500 fill:transparent
-    235v1
+    237v1
 end
 subgraph var_stream_502 ["var <tt>stream_502</tt>"]
     style var_stream_502 fill:transparent
-    236v1
+    238v1
+end
+subgraph var_stream_503 ["var <tt>stream_503</tt>"]
+    style var_stream_503 fill:transparent
+    239v1
 end
 subgraph var_stream_505 ["var <tt>stream_505</tt>"]
     style var_stream_505 fill:transparent
-    237v1
-end
-subgraph var_stream_509 ["var <tt>stream_509</tt>"]
-    style var_stream_509 fill:transparent
-    238v1
-end
-subgraph var_stream_510 ["var <tt>stream_510</tt>"]
-    style var_stream_510 fill:transparent
-    239v1
-end
-subgraph var_stream_512 ["var <tt>stream_512</tt>"]
-    style var_stream_512 fill:transparent
     240v1
 end
-subgraph var_stream_514 ["var <tt>stream_514</tt>"]
-    style var_stream_514 fill:transparent
+subgraph var_stream_507 ["var <tt>stream_507</tt>"]
+    style var_stream_507 fill:transparent
     241v1
+end
+subgraph var_stream_51 ["var <tt>stream_51</tt>"]
+    style var_stream_51 fill:transparent
+    26v1
 end
 subgraph var_stream_52 ["var <tt>stream_52</tt>"]
     style var_stream_52 fill:transparent
-    23v1
+    27v1
 end
 subgraph var_stream_53 ["var <tt>stream_53</tt>"]
     style var_stream_53 fill:transparent
-    24v1
+    28v1
 end
-subgraph var_stream_56 ["var <tt>stream_56</tt>"]
-    style var_stream_56 fill:transparent
-    25v1
+subgraph var_stream_54 ["var <tt>stream_54</tt>"]
+    style var_stream_54 fill:transparent
+    29v1
 end
-subgraph var_stream_58 ["var <tt>stream_58</tt>"]
-    style var_stream_58 fill:transparent
-    26v1
+subgraph var_stream_57 ["var <tt>stream_57</tt>"]
+    style var_stream_57 fill:transparent
+    30v1
 end
 subgraph var_stream_59 ["var <tt>stream_59</tt>"]
     style var_stream_59 fill:transparent
-    27v1
+    31v1
+end
+subgraph var_stream_6 ["var <tt>stream_6</tt>"]
+    style var_stream_6 fill:transparent
+    3v1
 end
 subgraph var_stream_60 ["var <tt>stream_60</tt>"]
     style var_stream_60 fill:transparent
-    28v1
+    32v1
 end
 subgraph var_stream_61 ["var <tt>stream_61</tt>"]
     style var_stream_61 fill:transparent
-    29v1
+    33v1
 end
-subgraph var_stream_64 ["var <tt>stream_64</tt>"]
-    style var_stream_64 fill:transparent
-    30v1
-end
-subgraph var_stream_66 ["var <tt>stream_66</tt>"]
-    style var_stream_66 fill:transparent
-    31v1
+subgraph var_stream_62 ["var <tt>stream_62</tt>"]
+    style var_stream_62 fill:transparent
+    34v1
 end
 subgraph var_stream_67 ["var <tt>stream_67</tt>"]
     style var_stream_67 fill:transparent
-    32v1
-end
-subgraph var_stream_68 ["var <tt>stream_68</tt>"]
-    style var_stream_68 fill:transparent
-    33v1
-end
-subgraph var_stream_69 ["var <tt>stream_69</tt>"]
-    style var_stream_69 fill:transparent
-    34v1
-end
-subgraph var_stream_7 ["var <tt>stream_7</tt>"]
-    style var_stream_7 fill:transparent
-    1v1
-end
-subgraph var_stream_74 ["var <tt>stream_74</tt>"]
-    style var_stream_74 fill:transparent
     35v1
 end
-subgraph var_stream_77 ["var <tt>stream_77</tt>"]
-    style var_stream_77 fill:transparent
+subgraph var_stream_70 ["var <tt>stream_70</tt>"]
+    style var_stream_70 fill:transparent
     38v1
     39v1
 end
-subgraph var_stream_80 ["var <tt>stream_80</tt>"]
-    style var_stream_80 fill:transparent
+subgraph var_stream_73 ["var <tt>stream_73</tt>"]
+    style var_stream_73 fill:transparent
     40v1
 end
-subgraph var_stream_81 ["var <tt>stream_81</tt>"]
-    style var_stream_81 fill:transparent
+subgraph var_stream_74 ["var <tt>stream_74</tt>"]
+    style var_stream_74 fill:transparent
     41v1
 end
-subgraph var_stream_83 ["var <tt>stream_83</tt>"]
-    style var_stream_83 fill:transparent
+subgraph var_stream_76 ["var <tt>stream_76</tt>"]
+    style var_stream_76 fill:transparent
     43v1
 end
-subgraph var_stream_84 ["var <tt>stream_84</tt>"]
-    style var_stream_84 fill:transparent
+subgraph var_stream_77 ["var <tt>stream_77</tt>"]
+    style var_stream_77 fill:transparent
     44v1
+end
+subgraph var_stream_78 ["var <tt>stream_78</tt>"]
+    style var_stream_78 fill:transparent
+    45v1
+end
+subgraph var_stream_8 ["var <tt>stream_8</tt>"]
+    style var_stream_8 fill:transparent
+    4v1
+end
+subgraph var_stream_80 ["var <tt>stream_80</tt>"]
+    style var_stream_80 fill:transparent
+    46v1
+end
+subgraph var_stream_82 ["var <tt>stream_82</tt>"]
+    style var_stream_82 fill:transparent
+    47v1
 end
 subgraph var_stream_85 ["var <tt>stream_85</tt>"]
     style var_stream_85 fill:transparent
-    45v1
-end
-subgraph var_stream_87 ["var <tt>stream_87</tt>"]
-    style var_stream_87 fill:transparent
-    46v1
-end
-subgraph var_stream_89 ["var <tt>stream_89</tt>"]
-    style var_stream_89 fill:transparent
-    47v1
-end
-subgraph var_stream_92 ["var <tt>stream_92</tt>"]
-    style var_stream_92 fill:transparent
     48v1
+end
+subgraph var_stream_91 ["var <tt>stream_91</tt>"]
+    style var_stream_91 fill:transparent
+    49v1
+end
+subgraph var_stream_93 ["var <tt>stream_93</tt>"]
+    style var_stream_93 fill:transparent
+    50v1
+end
+subgraph var_stream_97 ["var <tt>stream_97</tt>"]
+    style var_stream_97 fill:transparent
+    51v1
 end
 subgraph var_stream_98 ["var <tt>stream_98</tt>"]
     style var_stream_98 fill:transparent
-    49v1
+    52v1
+end
+subgraph var_stream_99 ["var <tt>stream_99</tt>"]
+    style var_stream_99 fill:transparent
+    53v1
+    54v1
 end

--- a/hydro_test/src/cluster/snapshots/two_pc_ir.snap
+++ b/hydro_test/src/cluster/snapshots/two_pc_ir.snap
@@ -5,127 +5,19 @@ expression: built.ir()
 [
     CycleSink {
         ident: Ident {
-            sym: cycle_0,
-        },
-        input: FilterMap {
-            f: stageleft :: runtime_support :: fn1_type_hint :: < u32 , core :: option :: Option < u32 > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; let num_clients_per_node__free = 100usize ; move | virtual_id | { if virtual_id < num_clients_per_node__free as u32 { Some (virtual_id + 1) } else { None } } }),
-            input: Tee {
-                inner: <tee 0>: ChainFirst {
-                    first: Batch {
-                        inner: Source {
-                            source: Iter(
-                                { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: tick :: * ; let e__free = { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; 0u32 } ; [e__free] },
-                            ),
-                            metadata: HydroIrMetadata {
-                                location_kind: Cluster(
-                                    2,
-                                ),
-                                collection_kind: Optional {
-                                    bound: Unbounded,
-                                    element_type: u32,
-                                },
-                            },
-                        },
-                        metadata: HydroIrMetadata {
-                            location_kind: Tick(
-                                0,
-                                Cluster(
-                                    2,
-                                ),
-                            ),
-                            collection_kind: Optional {
-                                bound: Bounded,
-                                element_type: u32,
-                            },
-                        },
-                    },
-                    second: DeferTick {
-                        input: CycleSource {
-                            ident: Ident {
-                                sym: cycle_0,
-                            },
-                            metadata: HydroIrMetadata {
-                                location_kind: Tick(
-                                    0,
-                                    Cluster(
-                                        2,
-                                    ),
-                                ),
-                                collection_kind: Optional {
-                                    bound: Bounded,
-                                    element_type: u32,
-                                },
-                            },
-                        },
-                        metadata: HydroIrMetadata {
-                            location_kind: Tick(
-                                0,
-                                Cluster(
-                                    2,
-                                ),
-                            ),
-                            collection_kind: Optional {
-                                bound: Bounded,
-                                element_type: u32,
-                            },
-                        },
-                    },
-                    metadata: HydroIrMetadata {
-                        location_kind: Tick(
-                            0,
-                            Cluster(
-                                2,
-                            ),
-                        ),
-                        collection_kind: Optional {
-                            bound: Bounded,
-                            element_type: u32,
-                        },
-                    },
-                },
-                metadata: HydroIrMetadata {
-                    location_kind: Tick(
-                        0,
-                        Cluster(
-                            2,
-                        ),
-                    ),
-                    collection_kind: Optional {
-                        bound: Bounded,
-                        element_type: u32,
-                    },
-                },
-            },
-            metadata: HydroIrMetadata {
-                location_kind: Tick(
-                    0,
-                    Cluster(
-                        2,
-                    ),
-                ),
-                collection_kind: Optional {
-                    bound: Bounded,
-                    element_type: u32,
-                },
-            },
-        },
-        op_metadata: HydroIrOpMetadata,
-    },
-    CycleSink {
-        ident: Ident {
-            sym: cycle_2,
+            sym: cycle_1,
         },
         input: AntiJoin {
             pos: Tee {
-                inner: <tee 1>: Chain {
+                inner: <tee 0>: Chain {
                     first: DeferTick {
                         input: CycleSource {
                             ident: Ident {
-                                sym: cycle_2,
+                                sym: cycle_1,
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    2,
+                                    1,
                                     Process(
                                         0,
                                     ),
@@ -140,7 +32,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                2,
+                                1,
                                 Process(
                                     0,
                                 ),
@@ -155,7 +47,7 @@ expression: built.ir()
                     },
                     second: Batch {
                         inner: Tee {
-                            inner: <tee 2>: Map {
+                            inner: <tee 1>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , core :: result :: Result < () , () >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: two_pc :: * ; | kv | (kv , Ok :: < () , () > (())) }),
                                 input: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
@@ -250,7 +142,7 @@ expression: built.ir()
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
                                                                                             location_kind: Tick(
-                                                                                                1,
+                                                                                                0,
                                                                                                 Process(
                                                                                                     0,
                                                                                                 ),
@@ -264,7 +156,7 @@ expression: built.ir()
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_kind: Tick(
-                                                                                            1,
+                                                                                            0,
                                                                                             Process(
                                                                                                 0,
                                                                                             ),
@@ -278,7 +170,7 @@ expression: built.ir()
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_kind: Tick(
-                                                                                        1,
+                                                                                        0,
                                                                                         Process(
                                                                                             0,
                                                                                         ),
@@ -294,7 +186,7 @@ expression: built.ir()
                                                                             },
                                                                             metadata: HydroIrMetadata {
                                                                                 location_kind: Tick(
-                                                                                    1,
+                                                                                    0,
                                                                                     Process(
                                                                                         0,
                                                                                     ),
@@ -309,7 +201,7 @@ expression: built.ir()
                                                                         },
                                                                         metadata: HydroIrMetadata {
                                                                             location_kind: Tick(
-                                                                                1,
+                                                                                0,
                                                                                 Process(
                                                                                     0,
                                                                                 ),
@@ -325,7 +217,7 @@ expression: built.ir()
                                                                     trusted: true,
                                                                     metadata: HydroIrMetadata {
                                                                         location_kind: Tick(
-                                                                            1,
+                                                                            0,
                                                                             Process(
                                                                                 0,
                                                                             ),
@@ -351,7 +243,7 @@ expression: built.ir()
                                                                                 ),
                                                                                 input: CycleSource {
                                                                                     ident: Ident {
-                                                                                        sym: cycle_1,
+                                                                                        sym: cycle_0,
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_kind: Cluster(
@@ -404,7 +296,7 @@ expression: built.ir()
                                                                     },
                                                                     metadata: HydroIrMetadata {
                                                                         location_kind: Tick(
-                                                                            1,
+                                                                            0,
                                                                             Process(
                                                                                 0,
                                                                             ),
@@ -419,7 +311,7 @@ expression: built.ir()
                                                                 },
                                                                 metadata: HydroIrMetadata {
                                                                     location_kind: Tick(
-                                                                        1,
+                                                                        0,
                                                                         Process(
                                                                             0,
                                                                         ),
@@ -434,7 +326,7 @@ expression: built.ir()
                                                             },
                                                             metadata: HydroIrMetadata {
                                                                 location_kind: Tick(
-                                                                    1,
+                                                                    0,
                                                                     Process(
                                                                         0,
                                                                     ),
@@ -548,7 +440,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                2,
+                                1,
                                 Process(
                                     0,
                                 ),
@@ -563,7 +455,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            2,
+                            1,
                             Process(
                                 0,
                             ),
@@ -578,7 +470,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        2,
+                        1,
                         Process(
                             0,
                         ),
@@ -592,21 +484,21 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <tee 3>: FilterMap {
+                inner: <tee 2>: FilterMap {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , (usize , usize)) , core :: option :: Option < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; let min__free = 3usize ; move | (key , (success , _error)) | if success >= min__free { Some (key) } else { None } }),
                     input: Cast {
                         inner: Cast {
                             inner: Tee {
-                                inner: <tee 4>: FoldKeyed {
+                                inner: <tee 3>: FoldKeyed {
                                     init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | | (0 , 0) }),
                                     acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < () , () > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } } }),
                                     input: ObserveNonDet {
                                         inner: Cast {
                                             inner: Tee {
-                                                inner: <tee 1>,
+                                                inner: <tee 0>,
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
-                                                        2,
+                                                        1,
                                                         Process(
                                                             0,
                                                         ),
@@ -621,7 +513,7 @@ expression: built.ir()
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    2,
+                                                    1,
                                                     Process(
                                                         0,
                                                     ),
@@ -638,7 +530,7 @@ expression: built.ir()
                                         trusted: false,
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                2,
+                                                1,
                                                 Process(
                                                     0,
                                                 ),
@@ -654,7 +546,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            2,
+                                            1,
                                             Process(
                                                 0,
                                             ),
@@ -668,7 +560,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        2,
+                                        1,
                                         Process(
                                             0,
                                         ),
@@ -682,7 +574,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    2,
+                                    1,
                                     Process(
                                         0,
                                     ),
@@ -698,7 +590,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                2,
+                                1,
                                 Process(
                                     0,
                                 ),
@@ -713,7 +605,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            2,
+                            1,
                             Process(
                                 0,
                             ),
@@ -728,7 +620,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        2,
+                        1,
                         Process(
                             0,
                         ),
@@ -743,7 +635,7 @@ expression: built.ir()
             },
             metadata: HydroIrMetadata {
                 location_kind: Tick(
-                    2,
+                    1,
                     Process(
                         0,
                     ),
@@ -760,16 +652,16 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_3,
+            sym: cycle_2,
         },
         input: DeferTick {
             input: CycleSource {
                 ident: Ident {
-                    sym: cycle_3,
+                    sym: cycle_2,
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        2,
+                        1,
                         Process(
                             0,
                         ),
@@ -784,7 +676,7 @@ expression: built.ir()
             },
             metadata: HydroIrMetadata {
                 location_kind: Tick(
-                    2,
+                    1,
                     Process(
                         0,
                     ),
@@ -801,19 +693,19 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_4,
+            sym: cycle_3,
         },
         input: AntiJoin {
             pos: Tee {
-                inner: <tee 5>: Chain {
+                inner: <tee 4>: Chain {
                     first: DeferTick {
                         input: CycleSource {
                             ident: Ident {
-                                sym: cycle_4,
+                                sym: cycle_3,
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    4,
+                                    3,
                                     Process(
                                         0,
                                     ),
@@ -828,7 +720,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                4,
+                                3,
                                 Process(
                                     0,
                                 ),
@@ -843,7 +735,7 @@ expression: built.ir()
                     },
                     second: Batch {
                         inner: Tee {
-                            inner: <tee 6>: Map {
+                            inner: <tee 5>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , core :: result :: Result < () , () >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: two_pc :: * ; | kv | (kv , Ok :: < () , () > (())) }),
                                 input: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32))) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
@@ -938,7 +830,7 @@ expression: built.ir()
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
                                                                                             location_kind: Tick(
-                                                                                                3,
+                                                                                                2,
                                                                                                 Process(
                                                                                                     0,
                                                                                                 ),
@@ -952,7 +844,7 @@ expression: built.ir()
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_kind: Tick(
-                                                                                            3,
+                                                                                            2,
                                                                                             Process(
                                                                                                 0,
                                                                                             ),
@@ -966,7 +858,7 @@ expression: built.ir()
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_kind: Tick(
-                                                                                        3,
+                                                                                        2,
                                                                                         Process(
                                                                                             0,
                                                                                         ),
@@ -982,7 +874,7 @@ expression: built.ir()
                                                                             },
                                                                             metadata: HydroIrMetadata {
                                                                                 location_kind: Tick(
-                                                                                    3,
+                                                                                    2,
                                                                                     Process(
                                                                                         0,
                                                                                     ),
@@ -997,7 +889,7 @@ expression: built.ir()
                                                                         },
                                                                         metadata: HydroIrMetadata {
                                                                             location_kind: Tick(
-                                                                                3,
+                                                                                2,
                                                                                 Process(
                                                                                     0,
                                                                                 ),
@@ -1013,7 +905,7 @@ expression: built.ir()
                                                                     trusted: true,
                                                                     metadata: HydroIrMetadata {
                                                                         location_kind: Tick(
-                                                                            3,
+                                                                            2,
                                                                             Process(
                                                                                 0,
                                                                             ),
@@ -1029,10 +921,10 @@ expression: built.ir()
                                                                 right: Batch {
                                                                     inner: YieldConcat {
                                                                         inner: Tee {
-                                                                            inner: <tee 3>,
+                                                                            inner: <tee 2>,
                                                                             metadata: HydroIrMetadata {
                                                                                 location_kind: Tick(
-                                                                                    2,
+                                                                                    1,
                                                                                     Process(
                                                                                         0,
                                                                                     ),
@@ -1059,7 +951,7 @@ expression: built.ir()
                                                                     },
                                                                     metadata: HydroIrMetadata {
                                                                         location_kind: Tick(
-                                                                            3,
+                                                                            2,
                                                                             Process(
                                                                                 0,
                                                                             ),
@@ -1074,7 +966,7 @@ expression: built.ir()
                                                                 },
                                                                 metadata: HydroIrMetadata {
                                                                     location_kind: Tick(
-                                                                        3,
+                                                                        2,
                                                                         Process(
                                                                             0,
                                                                         ),
@@ -1089,7 +981,7 @@ expression: built.ir()
                                                             },
                                                             metadata: HydroIrMetadata {
                                                                 location_kind: Tick(
-                                                                    3,
+                                                                    2,
                                                                     Process(
                                                                         0,
                                                                     ),
@@ -1203,7 +1095,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                4,
+                                3,
                                 Process(
                                     0,
                                 ),
@@ -1218,7 +1110,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            4,
+                            3,
                             Process(
                                 0,
                             ),
@@ -1233,7 +1125,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        4,
+                        3,
                         Process(
                             0,
                         ),
@@ -1247,21 +1139,21 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <tee 7>: FilterMap {
+                inner: <tee 6>: FilterMap {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) , (usize , usize)) , core :: option :: Option < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; let min__free = 3usize ; move | (key , (success , _error)) | if success >= min__free { Some (key) } else { None } }),
                     input: Cast {
                         inner: Cast {
                             inner: Tee {
-                                inner: <tee 8>: FoldKeyed {
+                                inner: <tee 7>: FoldKeyed {
                                     init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | | (0 , 0) }),
                                     acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < () , () > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } } }),
                                     input: ObserveNonDet {
                                         inner: Cast {
                                             inner: Tee {
-                                                inner: <tee 5>,
+                                                inner: <tee 4>,
                                                 metadata: HydroIrMetadata {
                                                     location_kind: Tick(
-                                                        4,
+                                                        3,
                                                         Process(
                                                             0,
                                                         ),
@@ -1276,7 +1168,7 @@ expression: built.ir()
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_kind: Tick(
-                                                    4,
+                                                    3,
                                                     Process(
                                                         0,
                                                     ),
@@ -1293,7 +1185,7 @@ expression: built.ir()
                                         trusted: false,
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                4,
+                                                3,
                                                 Process(
                                                     0,
                                                 ),
@@ -1309,7 +1201,7 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            4,
+                                            3,
                                             Process(
                                                 0,
                                             ),
@@ -1323,7 +1215,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        4,
+                                        3,
                                         Process(
                                             0,
                                         ),
@@ -1337,7 +1229,7 @@ expression: built.ir()
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    4,
+                                    3,
                                     Process(
                                         0,
                                     ),
@@ -1353,7 +1245,7 @@ expression: built.ir()
                         },
                         metadata: HydroIrMetadata {
                             location_kind: Tick(
-                                4,
+                                3,
                                 Process(
                                     0,
                                 ),
@@ -1368,7 +1260,7 @@ expression: built.ir()
                     },
                     metadata: HydroIrMetadata {
                         location_kind: Tick(
-                            4,
+                            3,
                             Process(
                                 0,
                             ),
@@ -1383,7 +1275,7 @@ expression: built.ir()
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        4,
+                        3,
                         Process(
                             0,
                         ),
@@ -1398,7 +1290,7 @@ expression: built.ir()
             },
             metadata: HydroIrMetadata {
                 location_kind: Tick(
-                    4,
+                    3,
                     Process(
                         0,
                     ),
@@ -1415,16 +1307,16 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_5,
+            sym: cycle_4,
         },
         input: DeferTick {
             input: CycleSource {
                 ident: Ident {
-                    sym: cycle_5,
+                    sym: cycle_4,
                 },
                 metadata: HydroIrMetadata {
                     location_kind: Tick(
-                        4,
+                        3,
                         Process(
                             0,
                         ),
@@ -1439,7 +1331,7 @@ expression: built.ir()
             },
             metadata: HydroIrMetadata {
                 location_kind: Tick(
-                    4,
+                    3,
                     Process(
                         0,
                     ),
@@ -1456,35 +1348,297 @@ expression: built.ir()
     },
     CycleSink {
         ident: Ident {
-            sym: cycle_1,
+            sym: cycle_5,
         },
-        input: ObserveNonDet {
-            inner: Map {
-                f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , core :: option :: Option < u32 >) , (u32 , u32) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; move | (virtual_id , payload) | { let value = if let Some (payload) = payload { payload + 1 } else { 0 } ; (virtual_id , value) } }),
-                input: YieldConcat {
-                    inner: Chain {
-                        first: Map {
-                            f: stageleft :: runtime_support :: fn1_type_hint :: < u32 , (u32 , core :: option :: Option < u32 >) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | virtual_id | (virtual_id , None) }),
-                            input: Tee {
-                                inner: <tee 9>: Cast {
-                                    inner: Tee {
-                                        inner: <tee 0>,
+        input: FilterMap {
+            f: stageleft :: runtime_support :: fn1_type_hint :: < u32 , core :: option :: Option < u32 > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; let num_clients_per_node__free = 100usize ; move | virtual_id | { if virtual_id < num_clients_per_node__free as u32 { Some (virtual_id + 1) } else { None } } }),
+            input: Tee {
+                inner: <tee 8>: ChainFirst {
+                    first: DeferTick {
+                        input: CycleSource {
+                            ident: Ident {
+                                sym: cycle_5,
+                            },
+                            metadata: HydroIrMetadata {
+                                location_kind: Tick(
+                                    4,
+                                    Cluster(
+                                        2,
+                                    ),
+                                ),
+                                collection_kind: Optional {
+                                    bound: Bounded,
+                                    element_type: u32,
+                                },
+                            },
+                        },
+                        metadata: HydroIrMetadata {
+                            location_kind: Tick(
+                                4,
+                                Cluster(
+                                    2,
+                                ),
+                            ),
+                            collection_kind: Optional {
+                                bound: Bounded,
+                                element_type: u32,
+                            },
+                        },
+                    },
+                    second: Map {
+                        f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , ()) , u32 > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | (d , _signal) | d }),
+                        input: CrossSingleton {
+                            left: Cast {
+                                inner: SingletonSource {
+                                    value: { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; 0u32 },
+                                    metadata: HydroIrMetadata {
+                                        location_kind: Tick(
+                                            4,
+                                            Cluster(
+                                                2,
+                                            ),
+                                        ),
+                                        collection_kind: Singleton {
+                                            bound: Bounded,
+                                            element_type: u32,
+                                        },
+                                    },
+                                },
+                                metadata: HydroIrMetadata {
+                                    location_kind: Tick(
+                                        4,
+                                        Cluster(
+                                            2,
+                                        ),
+                                    ),
+                                    collection_kind: Optional {
+                                        bound: Bounded,
+                                        element_type: u32,
+                                    },
+                                },
+                            },
+                            right: Map {
+                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _u | () }),
+                                input: Batch {
+                                    inner: Source {
+                                        source: Iter(
+                                            { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: tick :: * ; let e__free = { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; () } ; [e__free] },
+                                        ),
+                                        metadata: HydroIrMetadata {
+                                            location_kind: Cluster(
+                                                2,
+                                            ),
+                                            collection_kind: Optional {
+                                                bound: Unbounded,
+                                                element_type: (),
+                                            },
+                                        },
+                                    },
+                                    metadata: HydroIrMetadata {
+                                        location_kind: Tick(
+                                            4,
+                                            Cluster(
+                                                2,
+                                            ),
+                                        ),
+                                        collection_kind: Optional {
+                                            bound: Bounded,
+                                            element_type: (),
+                                        },
+                                    },
+                                },
+                                metadata: HydroIrMetadata {
+                                    location_kind: Tick(
+                                        4,
+                                        Cluster(
+                                            2,
+                                        ),
+                                    ),
+                                    collection_kind: Optional {
+                                        bound: Bounded,
+                                        element_type: (),
+                                    },
+                                },
+                            },
+                            metadata: HydroIrMetadata {
+                                location_kind: Tick(
+                                    4,
+                                    Cluster(
+                                        2,
+                                    ),
+                                ),
+                                collection_kind: Optional {
+                                    bound: Bounded,
+                                    element_type: (u32 , ()),
+                                },
+                            },
+                        },
+                        metadata: HydroIrMetadata {
+                            location_kind: Tick(
+                                4,
+                                Cluster(
+                                    2,
+                                ),
+                            ),
+                            collection_kind: Optional {
+                                bound: Bounded,
+                                element_type: u32,
+                            },
+                        },
+                    },
+                    metadata: HydroIrMetadata {
+                        location_kind: Tick(
+                            4,
+                            Cluster(
+                                2,
+                            ),
+                        ),
+                        collection_kind: Optional {
+                            bound: Bounded,
+                            element_type: u32,
+                        },
+                    },
+                },
+                metadata: HydroIrMetadata {
+                    location_kind: Tick(
+                        4,
+                        Cluster(
+                            2,
+                        ),
+                    ),
+                    collection_kind: Optional {
+                        bound: Bounded,
+                        element_type: u32,
+                    },
+                },
+            },
+            metadata: HydroIrMetadata {
+                location_kind: Tick(
+                    4,
+                    Cluster(
+                        2,
+                    ),
+                ),
+                collection_kind: Optional {
+                    bound: Bounded,
+                    element_type: u32,
+                },
+            },
+        },
+        op_metadata: HydroIrOpMetadata,
+    },
+    CycleSink {
+        ident: Ident {
+            sym: cycle_6,
+        },
+        input: ReduceKeyed {
+            f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: time :: Instant , std :: time :: Instant , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | curr_time , new_time | { if new_time > * curr_time { * curr_time = new_time ; } } }),
+            input: ObserveNonDet {
+                inner: Chain {
+                    first: Chain {
+                        first: Cast {
+                            inner: Tee {
+                                inner: <tee 9>: DeferTick {
+                                    input: CycleSource {
+                                        ident: Ident {
+                                            sym: cycle_6,
+                                        },
                                         metadata: HydroIrMetadata {
                                             location_kind: Tick(
-                                                0,
+                                                4,
                                                 Cluster(
                                                     2,
                                                 ),
                                             ),
-                                            collection_kind: Optional {
+                                            collection_kind: KeyedSingleton {
                                                 bound: Bounded,
+                                                key_type: u32,
+                                                value_type: std :: time :: Instant,
+                                            },
+                                        },
+                                    },
+                                    metadata: HydroIrMetadata {
+                                        location_kind: Tick(
+                                            4,
+                                            Cluster(
+                                                2,
+                                            ),
+                                        ),
+                                        collection_kind: KeyedSingleton {
+                                            bound: Bounded,
+                                            key_type: u32,
+                                            value_type: std :: time :: Instant,
+                                        },
+                                    },
+                                },
+                                metadata: HydroIrMetadata {
+                                    location_kind: Tick(
+                                        4,
+                                        Cluster(
+                                            2,
+                                        ),
+                                    ),
+                                    collection_kind: KeyedSingleton {
+                                        bound: Bounded,
+                                        key_type: u32,
+                                        value_type: std :: time :: Instant,
+                                    },
+                                },
+                            },
+                            metadata: HydroIrMetadata {
+                                location_kind: Tick(
+                                    4,
+                                    Cluster(
+                                        2,
+                                    ),
+                                ),
+                                collection_kind: KeyedStream {
+                                    bound: Bounded,
+                                    value_order: TotalOrder,
+                                    value_retry: ExactlyOnce,
+                                    key_type: u32,
+                                    value_type: std :: time :: Instant,
+                                },
+                            },
+                        },
+                        second: Cast {
+                            inner: Map {
+                                f: stageleft :: runtime_support :: fn1_type_hint :: < u32 , (u32 , std :: time :: Instant) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | virtual_id | (virtual_id , Instant :: now ()) }),
+                                input: Tee {
+                                    inner: <tee 10>: Cast {
+                                        inner: Tee {
+                                            inner: <tee 8>,
+                                            metadata: HydroIrMetadata {
+                                                location_kind: Tick(
+                                                    4,
+                                                    Cluster(
+                                                        2,
+                                                    ),
+                                                ),
+                                                collection_kind: Optional {
+                                                    bound: Bounded,
+                                                    element_type: u32,
+                                                },
+                                            },
+                                        },
+                                        metadata: HydroIrMetadata {
+                                            location_kind: Tick(
+                                                4,
+                                                Cluster(
+                                                    2,
+                                                ),
+                                            ),
+                                            collection_kind: Stream {
+                                                bound: Bounded,
+                                                order: TotalOrder,
+                                                retry: ExactlyOnce,
                                                 element_type: u32,
                                             },
                                         },
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            0,
+                                            4,
                                             Cluster(
                                                 2,
                                             ),
@@ -1499,7 +1653,7 @@ expression: built.ir()
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        0,
+                                        4,
                                         Cluster(
                                             2,
                                         ),
@@ -1508,150 +1662,361 @@ expression: built.ir()
                                         bound: Bounded,
                                         order: TotalOrder,
                                         retry: ExactlyOnce,
-                                        element_type: u32,
+                                        element_type: (u32 , std :: time :: Instant),
                                     },
                                 },
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    0,
+                                    4,
                                     Cluster(
                                         2,
                                     ),
                                 ),
-                                collection_kind: Stream {
+                                collection_kind: KeyedStream {
                                     bound: Bounded,
-                                    order: TotalOrder,
-                                    retry: ExactlyOnce,
-                                    element_type: (u32 , core :: option :: Option < u32 >),
+                                    value_order: TotalOrder,
+                                    value_retry: ExactlyOnce,
+                                    key_type: u32,
+                                    value_type: std :: time :: Instant,
                                 },
                             },
                         },
-                        second: Tee {
-                            inner: <tee 10>: Map {
-                                f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , u32) , (u32 , core :: option :: Option < u32 >) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (virtual_id , payload) | (virtual_id , Some (payload)) }),
-                                input: Batch {
-                                    inner: Network {
-                                        serialize_fn: Some(
-                                            :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
-                                        ),
-                                        instantiate_fn: <network instantiate>,
-                                        deserialize_fn: Some(
-                                            | res | { hydro_lang :: runtime_support :: bincode :: deserialize :: < (u32 , u32) > (& res . unwrap ()) . unwrap () },
-                                        ),
-                                        input: Cast {
-                                            inner: YieldConcat {
-                                                inner: Tee {
-                                                    inner: <tee 7>,
-                                                    metadata: HydroIrMetadata {
-                                                        location_kind: Tick(
-                                                            4,
-                                                            Process(
+                        metadata: HydroIrMetadata {
+                            location_kind: Tick(
+                                4,
+                                Cluster(
+                                    2,
+                                ),
+                            ),
+                            collection_kind: KeyedStream {
+                                bound: Bounded,
+                                value_order: TotalOrder,
+                                value_retry: ExactlyOnce,
+                                key_type: u32,
+                                value_type: std :: time :: Instant,
+                            },
+                        },
+                    },
+                    second: Tee {
+                        inner: <tee 11>: Map {
+                            f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , core :: option :: Option < u32 >) , (u32 , std :: time :: Instant) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < u32 > , std :: time :: Instant > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | _payload | Instant :: now () }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
+                            input: Tee {
+                                inner: <tee 12>: Map {
+                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , u32) , (u32 , core :: option :: Option < u32 >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < u32 , core :: option :: Option < u32 > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | payload | Some (payload) }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
+                                    input: Batch {
+                                        inner: Cast {
+                                            inner: Network {
+                                                serialize_fn: Some(
+                                                    :: hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , (u32 , u32)) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
+                                                ),
+                                                instantiate_fn: <network instantiate>,
+                                                deserialize_fn: Some(
+                                                    | res | { hydro_lang :: runtime_support :: bincode :: deserialize :: < (u32 , u32) > (& res . unwrap ()) . unwrap () },
+                                                ),
+                                                input: Cast {
+                                                    inner: YieldConcat {
+                                                        inner: Tee {
+                                                            inner: <tee 6>,
+                                                            metadata: HydroIrMetadata {
+                                                                location_kind: Tick(
+                                                                    3,
+                                                                    Process(
+                                                                        0,
+                                                                    ),
+                                                                ),
+                                                                collection_kind: Stream {
+                                                                    bound: Bounded,
+                                                                    order: NoOrder,
+                                                                    retry: ExactlyOnce,
+                                                                    element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)),
+                                                                },
+                                                            },
+                                                        },
+                                                        metadata: HydroIrMetadata {
+                                                            location_kind: Process(
                                                                 0,
                                                             ),
+                                                            collection_kind: Stream {
+                                                                bound: Unbounded,
+                                                                order: NoOrder,
+                                                                retry: ExactlyOnce,
+                                                                element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)),
+                                                            },
+                                                        },
+                                                    },
+                                                    metadata: HydroIrMetadata {
+                                                        location_kind: Process(
+                                                            0,
                                                         ),
-                                                        collection_kind: Stream {
-                                                            bound: Bounded,
-                                                            order: NoOrder,
-                                                            retry: ExactlyOnce,
-                                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)),
+                                                        collection_kind: KeyedStream {
+                                                            bound: Unbounded,
+                                                            value_order: NoOrder,
+                                                            value_retry: ExactlyOnce,
+                                                            key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client >,
+                                                            value_type: (u32 , u32),
                                                         },
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_kind: Process(
-                                                        0,
+                                                    location_kind: Cluster(
+                                                        2,
                                                     ),
                                                     collection_kind: Stream {
                                                         bound: Unbounded,
                                                         order: NoOrder,
                                                         retry: ExactlyOnce,
-                                                        element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , u32)),
+                                                        element_type: (u32 , u32),
                                                     },
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_kind: Process(
-                                                    0,
+                                                location_kind: Cluster(
+                                                    2,
                                                 ),
                                                 collection_kind: KeyedStream {
                                                     bound: Unbounded,
                                                     value_order: NoOrder,
                                                     value_retry: ExactlyOnce,
-                                                    key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client >,
-                                                    value_type: (u32 , u32),
+                                                    key_type: u32,
+                                                    value_type: u32,
                                                 },
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_kind: Cluster(
-                                                2,
+                                            location_kind: Tick(
+                                                4,
+                                                Cluster(
+                                                    2,
+                                                ),
                                             ),
-                                            collection_kind: Stream {
-                                                bound: Unbounded,
-                                                order: NoOrder,
-                                                retry: ExactlyOnce,
-                                                element_type: (u32 , u32),
+                                            collection_kind: KeyedStream {
+                                                bound: Bounded,
+                                                value_order: NoOrder,
+                                                value_retry: ExactlyOnce,
+                                                key_type: u32,
+                                                value_type: u32,
                                             },
                                         },
                                     },
                                     metadata: HydroIrMetadata {
                                         location_kind: Tick(
-                                            0,
+                                            4,
+                                            Cluster(
+                                                2,
+                                            ),
+                                        ),
+                                        collection_kind: KeyedStream {
+                                            bound: Bounded,
+                                            value_order: NoOrder,
+                                            value_retry: ExactlyOnce,
+                                            key_type: u32,
+                                            value_type: core :: option :: Option < u32 >,
+                                        },
+                                    },
+                                },
+                                metadata: HydroIrMetadata {
+                                    location_kind: Tick(
+                                        4,
+                                        Cluster(
+                                            2,
+                                        ),
+                                    ),
+                                    collection_kind: KeyedStream {
+                                        bound: Bounded,
+                                        value_order: NoOrder,
+                                        value_retry: ExactlyOnce,
+                                        key_type: u32,
+                                        value_type: core :: option :: Option < u32 >,
+                                    },
+                                },
+                            },
+                            metadata: HydroIrMetadata {
+                                location_kind: Tick(
+                                    4,
+                                    Cluster(
+                                        2,
+                                    ),
+                                ),
+                                collection_kind: KeyedStream {
+                                    bound: Bounded,
+                                    value_order: NoOrder,
+                                    value_retry: ExactlyOnce,
+                                    key_type: u32,
+                                    value_type: std :: time :: Instant,
+                                },
+                            },
+                        },
+                        metadata: HydroIrMetadata {
+                            location_kind: Tick(
+                                4,
+                                Cluster(
+                                    2,
+                                ),
+                            ),
+                            collection_kind: KeyedStream {
+                                bound: Bounded,
+                                value_order: NoOrder,
+                                value_retry: ExactlyOnce,
+                                key_type: u32,
+                                value_type: std :: time :: Instant,
+                            },
+                        },
+                    },
+                    metadata: HydroIrMetadata {
+                        location_kind: Tick(
+                            4,
+                            Cluster(
+                                2,
+                            ),
+                        ),
+                        collection_kind: KeyedStream {
+                            bound: Bounded,
+                            value_order: NoOrder,
+                            value_retry: ExactlyOnce,
+                            key_type: u32,
+                            value_type: std :: time :: Instant,
+                        },
+                    },
+                },
+                trusted: false,
+                metadata: HydroIrMetadata {
+                    location_kind: Tick(
+                        4,
+                        Cluster(
+                            2,
+                        ),
+                    ),
+                    collection_kind: KeyedStream {
+                        bound: Bounded,
+                        value_order: TotalOrder,
+                        value_retry: ExactlyOnce,
+                        key_type: u32,
+                        value_type: std :: time :: Instant,
+                    },
+                },
+            },
+            metadata: HydroIrMetadata {
+                location_kind: Tick(
+                    4,
+                    Cluster(
+                        2,
+                    ),
+                ),
+                collection_kind: KeyedSingleton {
+                    bound: Bounded,
+                    key_type: u32,
+                    value_type: std :: time :: Instant,
+                },
+            },
+        },
+        op_metadata: HydroIrOpMetadata,
+    },
+    CycleSink {
+        ident: Ident {
+            sym: cycle_0,
+        },
+        input: ObserveNonDet {
+            inner: Map {
+                f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , core :: option :: Option < u32 >) , (u32 , u32) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; move | (virtual_id , payload) | { let value = if let Some (payload) = payload { payload + 1 } else { 0 } ; (virtual_id , value) } }),
+                input: Cast {
+                    inner: YieldConcat {
+                        inner: Chain {
+                            first: Cast {
+                                inner: Map {
+                                    f: stageleft :: runtime_support :: fn1_type_hint :: < u32 , (u32 , core :: option :: Option < u32 >) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | virtual_id | (virtual_id , None) }),
+                                    input: Tee {
+                                        inner: <tee 10>,
+                                        metadata: HydroIrMetadata {
+                                            location_kind: Tick(
+                                                4,
+                                                Cluster(
+                                                    2,
+                                                ),
+                                            ),
+                                            collection_kind: Stream {
+                                                bound: Bounded,
+                                                order: TotalOrder,
+                                                retry: ExactlyOnce,
+                                                element_type: u32,
+                                            },
+                                        },
+                                    },
+                                    metadata: HydroIrMetadata {
+                                        location_kind: Tick(
+                                            4,
                                             Cluster(
                                                 2,
                                             ),
                                         ),
                                         collection_kind: Stream {
                                             bound: Bounded,
-                                            order: NoOrder,
+                                            order: TotalOrder,
                                             retry: ExactlyOnce,
-                                            element_type: (u32 , u32),
+                                            element_type: (u32 , core :: option :: Option < u32 >),
                                         },
                                     },
                                 },
                                 metadata: HydroIrMetadata {
                                     location_kind: Tick(
-                                        0,
+                                        4,
                                         Cluster(
                                             2,
                                         ),
                                     ),
-                                    collection_kind: Stream {
+                                    collection_kind: KeyedStream {
                                         bound: Bounded,
-                                        order: NoOrder,
-                                        retry: ExactlyOnce,
-                                        element_type: (u32 , core :: option :: Option < u32 >),
+                                        value_order: TotalOrder,
+                                        value_retry: ExactlyOnce,
+                                        key_type: u32,
+                                        value_type: core :: option :: Option < u32 >,
+                                    },
+                                },
+                            },
+                            second: Tee {
+                                inner: <tee 12>,
+                                metadata: HydroIrMetadata {
+                                    location_kind: Tick(
+                                        4,
+                                        Cluster(
+                                            2,
+                                        ),
+                                    ),
+                                    collection_kind: KeyedStream {
+                                        bound: Bounded,
+                                        value_order: NoOrder,
+                                        value_retry: ExactlyOnce,
+                                        key_type: u32,
+                                        value_type: core :: option :: Option < u32 >,
                                     },
                                 },
                             },
                             metadata: HydroIrMetadata {
                                 location_kind: Tick(
-                                    0,
+                                    4,
                                     Cluster(
                                         2,
                                     ),
                                 ),
-                                collection_kind: Stream {
+                                collection_kind: KeyedStream {
                                     bound: Bounded,
-                                    order: NoOrder,
-                                    retry: ExactlyOnce,
-                                    element_type: (u32 , core :: option :: Option < u32 >),
+                                    value_order: NoOrder,
+                                    value_retry: ExactlyOnce,
+                                    key_type: u32,
+                                    value_type: core :: option :: Option < u32 >,
                                 },
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_kind: Tick(
-                                0,
-                                Cluster(
-                                    2,
-                                ),
+                            location_kind: Cluster(
+                                2,
                             ),
-                            collection_kind: Stream {
-                                bound: Bounded,
-                                order: NoOrder,
-                                retry: ExactlyOnce,
-                                element_type: (u32 , core :: option :: Option < u32 >),
+                            collection_kind: KeyedStream {
+                                bound: Unbounded,
+                                value_order: NoOrder,
+                                value_retry: ExactlyOnce,
+                                key_type: u32,
+                                value_type: core :: option :: Option < u32 >,
                             },
                         },
                     },
@@ -1689,263 +2054,6 @@ expression: built.ir()
                     order: TotalOrder,
                     retry: ExactlyOnce,
                     element_type: (u32 , u32),
-                },
-            },
-        },
-        op_metadata: HydroIrOpMetadata,
-    },
-    CycleSink {
-        ident: Ident {
-            sym: cycle_6,
-        },
-        input: Cast {
-            inner: Cast {
-                inner: ReduceKeyed {
-                    f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: time :: Instant , std :: time :: Instant , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | curr_time , new_time | { if new_time > * curr_time { * curr_time = new_time ; } } }),
-                    input: ObserveNonDet {
-                        inner: Cast {
-                            inner: Chain {
-                                first: Chain {
-                                    first: Tee {
-                                        inner: <tee 11>: DeferTick {
-                                            input: CycleSource {
-                                                ident: Ident {
-                                                    sym: cycle_6,
-                                                },
-                                                metadata: HydroIrMetadata {
-                                                    location_kind: Tick(
-                                                        0,
-                                                        Cluster(
-                                                            2,
-                                                        ),
-                                                    ),
-                                                    collection_kind: Stream {
-                                                        bound: Bounded,
-                                                        order: NoOrder,
-                                                        retry: ExactlyOnce,
-                                                        element_type: (u32 , std :: time :: Instant),
-                                                    },
-                                                },
-                                            },
-                                            metadata: HydroIrMetadata {
-                                                location_kind: Tick(
-                                                    0,
-                                                    Cluster(
-                                                        2,
-                                                    ),
-                                                ),
-                                                collection_kind: Stream {
-                                                    bound: Bounded,
-                                                    order: NoOrder,
-                                                    retry: ExactlyOnce,
-                                                    element_type: (u32 , std :: time :: Instant),
-                                                },
-                                            },
-                                        },
-                                        metadata: HydroIrMetadata {
-                                            location_kind: Tick(
-                                                0,
-                                                Cluster(
-                                                    2,
-                                                ),
-                                            ),
-                                            collection_kind: Stream {
-                                                bound: Bounded,
-                                                order: NoOrder,
-                                                retry: ExactlyOnce,
-                                                element_type: (u32 , std :: time :: Instant),
-                                            },
-                                        },
-                                    },
-                                    second: Map {
-                                        f: stageleft :: runtime_support :: fn1_type_hint :: < u32 , (u32 , std :: time :: Instant) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | virtual_id | (virtual_id , Instant :: now ()) }),
-                                        input: Tee {
-                                            inner: <tee 9>,
-                                            metadata: HydroIrMetadata {
-                                                location_kind: Tick(
-                                                    0,
-                                                    Cluster(
-                                                        2,
-                                                    ),
-                                                ),
-                                                collection_kind: Stream {
-                                                    bound: Bounded,
-                                                    order: TotalOrder,
-                                                    retry: ExactlyOnce,
-                                                    element_type: u32,
-                                                },
-                                            },
-                                        },
-                                        metadata: HydroIrMetadata {
-                                            location_kind: Tick(
-                                                0,
-                                                Cluster(
-                                                    2,
-                                                ),
-                                            ),
-                                            collection_kind: Stream {
-                                                bound: Bounded,
-                                                order: TotalOrder,
-                                                retry: ExactlyOnce,
-                                                element_type: (u32 , std :: time :: Instant),
-                                            },
-                                        },
-                                    },
-                                    metadata: HydroIrMetadata {
-                                        location_kind: Tick(
-                                            0,
-                                            Cluster(
-                                                2,
-                                            ),
-                                        ),
-                                        collection_kind: Stream {
-                                            bound: Bounded,
-                                            order: NoOrder,
-                                            retry: ExactlyOnce,
-                                            element_type: (u32 , std :: time :: Instant),
-                                        },
-                                    },
-                                },
-                                second: Tee {
-                                    inner: <tee 12>: Map {
-                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , core :: option :: Option < u32 >) , (u32 , std :: time :: Instant) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (key , _payload) | (key , Instant :: now ()) }),
-                                        input: Tee {
-                                            inner: <tee 10>,
-                                            metadata: HydroIrMetadata {
-                                                location_kind: Tick(
-                                                    0,
-                                                    Cluster(
-                                                        2,
-                                                    ),
-                                                ),
-                                                collection_kind: Stream {
-                                                    bound: Bounded,
-                                                    order: NoOrder,
-                                                    retry: ExactlyOnce,
-                                                    element_type: (u32 , core :: option :: Option < u32 >),
-                                                },
-                                            },
-                                        },
-                                        metadata: HydroIrMetadata {
-                                            location_kind: Tick(
-                                                0,
-                                                Cluster(
-                                                    2,
-                                                ),
-                                            ),
-                                            collection_kind: Stream {
-                                                bound: Bounded,
-                                                order: NoOrder,
-                                                retry: ExactlyOnce,
-                                                element_type: (u32 , std :: time :: Instant),
-                                            },
-                                        },
-                                    },
-                                    metadata: HydroIrMetadata {
-                                        location_kind: Tick(
-                                            0,
-                                            Cluster(
-                                                2,
-                                            ),
-                                        ),
-                                        collection_kind: Stream {
-                                            bound: Bounded,
-                                            order: NoOrder,
-                                            retry: ExactlyOnce,
-                                            element_type: (u32 , std :: time :: Instant),
-                                        },
-                                    },
-                                },
-                                metadata: HydroIrMetadata {
-                                    location_kind: Tick(
-                                        0,
-                                        Cluster(
-                                            2,
-                                        ),
-                                    ),
-                                    collection_kind: Stream {
-                                        bound: Bounded,
-                                        order: NoOrder,
-                                        retry: ExactlyOnce,
-                                        element_type: (u32 , std :: time :: Instant),
-                                    },
-                                },
-                            },
-                            metadata: HydroIrMetadata {
-                                location_kind: Tick(
-                                    0,
-                                    Cluster(
-                                        2,
-                                    ),
-                                ),
-                                collection_kind: KeyedStream {
-                                    bound: Bounded,
-                                    value_order: NoOrder,
-                                    value_retry: ExactlyOnce,
-                                    key_type: u32,
-                                    value_type: std :: time :: Instant,
-                                },
-                            },
-                        },
-                        trusted: false,
-                        metadata: HydroIrMetadata {
-                            location_kind: Tick(
-                                0,
-                                Cluster(
-                                    2,
-                                ),
-                            ),
-                            collection_kind: KeyedStream {
-                                bound: Bounded,
-                                value_order: TotalOrder,
-                                value_retry: ExactlyOnce,
-                                key_type: u32,
-                                value_type: std :: time :: Instant,
-                            },
-                        },
-                    },
-                    metadata: HydroIrMetadata {
-                        location_kind: Tick(
-                            0,
-                            Cluster(
-                                2,
-                            ),
-                        ),
-                        collection_kind: KeyedSingleton {
-                            bound: Bounded,
-                            key_type: u32,
-                            value_type: std :: time :: Instant,
-                        },
-                    },
-                },
-                metadata: HydroIrMetadata {
-                    location_kind: Tick(
-                        0,
-                        Cluster(
-                            2,
-                        ),
-                    ),
-                    collection_kind: KeyedStream {
-                        bound: Bounded,
-                        value_order: TotalOrder,
-                        value_retry: ExactlyOnce,
-                        key_type: u32,
-                        value_type: std :: time :: Instant,
-                    },
-                },
-            },
-            metadata: HydroIrMetadata {
-                location_kind: Tick(
-                    0,
-                    Cluster(
-                        2,
-                    ),
-                ),
-                collection_kind: Stream {
-                    bound: Bounded,
-                    order: NoOrder,
-                    retry: ExactlyOnce,
-                    element_type: (u32 , std :: time :: Instant),
                 },
             },
         },
@@ -2168,50 +2276,50 @@ expression: built.ir()
                                                                                                                     input: CrossSingleton {
                                                                                                                         left: Batch {
                                                                                                                             inner: Map {
-                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage) , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (_ , stats) | { stats } }),
+                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage) , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (_ , stats) | stats }),
                                                                                                                                 input: Fold {
                                                                                                                                     init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | | (0 , { RollingAverage :: new () }) }),
                                                                                                                                     acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage) , (usize , bool) , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (total , stats) , (batch_size , reset) | { if reset { if * total > 0 { stats . add_sample (* total as f64) ; } * total = 0 ; } else { * total += batch_size ; } } }),
-                                                                                                                                    input: YieldConcat {
-                                                                                                                                        inner: Chain {
-                                                                                                                                            first: Cast {
-                                                                                                                                                inner: Map {
-                                                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < usize , (usize , bool) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | batch_size | (batch_size , false) }),
-                                                                                                                                                    input: Map {
-                                                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , ()) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _signal) | d }),
-                                                                                                                                                        input: CrossSingleton {
-                                                                                                                                                            left: Fold {
-                                                                                                                                                                init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | | 0usize }),
-                                                                                                                                                                acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , (u32 , core :: option :: Option < u32 >) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | count , _ | * count += 1 }),
-                                                                                                                                                                input: ObserveNonDet {
+                                                                                                                                    input: Chain {
+                                                                                                                                        first: Map {
+                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < usize , (usize , bool) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | batch_size | (batch_size , false) }),
+                                                                                                                                            input: YieldConcat {
+                                                                                                                                                inner: Cast {
+                                                                                                                                                    inner: Fold {
+                                                                                                                                                        init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | | 0usize }),
+                                                                                                                                                        acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , core :: option :: Option < u32 > , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | count , _ | * count += 1 }),
+                                                                                                                                                        input: ObserveNonDet {
+                                                                                                                                                            inner: Map {
+                                                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , core :: option :: Option < u32 >) , core :: option :: Option < u32 > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
+                                                                                                                                                                input: Cast {
                                                                                                                                                                     inner: Tee {
-                                                                                                                                                                        inner: <tee 10>,
+                                                                                                                                                                        inner: <tee 12>,
                                                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                                                             location_kind: Tick(
-                                                                                                                                                                                0,
+                                                                                                                                                                                4,
                                                                                                                                                                                 Cluster(
                                                                                                                                                                                     2,
                                                                                                                                                                                 ),
                                                                                                                                                                             ),
-                                                                                                                                                                            collection_kind: Stream {
+                                                                                                                                                                            collection_kind: KeyedStream {
                                                                                                                                                                                 bound: Bounded,
-                                                                                                                                                                                order: NoOrder,
-                                                                                                                                                                                retry: ExactlyOnce,
-                                                                                                                                                                                element_type: (u32 , core :: option :: Option < u32 >),
+                                                                                                                                                                                value_order: NoOrder,
+                                                                                                                                                                                value_retry: ExactlyOnce,
+                                                                                                                                                                                key_type: u32,
+                                                                                                                                                                                value_type: core :: option :: Option < u32 >,
                                                                                                                                                                             },
                                                                                                                                                                         },
                                                                                                                                                                     },
-                                                                                                                                                                    trusted: true,
                                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                                         location_kind: Tick(
-                                                                                                                                                                            0,
+                                                                                                                                                                            4,
                                                                                                                                                                             Cluster(
                                                                                                                                                                                 2,
                                                                                                                                                                             ),
                                                                                                                                                                         ),
                                                                                                                                                                         collection_kind: Stream {
                                                                                                                                                                             bound: Bounded,
-                                                                                                                                                                            order: TotalOrder,
+                                                                                                                                                                            order: NoOrder,
                                                                                                                                                                             retry: ExactlyOnce,
                                                                                                                                                                             element_type: (u32 , core :: option :: Option < u32 >),
                                                                                                                                                                         },
@@ -2219,216 +2327,43 @@ expression: built.ir()
                                                                                                                                                                 },
                                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                                     location_kind: Tick(
-                                                                                                                                                                        0,
+                                                                                                                                                                        4,
                                                                                                                                                                         Cluster(
                                                                                                                                                                             2,
                                                                                                                                                                         ),
                                                                                                                                                                     ),
-                                                                                                                                                                    collection_kind: Singleton {
+                                                                                                                                                                    collection_kind: Stream {
                                                                                                                                                                         bound: Bounded,
-                                                                                                                                                                        element_type: usize,
+                                                                                                                                                                        order: NoOrder,
+                                                                                                                                                                        retry: ExactlyOnce,
+                                                                                                                                                                        element_type: core :: option :: Option < u32 >,
                                                                                                                                                                     },
                                                                                                                                                                 },
                                                                                                                                                             },
-                                                                                                                                                            right: Map {
-                                                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _u | () }),
-                                                                                                                                                                input: Filter {
-                                                                                                                                                                    f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | o | o . is_none () }),
-                                                                                                                                                                    input: Cast {
-                                                                                                                                                                        inner: ChainFirst {
-                                                                                                                                                                            first: Map {
-                                                                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                                                                                                                                                input: Map {
-                                                                                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _ | () }),
-                                                                                                                                                                                    input: Tee {
-                                                                                                                                                                                        inner: <tee 16>: Reduce {
-                                                                                                                                                                                            f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
-                                                                                                                                                                                            input: Batch {
-                                                                                                                                                                                                inner: Source {
-                                                                                                                                                                                                    source: Stream(
-                                                                                                                                                                                                        { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let interval__free = { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; Duration :: from_secs (1) } ; tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval (interval__free)) },
-                                                                                                                                                                                                    ),
-                                                                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                                                                        location_kind: Cluster(
-                                                                                                                                                                                                            2,
-                                                                                                                                                                                                        ),
-                                                                                                                                                                                                        collection_kind: Stream {
-                                                                                                                                                                                                            bound: Unbounded,
-                                                                                                                                                                                                            order: TotalOrder,
-                                                                                                                                                                                                            retry: ExactlyOnce,
-                                                                                                                                                                                                            element_type: hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
-                                                                                                                                                                                                        },
-                                                                                                                                                                                                    },
-                                                                                                                                                                                                },
-                                                                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                                                                    location_kind: Tick(
-                                                                                                                                                                                                        0,
-                                                                                                                                                                                                        Cluster(
-                                                                                                                                                                                                            2,
-                                                                                                                                                                                                        ),
-                                                                                                                                                                                                    ),
-                                                                                                                                                                                                    collection_kind: Stream {
-                                                                                                                                                                                                        bound: Bounded,
-                                                                                                                                                                                                        order: TotalOrder,
-                                                                                                                                                                                                        retry: ExactlyOnce,
-                                                                                                                                                                                                        element_type: hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
-                                                                                                                                                                                                    },
-                                                                                                                                                                                                },
-                                                                                                                                                                                            },
-                                                                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                                                                location_kind: Tick(
-                                                                                                                                                                                                    0,
-                                                                                                                                                                                                    Cluster(
-                                                                                                                                                                                                        2,
-                                                                                                                                                                                                    ),
-                                                                                                                                                                                                ),
-                                                                                                                                                                                                collection_kind: Optional {
-                                                                                                                                                                                                    bound: Bounded,
-                                                                                                                                                                                                    element_type: hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
-                                                                                                                                                                                                },
-                                                                                                                                                                                            },
-                                                                                                                                                                                        },
-                                                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                                                            location_kind: Tick(
-                                                                                                                                                                                                0,
-                                                                                                                                                                                                Cluster(
-                                                                                                                                                                                                    2,
-                                                                                                                                                                                                ),
-                                                                                                                                                                                            ),
-                                                                                                                                                                                            collection_kind: Optional {
-                                                                                                                                                                                                bound: Bounded,
-                                                                                                                                                                                                element_type: hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
-                                                                                                                                                                                            },
-                                                                                                                                                                                        },
-                                                                                                                                                                                    },
-                                                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                                                        location_kind: Tick(
-                                                                                                                                                                                            0,
-                                                                                                                                                                                            Cluster(
-                                                                                                                                                                                                2,
-                                                                                                                                                                                            ),
-                                                                                                                                                                                        ),
-                                                                                                                                                                                        collection_kind: Optional {
-                                                                                                                                                                                            bound: Bounded,
-                                                                                                                                                                                            element_type: (),
-                                                                                                                                                                                        },
-                                                                                                                                                                                    },
-                                                                                                                                                                                },
-                                                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                                                    location_kind: Tick(
-                                                                                                                                                                                        0,
-                                                                                                                                                                                        Cluster(
-                                                                                                                                                                                            2,
-                                                                                                                                                                                        ),
-                                                                                                                                                                                    ),
-                                                                                                                                                                                    collection_kind: Optional {
-                                                                                                                                                                                        bound: Bounded,
-                                                                                                                                                                                        element_type: core :: option :: Option < () >,
-                                                                                                                                                                                    },
-                                                                                                                                                                                },
-                                                                                                                                                                            },
-                                                                                                                                                                            second: Cast {
-                                                                                                                                                                                inner: SingletonSource {
-                                                                                                                                                                                    value: :: std :: option :: Option :: None,
-                                                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                                                        location_kind: Tick(
-                                                                                                                                                                                            0,
-                                                                                                                                                                                            Cluster(
-                                                                                                                                                                                                2,
-                                                                                                                                                                                            ),
-                                                                                                                                                                                        ),
-                                                                                                                                                                                        collection_kind: Singleton {
-                                                                                                                                                                                            bound: Bounded,
-                                                                                                                                                                                            element_type: core :: option :: Option < () >,
-                                                                                                                                                                                        },
-                                                                                                                                                                                    },
-                                                                                                                                                                                },
-                                                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                                                    location_kind: Tick(
-                                                                                                                                                                                        0,
-                                                                                                                                                                                        Cluster(
-                                                                                                                                                                                            2,
-                                                                                                                                                                                        ),
-                                                                                                                                                                                    ),
-                                                                                                                                                                                    collection_kind: Optional {
-                                                                                                                                                                                        bound: Bounded,
-                                                                                                                                                                                        element_type: core :: option :: Option < () >,
-                                                                                                                                                                                    },
-                                                                                                                                                                                },
-                                                                                                                                                                            },
-                                                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                                                location_kind: Tick(
-                                                                                                                                                                                    0,
-                                                                                                                                                                                    Cluster(
-                                                                                                                                                                                        2,
-                                                                                                                                                                                    ),
-                                                                                                                                                                                ),
-                                                                                                                                                                                collection_kind: Optional {
-                                                                                                                                                                                    bound: Bounded,
-                                                                                                                                                                                    element_type: core :: option :: Option < () >,
-                                                                                                                                                                                },
-                                                                                                                                                                            },
-                                                                                                                                                                        },
-                                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                                            location_kind: Tick(
-                                                                                                                                                                                0,
-                                                                                                                                                                                Cluster(
-                                                                                                                                                                                    2,
-                                                                                                                                                                                ),
-                                                                                                                                                                            ),
-                                                                                                                                                                            collection_kind: Singleton {
-                                                                                                                                                                                bound: Bounded,
-                                                                                                                                                                                element_type: core :: option :: Option < () >,
-                                                                                                                                                                            },
-                                                                                                                                                                        },
-                                                                                                                                                                    },
-                                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                                        location_kind: Tick(
-                                                                                                                                                                            0,
-                                                                                                                                                                            Cluster(
-                                                                                                                                                                                2,
-                                                                                                                                                                            ),
-                                                                                                                                                                        ),
-                                                                                                                                                                        collection_kind: Optional {
-                                                                                                                                                                            bound: Bounded,
-                                                                                                                                                                            element_type: core :: option :: Option < () >,
-                                                                                                                                                                        },
-                                                                                                                                                                    },
-                                                                                                                                                                },
-                                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                                    location_kind: Tick(
-                                                                                                                                                                        0,
-                                                                                                                                                                        Cluster(
-                                                                                                                                                                            2,
-                                                                                                                                                                        ),
-                                                                                                                                                                    ),
-                                                                                                                                                                    collection_kind: Optional {
-                                                                                                                                                                        bound: Bounded,
-                                                                                                                                                                        element_type: (),
-                                                                                                                                                                    },
-                                                                                                                                                                },
-                                                                                                                                                            },
+                                                                                                                                                            trusted: true,
                                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                                 location_kind: Tick(
-                                                                                                                                                                    0,
+                                                                                                                                                                    4,
                                                                                                                                                                     Cluster(
                                                                                                                                                                         2,
                                                                                                                                                                     ),
                                                                                                                                                                 ),
-                                                                                                                                                                collection_kind: Optional {
+                                                                                                                                                                collection_kind: Stream {
                                                                                                                                                                     bound: Bounded,
-                                                                                                                                                                    element_type: (usize , ()),
+                                                                                                                                                                    order: TotalOrder,
+                                                                                                                                                                    retry: ExactlyOnce,
+                                                                                                                                                                    element_type: core :: option :: Option < u32 >,
                                                                                                                                                                 },
                                                                                                                                                             },
                                                                                                                                                         },
                                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                                             location_kind: Tick(
-                                                                                                                                                                0,
+                                                                                                                                                                4,
                                                                                                                                                                 Cluster(
                                                                                                                                                                     2,
                                                                                                                                                                 ),
                                                                                                                                                             ),
-                                                                                                                                                            collection_kind: Optional {
+                                                                                                                                                            collection_kind: Singleton {
                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                 element_type: usize,
                                                                                                                                                             },
@@ -2436,101 +2371,67 @@ expression: built.ir()
                                                                                                                                                     },
                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                         location_kind: Tick(
-                                                                                                                                                            0,
+                                                                                                                                                            4,
                                                                                                                                                             Cluster(
                                                                                                                                                                 2,
                                                                                                                                                             ),
                                                                                                                                                         ),
-                                                                                                                                                        collection_kind: Optional {
+                                                                                                                                                        collection_kind: Stream {
                                                                                                                                                             bound: Bounded,
-                                                                                                                                                            element_type: (usize , bool),
+                                                                                                                                                            order: TotalOrder,
+                                                                                                                                                            retry: ExactlyOnce,
+                                                                                                                                                            element_type: usize,
                                                                                                                                                         },
                                                                                                                                                     },
                                                                                                                                                 },
                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                    location_kind: Tick(
-                                                                                                                                                        0,
-                                                                                                                                                        Cluster(
-                                                                                                                                                            2,
-                                                                                                                                                        ),
+                                                                                                                                                    location_kind: Cluster(
+                                                                                                                                                        2,
                                                                                                                                                     ),
                                                                                                                                                     collection_kind: Stream {
-                                                                                                                                                        bound: Bounded,
+                                                                                                                                                        bound: Unbounded,
                                                                                                                                                         order: TotalOrder,
                                                                                                                                                         retry: ExactlyOnce,
-                                                                                                                                                        element_type: (usize , bool),
-                                                                                                                                                    },
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                            second: Cast {
-                                                                                                                                                inner: DeferTick {
-                                                                                                                                                    input: Map {
-                                                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , (usize , bool) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | _ | (0 , true) }),
-                                                                                                                                                        input: Tee {
-                                                                                                                                                            inner: <tee 16>,
-                                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                                location_kind: Tick(
-                                                                                                                                                                    0,
-                                                                                                                                                                    Cluster(
-                                                                                                                                                                        2,
-                                                                                                                                                                    ),
-                                                                                                                                                                ),
-                                                                                                                                                                collection_kind: Optional {
-                                                                                                                                                                    bound: Bounded,
-                                                                                                                                                                    element_type: hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
-                                                                                                                                                                },
-                                                                                                                                                            },
-                                                                                                                                                        },
-                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                            location_kind: Tick(
-                                                                                                                                                                0,
-                                                                                                                                                                Cluster(
-                                                                                                                                                                    2,
-                                                                                                                                                                ),
-                                                                                                                                                            ),
-                                                                                                                                                            collection_kind: Optional {
-                                                                                                                                                                bound: Bounded,
-                                                                                                                                                                element_type: (usize , bool),
-                                                                                                                                                            },
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                        location_kind: Tick(
-                                                                                                                                                            0,
-                                                                                                                                                            Cluster(
-                                                                                                                                                                2,
-                                                                                                                                                            ),
-                                                                                                                                                        ),
-                                                                                                                                                        collection_kind: Optional {
-                                                                                                                                                            bound: Bounded,
-                                                                                                                                                            element_type: (usize , bool),
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                },
-                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                    location_kind: Tick(
-                                                                                                                                                        0,
-                                                                                                                                                        Cluster(
-                                                                                                                                                            2,
-                                                                                                                                                        ),
-                                                                                                                                                    ),
-                                                                                                                                                    collection_kind: Stream {
-                                                                                                                                                        bound: Bounded,
-                                                                                                                                                        order: TotalOrder,
-                                                                                                                                                        retry: ExactlyOnce,
-                                                                                                                                                        element_type: (usize , bool),
+                                                                                                                                                        element_type: usize,
                                                                                                                                                     },
                                                                                                                                                 },
                                                                                                                                             },
                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                location_kind: Tick(
-                                                                                                                                                    0,
-                                                                                                                                                    Cluster(
-                                                                                                                                                        2,
-                                                                                                                                                    ),
+                                                                                                                                                location_kind: Cluster(
+                                                                                                                                                    2,
                                                                                                                                                 ),
                                                                                                                                                 collection_kind: Stream {
-                                                                                                                                                    bound: Bounded,
+                                                                                                                                                    bound: Unbounded,
+                                                                                                                                                    order: TotalOrder,
+                                                                                                                                                    retry: ExactlyOnce,
+                                                                                                                                                    element_type: (usize , bool),
+                                                                                                                                                },
+                                                                                                                                            },
+                                                                                                                                        },
+                                                                                                                                        second: Map {
+                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , (usize , bool) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | _ | (0 , true) }),
+                                                                                                                                            input: Source {
+                                                                                                                                                source: Stream(
+                                                                                                                                                    { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; let interval__free = { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; Duration :: from_secs (1) } ; tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval (interval__free)) },
+                                                                                                                                                ),
+                                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                                    location_kind: Cluster(
+                                                                                                                                                        2,
+                                                                                                                                                    ),
+                                                                                                                                                    collection_kind: Stream {
+                                                                                                                                                        bound: Unbounded,
+                                                                                                                                                        order: TotalOrder,
+                                                                                                                                                        retry: ExactlyOnce,
+                                                                                                                                                        element_type: hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
+                                                                                                                                                    },
+                                                                                                                                                },
+                                                                                                                                            },
+                                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                                location_kind: Cluster(
+                                                                                                                                                    2,
+                                                                                                                                                ),
+                                                                                                                                                collection_kind: Stream {
+                                                                                                                                                    bound: Unbounded,
                                                                                                                                                     order: TotalOrder,
                                                                                                                                                     retry: ExactlyOnce,
                                                                                                                                                     element_type: (usize , bool),
@@ -3626,30 +3527,129 @@ expression: built.ir()
                                                                                                                             input: ObserveNonDet {
                                                                                                                                 inner: YieldConcat {
                                                                                                                                     inner: Map {
-                                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , (std :: time :: Instant , std :: time :: Instant)) , core :: time :: Duration > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (_virtual_id , (prev_time , curr_time)) | curr_time . duration_since (prev_time) }),
-                                                                                                                                        input: Join {
-                                                                                                                                            left: Tee {
-                                                                                                                                                inner: <tee 11>,
-                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                    location_kind: Tick(
-                                                                                                                                                        0,
-                                                                                                                                                        Cluster(
-                                                                                                                                                            2,
+                                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: time :: Instant , std :: time :: Instant) , core :: time :: Duration > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (prev_time , curr_time) | curr_time . duration_since (prev_time) }),
+                                                                                                                                        input: Map {
+                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , (std :: time :: Instant , std :: time :: Instant)) , (std :: time :: Instant , std :: time :: Instant) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
+                                                                                                                                            input: Cast {
+                                                                                                                                                inner: Cast {
+                                                                                                                                                    inner: Join {
+                                                                                                                                                        left: Cast {
+                                                                                                                                                            inner: Cast {
+                                                                                                                                                                inner: Tee {
+                                                                                                                                                                    inner: <tee 9>,
+                                                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                                                        location_kind: Tick(
+                                                                                                                                                                            4,
+                                                                                                                                                                            Cluster(
+                                                                                                                                                                                2,
+                                                                                                                                                                            ),
+                                                                                                                                                                        ),
+                                                                                                                                                                        collection_kind: KeyedSingleton {
+                                                                                                                                                                            bound: Bounded,
+                                                                                                                                                                            key_type: u32,
+                                                                                                                                                                            value_type: std :: time :: Instant,
+                                                                                                                                                                        },
+                                                                                                                                                                    },
+                                                                                                                                                                },
+                                                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                                                    location_kind: Tick(
+                                                                                                                                                                        4,
+                                                                                                                                                                        Cluster(
+                                                                                                                                                                            2,
+                                                                                                                                                                        ),
+                                                                                                                                                                    ),
+                                                                                                                                                                    collection_kind: KeyedStream {
+                                                                                                                                                                        bound: Bounded,
+                                                                                                                                                                        value_order: TotalOrder,
+                                                                                                                                                                        value_retry: ExactlyOnce,
+                                                                                                                                                                        key_type: u32,
+                                                                                                                                                                        value_type: std :: time :: Instant,
+                                                                                                                                                                    },
+                                                                                                                                                                },
+                                                                                                                                                            },
+                                                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                                                location_kind: Tick(
+                                                                                                                                                                    4,
+                                                                                                                                                                    Cluster(
+                                                                                                                                                                        2,
+                                                                                                                                                                    ),
+                                                                                                                                                                ),
+                                                                                                                                                                collection_kind: Stream {
+                                                                                                                                                                    bound: Bounded,
+                                                                                                                                                                    order: NoOrder,
+                                                                                                                                                                    retry: ExactlyOnce,
+                                                                                                                                                                    element_type: (u32 , std :: time :: Instant),
+                                                                                                                                                                },
+                                                                                                                                                            },
+                                                                                                                                                        },
+                                                                                                                                                        right: Cast {
+                                                                                                                                                            inner: Tee {
+                                                                                                                                                                inner: <tee 11>,
+                                                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                                                    location_kind: Tick(
+                                                                                                                                                                        4,
+                                                                                                                                                                        Cluster(
+                                                                                                                                                                            2,
+                                                                                                                                                                        ),
+                                                                                                                                                                    ),
+                                                                                                                                                                    collection_kind: KeyedStream {
+                                                                                                                                                                        bound: Bounded,
+                                                                                                                                                                        value_order: NoOrder,
+                                                                                                                                                                        value_retry: ExactlyOnce,
+                                                                                                                                                                        key_type: u32,
+                                                                                                                                                                        value_type: std :: time :: Instant,
+                                                                                                                                                                    },
+                                                                                                                                                                },
+                                                                                                                                                            },
+                                                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                                                location_kind: Tick(
+                                                                                                                                                                    4,
+                                                                                                                                                                    Cluster(
+                                                                                                                                                                        2,
+                                                                                                                                                                    ),
+                                                                                                                                                                ),
+                                                                                                                                                                collection_kind: Stream {
+                                                                                                                                                                    bound: Bounded,
+                                                                                                                                                                    order: NoOrder,
+                                                                                                                                                                    retry: ExactlyOnce,
+                                                                                                                                                                    element_type: (u32 , std :: time :: Instant),
+                                                                                                                                                                },
+                                                                                                                                                            },
+                                                                                                                                                        },
+                                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                                            location_kind: Tick(
+                                                                                                                                                                4,
+                                                                                                                                                                Cluster(
+                                                                                                                                                                    2,
+                                                                                                                                                                ),
+                                                                                                                                                            ),
+                                                                                                                                                            collection_kind: Stream {
+                                                                                                                                                                bound: Bounded,
+                                                                                                                                                                order: NoOrder,
+                                                                                                                                                                retry: ExactlyOnce,
+                                                                                                                                                                element_type: (u32 , (std :: time :: Instant , std :: time :: Instant)),
+                                                                                                                                                            },
+                                                                                                                                                        },
+                                                                                                                                                    },
+                                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                                        location_kind: Tick(
+                                                                                                                                                            4,
+                                                                                                                                                            Cluster(
+                                                                                                                                                                2,
+                                                                                                                                                            ),
                                                                                                                                                         ),
-                                                                                                                                                    ),
-                                                                                                                                                    collection_kind: Stream {
-                                                                                                                                                        bound: Bounded,
-                                                                                                                                                        order: NoOrder,
-                                                                                                                                                        retry: ExactlyOnce,
-                                                                                                                                                        element_type: (u32 , std :: time :: Instant),
+                                                                                                                                                        collection_kind: KeyedStream {
+                                                                                                                                                            bound: Bounded,
+                                                                                                                                                            value_order: NoOrder,
+                                                                                                                                                            value_retry: ExactlyOnce,
+                                                                                                                                                            key_type: u32,
+                                                                                                                                                            value_type: (std :: time :: Instant , std :: time :: Instant),
+                                                                                                                                                        },
                                                                                                                                                     },
                                                                                                                                                 },
-                                                                                                                                            },
-                                                                                                                                            right: Tee {
-                                                                                                                                                inner: <tee 12>,
                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                     location_kind: Tick(
-                                                                                                                                                        0,
+                                                                                                                                                        4,
                                                                                                                                                         Cluster(
                                                                                                                                                             2,
                                                                                                                                                         ),
@@ -3658,13 +3658,13 @@ expression: built.ir()
                                                                                                                                                         bound: Bounded,
                                                                                                                                                         order: NoOrder,
                                                                                                                                                         retry: ExactlyOnce,
-                                                                                                                                                        element_type: (u32 , std :: time :: Instant),
+                                                                                                                                                        element_type: (u32 , (std :: time :: Instant , std :: time :: Instant)),
                                                                                                                                                     },
                                                                                                                                                 },
                                                                                                                                             },
                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                 location_kind: Tick(
-                                                                                                                                                    0,
+                                                                                                                                                    4,
                                                                                                                                                     Cluster(
                                                                                                                                                         2,
                                                                                                                                                     ),
@@ -3673,13 +3673,13 @@ expression: built.ir()
                                                                                                                                                     bound: Bounded,
                                                                                                                                                     order: NoOrder,
                                                                                                                                                     retry: ExactlyOnce,
-                                                                                                                                                    element_type: (u32 , (std :: time :: Instant , std :: time :: Instant)),
+                                                                                                                                                    element_type: (std :: time :: Instant , std :: time :: Instant),
                                                                                                                                                 },
                                                                                                                                             },
                                                                                                                                         },
                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                             location_kind: Tick(
-                                                                                                                                                0,
+                                                                                                                                                4,
                                                                                                                                                 Cluster(
                                                                                                                                                     2,
                                                                                                                                                 ),

--- a/hydro_test/src/cluster/snapshots/two_pc_ir@coordinator_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/two_pc_ir@coordinator_mermaid.snap
@@ -123,162 +123,162 @@ linkStyle default stroke:#aaa
 68v1
 70v1
 72v1
+subgraph var_cycle_1 ["var <tt>cycle_1</tt>"]
+    style var_cycle_1 fill:transparent
+    24v1
+end
 subgraph var_cycle_2 ["var <tt>cycle_2</tt>"]
     style var_cycle_2 fill:transparent
-    24v1
+    26v1
 end
 subgraph var_cycle_3 ["var <tt>cycle_3</tt>"]
     style var_cycle_3 fill:transparent
-    26v1
+    48v1
 end
 subgraph var_cycle_4 ["var <tt>cycle_4</tt>"]
     style var_cycle_4 fill:transparent
-    48v1
-end
-subgraph var_cycle_5 ["var <tt>cycle_5</tt>"]
-    style var_cycle_5 fill:transparent
     50v1
+end
+subgraph var_stream_1 ["var <tt>stream_1</tt>"]
+    style var_stream_1 fill:transparent
+    1v1
 end
 subgraph var_stream_10 ["var <tt>stream_10</tt>"]
     style var_stream_10 fill:transparent
-    3v1
-end
-subgraph var_stream_12 ["var <tt>stream_12</tt>"]
-    style var_stream_12 fill:transparent
-    4v1
-end
-subgraph var_stream_14 ["var <tt>stream_14</tt>"]
-    style var_stream_14 fill:transparent
-    5v1
-end
-subgraph var_stream_17 ["var <tt>stream_17</tt>"]
-    style var_stream_17 fill:transparent
     6v1
 end
-subgraph var_stream_20 ["var <tt>stream_20</tt>"]
-    style var_stream_20 fill:transparent
+subgraph var_stream_13 ["var <tt>stream_13</tt>"]
+    style var_stream_13 fill:transparent
     8v1
     7v1
 end
-subgraph var_stream_24 ["var <tt>stream_24</tt>"]
-    style var_stream_24 fill:transparent
+subgraph var_stream_17 ["var <tt>stream_17</tt>"]
+    style var_stream_17 fill:transparent
     9v1
 end
-subgraph var_stream_28 ["var <tt>stream_28</tt>"]
-    style var_stream_28 fill:transparent
+subgraph var_stream_2 ["var <tt>stream_2</tt>"]
+    style var_stream_2 fill:transparent
+    2v1
+end
+subgraph var_stream_21 ["var <tt>stream_21</tt>"]
+    style var_stream_21 fill:transparent
     13v1
     12v1
 end
-subgraph var_stream_31 ["var <tt>stream_31</tt>"]
-    style var_stream_31 fill:transparent
+subgraph var_stream_24 ["var <tt>stream_24</tt>"]
+    style var_stream_24 fill:transparent
     14v1
 end
-subgraph var_stream_32 ["var <tt>stream_32</tt>"]
-    style var_stream_32 fill:transparent
+subgraph var_stream_25 ["var <tt>stream_25</tt>"]
+    style var_stream_25 fill:transparent
     15v1
 end
-subgraph var_stream_35 ["var <tt>stream_35</tt>"]
-    style var_stream_35 fill:transparent
+subgraph var_stream_28 ["var <tt>stream_28</tt>"]
+    style var_stream_28 fill:transparent
     17v1
 end
-subgraph var_stream_36 ["var <tt>stream_36</tt>"]
-    style var_stream_36 fill:transparent
+subgraph var_stream_29 ["var <tt>stream_29</tt>"]
+    style var_stream_29 fill:transparent
     18v1
 end
-subgraph var_stream_40 ["var <tt>stream_40</tt>"]
-    style var_stream_40 fill:transparent
+subgraph var_stream_3 ["var <tt>stream_3</tt>"]
+    style var_stream_3 fill:transparent
+    3v1
+end
+subgraph var_stream_33 ["var <tt>stream_33</tt>"]
+    style var_stream_33 fill:transparent
     19v1
+end
+subgraph var_stream_37 ["var <tt>stream_37</tt>"]
+    style var_stream_37 fill:transparent
+    21v1
+end
+subgraph var_stream_38 ["var <tt>stream_38</tt>"]
+    style var_stream_38 fill:transparent
+    22v1
+end
+subgraph var_stream_39 ["var <tt>stream_39</tt>"]
+    style var_stream_39 fill:transparent
+    23v1
+end
+subgraph var_stream_41 ["var <tt>stream_41</tt>"]
+    style var_stream_41 fill:transparent
+    25v1
+end
+subgraph var_stream_43 ["var <tt>stream_43</tt>"]
+    style var_stream_43 fill:transparent
+    27v1
 end
 subgraph var_stream_44 ["var <tt>stream_44</tt>"]
     style var_stream_44 fill:transparent
-    21v1
+    28v1
 end
 subgraph var_stream_45 ["var <tt>stream_45</tt>"]
     style var_stream_45 fill:transparent
-    22v1
+    29v1
 end
-subgraph var_stream_46 ["var <tt>stream_46</tt>"]
-    style var_stream_46 fill:transparent
-    23v1
+subgraph var_stream_47 ["var <tt>stream_47</tt>"]
+    style var_stream_47 fill:transparent
+    30v1
 end
-subgraph var_stream_48 ["var <tt>stream_48</tt>"]
-    style var_stream_48 fill:transparent
-    25v1
+subgraph var_stream_49 ["var <tt>stream_49</tt>"]
+    style var_stream_49 fill:transparent
+    31v1
 end
-subgraph var_stream_50 ["var <tt>stream_50</tt>"]
-    style var_stream_50 fill:transparent
-    27v1
-end
-subgraph var_stream_51 ["var <tt>stream_51</tt>"]
-    style var_stream_51 fill:transparent
-    28v1
+subgraph var_stream_5 ["var <tt>stream_5</tt>"]
+    style var_stream_5 fill:transparent
+    4v1
 end
 subgraph var_stream_52 ["var <tt>stream_52</tt>"]
     style var_stream_52 fill:transparent
-    29v1
-end
-subgraph var_stream_54 ["var <tt>stream_54</tt>"]
-    style var_stream_54 fill:transparent
-    30v1
-end
-subgraph var_stream_56 ["var <tt>stream_56</tt>"]
-    style var_stream_56 fill:transparent
-    31v1
-end
-subgraph var_stream_59 ["var <tt>stream_59</tt>"]
-    style var_stream_59 fill:transparent
     32v1
 end
-subgraph var_stream_64 ["var <tt>stream_64</tt>"]
-    style var_stream_64 fill:transparent
+subgraph var_stream_57 ["var <tt>stream_57</tt>"]
+    style var_stream_57 fill:transparent
     33v1
 end
-subgraph var_stream_68 ["var <tt>stream_68</tt>"]
-    style var_stream_68 fill:transparent
+subgraph var_stream_61 ["var <tt>stream_61</tt>"]
+    style var_stream_61 fill:transparent
     37v1
     36v1
 end
-subgraph var_stream_71 ["var <tt>stream_71</tt>"]
-    style var_stream_71 fill:transparent
+subgraph var_stream_64 ["var <tt>stream_64</tt>"]
+    style var_stream_64 fill:transparent
     38v1
 end
-subgraph var_stream_72 ["var <tt>stream_72</tt>"]
-    style var_stream_72 fill:transparent
+subgraph var_stream_65 ["var <tt>stream_65</tt>"]
+    style var_stream_65 fill:transparent
     39v1
 end
-subgraph var_stream_75 ["var <tt>stream_75</tt>"]
-    style var_stream_75 fill:transparent
+subgraph var_stream_68 ["var <tt>stream_68</tt>"]
+    style var_stream_68 fill:transparent
     41v1
 end
-subgraph var_stream_76 ["var <tt>stream_76</tt>"]
-    style var_stream_76 fill:transparent
+subgraph var_stream_69 ["var <tt>stream_69</tt>"]
+    style var_stream_69 fill:transparent
     42v1
 end
-subgraph var_stream_8 ["var <tt>stream_8</tt>"]
-    style var_stream_8 fill:transparent
-    1v1
+subgraph var_stream_7 ["var <tt>stream_7</tt>"]
+    style var_stream_7 fill:transparent
+    5v1
 end
-subgraph var_stream_80 ["var <tt>stream_80</tt>"]
-    style var_stream_80 fill:transparent
+subgraph var_stream_73 ["var <tt>stream_73</tt>"]
+    style var_stream_73 fill:transparent
     43v1
 end
-subgraph var_stream_84 ["var <tt>stream_84</tt>"]
-    style var_stream_84 fill:transparent
+subgraph var_stream_77 ["var <tt>stream_77</tt>"]
+    style var_stream_77 fill:transparent
     45v1
 end
-subgraph var_stream_85 ["var <tt>stream_85</tt>"]
-    style var_stream_85 fill:transparent
+subgraph var_stream_78 ["var <tt>stream_78</tt>"]
+    style var_stream_78 fill:transparent
     46v1
 end
-subgraph var_stream_86 ["var <tt>stream_86</tt>"]
-    style var_stream_86 fill:transparent
+subgraph var_stream_79 ["var <tt>stream_79</tt>"]
+    style var_stream_79 fill:transparent
     47v1
 end
-subgraph var_stream_88 ["var <tt>stream_88</tt>"]
-    style var_stream_88 fill:transparent
+subgraph var_stream_81 ["var <tt>stream_81</tt>"]
+    style var_stream_81 fill:transparent
     49v1
-end
-subgraph var_stream_9 ["var <tt>stream_9</tt>"]
-    style var_stream_9 fill:transparent
-    2v1
 end

--- a/hydro_test/src/cluster/snapshots/two_pc_ir@participants_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/two_pc_ir@participants_mermaid.snap
@@ -26,13 +26,13 @@ linkStyle default stroke:#aaa
 4v1
 7v1
 8v1
-subgraph var_stream_27 ["var <tt>stream_27</tt>"]
-    style var_stream_27 fill:transparent
+subgraph var_stream_20 ["var <tt>stream_20</tt>"]
+    style var_stream_20 fill:transparent
     1v1
     2v1
 end
-subgraph var_stream_67 ["var <tt>stream_67</tt>"]
-    style var_stream_67 fill:transparent
+subgraph var_stream_60 ["var <tt>stream_60</tt>"]
+    style var_stream_60 fill:transparent
     5v1
     6v1
 end


### PR DESCRIPTION

This also fixes a bug where the throughput reset timer would cause a batch of payloads to be not counted in the throughput.

We add support for tick-cycles / `use::state` to `Optional` and `KeyedSingleton` to support this code more cleanly.

To further simplify the code, we add `merge_ordered` to combine two streams while preserving order. This makes it possible to implement throughput windowing without slices.
