### PR TITLE
feat(hydro_lang): make network channels configurable with a generic `Stream::send` API

### DIFF
--- a/docs/docs/hydro/learn/quickstart/partitioned-counter.mdx
+++ b/docs/docs/hydro/learn/quickstart/partitioned-counter.mdx
@@ -68,17 +68,17 @@ The `prefix_key` method adds a new key to the front of the keyed stream. Here, y
 
 :::
 
-Now you'll use `demux_bincode` to send data from the leader to the cluster. This is where Hydro fundamentally differs from traditional distributed systems frameworks. In most frameworks, you write separate programs for each service (one for the leader, one for the shards), then configure external message brokers or RPC systems to connect them. You have to manually serialize messages, manage network connections, and coordinate deployment.
+Now you'll use `demux` to send data from the leader to the cluster using the configured network protocol and serialization format. This is where Hydro fundamentally differs from traditional distributed systems frameworks. In most frameworks, you write separate programs for each service (one for the leader, one for the shards), then configure external message brokers or RPC systems to connect them. You have to manually serialize messages, manage network connections, and coordinate deployment.
 
-In Hydro, you write a **single Rust function** that describes the entire distributed service. When you call `demux_bincode`, you're performing network communication right in the middle of your function - but it feels like ordinary Rust code. The Hydro compiler automatically generates the network code, handles serialization, and deploys the right code to each machine. You can reason about your entire distributed system in one place, with full type safety and IDE support.
+In Hydro, you write a **single Rust function** that describes the entire distributed service. When you call `demux`, you're performing network communication right in the middle of your function - but it feels like ordinary Rust code. The Hydro compiler automatically generates the network code, handles serialization, and deploys the right code to each machine. You can reason about your entire distributed system in one place, with full type safety and IDE support.
 
-The `demux_bincode` method sends each element to the cluster member specified by the first component of the key:
+The `demux` method sends each element to the cluster member specified by the first component of the key:
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/partitioned_counter.rs">src/partitioned_counter.rs</Link>
 } showLineNumbers={20}>{highlightLines(getLines(partitionedCounterSrc, 20, 34), [7, 15])}</CodeBlock>
 
-After `demux_bincode`, the stream is now located at the cluster. The stream returned by a demux operator preserves the remaining keys after the `MemberId` is consumed for routing. In this case, we are left with a `KeyedStream<u32, String, Cluster<'a, CounterShard>>` - a stream keyed by client ID and key name, located on the cluster.
+After `demux`, the stream is now located at the cluster. The stream returned by a demux operator preserves the remaining keys after the `MemberId` is consumed for routing. In this case, we are left with a `KeyedStream<u32, String, Cluster<'a, CounterShard>>` - a stream keyed by client ID and key name, located on the cluster.
 
 ## Running the Counter on the Cluster
 
@@ -96,7 +96,7 @@ Finally, you need to send the responses back to the leader process:
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/partitioned_counter.rs">src/partitioned_counter.rs</Link>
 } showLineNumbers={41}>{getLines(partitionedCounterSrc, 41, 44)}</CodeBlock>
 
-The `send_bincode` method sends data from the cluster to the leader process. When data moves from a cluster to a process, it arrives as a keyed stream with `MemberId` as the first key. The `drop_key_prefix` method removes this `MemberId` key, leaving just the original keys (client ID and response data).
+The `send` method sends data from the cluster to the leader process. When data moves from a cluster to a process, it arrives as a keyed stream with `MemberId` as the first key. The `drop_key_prefix` method removes this `MemberId` key, leaving just the original keys (client ID and response data).
 
 This is a standard Hydro pattern for building a partitioned service in Hydro: prefix a key for routing, demux to cluster, process, send back, drop the routing key. You will find similar code in key-value stores and even consensus protocols.
 

--- a/docs/docs/hydro/reference/locations/index.md
+++ b/docs/docs/hydro/reference/locations/index.md
@@ -3,7 +3,7 @@ Hydro is a **global**, **distributed** programming model. This means that the da
 
 Each [live collection](pathname:///rustdoc/hydro_lang/live_collections/) has a type parameter `L` which will always be a type that implements the `Location` trait (e.g. [`Process`](./processes.md) and [`Cluster`](./clusters.md), documented in this section). Computation has to happen at a single place, so Hydro APIs that consume multiple live collections will require all inputs to have the same location type. Moreover, most Hydro APIs that transform live collections will emit a new live collection output with the same location type as the input.
 
-To create distributed programs, Hydro provides a variety of APIs to _move_ live collections between locations via network send/receive. For example, `Stream`s can be sent from one process to another process using `.send_bincode(&loc2)` (which uses [bincode](https://docs.rs/bincode/latest/bincode/) as a serialization format). The sections for each location type ([`Process`](./processes.md), [`Cluster`](./clusters.md)) discuss the networking APIs in further detail.
+To create distributed programs, Hydro provides a variety of APIs to _move_ live collections between locations via network send/receive. For example, `Stream`s can be sent from one process to another process using `.send(&loc2, ...)`. The sections for each location type ([`Process`](./processes.md), [`Cluster`](./clusters.md)) discuss the networking APIs in further detail.
 
 ## Creating Locations
 Locations can be created by calling the appropriate method on the global `FlowBuilder` (e.g. `flow.process()` or `flow.cluster()`). These methods will return a handle to the location that can be used to create live collections and run computations.

--- a/docs/docs/hydro/reference/locations/processes.md
+++ b/docs/docs/hydro/reference/locations/processes.md
@@ -30,7 +30,7 @@ let numbers = leader.source_iter(q!(vec![1, 2, 3, 4]));
 ```
 
 ## Networking
-Because a process represents a single machine, it is straightforward to send data to and from a process. For example, we can send a stream of integers from the leader process to another process using the `send_bincode` method (which uses [bincode](https://docs.rs/bincode/latest/bincode/) as a serialization format). This automatically sets up network senders and receivers on the two processes.
+Because a process represents a single machine, it is straightforward to send data to and from a process. For example, we can send a stream of integers from the leader process to another process using the `send` method (which can be configured to use a particular network protocol and serialization format). This automatically sets up network senders and receivers on the two processes.
 
 ```rust,no_run
 # use hydro_lang::prelude::*;
@@ -39,5 +39,5 @@ Because a process represents a single machine, it is straightforward to send dat
 # let leader: Process<Leader> = flow.process::<Leader>();
 let numbers = leader.source_iter(q!(vec![1, 2, 3, 4]));
 let process2: Process<()> = flow.process::<()>();
-let on_p2: Stream<_, Process<()>, _> = numbers.send_bincode(&process2);
+let on_p2: Stream<_, Process<()>, _> = numbers.send(&process2, TCP.bincode());
 ```

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -123,11 +123,11 @@ export default function Home() {
             <CodeBlock
           language="rust">
             {`fn reduce_from_cluster(
-  data: Stream<usize, Cluster<Worker>, Unbounded>,
+  data: Stream<usize, Cluster<Worker>>,
   leader: &Process<Leader>
-) -> Singleton<usize, Process<Leader>, Unbounded> {
+) -> Singleton<usize, Process<Leader>> {
   data
-    .send_bincode(leader)
+    .send(leader, TCP.bincode())
     // Stream<(MemberId<Worker>, usize), Process<Leader>, ..., NoOrder>
     .map(q!(|v| v.1)) // drop the ID
     .fold_commutative(q!(0), q!(|acc, v| *acc += v))

--- a/hydro_lang/src/lib.rs
+++ b/hydro_lang/src/lib.rs
@@ -52,6 +52,7 @@ pub mod prelude {
     pub use crate::live_collections::sliced::sliced;
     pub use crate::live_collections::stream::Stream;
     pub use crate::location::{Cluster, External, Location as _, Process, Tick};
+    pub use crate::networking::TCP;
     pub use crate::nondet::{NonDet, nondet};
 
     /// A macro to set up a Hydro crate.
@@ -80,6 +81,8 @@ pub mod nondet;
 pub mod live_collections;
 
 pub mod location;
+
+pub mod networking;
 
 pub mod telemetry;
 

--- a/hydro_lang/src/live_collections/keyed_stream/networking.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/networking.rs
@@ -7,15 +7,16 @@ use stageleft::{q, quote_type};
 use super::KeyedStream;
 use crate::compile::ir::{DebugInstantiate, HydroNode};
 use crate::live_collections::boundedness::{Boundedness, Unbounded};
-use crate::live_collections::stream::networking::{deserialize_bincode, serialize_bincode};
 use crate::live_collections::stream::{Ordering, Retries, Stream};
 #[cfg(stageleft_runtime)]
 use crate::location::dynamic::DynLocation;
 use crate::location::{Cluster, MemberId, Process};
+use crate::networking::{NetworkFor, TCP};
 
 impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
     KeyedStream<MemberId<L2>, T, Process<'a, L>, B, O, R>
 {
+    #[deprecated = "use KeyedStream::demux(..., TCP.bincode()) instead"]
     /// Sends each group of this stream to a specific member of a cluster, with the [`MemberId`] key
     /// identifying the recipient for each group and using [`bincode`] to serialize/deserialize messages.
     ///
@@ -60,18 +61,68 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
     where
         T: Serialize + DeserializeOwned,
     {
-        let serialize_pipeline = Some(serialize_bincode::<T>(true));
+        self.demux(other, TCP.bincode())
+    }
 
-        let deserialize_pipeline = Some(deserialize_bincode::<T>(None));
+    /// Sends each group of this stream to a specific member of a cluster, with the [`MemberId`] key
+    /// identifying the recipient for each group and using the configuration in `via` to set up the
+    /// message transport.
+    ///
+    /// Each key must be a `MemberId<L2>` and each value must be a `T` where the key specifies
+    /// which cluster member should receive the data. Unlike [`Stream::broadcast`], this
+    /// API allows precise targeting of specific cluster members rather than broadcasting to
+    /// all members.
+    ///
+    /// # Example
+    /// ```rust
+    /// # #[cfg(feature = "deploy")] {
+    /// # use hydro_lang::prelude::*;
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(hydro_lang::test_util::multi_location_test(|flow, p2| {
+    /// let p1 = flow.process::<()>();
+    /// let workers: Cluster<()> = flow.cluster::<()>();
+    /// let numbers: Stream<_, Process<_>, _> = p1.source_iter(q!(vec![0, 1, 2, 3]));
+    /// let on_worker: Stream<_, Cluster<_>, _> = numbers
+    ///     .map(q!(|x| (hydro_lang::location::MemberId::from_raw_id(x), x)))
+    ///     .into_keyed()
+    ///     .demux(&workers, TCP.bincode());
+    /// # on_worker.send(&p2, TCP.bincode()).entries()
+    /// // if there are 4 members in the cluster, each receives one element
+    /// // - MemberId::<()>(0): [0]
+    /// // - MemberId::<()>(1): [1]
+    /// // - MemberId::<()>(2): [2]
+    /// // - MemberId::<()>(3): [3]
+    /// # }, |mut stream| async move {
+    /// # let mut results = Vec::new();
+    /// # for w in 0..4 {
+    /// #     results.push(format!("{:?}", stream.next().await.unwrap()));
+    /// # }
+    /// # results.sort();
+    /// # assert_eq!(results, vec!["(MemberId::<()>(0), 0)", "(MemberId::<()>(1), 1)", "(MemberId::<()>(2), 2)", "(MemberId::<()>(3), 3)"]);
+    /// # }));
+    /// # }
+    /// ```
+    pub fn demux<N: NetworkFor<T>>(
+        self,
+        to: &Cluster<'a, L2>,
+        via: N,
+    ) -> Stream<T, Cluster<'a, L2>, Unbounded, O, R>
+    where
+        T: Serialize + DeserializeOwned,
+    {
+        let _ = via;
+        let serialize_pipeline = Some(N::serialize_thunk(true));
+
+        let deserialize_pipeline = Some(N::deserialize_thunk(None));
 
         Stream::new(
-            other.clone(),
+            to.clone(),
             HydroNode::Network {
                 serialize_fn: serialize_pipeline.map(|e| e.into()),
                 instantiate_fn: DebugInstantiate::Building,
                 deserialize_fn: deserialize_pipeline.map(|e| e.into()),
                 input: Box::new(self.ir_node.into_inner()),
-                metadata: other.new_node_metadata(
+                metadata: to.new_node_metadata(
                     Stream::<T, Cluster<'a, L2>, Unbounded, O, R>::collection_kind(),
                 ),
             },
@@ -82,6 +133,7 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
 impl<'a, K, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
     KeyedStream<(MemberId<L2>, K), T, Process<'a, L>, B, O, R>
 {
+    #[deprecated = "use KeyedStream::demux(..., TCP.bincode()) instead"]
     /// Sends each group of this stream to a specific member of a cluster. The input stream has a
     /// compound key where the first element is the recipient's [`MemberId`] and the second element
     /// is a key that will be sent along with the value, using [`bincode`] to serialize/deserialize
@@ -123,12 +175,58 @@ impl<'a, K, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
         K: Serialize + DeserializeOwned,
         T: Serialize + DeserializeOwned,
     {
-        let serialize_pipeline = Some(serialize_bincode::<(K, T)>(true));
+        self.demux(other, TCP.bincode())
+    }
 
-        let deserialize_pipeline = Some(deserialize_bincode::<(K, T)>(None));
+    /// Sends each group of this stream to a specific member of a cluster. The input stream has a
+    /// compound key where the first element is the recipient's [`MemberId`] and the second element
+    /// is a key that will be sent along with the value, using the configuration in `via` to set up
+    /// the message transport.
+    ///
+    /// # Example
+    /// ```rust
+    /// # #[cfg(feature = "deploy")] {
+    /// # use hydro_lang::prelude::*;
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(hydro_lang::test_util::multi_location_test(|flow, p2| {
+    /// let p1 = flow.process::<()>();
+    /// let workers: Cluster<()> = flow.cluster::<()>();
+    /// let to_send: KeyedStream<_, _, Process<_>, _> = p1
+    ///     .source_iter(q!(vec![0, 1, 2, 3]))
+    ///     .map(q!(|x| ((hydro_lang::location::MemberId::from_raw_id(x), x), x + 123)))
+    ///     .into_keyed();
+    /// let on_worker: KeyedStream<_, _, Cluster<_>, _> = to_send.demux(&workers, TCP.bincode());
+    /// # on_worker.entries().send(&p2, TCP.bincode()).entries()
+    /// // if there are 4 members in the cluster, each receives one element
+    /// // - MemberId::<()>(0): { 0: [123] }
+    /// // - MemberId::<()>(1): { 1: [124] }
+    /// // - ...
+    /// # }, |mut stream| async move {
+    /// # let mut results = Vec::new();
+    /// # for w in 0..4 {
+    /// #     results.push(format!("{:?}", stream.next().await.unwrap()));
+    /// # }
+    /// # results.sort();
+    /// # assert_eq!(results, vec!["(MemberId::<()>(0), (0, 123))", "(MemberId::<()>(1), (1, 124))", "(MemberId::<()>(2), (2, 125))", "(MemberId::<()>(3), (3, 126))"]);
+    /// # }));
+    /// # }
+    /// ```
+    pub fn demux<N: NetworkFor<(K, T)>>(
+        self,
+        to: &Cluster<'a, L2>,
+        via: N,
+    ) -> KeyedStream<K, T, Cluster<'a, L2>, Unbounded, O, R>
+    where
+        K: Serialize + DeserializeOwned,
+        T: Serialize + DeserializeOwned,
+    {
+        let _ = via;
+        let serialize_pipeline = Some(N::serialize_thunk(true));
+
+        let deserialize_pipeline = Some(N::deserialize_thunk(None));
 
         KeyedStream::new(
-            other.clone(),
+            to.clone(),
             HydroNode::Network {
                 serialize_fn: serialize_pipeline.map(|e| e.into()),
                 instantiate_fn: DebugInstantiate::Building,
@@ -139,14 +237,9 @@ impl<'a, K, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
                         .ir_node
                         .into_inner(),
                 ),
-                metadata: other.new_node_metadata(KeyedStream::<
-                    K,
-                    T,
-                    Cluster<'a, L2>,
-                    Unbounded,
-                    O,
-                    R,
-                >::collection_kind()),
+                metadata: to.new_node_metadata(
+                    KeyedStream::<K, T, Cluster<'a, L2>, Unbounded, O, R>::collection_kind(),
+                ),
             },
         )
     }
@@ -155,6 +248,7 @@ impl<'a, K, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
 impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
     KeyedStream<MemberId<L2>, T, Cluster<'a, L>, B, O, R>
 {
+    #[deprecated = "use KeyedStream::demux(..., TCP.bincode()) instead"]
     /// Sends each group of this stream at each source member to a specific member of a destination
     /// cluster, with the [`MemberId`] key identifying the recipient for each group and using
     /// [`bincode`] to serialize/deserialize messages.
@@ -209,18 +303,77 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
     where
         T: Serialize + DeserializeOwned,
     {
-        let serialize_pipeline = Some(serialize_bincode::<T>(true));
+        self.demux(other, TCP.bincode())
+    }
 
-        let deserialize_pipeline = Some(deserialize_bincode::<T>(Some(&quote_type::<L>())));
+    /// Sends each group of this stream at each source member to a specific member of a destination
+    /// cluster, with the [`MemberId`] key identifying the recipient for each group and using the
+    /// configuration in `via` to set up the message transport.
+    ///
+    /// Each key must be a `MemberId<L2>` and each value must be a `T` where the key specifies
+    /// which cluster member should receive the data. Unlike [`Stream::broadcast`], this
+    /// API allows precise targeting of specific cluster members rather than broadcasting to all
+    /// members.
+    ///
+    /// Each cluster member sends its local stream elements, and they are collected at each
+    /// destination member as a [`KeyedStream`] where keys identify the source cluster member.
+    ///
+    /// # Example
+    /// ```rust
+    /// # #[cfg(feature = "deploy")] {
+    /// # use hydro_lang::prelude::*;
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(hydro_lang::test_util::multi_location_test(|flow, p2| {
+    /// # type Source = ();
+    /// # type Destination = ();
+    /// let source: Cluster<Source> = flow.cluster::<Source>();
+    /// let to_send: KeyedStream<_, _, Cluster<_>, _> = source
+    ///     .source_iter(q!(vec![0, 1, 2, 3]))
+    ///     .map(q!(|x| (hydro_lang::location::MemberId::from_raw_id(x), x)))
+    ///     .into_keyed();
+    /// let destination: Cluster<Destination> = flow.cluster::<Destination>();
+    /// let all_received = to_send.demux(&destination, TCP.bincode()); // KeyedStream<MemberId<Source>, i32, ...>
+    /// # all_received.entries().send(&p2, TCP.bincode()).entries()
+    /// # }, |mut stream| async move {
+    /// // if there are 4 members in the destination cluster, each receives one message from each source member
+    /// // - Destination(0): { Source(0): [0], Source(1): [0], ... }
+    /// // - Destination(1): { Source(0): [1], Source(1): [1], ... }
+    /// // - ...
+    /// # let mut results = Vec::new();
+    /// # for w in 0..16 {
+    /// #     results.push(format!("{:?}", stream.next().await.unwrap()));
+    /// # }
+    /// # results.sort();
+    /// # assert_eq!(results, vec![
+    /// #   "(MemberId::<()>(0), (MemberId::<()>(0), 0))", "(MemberId::<()>(0), (MemberId::<()>(1), 0))", "(MemberId::<()>(0), (MemberId::<()>(2), 0))", "(MemberId::<()>(0), (MemberId::<()>(3), 0))",
+    /// #   "(MemberId::<()>(1), (MemberId::<()>(0), 1))", "(MemberId::<()>(1), (MemberId::<()>(1), 1))", "(MemberId::<()>(1), (MemberId::<()>(2), 1))", "(MemberId::<()>(1), (MemberId::<()>(3), 1))",
+    /// #   "(MemberId::<()>(2), (MemberId::<()>(0), 2))", "(MemberId::<()>(2), (MemberId::<()>(1), 2))", "(MemberId::<()>(2), (MemberId::<()>(2), 2))", "(MemberId::<()>(2), (MemberId::<()>(3), 2))",
+    /// #   "(MemberId::<()>(3), (MemberId::<()>(0), 3))", "(MemberId::<()>(3), (MemberId::<()>(1), 3))", "(MemberId::<()>(3), (MemberId::<()>(2), 3))", "(MemberId::<()>(3), (MemberId::<()>(3), 3))"
+    /// # ]);
+    /// # }));
+    /// # }
+    /// ```
+    pub fn demux<N: NetworkFor<T>>(
+        self,
+        to: &Cluster<'a, L2>,
+        via: N,
+    ) -> KeyedStream<MemberId<L>, T, Cluster<'a, L2>, Unbounded, O, R>
+    where
+        T: Serialize + DeserializeOwned,
+    {
+        let _ = via;
+        let serialize_pipeline = Some(N::serialize_thunk(true));
+
+        let deserialize_pipeline = Some(N::deserialize_thunk(Some(&quote_type::<L>())));
 
         let raw_stream: Stream<(MemberId<L>, T), Cluster<'a, L2>, Unbounded, O, R> = Stream::new(
-            other.clone(),
+            to.clone(),
             HydroNode::Network {
                 serialize_fn: serialize_pipeline.map(|e| e.into()),
                 instantiate_fn: DebugInstantiate::Building,
                 deserialize_fn: deserialize_pipeline.map(|e| e.into()),
                 input: Box::new(self.ir_node.into_inner()),
-                metadata: other.new_node_metadata(Stream::<
+                metadata: to.new_node_metadata(Stream::<
                     (MemberId<L>, T),
                     Cluster<'a, L2>,
                     Unbounded,
@@ -238,6 +391,7 @@ impl<'a, K, V, L, B: Boundedness, O: Ordering, R: Retries>
     KeyedStream<K, V, Cluster<'a, L>, B, O, R>
 {
     #[expect(clippy::type_complexity, reason = "compound key types with ordering")]
+    #[deprecated = "use KeyedStream::send(..., TCP.bincode()) instead"]
     /// "Moves" elements of this keyed stream from a cluster to a process by sending them over the
     /// network, using [`bincode`] to serialize/deserialize messages. The resulting [`KeyedStream`]
     /// has a compound key where the first element is the sender's [`MemberId`] and the second
@@ -300,19 +454,87 @@ impl<'a, K, V, L, B: Boundedness, O: Ordering, R: Retries>
         K: Serialize + DeserializeOwned,
         V: Serialize + DeserializeOwned,
     {
-        let serialize_pipeline = Some(serialize_bincode::<(K, V)>(false));
+        self.send(other, TCP.bincode())
+    }
 
-        let deserialize_pipeline = Some(deserialize_bincode::<(K, V)>(Some(&quote_type::<L>())));
+    #[expect(clippy::type_complexity, reason = "compound key types with ordering")]
+    /// "Moves" elements of this keyed stream from a cluster to a process by sending them over the
+    /// network, using the configuration in `via` to set up the message transport. The resulting
+    /// [`KeyedStream`] has a compound key where the first element is the sender's [`MemberId`] and
+    /// the second element is the original key.
+    ///
+    /// # Example
+    /// ```rust
+    /// # #[cfg(feature = "deploy")] {
+    /// # use hydro_lang::prelude::*;
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(hydro_lang::test_util::multi_location_test(|flow, p2| {
+    /// # type Source = ();
+    /// # type Destination = ();
+    /// let source: Cluster<Source> = flow.cluster::<Source>();
+    /// let to_send: KeyedStream<_, _, Cluster<_>, _> = source
+    ///     .source_iter(q!(vec![0, 1, 2, 3]))
+    ///     .map(q!(|x| (x, x + 123)))
+    ///     .into_keyed();
+    /// let destination_process = flow.process::<Destination>();
+    /// let all_received = to_send.send(&destination_process, TCP.bincode()); // KeyedStream<(MemberId<Source>, i32), i32, ...>
+    /// # all_received.entries().send(&p2, TCP.bincode())
+    /// # }, |mut stream| async move {
+    /// // if there are 4 members in the source cluster, the destination process receives four messages from each source member
+    /// // {
+    /// //     (MemberId<Source>(0), 0): [123], (MemberId<Source>(1), 0): [123], ...,
+    /// //     (MemberId<Source>(0), 1): [124], (MemberId<Source>(1), 1): [124], ...,
+    /// //     ...
+    /// // }
+    /// # let mut results = Vec::new();
+    /// # for w in 0..16 {
+    /// #     results.push(format!("{:?}", stream.next().await.unwrap()));
+    /// # }
+    /// # results.sort();
+    /// # assert_eq!(results, vec![
+    /// #   "((MemberId::<()>(0), 0), 123)",
+    /// #   "((MemberId::<()>(0), 1), 124)",
+    /// #   "((MemberId::<()>(0), 2), 125)",
+    /// #   "((MemberId::<()>(0), 3), 126)",
+    /// #   "((MemberId::<()>(1), 0), 123)",
+    /// #   "((MemberId::<()>(1), 1), 124)",
+    /// #   "((MemberId::<()>(1), 2), 125)",
+    /// #   "((MemberId::<()>(1), 3), 126)",
+    /// #   "((MemberId::<()>(2), 0), 123)",
+    /// #   "((MemberId::<()>(2), 1), 124)",
+    /// #   "((MemberId::<()>(2), 2), 125)",
+    /// #   "((MemberId::<()>(2), 3), 126)",
+    /// #   "((MemberId::<()>(3), 0), 123)",
+    /// #   "((MemberId::<()>(3), 1), 124)",
+    /// #   "((MemberId::<()>(3), 2), 125)",
+    /// #   "((MemberId::<()>(3), 3), 126)",
+    /// # ]);
+    /// # }));
+    /// # }
+    /// ```
+    pub fn send<L2, N: NetworkFor<(K, V)>>(
+        self,
+        to: &Process<'a, L2>,
+        via: N,
+    ) -> KeyedStream<(MemberId<L>, K), V, Process<'a, L2>, Unbounded, O, R>
+    where
+        K: Serialize + DeserializeOwned,
+        V: Serialize + DeserializeOwned,
+    {
+        let _ = via;
+        let serialize_pipeline = Some(N::serialize_thunk(false));
+
+        let deserialize_pipeline = Some(N::deserialize_thunk(Some(&quote_type::<L>())));
 
         let raw_stream: Stream<(MemberId<L>, (K, V)), Process<'a, L2>, Unbounded, O, R> =
             Stream::new(
-                other.clone(),
+                to.clone(),
                 HydroNode::Network {
                     serialize_fn: serialize_pipeline.map(|e| e.into()),
                     instantiate_fn: DebugInstantiate::Building,
                     deserialize_fn: deserialize_pipeline.map(|e| e.into()),
                     input: Box::new(self.ir_node.into_inner()),
-                    metadata: other.new_node_metadata(Stream::<
+                    metadata: to.new_node_metadata(Stream::<
                         (MemberId<L>, (K, V)),
                         Cluster<'a, L2>,
                         Unbounded,

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -3026,6 +3026,8 @@ mod tests {
     #[cfg(feature = "deploy")]
     #[tokio::test]
     async fn first_ten_distributed() {
+        use crate::networking::TCP;
+
         let mut deployment = Deployment::new();
 
         let flow = FlowBuilder::new();
@@ -3036,7 +3038,7 @@ mod tests {
         let numbers = first_node.source_iter(q!(0..10));
         let out_port = numbers
             .map(q!(|n| SendOverNetwork { n }))
-            .send_bincode(&second_node)
+            .send(&second_node, TCP.bincode())
             .send_bincode_external(&external);
 
         let nodes = flow

--- a/hydro_lang/src/live_collections/stream/networking.rs
+++ b/hydro_lang/src/live_collections/stream/networking.rs
@@ -18,6 +18,7 @@ use crate::live_collections::stream::Retries;
 use crate::location::dynamic::DynLocation;
 use crate::location::external_process::ExternalBincodeStream;
 use crate::location::{Cluster, External, Location, MemberId, MembershipEvent, NoTick, Process};
+use crate::networking::{NetworkFor, TCP};
 use crate::nondet::NonDet;
 #[cfg(feature = "sim")]
 use crate::sim::SimReceiver;
@@ -88,6 +89,7 @@ pub(crate) fn deserialize_bincode<T: DeserializeOwned>(tagged: Option<&syn::Type
 }
 
 impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Process<'a, L>, B, O, R> {
+    #[deprecated = "use Stream::send(..., TCP.bincode()) instead"]
     /// "Moves" elements of this stream to a new distributed location by sending them over the network,
     /// using [`bincode`] to serialize/deserialize messages.
     ///
@@ -123,24 +125,64 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Process<'a, L>
     where
         T: Serialize + DeserializeOwned,
     {
-        let serialize_pipeline = Some(serialize_bincode::<T>(false));
+        self.send(other, TCP.bincode())
+    }
 
-        let deserialize_pipeline = Some(deserialize_bincode::<T>(None));
+    /// "Moves" elements of this stream to a new distributed location by sending them over the network,
+    /// using the configuration in `via` to set up the message transport.
+    ///
+    /// The returned stream captures the elements received at the destination, where values will
+    /// asynchronously arrive over the network. Sending from a [`Process`] to another [`Process`]
+    /// preserves ordering and retries guarantees when using a single TCP channel to send the values.
+    /// The recipient is guaranteed to receive a _prefix_ or the sent messages; if the connection is
+    /// dropped no further messages will be sent.
+    ///
+    /// # Example
+    /// ```rust
+    /// # #[cfg(feature = "deploy")] {
+    /// # use hydro_lang::prelude::*;
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(hydro_lang::test_util::multi_location_test(|flow, p_out| {
+    /// let p1 = flow.process::<()>();
+    /// let numbers: Stream<_, Process<_>, Unbounded> = p1.source_iter(q!(vec![1, 2, 3]));
+    /// let p2 = flow.process::<()>();
+    /// let on_p2: Stream<_, Process<_>, Unbounded> = numbers.send(&p2, TCP.bincode());
+    /// // 1, 2, 3
+    /// # on_p2.send(&p_out, TCP.bincode())
+    /// # }, |mut stream| async move {
+    /// # for w in 1..=3 {
+    /// #     assert_eq!(stream.next().await, Some(w));
+    /// # }
+    /// # }));
+    /// # }
+    /// ```
+    pub fn send<L2, N: NetworkFor<T>>(
+        self,
+        to: &Process<'a, L2>,
+        via: N,
+    ) -> Stream<T, Process<'a, L2>, Unbounded, O, R>
+    where
+        T: Serialize + DeserializeOwned,
+    {
+        let _ = via;
+        let serialize_pipeline = Some(N::serialize_thunk(false));
+        let deserialize_pipeline = Some(N::deserialize_thunk(None));
 
         Stream::new(
-            other.clone(),
+            to.clone(),
             HydroNode::Network {
                 serialize_fn: serialize_pipeline.map(|e| e.into()),
                 instantiate_fn: DebugInstantiate::Building,
                 deserialize_fn: deserialize_pipeline.map(|e| e.into()),
                 input: Box::new(self.ir_node.into_inner()),
-                metadata: other.new_node_metadata(
+                metadata: to.new_node_metadata(
                     Stream::<T, Process<'a, L2>, Unbounded, O, R>::collection_kind(),
                 ),
             },
         )
     }
 
+    #[deprecated = "use Stream::broadcast(..., TCP.bincode()) instead"]
     /// Broadcasts elements of this stream to all members of a cluster by sending them over the network,
     /// using [`bincode`] to serialize/deserialize messages.
     ///
@@ -189,7 +231,59 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Process<'a, L>
     where
         T: Clone + Serialize + DeserializeOwned,
     {
-        let ids = track_membership(self.location.source_cluster_members(other));
+        self.broadcast(other, TCP.bincode(), nondet_membership)
+    }
+
+    /// Broadcasts elements of this stream to all members of a cluster by sending them over the network,
+    /// using the configuration in `via` to set up the message transport.
+    ///
+    /// Each element in the stream will be sent to **every** member of the cluster based on the latest
+    /// membership information. This is a common pattern in distributed systems for broadcasting data to
+    /// all nodes in a cluster. Unlike [`Stream::demux`], which requires `(MemberId, T)` tuples to
+    /// target specific members, `broadcast` takes a stream of **only data elements** and sends
+    /// each element to all cluster members.
+    ///
+    /// # Non-Determinism
+    /// The set of cluster members may asynchronously change over time. Each element is only broadcast
+    /// to the current cluster members _at that point in time_. Depending on when we are notified of
+    /// membership changes, we will broadcast each element to different members.
+    ///
+    /// # Example
+    /// ```rust
+    /// # #[cfg(feature = "deploy")] {
+    /// # use hydro_lang::prelude::*;
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(hydro_lang::test_util::multi_location_test(|flow, p2| {
+    /// let p1 = flow.process::<()>();
+    /// let workers: Cluster<()> = flow.cluster::<()>();
+    /// let numbers: Stream<_, Process<_>, _> = p1.source_iter(q!(vec![123]));
+    /// let on_worker: Stream<_, Cluster<_>, _> = numbers.broadcast(&workers, TCP.bincode(), nondet!(/** assuming stable membership */));
+    /// # on_worker.send(&p2, TCP.bincode()).entries()
+    /// // if there are 4 members in the cluster, each receives one element
+    /// // - MemberId::<()>(0): [123]
+    /// // - MemberId::<()>(1): [123]
+    /// // - MemberId::<()>(2): [123]
+    /// // - MemberId::<()>(3): [123]
+    /// # }, |mut stream| async move {
+    /// # let mut results = Vec::new();
+    /// # for w in 0..4 {
+    /// #     results.push(format!("{:?}", stream.next().await.unwrap()));
+    /// # }
+    /// # results.sort();
+    /// # assert_eq!(results, vec!["(MemberId::<()>(0), 123)", "(MemberId::<()>(1), 123)", "(MemberId::<()>(2), 123)", "(MemberId::<()>(3), 123)"]);
+    /// # }));
+    /// # }
+    /// ```
+    pub fn broadcast<L2: 'a, N: NetworkFor<T>>(
+        self,
+        to: &Cluster<'a, L2>,
+        via: N,
+        nondet_membership: NonDet,
+    ) -> Stream<T, Cluster<'a, L2>, Unbounded, O, R>
+    where
+        T: Clone + Serialize + DeserializeOwned,
+    {
+        let ids = track_membership(self.location.source_cluster_members(to));
         sliced! {
             let members_snapshot = use(ids, nondet_membership);
             let elements = use(self, nondet_membership);
@@ -197,7 +291,7 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Process<'a, L>
             let current_members = members_snapshot.filter(q!(|b| *b));
             elements.repeat_with_keys(current_members)
         }
-        .demux_bincode(other)
+        .demux(to, via)
     }
 
     /// Sends the elements of this stream to an external (non-Hydro) process, using [`bincode`]
@@ -284,6 +378,7 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Process<'a, L>
 impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
     Stream<(MemberId<L2>, T), Process<'a, L>, B, O, R>
 {
+    #[deprecated = "use Stream::demux(..., TCP.bincode()) instead"]
     /// Sends elements of this stream to specific members of a cluster, identified by a [`MemberId`],
     /// using [`bincode`] to serialize/deserialize messages.
     ///
@@ -327,11 +422,59 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
     where
         T: Serialize + DeserializeOwned,
     {
-        self.into_keyed().demux_bincode(other)
+        self.demux(other, TCP.bincode())
+    }
+
+    /// Sends elements of this stream to specific members of a cluster, identified by a [`MemberId`],
+    /// using the configuration in `via` to set up the message transport.
+    ///
+    /// Each element in the stream must be a tuple `(MemberId<L2>, T)` where the first element
+    /// specifies which cluster member should receive the data. Unlike [`Stream::broadcast`],
+    /// this API allows precise targeting of specific cluster members rather than broadcasting to
+    /// all members.
+    ///
+    /// # Example
+    /// ```rust
+    /// # #[cfg(feature = "deploy")] {
+    /// # use hydro_lang::prelude::*;
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(hydro_lang::test_util::multi_location_test(|flow, p2| {
+    /// let p1 = flow.process::<()>();
+    /// let workers: Cluster<()> = flow.cluster::<()>();
+    /// let numbers: Stream<_, Process<_>, _> = p1.source_iter(q!(vec![0, 1, 2, 3]));
+    /// let on_worker: Stream<_, Cluster<_>, _> = numbers
+    ///     .map(q!(|x| (hydro_lang::location::MemberId::from_raw_id(x), x)))
+    ///     .demux(&workers, TCP.bincode());
+    /// # on_worker.send(&p2, TCP.bincode()).entries()
+    /// // if there are 4 members in the cluster, each receives one element
+    /// // - MemberId::<()>(0): [0]
+    /// // - MemberId::<()>(1): [1]
+    /// // - MemberId::<()>(2): [2]
+    /// // - MemberId::<()>(3): [3]
+    /// # }, |mut stream| async move {
+    /// # let mut results = Vec::new();
+    /// # for w in 0..4 {
+    /// #     results.push(format!("{:?}", stream.next().await.unwrap()));
+    /// # }
+    /// # results.sort();
+    /// # assert_eq!(results, vec!["(MemberId::<()>(0), 0)", "(MemberId::<()>(1), 1)", "(MemberId::<()>(2), 2)", "(MemberId::<()>(3), 3)"]);
+    /// # }));
+    /// # }
+    /// ```
+    pub fn demux<N: NetworkFor<T>>(
+        self,
+        to: &Cluster<'a, L2>,
+        via: N,
+    ) -> Stream<T, Cluster<'a, L2>, Unbounded, O, R>
+    where
+        T: Serialize + DeserializeOwned,
+    {
+        self.into_keyed().demux(to, via)
     }
 }
 
 impl<'a, T, L, B: Boundedness> Stream<T, Process<'a, L>, B, TotalOrder, ExactlyOnce> {
+    #[deprecated = "use Stream::round_robin(..., TCP.bincode()) instead"]
     /// Distributes elements of this stream to cluster members in a round-robin fashion, using
     /// [`bincode`] to serialize/deserialize messages.
     ///
@@ -385,7 +528,64 @@ impl<'a, T, L, B: Boundedness> Stream<T, Process<'a, L>, B, TotalOrder, ExactlyO
     where
         T: Serialize + DeserializeOwned,
     {
-        let ids = track_membership(self.location.source_cluster_members(other));
+        self.round_robin(other, TCP.bincode(), nondet_membership)
+    }
+
+    /// Distributes elements of this stream to cluster members in a round-robin fashion, using
+    /// the configuration in `via` to set up the message transport.
+    ///
+    /// This provides load balancing by evenly distributing work across cluster members. The
+    /// distribution is deterministic based on element order - the first element goes to member 0,
+    /// the second to member 1, and so on, wrapping around when reaching the end of the member list.
+    ///
+    /// # Non-Determinism
+    /// The set of cluster members may asynchronously change over time. Each element is distributed
+    /// based on the current cluster membership _at that point in time_. Depending on when cluster
+    /// members join and leave, the round-robin pattern will change. Furthermore, even when the
+    /// membership is stable, the order of members in the round-robin pattern may change across runs.
+    ///
+    /// # Ordering Requirements
+    /// This method is only available on streams with [`TotalOrder`] and [`ExactlyOnce`], since the
+    /// order of messages and retries affects the round-robin pattern.
+    ///
+    /// # Example
+    /// ```rust
+    /// # #[cfg(feature = "deploy")] {
+    /// # use hydro_lang::prelude::*;
+    /// # use hydro_lang::live_collections::stream::{TotalOrder, ExactlyOnce};
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(hydro_lang::test_util::multi_location_test(|flow, p2| {
+    /// let p1 = flow.process::<()>();
+    /// let workers: Cluster<()> = flow.cluster::<()>();
+    /// let numbers: Stream<_, Process<_>, _, TotalOrder, ExactlyOnce> = p1.source_iter(q!(vec![1, 2, 3, 4]));
+    /// let on_worker: Stream<_, Cluster<_>, _> = numbers.round_robin(&workers, TCP.bincode(), nondet!(/** assuming stable membership */));
+    /// on_worker.send(&p2, TCP.bincode())
+    /// # .first().values() // we use first to assert that each member gets one element
+    /// // with 4 cluster members, elements are distributed (with a non-deterministic round-robin order):
+    /// // - MemberId::<()>(?): [1]
+    /// // - MemberId::<()>(?): [2]
+    /// // - MemberId::<()>(?): [3]
+    /// // - MemberId::<()>(?): [4]
+    /// # }, |mut stream| async move {
+    /// # let mut results = Vec::new();
+    /// # for w in 0..4 {
+    /// #     results.push(stream.next().await.unwrap());
+    /// # }
+    /// # results.sort();
+    /// # assert_eq!(results, vec![1, 2, 3, 4]);
+    /// # }));
+    /// # }
+    /// ```
+    pub fn round_robin<L2: 'a, N: NetworkFor<T>>(
+        self,
+        to: &Cluster<'a, L2>,
+        via: N,
+        nondet_membership: NonDet,
+    ) -> Stream<T, Cluster<'a, L2>, Unbounded, TotalOrder, ExactlyOnce>
+    where
+        T: Serialize + DeserializeOwned,
+    {
+        let ids = track_membership(self.location.source_cluster_members(to));
         sliced! {
             let members_snapshot = use(ids, nondet_membership);
             let elements = use(self.enumerate(), nondet_membership);
@@ -403,11 +603,12 @@ impl<'a, T, L, B: Boundedness> Stream<T, Process<'a, L>, B, TotalOrder, ExactlyO
                     data.1
                 )))
         }
-        .demux_bincode(other)
+        .demux(to, via)
     }
 }
 
 impl<'a, T, L, B: Boundedness> Stream<T, Cluster<'a, L>, B, TotalOrder, ExactlyOnce> {
+    #[deprecated = "use Stream::round_robin(..., TCP.bincode()) instead"]
     /// Distributes elements of this stream to cluster members in a round-robin fashion, using
     /// [`bincode`] to serialize/deserialize messages.
     ///
@@ -466,7 +667,69 @@ impl<'a, T, L, B: Boundedness> Stream<T, Cluster<'a, L>, B, TotalOrder, ExactlyO
     where
         T: Serialize + DeserializeOwned,
     {
-        let ids = track_membership(self.location.source_cluster_members(other));
+        self.round_robin(other, TCP.bincode(), nondet_membership)
+    }
+
+    /// Distributes elements of this stream to cluster members in a round-robin fashion, using
+    /// the configuration in `via` to set up the message transport.
+    ///
+    /// This provides load balancing by evenly distributing work across cluster members. The
+    /// distribution is deterministic based on element order - the first element goes to member 0,
+    /// the second to member 1, and so on, wrapping around when reaching the end of the member list.
+    ///
+    /// # Non-Determinism
+    /// The set of cluster members may asynchronously change over time. Each element is distributed
+    /// based on the current cluster membership _at that point in time_. Depending on when cluster
+    /// members join and leave, the round-robin pattern will change. Furthermore, even when the
+    /// membership is stable, the order of members in the round-robin pattern may change across runs.
+    ///
+    /// # Ordering Requirements
+    /// This method is only available on streams with [`TotalOrder`] and [`ExactlyOnce`], since the
+    /// order of messages and retries affects the round-robin pattern.
+    ///
+    /// # Example
+    /// ```rust
+    /// # #[cfg(feature = "deploy")] {
+    /// # use hydro_lang::prelude::*;
+    /// # use hydro_lang::live_collections::stream::{TotalOrder, ExactlyOnce, NoOrder};
+    /// # use hydro_lang::location::MemberId;
+    /// # use futures::StreamExt;
+    /// # std::thread::spawn(|| {
+    /// # tokio_test::block_on(hydro_lang::test_util::multi_location_test(|flow, p2| {
+    /// let p1 = flow.process::<()>();
+    /// let workers1: Cluster<()> = flow.cluster::<()>();
+    /// let workers2: Cluster<()> = flow.cluster::<()>();
+    /// let numbers: Stream<_, Process<_>, _, TotalOrder, ExactlyOnce> = p1.source_iter(q!(0..=16));
+    /// let on_worker1: Stream<_, Cluster<_>, _> = numbers.round_robin(&workers1, TCP.bincode(), nondet!(/** assuming stable membership */));
+    /// let on_worker2: Stream<_, Cluster<_>, _> = on_worker1.round_robin(&workers2, TCP.bincode(), nondet!(/** assuming stable membership */)).entries().assume_ordering(nondet!(/** assuming stable membership */));
+    /// on_worker2.send(&p2, TCP.bincode())
+    /// # .entries()
+    /// # .map(q!(|(w2, (w1, v))| ((w2, w1), v)))
+    /// # }, |mut stream| async move {
+    /// # let mut results = Vec::new();
+    /// # let mut locations = std::collections::HashSet::new();
+    /// # for w in 0..=16 {
+    /// #     let (location, v) = stream.next().await.unwrap();
+    /// #     locations.insert(location);
+    /// #     results.push(v);
+    /// # }
+    /// # results.sort();
+    /// # assert_eq!(results, (0..=16).collect::<Vec<_>>());
+    /// # assert_eq!(locations.len(), 16);
+    /// # }));
+    /// # }).join().unwrap();
+    /// # }
+    /// ```
+    pub fn round_robin<L2: 'a, N: NetworkFor<T>>(
+        self,
+        to: &Cluster<'a, L2>,
+        via: N,
+        nondet_membership: NonDet,
+    ) -> KeyedStream<MemberId<L>, T, Cluster<'a, L2>, Unbounded, TotalOrder, ExactlyOnce>
+    where
+        T: Serialize + DeserializeOwned,
+    {
+        let ids = track_membership(self.location.source_cluster_members(to));
         sliced! {
             let members_snapshot = use(ids, nondet_membership);
             let elements = use(self.enumerate(), nondet_membership);
@@ -484,11 +747,12 @@ impl<'a, T, L, B: Boundedness> Stream<T, Cluster<'a, L>, B, TotalOrder, ExactlyO
                     data.1
                 )))
         }
-        .demux_bincode(other)
+        .demux(to, via)
     }
 }
 
 impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Cluster<'a, L>, B, O, R> {
+    #[deprecated = "use Stream::send(..., TCP.bincode()) instead"]
     /// "Moves" elements of this stream from a cluster to a process by sending them over the network,
     /// using [`bincode`] to serialize/deserialize messages.
     ///
@@ -549,18 +813,83 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Cluster<'a, L>
     where
         T: Serialize + DeserializeOwned,
     {
-        let serialize_pipeline = Some(serialize_bincode::<T>(false));
+        self.send(other, TCP.bincode())
+    }
 
-        let deserialize_pipeline = Some(deserialize_bincode::<T>(Some(&quote_type::<L>())));
+    /// "Moves" elements of this stream from a cluster to a process by sending them over the network,
+    /// using the configuration in `via` to set up the message transport.
+    ///
+    /// Each cluster member sends its local stream elements, and they are collected at the destination
+    /// as a [`KeyedStream`] where keys identify the source cluster member.
+    ///
+    /// # Example
+    /// ```rust
+    /// # #[cfg(feature = "deploy")] {
+    /// # use hydro_lang::prelude::*;
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(hydro_lang::test_util::multi_location_test(|flow, process| {
+    /// let workers: Cluster<()> = flow.cluster::<()>();
+    /// let numbers: Stream<_, Cluster<_>, _> = workers.source_iter(q!(vec![1]));
+    /// let all_received = numbers.send(&process, TCP.bincode()); // KeyedStream<MemberId<()>, i32, ...>
+    /// # all_received.entries()
+    /// # }, |mut stream| async move {
+    /// // if there are 4 members in the cluster, we should receive 4 elements
+    /// // { MemberId::<()>(0): [1], MemberId::<()>(1): [1], MemberId::<()>(2): [1], MemberId::<()>(3): [1] }
+    /// # let mut results = Vec::new();
+    /// # for w in 0..4 {
+    /// #     results.push(format!("{:?}", stream.next().await.unwrap()));
+    /// # }
+    /// # results.sort();
+    /// # assert_eq!(results, vec!["(MemberId::<()>(0), 1)", "(MemberId::<()>(1), 1)", "(MemberId::<()>(2), 1)", "(MemberId::<()>(3), 1)"]);
+    /// # }));
+    /// # }
+    /// ```
+    ///
+    /// If you don't need to know the source for each element, you can use `.values()`
+    /// to get just the data:
+    /// ```rust
+    /// # #[cfg(feature = "deploy")] {
+    /// # use hydro_lang::prelude::*;
+    /// # use hydro_lang::live_collections::stream::NoOrder;
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(hydro_lang::test_util::multi_location_test(|flow, process| {
+    /// # let workers: Cluster<()> = flow.cluster::<()>();
+    /// # let numbers: Stream<_, Cluster<_>, _> = workers.source_iter(q!(vec![1]));
+    /// let values: Stream<i32, _, _, NoOrder> = numbers.send(&process, TCP.bincode()).values();
+    /// # values
+    /// # }, |mut stream| async move {
+    /// # let mut results = Vec::new();
+    /// # for w in 0..4 {
+    /// #     results.push(format!("{:?}", stream.next().await.unwrap()));
+    /// # }
+    /// # results.sort();
+    /// // if there are 4 members in the cluster, we should receive 4 elements
+    /// // 1, 1, 1, 1
+    /// # assert_eq!(results, vec!["1", "1", "1", "1"]);
+    /// # }));
+    /// # }
+    /// ```
+    pub fn send<L2, N: NetworkFor<T>>(
+        self,
+        to: &Process<'a, L2>,
+        via: N,
+    ) -> KeyedStream<MemberId<L>, T, Process<'a, L2>, Unbounded, O, R>
+    where
+        T: Serialize + DeserializeOwned,
+    {
+        let _ = via;
+        let serialize_pipeline = Some(N::serialize_thunk(false));
+
+        let deserialize_pipeline = Some(N::deserialize_thunk(Some(&quote_type::<L>())));
 
         let raw_stream: Stream<(MemberId<L>, T), Process<'a, L2>, Unbounded, O, R> = Stream::new(
-            other.clone(),
+            to.clone(),
             HydroNode::Network {
                 serialize_fn: serialize_pipeline.map(|e| e.into()),
                 instantiate_fn: DebugInstantiate::Building,
                 deserialize_fn: deserialize_pipeline.map(|e| e.into()),
                 input: Box::new(self.ir_node.into_inner()),
-                metadata: other.new_node_metadata(Stream::<
+                metadata: to.new_node_metadata(Stream::<
                     (MemberId<L>, T),
                     Process<'a, L2>,
                     Unbounded,
@@ -573,6 +902,7 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Cluster<'a, L>
         raw_stream.into_keyed()
     }
 
+    #[deprecated = "use Stream::broadcast(..., TCP.bincode()) instead"]
     /// Broadcasts elements of this stream at each source member to all members of a destination
     /// cluster, using [`bincode`] to serialize/deserialize messages.
     ///
@@ -628,7 +958,66 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Cluster<'a, L>
     where
         T: Clone + Serialize + DeserializeOwned,
     {
-        let ids = track_membership(self.location.source_cluster_members(other));
+        self.broadcast(other, TCP.bincode(), nondet_membership)
+    }
+
+    /// Broadcasts elements of this stream at each source member to all members of a destination
+    /// cluster, using the configuration in `via` to set up the message transport.
+    ///
+    /// Each source member sends each of its stream elements to **every** member of the cluster
+    /// based on its latest membership information. Unlike [`Stream::demux`], which requires
+    /// `(MemberId, T)` tuples to target specific members, `broadcast` takes a stream of
+    /// **only data elements** and sends each element to all cluster members.
+    ///
+    /// # Non-Determinism
+    /// The set of cluster members may asynchronously change over time. Each element is only broadcast
+    /// to the current cluster members known _at that point in time_ at the source member. Depending
+    /// on when each source member is notified of membership changes, it will broadcast each element
+    /// to different members.
+    ///
+    /// # Example
+    /// ```rust
+    /// # #[cfg(feature = "deploy")] {
+    /// # use hydro_lang::prelude::*;
+    /// # use hydro_lang::location::MemberId;
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(hydro_lang::test_util::multi_location_test(|flow, p2| {
+    /// # type Source = ();
+    /// # type Destination = ();
+    /// let source: Cluster<Source> = flow.cluster::<Source>();
+    /// let numbers: Stream<_, Cluster<Source>, _> = source.source_iter(q!(vec![123]));
+    /// let destination: Cluster<Destination> = flow.cluster::<Destination>();
+    /// let on_destination: KeyedStream<MemberId<Source>, _, Cluster<Destination>, _> = numbers.broadcast(&destination, TCP.bincode(), nondet!(/** assuming stable membership */));
+    /// # on_destination.entries().send(&p2, TCP.bincode()).entries()
+    /// // if there are 4 members in the desination, each receives one element from each source member
+    /// // - Destination(0): { Source(0): [123], Source(1): [123], ... }
+    /// // - Destination(1): { Source(0): [123], Source(1): [123], ... }
+    /// // - ...
+    /// # }, |mut stream| async move {
+    /// # let mut results = Vec::new();
+    /// # for w in 0..16 {
+    /// #     results.push(format!("{:?}", stream.next().await.unwrap()));
+    /// # }
+    /// # results.sort();
+    /// # assert_eq!(results, vec![
+    /// #   "(MemberId::<()>(0), (MemberId::<()>(0), 123))", "(MemberId::<()>(0), (MemberId::<()>(1), 123))", "(MemberId::<()>(0), (MemberId::<()>(2), 123))", "(MemberId::<()>(0), (MemberId::<()>(3), 123))",
+    /// #   "(MemberId::<()>(1), (MemberId::<()>(0), 123))", "(MemberId::<()>(1), (MemberId::<()>(1), 123))", "(MemberId::<()>(1), (MemberId::<()>(2), 123))", "(MemberId::<()>(1), (MemberId::<()>(3), 123))",
+    /// #   "(MemberId::<()>(2), (MemberId::<()>(0), 123))", "(MemberId::<()>(2), (MemberId::<()>(1), 123))", "(MemberId::<()>(2), (MemberId::<()>(2), 123))", "(MemberId::<()>(2), (MemberId::<()>(3), 123))",
+    /// #   "(MemberId::<()>(3), (MemberId::<()>(0), 123))", "(MemberId::<()>(3), (MemberId::<()>(1), 123))", "(MemberId::<()>(3), (MemberId::<()>(2), 123))", "(MemberId::<()>(3), (MemberId::<()>(3), 123))"
+    /// # ]);
+    /// # }));
+    /// # }
+    /// ```
+    pub fn broadcast<L2: 'a, N: NetworkFor<T>>(
+        self,
+        to: &Cluster<'a, L2>,
+        via: N,
+        nondet_membership: NonDet,
+    ) -> KeyedStream<MemberId<L>, T, Cluster<'a, L2>, Unbounded, O, R>
+    where
+        T: Clone + Serialize + DeserializeOwned,
+    {
+        let ids = track_membership(self.location.source_cluster_members(to));
         sliced! {
             let members_snapshot = use(ids, nondet_membership);
             let elements = use(self, nondet_membership);
@@ -636,13 +1025,14 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Cluster<'a, L>
             let current_members = members_snapshot.filter(q!(|b| *b));
             elements.repeat_with_keys(current_members)
         }
-        .demux_bincode(other)
+        .demux(to, via)
     }
 }
 
 impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
     Stream<(MemberId<L2>, T), Cluster<'a, L>, B, O, R>
 {
+    #[deprecated = "use Stream::demux(..., TCP.bincode()) instead"]
     /// Sends elements of this stream at each source member to specific members of a destination
     /// cluster, identified by a [`MemberId`], using [`bincode`] to serialize/deserialize messages.
     ///
@@ -695,7 +1085,64 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
     where
         T: Serialize + DeserializeOwned,
     {
-        self.into_keyed().demux_bincode(other)
+        self.demux(other, TCP.bincode())
+    }
+
+    /// Sends elements of this stream at each source member to specific members of a destination
+    /// cluster, identified by a [`MemberId`], using the configuration in `via` to set up the
+    /// message transport.
+    ///
+    /// Each element in the stream must be a tuple `(MemberId<L2>, T)` where the first element
+    /// specifies which cluster member should receive the data. Unlike [`Stream::broadcast`],
+    /// this API allows precise targeting of specific cluster members rather than broadcasting to
+    /// all members.
+    ///
+    /// Each cluster member sends its local stream elements, and they are collected at each
+    /// destination member as a [`KeyedStream`] where keys identify the source cluster member.
+    ///
+    /// # Example
+    /// ```rust
+    /// # #[cfg(feature = "deploy")] {
+    /// # use hydro_lang::prelude::*;
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(hydro_lang::test_util::multi_location_test(|flow, p2| {
+    /// # type Source = ();
+    /// # type Destination = ();
+    /// let source: Cluster<Source> = flow.cluster::<Source>();
+    /// let to_send: Stream<_, Cluster<_>, _> = source
+    ///     .source_iter(q!(vec![0, 1, 2, 3]))
+    ///     .map(q!(|x| (hydro_lang::location::MemberId::from_raw_id(x), x)));
+    /// let destination: Cluster<Destination> = flow.cluster::<Destination>();
+    /// let all_received = to_send.demux(&destination, TCP.bincode()); // KeyedStream<MemberId<Source>, i32, ...>
+    /// # all_received.entries().send(&p2, TCP.bincode()).entries()
+    /// # }, |mut stream| async move {
+    /// // if there are 4 members in the destination cluster, each receives one message from each source member
+    /// // - Destination(0): { Source(0): [0], Source(1): [0], ... }
+    /// // - Destination(1): { Source(0): [1], Source(1): [1], ... }
+    /// // - ...
+    /// # let mut results = Vec::new();
+    /// # for w in 0..16 {
+    /// #     results.push(format!("{:?}", stream.next().await.unwrap()));
+    /// # }
+    /// # results.sort();
+    /// # assert_eq!(results, vec![
+    /// #   "(MemberId::<()>(0), (MemberId::<()>(0), 0))", "(MemberId::<()>(0), (MemberId::<()>(1), 0))", "(MemberId::<()>(0), (MemberId::<()>(2), 0))", "(MemberId::<()>(0), (MemberId::<()>(3), 0))",
+    /// #   "(MemberId::<()>(1), (MemberId::<()>(0), 1))", "(MemberId::<()>(1), (MemberId::<()>(1), 1))", "(MemberId::<()>(1), (MemberId::<()>(2), 1))", "(MemberId::<()>(1), (MemberId::<()>(3), 1))",
+    /// #   "(MemberId::<()>(2), (MemberId::<()>(0), 2))", "(MemberId::<()>(2), (MemberId::<()>(1), 2))", "(MemberId::<()>(2), (MemberId::<()>(2), 2))", "(MemberId::<()>(2), (MemberId::<()>(3), 2))",
+    /// #   "(MemberId::<()>(3), (MemberId::<()>(0), 3))", "(MemberId::<()>(3), (MemberId::<()>(1), 3))", "(MemberId::<()>(3), (MemberId::<()>(2), 3))", "(MemberId::<()>(3), (MemberId::<()>(3), 3))"
+    /// # ]);
+    /// # }));
+    /// # }
+    /// ```
+    pub fn demux<N: NetworkFor<T>>(
+        self,
+        to: &Cluster<'a, L2>,
+        via: N,
+    ) -> KeyedStream<MemberId<L>, T, Cluster<'a, L2>, Unbounded, O, R>
+    where
+        T: Serialize + DeserializeOwned,
+    {
+        self.into_keyed().demux(to, via)
     }
 }
 
@@ -707,6 +1154,8 @@ mod tests {
     #[cfg(feature = "sim")]
     use crate::location::{Location, MemberId};
     #[cfg(feature = "sim")]
+    use crate::networking::TCP;
+    #[cfg(feature = "sim")]
     use crate::nondet::nondet;
     #[cfg(feature = "sim")]
     use crate::prelude::FlowBuilder;
@@ -714,6 +1163,8 @@ mod tests {
     #[cfg(feature = "sim")]
     #[test]
     fn sim_send_bincode_o2o() {
+        use crate::networking::TCP;
+
         let flow = FlowBuilder::new();
         let node = flow.process::<()>();
         let node2 = flow.process::<()>();
@@ -721,7 +1172,7 @@ mod tests {
         let (in_send, input) = node.sim_input();
 
         let out_recv = input
-            .send_bincode(&node2)
+            .send(&node2, TCP.bincode())
             .batch(&node2.tick(), nondet!(/** test */))
             .count()
             .all_ticks()
@@ -749,7 +1200,7 @@ mod tests {
         let input = cluster.source_iter(q!(vec![1]));
 
         let out_recv = input
-            .send_bincode(&node)
+            .send(&node, TCP.bincode())
             .entries()
             .batch(&node.tick(), nondet!(/** test */))
             .all_ticks()
@@ -782,13 +1233,13 @@ mod tests {
 
         let out_recv_1 = cluster1
             .source_iter(q!(vec![1]))
-            .send_bincode(&node)
+            .send(&node, TCP.bincode())
             .entries()
             .sim_output();
 
         let out_recv_2 = cluster2
             .source_iter(q!(vec![2]))
-            .send_bincode(&node)
+            .send(&node, TCP.bincode())
             .entries()
             .sim_output();
 
@@ -831,9 +1282,9 @@ mod tests {
         ]));
 
         let out_recv = input
-            .demux_bincode(&cluster)
+            .demux(&cluster, TCP.bincode())
             .map(q!(|x| x + 1))
-            .send_bincode(&node)
+            .send(&node, TCP.bincode())
             .entries()
             .sim_output();
 
@@ -859,9 +1310,9 @@ mod tests {
         let input = node.source_iter(q!(vec![123, 456]));
 
         let out_recv = input
-            .broadcast_bincode(&cluster, nondet!(/** test */))
+            .broadcast(&cluster, TCP.bincode(), nondet!(/** test */))
             .map(q!(|x| x + 1))
-            .send_bincode(&node)
+            .send(&node, TCP.bincode())
             .entries()
             .sim_output();
 
@@ -901,15 +1352,15 @@ mod tests {
         ]));
 
         let out_recv = input
-            .demux_bincode(&cluster)
+            .demux(&cluster, TCP.bincode())
             .map(q!(|x| x + 1))
             .flat_map_ordered(q!(|x| vec![
                 (MemberId::from_raw_id(0), x),
                 (MemberId::from_raw_id(1), x),
             ]))
-            .demux_bincode(&cluster)
+            .demux(&cluster, TCP.bincode())
             .entries()
-            .send_bincode(&node)
+            .send(&node, TCP.bincode())
             .entries()
             .sim_output();
 

--- a/hydro_lang/src/location/cluster.rs
+++ b/hydro_lang/src/location/cluster.rs
@@ -166,6 +166,8 @@ mod tests {
     #[cfg(feature = "sim")]
     use crate::location::{Location, MemberId, MembershipEvent};
     #[cfg(feature = "sim")]
+    use crate::networking::TCP;
+    #[cfg(feature = "sim")]
     use crate::nondet::nondet;
     #[cfg(feature = "sim")]
     use crate::prelude::FlowBuilder;
@@ -181,12 +183,12 @@ mod tests {
 
         let out_recv = cluster1
             .source_iter(q!(vec![CLUSTER_SELF_ID]))
-            .send_bincode(&node)
+            .send(&node, TCP.bincode())
             .values()
             .interleave(
                 cluster2
                     .source_iter(q!(vec![CLUSTER_SELF_ID]))
-                    .send_bincode(&node)
+                    .send(&node, TCP.bincode())
                     .values(),
             )
             .sim_output();
@@ -215,7 +217,7 @@ mod tests {
             .batch(&cluster.tick(), nondet!(/** test */))
             .count()
             .all_ticks()
-            .send_bincode(&node)
+            .send(&node, TCP.bincode())
             .entries()
             .map(q!(|(id, v)| (id, v)))
             .sim_output();

--- a/hydro_lang/src/networking/mod.rs
+++ b/hydro_lang/src/networking/mod.rs
@@ -1,0 +1,86 @@
+//! Types for configuring network channels with serialization formats, transports, etc.
+
+use std::marker::PhantomData;
+
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+use crate::live_collections::stream::networking::{deserialize_bincode, serialize_bincode};
+
+#[sealed::sealed]
+trait SerKind<T: ?Sized> {
+    fn serialize_thunk(is_demux: bool) -> syn::Expr;
+
+    fn deserialize_thunk(tagged: Option<&syn::Type>) -> syn::Expr;
+}
+
+/// Serialize items using the [`bincode`] crate.
+pub enum Bincode {}
+
+#[sealed::sealed]
+impl<T: Serialize + DeserializeOwned> SerKind<T> for Bincode {
+    fn serialize_thunk(is_demux: bool) -> syn::Expr {
+        serialize_bincode::<T>(is_demux)
+    }
+
+    fn deserialize_thunk(tagged: Option<&syn::Type>) -> syn::Expr {
+        deserialize_bincode::<T>(tagged)
+    }
+}
+
+/// An unconfigured serialization backend.
+pub enum NoSer {}
+
+#[sealed::sealed]
+trait TransportKind {}
+
+/// Send items across a length-delimited TCP channel.
+pub enum Tcp {}
+
+#[sealed::sealed]
+impl TransportKind for Tcp {}
+
+/// A networking backend implementation that supports items of type `T`.
+#[sealed::sealed]
+pub trait NetworkFor<T: ?Sized> {
+    /// Generates serialization logic for sending `T`.
+    fn serialize_thunk(is_demux: bool) -> syn::Expr;
+
+    /// Generates deserialization logic for receiving `T`.
+    fn deserialize_thunk(tagged: Option<&syn::Type>) -> syn::Expr;
+}
+
+/// A network channel configuration with `T` as transport backend and `S` as the serialization
+/// backend.
+pub struct NetworkingConfig<Tr: ?Sized, S: ?Sized> {
+    _phantom: (PhantomData<Tr>, PhantomData<S>),
+}
+
+impl<Tr: ?Sized, S: ?Sized> NetworkingConfig<Tr, S> {
+    /// Configures the network channel to use [`bincode`] to serialize items.
+    pub const fn bincode(self) -> NetworkingConfig<Tr, Bincode> {
+        NetworkingConfig {
+            _phantom: (PhantomData, PhantomData),
+        }
+    }
+}
+
+#[sealed::sealed]
+impl<Tr: ?Sized, S: ?Sized, T: ?Sized> NetworkFor<T> for NetworkingConfig<Tr, S>
+where
+    Tr: TransportKind,
+    S: SerKind<T>,
+{
+    fn serialize_thunk(is_demux: bool) -> syn::Expr {
+        S::serialize_thunk(is_demux)
+    }
+
+    fn deserialize_thunk(tagged: Option<&syn::Type>) -> syn::Expr {
+        S::deserialize_thunk(tagged)
+    }
+}
+
+/// A network channel that uses length-delimited TCP for transport.
+pub const TCP: NetworkingConfig<Tcp, NoSer> = NetworkingConfig {
+    _phantom: (PhantomData, PhantomData),
+};

--- a/hydro_lang/src/tests/hydro_deploy.rs
+++ b/hydro_lang/src/tests/hydro_deploy.rs
@@ -36,15 +36,15 @@ fn distributed_echo<'a>(
 
     let rx = rx
         .map(q!(|n| n + 1))
-        .round_robin_bincode(c2, nondet!(/** test */))
+        .round_robin(c2, TCP.bincode(), nondet!(/** test */))
         .map(q!(|n| n + 1))
-        .round_robin_bincode(c3, nondet!(/** test */))
+        .round_robin(c3, TCP.bincode(), nondet!(/** test */))
         .values()
         .map(q!(|n| n + 1))
-        .send_bincode(p4)
+        .send(p4, TCP.bincode())
         .values()
         .map(q!(|n| n + 1))
-        .send_bincode(p5)
+        .send(p5, TCP.bincode())
         .map(q!(|n| n + 1))
         .send_bincode_external(external);
 

--- a/hydro_lang/tests/compile-fail/send_lifetime.rs
+++ b/hydro_lang/tests/compile-fail/send_lifetime.rs
@@ -4,7 +4,7 @@ struct P1 {}
 struct P2 {}
 
 fn test<'a, 'b>(p1: &Process<'a, P1>, p2: &Process<'b, P2>) {
-    p1.source_iter(q!(0..10)).send_bincode(p2).for_each(q!(|n| println!("{}", n)));
+    p1.source_iter(q!(0..10)).send(p2, TCP.bincode()).for_each(q!(|n| println!("{}", n)));
 }
 
 fn main() {}

--- a/hydro_lang/tests/compile-fail/send_lifetime.stderr
+++ b/hydro_lang/tests/compile-fail/send_lifetime.stderr
@@ -1,11 +1,11 @@
 error: lifetime may not live long enough
- --> tests/compile-fail/send_bincode_lifetime.rs:7:5
+ --> tests/compile-fail/send_lifetime.rs:7:5
   |
 6 | fn test<'a, 'b>(p1: &Process<'a, P1>, p2: &Process<'b, P2>) {
   |         --  -- lifetime `'b` defined here
   |         |
   |         lifetime `'a` defined here
-7 |     p1.source_iter(q!(0..10)).send_bincode(p2).for_each(q!(|n| println!("{}", n)));
+7 |     p1.source_iter(q!(0..10)).send(p2, TCP.bincode()).for_each(q!(|n| println!("{}", n)));
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
   |
   = help: consider adding the following bound: `'b: 'a`
@@ -14,14 +14,14 @@ error: lifetime may not live long enough
   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
- --> tests/compile-fail/send_bincode_lifetime.rs:7:5
+ --> tests/compile-fail/send_lifetime.rs:7:5
   |
 6 | fn test<'a, 'b>(p1: &Process<'a, P1>, p2: &Process<'b, P2>) {
   |         --  -- lifetime `'b` defined here
   |         |
   |         lifetime `'a` defined here
-7 |     p1.source_iter(q!(0..10)).send_bincode(p2).for_each(q!(|n| println!("{}", n)));
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'a` must outlive `'b`
+7 |     p1.source_iter(q!(0..10)).send(p2, TCP.bincode()).for_each(q!(|n| println!("{}", n)));
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'a` must outlive `'b`
   |
   = help: consider adding the following bound: `'a: 'b`
   = note: requirement occurs because of the type `hydro_lang::prelude::Process<'_, P2>`, which makes the generic argument `'_` invariant

--- a/hydro_std/src/bench_client/mod.rs
+++ b/hydro_std/src/bench_client/mod.rs
@@ -206,7 +206,7 @@ pub fn print_bench_results<'a, Client: 'a, Aggregator>(
     let keyed_throughputs = results
         .throughput
         .sample_every(q!(Duration::from_millis(1000)), nondet_sampling)
-        .send_bincode(aggregator);
+        .send(aggregator, TCP.bincode());
 
     let latest_throughputs = keyed_throughputs.reduce_idempotent(q!(|combined, new| {
         *combined = new;
@@ -279,7 +279,7 @@ pub fn print_bench_results<'a, Client: 'a, Aggregator>(
                 histogram: latencies,
             }
         }))
-        .send_bincode(aggregator);
+        .send(aggregator, TCP.bincode());
 
     let most_recent_histograms = keyed_latencies
         .map(q!(|histogram| histogram.histogram.borrow().clone()))

--- a/hydro_std/src/compartmentalize.rs
+++ b/hydro_std/src/compartmentalize.rs
@@ -28,7 +28,7 @@ impl<'a, T, C1, C2, Order: Ordering> PartitionStream<'a, T, C1, C2, Order>
     where
         T: Clone + Serialize + DeserializeOwned,
     {
-        self.map(dist_policy).demux_bincode(other).values()
+        self.map(dist_policy).demux(other, TCP.bincode()).values()
     }
 }
 
@@ -60,7 +60,7 @@ where
                 MemberId::from_tagless(CLUSTER_SELF_ID.clone().into_tagless()), // this is a seemingly round about way to convert from one member id tag to another.
                 b.clone()
             )))
-            .demux_bincode(other)
+            .demux(other, TCP.bincode())
             .values();
 
         sent.assume_ordering(
@@ -88,6 +88,6 @@ impl<'a, T, L, B: Boundedness, Order: Ordering>
     where
         T: Clone + Serialize + DeserializeOwned,
     {
-        self.send_bincode(other)
+        self.send(other, TCP.bincode())
     }
 }

--- a/hydro_test/src/cluster/compartmentalized_paxos.rs
+++ b/hydro_test/src/cluster/compartmentalized_paxos.rs
@@ -277,7 +277,7 @@ fn sequence_payload<'a, P: PaxosPayload>(
             ((slot, ballot), payload)
         ))))
         .all_ticks()
-        .demux_bincode(proxy_leaders)
+        .demux(proxy_leaders, TCP.bincode())
         .values()
         .atomic(proxy_leader_tick);
 
@@ -305,7 +305,7 @@ fn sequence_payload<'a, P: PaxosPayload>(
             p2as
         }))
         .end_atomic()
-        .demux_bincode(acceptors)
+        .demux(acceptors, TCP.bincode())
         .values();
 
     let (a_log, a_to_proxy_leaders_p2b) = acceptor_p2(
@@ -336,7 +336,7 @@ fn sequence_payload<'a, P: PaxosPayload>(
     let pl_failed_p2b_to_proposer = fails
         .map(q!(|(_, ballot)| (ballot.proposer_id.clone(), ballot)))
         .inspect(q!(|(_, ballot)| println!("Failed P2b: {:?}", ballot)))
-        .demux_bincode(proposers)
+        .demux(proposers, TCP.bincode())
         .values();
 
     (

--- a/hydro_test/src/cluster/compute_pi.rs
+++ b/hydro_test/src/cluster/compute_pi.rs
@@ -30,7 +30,7 @@ pub fn compute_pi<'a>(
         .all_ticks();
 
     let estimate = trials
-        .send_bincode(&process)
+        .send(&process, TCP.bincode())
         .values()
         .reduce_commutative(q!(|(inside, total), (inside_batch, total_batch)| {
             *inside += inside_batch;

--- a/hydro_test/src/cluster/many_to_many.rs
+++ b/hydro_test/src/cluster/many_to_many.rs
@@ -4,7 +4,7 @@ pub fn many_to_many<'a>(flow: &FlowBuilder<'a>) -> Cluster<'a, ()> {
     let cluster = flow.cluster();
     cluster
         .source_iter(q!(0..2))
-        .broadcast_bincode(&cluster, nondet!(/** test */))
+        .broadcast(&cluster, TCP.bincode(), nondet!(/** test */))
         .entries()
         .assume_ordering(nondet!(/** intentionally unordered logs */))
         .for_each(q!(|n| println!("cluster received: {:?}", n)));

--- a/hydro_test/src/cluster/map_reduce.rs
+++ b/hydro_test/src/cluster/map_reduce.rs
@@ -12,7 +12,7 @@ pub fn map_reduce<'a>(flow: &FlowBuilder<'a>) -> (Process<'a, Leader>, Cluster<'
         .map(q!(|s| s.to_string()));
 
     let partitioned_words = words
-        .round_robin_bincode(&cluster, nondet!(/** test */))
+        .round_robin(&cluster, TCP.bincode(), nondet!(/** test */))
         .map(q!(|string| (string, ())))
         .into_keyed();
 
@@ -28,7 +28,7 @@ pub fn map_reduce<'a>(flow: &FlowBuilder<'a>) -> (Process<'a, Leader>, Cluster<'
             string, count
         )))
         .all_ticks()
-        .send_bincode(&process)
+        .send(&process, TCP.bincode())
         .values();
 
     let reduced = batches

--- a/hydro_test/src/cluster/paxos.rs
+++ b/hydro_test/src/cluster/paxos.rs
@@ -304,7 +304,7 @@ pub fn leader_election<'a, L: Clone + Debug + Serialize + DeserializeOwned>(
         .if_some_then(p_ballot.clone())
         .all_ticks()
         .inspect(q!(|_| println!("Proposer leader expired, sending P1a")))
-        .broadcast_bincode(acceptors, nondet!(/** TODO */))
+        .broadcast(acceptors, TCP.bincode(), nondet!(/** TODO */))
         .values();
 
     let (a_max_ballot, a_to_proposers_p1b) = acceptor_p1(
@@ -416,7 +416,7 @@ fn p_leader_heartbeat<'a>(
                 nondet_reelection
             ),
         )
-        .broadcast_bincode(proposers, nondet!(/** TODO */))
+        .broadcast(proposers, TCP.bincode(), nondet!(/** TODO */))
         .values();
 
     let p_leader_expired = p_to_proposers_i_am_leader
@@ -492,7 +492,7 @@ fn acceptor_p1<'a, L: Serialize + DeserializeOwned + Clone>(
                 )
             )))
             .all_ticks()
-            .demux_bincode(proposers)
+            .demux(proposers, TCP.bincode())
             .values(),
     )
 }
@@ -723,7 +723,7 @@ fn sequence_payload<'a, P: PaxosPayload>(
                 slot,
                 value
             }))
-            .broadcast_bincode(acceptors, nondet!(/** TODO */))
+            .broadcast(acceptors, TCP.bincode(), nondet!(/** TODO */))
             .values(),
         a_checkpoint,
         proposers,
@@ -861,7 +861,7 @@ pub fn acceptor_p2<'a, P: PaxosPayload, S: Clone>(
             )
         )))
         .all_ticks()
-        .demux_bincode(proposers)
+        .demux(proposers, TCP.bincode())
         .values();
 
     (

--- a/hydro_test/src/cluster/paxos_bench.rs
+++ b/hydro_test/src/cluster/paxos_bench.rs
@@ -45,7 +45,7 @@ pub fn paxos_bench<'a>(
         );
 
         let sequenced_to_replicas = sequenced_payloads
-            .broadcast_bincode(replicas, nondet!(/** TODO */))
+            .broadcast(replicas, TCP.bincode(), nondet!(/** TODO */))
             .values();
 
         // Replicas
@@ -55,7 +55,7 @@ pub fn paxos_bench<'a>(
         // Get the latest checkpoint sequence per replica
         let a_checkpoint = {
             let a_checkpoint_largest_seqs = replica_checkpoint
-                .broadcast_bincode(&acceptors, nondet!(/** TODO */))
+                .broadcast(&acceptors, TCP.bincode(), nondet!(/** TODO */))
                 .reduce_commutative(q!(|curr_seq, seq| {
                     if seq > *curr_seq {
                         *curr_seq = seq;
@@ -93,7 +93,7 @@ pub fn paxos_bench<'a>(
                 payload.value.0,
                 ((payload.key, payload.value.1), Ok(()))
             )))
-            .demux_bincode(clients)
+            .demux(clients, TCP.bincode())
             .values();
 
         // we only mark a transaction as committed when all replicas have applied it

--- a/hydro_test/src/cluster/paxos_with_client.rs
+++ b/hydro_test/src/cluster/paxos_with_client.rs
@@ -59,7 +59,7 @@ pub trait PaxosLike<'a>: Sized {
             move |new_leader_elected| {
                 let cur_leader_id = Self::get_recipient_from_ballot(
                     new_leader_elected
-                        .broadcast_bincode(clients, nondet!(/** TODO */))
+                        .broadcast(clients, TCP.bincode(), nondet!(/** TODO */))
                         .values()
                         .inspect(q!(|ballot| println!(
                             "Client notified that leader was elected: {:?}",
@@ -88,7 +88,7 @@ pub trait PaxosLike<'a>: Sized {
                     all_payloads.cross_singleton(latest_leader)
                 }
                 .map(q!(move |(payload, leader_id)| (leader_id, payload)))
-                .demux_bincode(&leaders)
+                .demux(&leaders, TCP.bincode())
                 .values();
 
                 let payloads_at_proposer = {

--- a/hydro_test/src/cluster/simple_cluster.rs
+++ b/hydro_test/src/cluster/simple_cluster.rs
@@ -61,12 +61,12 @@ pub fn simple_cluster<'a>(flow: &FlowBuilder<'a>) -> (Process<'a, ()>, Cluster<'
 
     ids.cross_product(numbers)
         .map(q!(|(id, n)| (id.clone(), (id, n))))
-        .demux_bincode(&cluster)
+        .demux(&cluster, TCP.bincode())
         .inspect(q!(move |n| println!(
             "cluster received: {:?} (self cluster id: {})",
             n, CLUSTER_SELF_ID
         )))
-        .send_bincode(&process)
+        .send(&process, TCP.bincode())
         .entries()
         .assume_ordering(nondet!(/** testing, order does not matter */))
         .for_each(q!(|(id, d)| println!("node received: ({}, {:?})", id, d)));

--- a/hydro_test/src/cluster/two_pc.rs
+++ b/hydro_test/src/cluster/two_pc.rs
@@ -22,15 +22,17 @@ where
 {
     // TODO: Coordinator logs
     // broadcast prepare message to participants
-    let p_prepare = payloads
-        .ir_node_named("c_prepare")
-        .broadcast_bincode(participants, nondet!(/** TODO */));
+    let p_prepare = payloads.ir_node_named("c_prepare").broadcast(
+        participants,
+        TCP.bincode(),
+        nondet!(/** TODO */),
+    );
 
     // participant 1 aborts transaction 1
     // TODO: Participants log
     let c_votes = p_prepare
         .ir_node_named("p_prepare")
-        .send_bincode(coordinator)
+        .send(coordinator, TCP.bincode())
         .ir_node_named("c_votes")
         .values();
 
@@ -44,12 +46,12 @@ where
     // TODO: Coordinator log
 
     // broadcast commit transactions to participants.
-    let p_commit = c_all_vote_yes.broadcast_bincode(participants, nondet!(/** TODO */));
+    let p_commit = c_all_vote_yes.broadcast(participants, TCP.bincode(), nondet!(/** TODO */));
     // TODO: Participants log
 
     let c_commits = p_commit
         .ir_node_named("p_commits")
-        .send_bincode(coordinator)
+        .send(coordinator, TCP.bincode())
         .ir_node_named("c_commits")
         .values();
     let (c_all_commit, _) = collect_quorum(

--- a/hydro_test/src/cluster/two_pc_bench.rs
+++ b/hydro_test/src/cluster/two_pc_bench.rs
@@ -25,9 +25,9 @@ pub fn two_pc_bench<'a>(
                 coordinator,
                 participants,
                 num_participants,
-                payloads.send_bincode(coordinator).entries(),
+                payloads.send(coordinator, TCP.bincode()).entries(),
             )
-            .demux_bincode(clients)
+            .demux(clients, TCP.bincode())
         },
         num_clients_per_node,
         nondet!(/** bench */),

--- a/hydro_test/src/distributed/first_ten.rs
+++ b/hydro_test/src/distributed/first_ten.rs
@@ -21,7 +21,7 @@ pub fn first_ten_distributed<'a>(
     let numbers = process.source_iter(q!(0..10));
     numbers
         .map(q!(|n| SendOverNetwork { n }))
-        .send_bincode(second_process)
+        .send(second_process, TCP.bincode())
         .for_each(q!(|n| println!("{}", n.n)));
 
     numbers_external_port

--- a/hydro_test/src/tutorials/partitioned_counter.rs
+++ b/hydro_test/src/tutorials/partitioned_counter.rs
@@ -23,7 +23,7 @@ pub fn sharded_counter_service<'a>(
             key.hash(&mut hasher);
             MemberId::from_raw_id(hasher.finish() as u32 % 5)
         }))
-        .demux_bincode(shard_servers);
+        .demux(shard_servers, TCP.bincode());
 
     let sharded_get_requests = get_requests
         .prefix_key(q!(|(_client, key)| {
@@ -31,16 +31,20 @@ pub fn sharded_counter_service<'a>(
             key.hash(&mut hasher);
             MemberId::from_raw_id(hasher.finish() as u32 % 5)
         }))
-        .demux_bincode(shard_servers);
+        .demux(shard_servers, TCP.bincode());
 
     let (sharded_increment_ack, sharded_get_response) = super::keyed_counter::keyed_counter_service(
         sharded_increment_requests,
         sharded_get_requests,
     );
 
-    let increment_ack = sharded_increment_ack.send_bincode(leader).drop_key_prefix();
+    let increment_ack = sharded_increment_ack
+        .send(leader, TCP.bincode())
+        .drop_key_prefix();
 
-    let get_response = sharded_get_response.send_bincode(leader).drop_key_prefix();
+    let get_response = sharded_get_response
+        .send(leader, TCP.bincode())
+        .drop_key_prefix();
 
     (increment_ack, get_response)
 }


### PR DESCRIPTION
This eliminates the hardcoding of networking APIs to specific serialization formats, transport protocols, etc. Includes similar refactors across `demux` / `round_robin` / etc APIs.
