### PR TITLE
refactor(hydro_lang)!: cleanup port handling with newtypes, trait changes

### DIFF
--- a/hydro_lang/src/compile/builder.rs
+++ b/hydro_lang/src/compile/builder.rs
@@ -1,10 +1,7 @@
 use std::any::type_name;
 use std::cell::RefCell;
-use std::fmt::{Display, Formatter};
 use std::marker::PhantomData;
 use std::rc::Rc;
-
-use serde::Serialize;
 
 #[cfg(feature = "build")]
 use super::compiled::CompiledFlow;
@@ -19,31 +16,9 @@ use crate::location::{Cluster, External, Process};
 use crate::sim::flow::SimFlow;
 use crate::staging_util::Invariant;
 
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-#[serde(from = "usize", into = "usize")]
-pub struct ExternalPortId(usize);
-impl ExternalPortId {
-    /// Gets the current ID and increments for the next.
-    pub fn get_and_increment(&mut self) -> Self {
-        let id = self.0;
-        self.0 += 1;
-        Self(id)
-    }
-}
-impl From<usize> for ExternalPortId {
-    fn from(x: usize) -> Self {
-        Self(x)
-    }
-}
-impl From<ExternalPortId> for usize {
-    fn from(x: ExternalPortId) -> Self {
-        x.0
-    }
-}
-impl Display for ExternalPortId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "ex{}", self.0)
-    }
+crate::newtype_counter! {
+    /// Counter for generating unique external output identifiers.
+    pub struct ExternalPortId(usize);
 }
 
 pub(crate) type FlowState = Rc<RefCell<FlowStateInner>>;

--- a/hydro_lang/src/compile/built.rs
+++ b/hydro_lang/src/compile/built.rs
@@ -222,14 +222,12 @@ impl<'a> BuiltFlow<'a> {
     /// Creates a simulation for this builder, which can be used to run deterministic simulations
     /// of the Hydro program.
     pub fn sim(mut self) -> SimFlow<'a> {
-        use std::cell::{Cell, RefCell};
+        use std::cell::RefCell;
         use std::rc::Rc;
 
-        use crate::sim::graph::SimExternal;
+        use crate::sim::graph::{SimExternal, SimExternalPortRegistry, SimNodePort};
 
-        let external_ports = Rc::new(RefCell::new((vec![], 0)));
-
-        let global_port_counter = Rc::new(Cell::new(0));
+        let shared_port_counter = Rc::new(RefCell::new(SimNodePort::default()));
         let processes = self
             .process_id_name
             .iter()
@@ -237,7 +235,7 @@ impl<'a> BuiltFlow<'a> {
                 (
                     id.0,
                     SimNode {
-                        port_counter: global_port_counter.clone(),
+                        shared_port_counter: shared_port_counter.clone(),
                     },
                 )
             })
@@ -250,13 +248,13 @@ impl<'a> BuiltFlow<'a> {
                 (
                     id.0,
                     SimNode {
-                        port_counter: global_port_counter.clone(),
+                        shared_port_counter: shared_port_counter.clone(),
                     },
                 )
             })
             .collect();
 
-        let all_external_registered = Rc::new(RefCell::new(HashMap::new()));
+        let externals_port_registry = Rc::new(RefCell::new(SimExternalPortRegistry::default()));
         let externals = self
             .external_id_name
             .iter()
@@ -264,8 +262,7 @@ impl<'a> BuiltFlow<'a> {
                 (
                     id.0,
                     SimExternal {
-                        external_ports: external_ports.clone(),
-                        registered: all_external_registered.clone(),
+                        shared_inner: externals_port_registry.clone(),
                     },
                 )
             })
@@ -273,15 +270,14 @@ impl<'a> BuiltFlow<'a> {
 
         SimFlow {
             ir: std::mem::take(&mut self.ir),
-            external_ports,
             processes,
             clusters,
             cluster_max_sizes: HashMap::new(),
             externals,
-            external_registered: all_external_registered.clone(),
-            _process_id_name: std::mem::take(&mut self.process_id_name),
-            _external_id_name: std::mem::take(&mut self.external_id_name),
-            _cluster_id_name: std::mem::take(&mut self.cluster_id_name),
+            externals_port_registry,
+            _process_id_name: self.process_id_name,
+            _external_id_name: self.external_id_name,
+            _cluster_id_name: self.cluster_id_name,
             _phantom: PhantomData,
         }
     }

--- a/hydro_lang/src/compile/deploy_provider.rs
+++ b/hydro_lang/src/compile/deploy_provider.rs
@@ -14,14 +14,13 @@ use crate::location::member_id::TaglessMemberId;
 use crate::location::{MembershipEvent, NetworkHint};
 
 pub trait Deploy<'a> {
+    type Meta: Default;
     type InstantiateEnv;
 
     type Process: Node<Meta = Self::Meta, InstantiateEnv = Self::InstantiateEnv> + Clone;
     type Cluster: Node<Meta = Self::Meta, InstantiateEnv = Self::InstantiateEnv> + Clone;
     type External: Node<Meta = Self::Meta, InstantiateEnv = Self::InstantiateEnv>
         + RegisterPort<'a, Self>;
-    type Port: Clone;
-    type Meta: Default;
 
     /// Type of ID used to switch between different subgraphs at runtime.
     type GraphId;
@@ -29,79 +28,72 @@ pub trait Deploy<'a> {
     fn has_trivial_node() -> bool {
         false
     }
-
     fn trivial_process(_id: usize) -> Self::Process {
         panic!("No trivial process")
     }
-
     fn trivial_cluster(_id: usize) -> Self::Cluster {
         panic!("No trivial cluster")
     }
-
     fn trivial_external(_id: usize) -> Self::External {
         panic!("No trivial external process")
     }
 
-    fn allocate_process_port(process: &Self::Process) -> Self::Port;
-    fn allocate_cluster_port(cluster: &Self::Cluster) -> Self::Port;
-    fn allocate_external_port(external: &Self::External) -> Self::Port;
-
     fn o2o_sink_source(
         p1: &Self::Process,
-        p1_port: &Self::Port,
+        p1_port: &<Self::Process as Node>::Port,
         p2: &Self::Process,
-        p2_port: &Self::Port,
+        p2_port: &<Self::Process as Node>::Port,
     ) -> (syn::Expr, syn::Expr);
     fn o2o_connect(
         p1: &Self::Process,
-        p1_port: &Self::Port,
+        p1_port: &<Self::Process as Node>::Port,
         p2: &Self::Process,
-        p2_port: &Self::Port,
+        p2_port: &<Self::Process as Node>::Port,
     ) -> Box<dyn FnOnce()>;
 
     fn o2m_sink_source(
         p1: &Self::Process,
-        p1_port: &Self::Port,
+        p1_port: &<Self::Process as Node>::Port,
         c2: &Self::Cluster,
-        c2_port: &Self::Port,
+        c2_port: &<Self::Cluster as Node>::Port,
     ) -> (syn::Expr, syn::Expr);
     fn o2m_connect(
         p1: &Self::Process,
-        p1_port: &Self::Port,
+        p1_port: &<Self::Process as Node>::Port,
         c2: &Self::Cluster,
-        c2_port: &Self::Port,
+        c2_port: &<Self::Cluster as Node>::Port,
     ) -> Box<dyn FnOnce()>;
 
     fn m2o_sink_source(
         c1: &Self::Cluster,
-        c1_port: &Self::Port,
+        c1_port: &<Self::Cluster as Node>::Port,
         p2: &Self::Process,
-        p2_port: &Self::Port,
+        p2_port: &<Self::Process as Node>::Port,
     ) -> (syn::Expr, syn::Expr);
     fn m2o_connect(
         c1: &Self::Cluster,
-        c1_port: &Self::Port,
+        c1_port: &<Self::Cluster as Node>::Port,
         p2: &Self::Process,
-        p2_port: &Self::Port,
+        p2_port: &<Self::Process as Node>::Port,
     ) -> Box<dyn FnOnce()>;
 
     fn m2m_sink_source(
         c1: &Self::Cluster,
-        c1_port: &Self::Port,
+        c1_port: &<Self::Cluster as Node>::Port,
         c2: &Self::Cluster,
-        c2_port: &Self::Port,
+        c2_port: &<Self::Cluster as Node>::Port,
     ) -> (syn::Expr, syn::Expr);
     fn m2m_connect(
         c1: &Self::Cluster,
-        c1_port: &Self::Port,
+        c1_port: &<Self::Cluster as Node>::Port,
         c2: &Self::Cluster,
-        c2_port: &Self::Port,
+        c2_port: &<Self::Cluster as Node>::Port,
     ) -> Box<dyn FnOnce()>;
 
     fn e2o_many_source(
         extra_stmts: &mut Vec<syn::Stmt>,
         p2: &Self::Process,
-        p2_port: &Self::Port,
+        p2_port: &<Self::Process as Node>::Port,
         codec_type: &syn::Type,
         shared_handle: String,
     ) -> syn::Expr;
@@ -110,26 +102,26 @@ pub trait Deploy<'a> {
     fn e2o_source(
         extra_stmts: &mut Vec<syn::Stmt>,
         p1: &Self::External,
-        p1_port: &Self::Port,
+        p1_port: &<Self::External as Node>::Port,
         p2: &Self::Process,
-        p2_port: &Self::Port,
+        p2_port: &<Self::Process as Node>::Port,
         codec_type: &syn::Type,
         shared_handle: String,
     ) -> syn::Expr;
     fn e2o_connect(
         p1: &Self::External,
-        p1_port: &Self::Port,
+        p1_port: &<Self::External as Node>::Port,
         p2: &Self::Process,
-        p2_port: &Self::Port,
+        p2_port: &<Self::Process as Node>::Port,
         many: bool,
         server_hint: NetworkHint,
     ) -> Box<dyn FnOnce()>;
 
     fn o2e_sink(
         p1: &Self::Process,
-        p1_port: &Self::Port,
+        p1_port: &<Self::Process as Node>::Port,
         p2: &Self::External,
-        p2_port: &Self::Port,
+        p2_port: &<Self::External as Node>::Port,
         shared_handle: String,
     ) -> syn::Expr;
 
@@ -185,10 +177,17 @@ where
 }
 
 pub trait Node {
-    type Port;
-    type Meta;
+    /// A logical communication endpoint for this node.
+    ///
+    /// Implementors are free to choose the concrete representation (for example,
+    /// a handle or identifier), but it must be `Clone` so that a single logical
+    /// port can be duplicated and passed to multiple consumers. New ports are
+    /// allocated via [`Self::next_port`].
+    type Port: Clone;
+    type Meta: Default;
     type InstantiateEnv;
 
+    /// Allocates and returns a new port.
     fn next_port(&self) -> Self::Port;
 
     fn update_meta(&self, meta: &Self::Meta);
@@ -207,11 +206,11 @@ pub type DynSourceSink<Out, In, InErr> = (
     Pin<Box<dyn Sink<In, Error = InErr>>>,
 );
 
-pub trait RegisterPort<'a, D>: Clone
+pub trait RegisterPort<'a, D>: Node + Clone
 where
     D: Deploy<'a> + ?Sized,
 {
-    fn register(&self, external_port_id: ExternalPortId, port: D::Port);
+    fn register(&self, external_port_id: ExternalPortId, port: Self::Port);
 
     fn as_bytes_bidi(
         &self,

--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -23,7 +23,7 @@ use syn::visit_mut::VisitMut;
 
 use crate::compile::builder::ExternalPortId;
 #[cfg(feature = "build")]
-use crate::compile::deploy_provider::{Deploy, RegisterPort};
+use crate::compile::deploy_provider::{Deploy, Node, RegisterPort};
 use crate::location::NetworkHint;
 use crate::location::dynamic::LocationId;
 
@@ -726,8 +726,8 @@ impl HydroRoot {
                                             })
                                             .clone();
 
-                                        let sink_port = D::allocate_process_port(&from_node);
-                                        let source_port: <D as Deploy<'a>>::Port = D::allocate_external_port(&to_node);
+                                        let sink_port = from_node.next_port();
+                                        let source_port = to_node.next_port();
 
                                         if *unpaired {
                                             use stageleft::quote_type;
@@ -843,8 +843,8 @@ impl HydroRoot {
                                         })
                                         .clone();
 
-                                    let sink_port = D::allocate_external_port(&from_node);
-                                    let source_port = D::allocate_process_port(&to_node);
+                                    let sink_port = from_node.next_port();
+                                    let source_port = to_node.next_port();
 
                                     from_node.register(*from_port_id, sink_port.clone());
 
@@ -3775,8 +3775,8 @@ where
                 })
                 .clone();
 
-            let sink_port = D::allocate_process_port(&from_node);
-            let source_port = D::allocate_process_port(&to_node);
+            let sink_port = from_node.next_port();
+            let source_port = to_node.next_port();
 
             (
                 D::o2o_sink_source(&from_node, &sink_port, &to_node, &source_port),
@@ -3797,8 +3797,8 @@ where
                 })
                 .clone();
 
-            let sink_port = D::allocate_process_port(&from_node);
-            let source_port = D::allocate_cluster_port(&to_node);
+            let sink_port = from_node.next_port();
+            let source_port = to_node.next_port();
 
             (
                 D::o2m_sink_source(&from_node, &sink_port, &to_node, &source_port),
@@ -3819,8 +3819,8 @@ where
                 })
                 .clone();
 
-            let sink_port = D::allocate_cluster_port(&from_node);
-            let source_port = D::allocate_process_port(&to_node);
+            let sink_port = from_node.next_port();
+            let source_port = to_node.next_port();
 
             (
                 D::m2o_sink_source(&from_node, &sink_port, &to_node, &source_port),
@@ -3841,8 +3841,8 @@ where
                 })
                 .clone();
 
-            let sink_port = D::allocate_cluster_port(&from_node);
-            let source_port = D::allocate_cluster_port(&to_node);
+            let sink_port = from_node.next_port();
+            let source_port = to_node.next_port();
 
             (
                 D::m2m_sink_source(&from_node, &sink_port, &to_node, &source_port),

--- a/hydro_lang/src/deploy/deploy_graph.rs
+++ b/hydro_lang/src/deploy/deploy_graph.rs
@@ -42,31 +42,20 @@ use crate::staging_util::get_this_crate;
 pub enum HydroDeploy {}
 
 impl<'a> Deploy<'a> for HydroDeploy {
+    type Meta = HashMap<usize, Vec<TaglessMemberId>>;
     type InstantiateEnv = Deployment;
+
     type Process = DeployNode;
     type Cluster = DeployCluster;
     type External = DeployExternal;
-    type Meta = HashMap<usize, Vec<TaglessMemberId>>;
+
     type GraphId = ();
-    type Port = String;
-
-    fn allocate_process_port(process: &Self::Process) -> Self::Port {
-        process.next_port()
-    }
-
-    fn allocate_cluster_port(cluster: &Self::Cluster) -> Self::Port {
-        cluster.next_port()
-    }
-
-    fn allocate_external_port(external: &Self::External) -> Self::Port {
-        external.next_port()
-    }
 
     fn o2o_sink_source(
         _p1: &Self::Process,
-        p1_port: &Self::Port,
+        p1_port: &<Self::Process as Node>::Port,
         _p2: &Self::Process,
-        p2_port: &Self::Port,
+        p2_port: &<Self::Process as Node>::Port,
     ) -> (syn::Expr, syn::Expr) {
         let p1_port = p1_port.as_str();
         let p2_port = p2_port.as_str();
@@ -79,9 +68,9 @@ impl<'a> Deploy<'a> for HydroDeploy {
 
     fn o2o_connect(
         p1: &Self::Process,
-        p1_port: &Self::Port,
+        p1_port: &<Self::Process as Node>::Port,
         p2: &Self::Process,
-        p2_port: &Self::Port,
+        p2_port: &<Self::Process as Node>::Port,
     ) -> Box<dyn FnOnce()> {
         let p1 = p1.clone();
         let p1_port = p1_port.clone();
@@ -103,9 +92,9 @@ impl<'a> Deploy<'a> for HydroDeploy {
 
     fn o2m_sink_source(
         _p1: &Self::Process,
-        p1_port: &Self::Port,
+        p1_port: &<Self::Process as Node>::Port,
         _c2: &Self::Cluster,
-        c2_port: &Self::Port,
+        c2_port: &<Self::Cluster as Node>::Port,
     ) -> (syn::Expr, syn::Expr) {
         let p1_port = p1_port.as_str();
         let c2_port = c2_port.as_str();
@@ -118,9 +107,9 @@ impl<'a> Deploy<'a> for HydroDeploy {
 
     fn o2m_connect(
         p1: &Self::Process,
-        p1_port: &Self::Port,
+        p1_port: &<Self::Process as Node>::Port,
         c2: &Self::Cluster,
-        c2_port: &Self::Port,
+        c2_port: &<Self::Cluster as Node>::Port,
     ) -> Box<dyn FnOnce()> {
         let p1 = p1.clone();
         let p1_port = p1_port.clone();
@@ -154,9 +143,9 @@ impl<'a> Deploy<'a> for HydroDeploy {
 
     fn m2o_sink_source(
         _c1: &Self::Cluster,
-        c1_port: &Self::Port,
+        c1_port: &<Self::Cluster as Node>::Port,
         _p2: &Self::Process,
-        p2_port: &Self::Port,
+        p2_port: &<Self::Process as Node>::Port,
     ) -> (syn::Expr, syn::Expr) {
         let c1_port = c1_port.as_str();
         let p2_port = p2_port.as_str();
@@ -169,9 +158,9 @@ impl<'a> Deploy<'a> for HydroDeploy {
 
     fn m2o_connect(
         c1: &Self::Cluster,
-        c1_port: &Self::Port,
+        c1_port: &<Self::Cluster as Node>::Port,
         p2: &Self::Process,
-        p2_port: &Self::Port,
+        p2_port: &<Self::Process as Node>::Port,
     ) -> Box<dyn FnOnce()> {
         let c1 = c1.clone();
         let c1_port = c1_port.clone();
@@ -197,9 +186,9 @@ impl<'a> Deploy<'a> for HydroDeploy {
 
     fn m2m_sink_source(
         _c1: &Self::Cluster,
-        c1_port: &Self::Port,
+        c1_port: &<Self::Cluster as Node>::Port,
         _c2: &Self::Cluster,
-        c2_port: &Self::Port,
+        c2_port: &<Self::Cluster as Node>::Port,
     ) -> (syn::Expr, syn::Expr) {
         let c1_port = c1_port.as_str();
         let c2_port = c2_port.as_str();
@@ -212,9 +201,9 @@ impl<'a> Deploy<'a> for HydroDeploy {
 
     fn m2m_connect(
         c1: &Self::Cluster,
-        c1_port: &Self::Port,
+        c1_port: &<Self::Cluster as Node>::Port,
         c2: &Self::Cluster,
-        c2_port: &Self::Port,
+        c2_port: &<Self::Cluster as Node>::Port,
     ) -> Box<dyn FnOnce()> {
         let c1 = c1.clone();
         let c1_port = c1_port.clone();
@@ -253,7 +242,7 @@ impl<'a> Deploy<'a> for HydroDeploy {
     fn e2o_many_source(
         extra_stmts: &mut Vec<syn::Stmt>,
         _p2: &Self::Process,
-        p2_port: &Self::Port,
+        p2_port: &<Self::Process as Node>::Port,
         codec_type: &syn::Type,
         shared_handle: String,
     ) -> syn::Expr {
@@ -308,9 +297,9 @@ impl<'a> Deploy<'a> for HydroDeploy {
     fn e2o_source(
         extra_stmts: &mut Vec<syn::Stmt>,
         _p1: &Self::External,
-        _p1_port: &Self::Port,
+        _p1_port: &<Self::External as Node>::Port,
         _p2: &Self::Process,
-        p2_port: &Self::Port,
+        p2_port: &<Self::Process as Node>::Port,
         codec_type: &syn::Type,
         shared_handle: String,
     ) -> syn::Expr {
@@ -348,9 +337,9 @@ impl<'a> Deploy<'a> for HydroDeploy {
 
     fn e2o_connect(
         p1: &Self::External,
-        p1_port: &Self::Port,
+        p1_port: &<Self::External as Node>::Port,
         p2: &Self::Process,
-        p2_port: &Self::Port,
+        p2_port: &<Self::Process as Node>::Port,
         _many: bool,
         server_hint: NetworkHint,
     ) -> Box<dyn FnOnce()> {
@@ -384,9 +373,9 @@ impl<'a> Deploy<'a> for HydroDeploy {
 
     fn o2e_sink(
         _p1: &Self::Process,
-        _p1_port: &Self::Port,
+        _p1_port: &<Self::Process as Node>::Port,
         _p2: &Self::External,
-        _p2_port: &Self::Port,
+        _p2_port: &<Self::External as Node>::Port,
         shared_handle: String,
     ) -> syn::Expr {
         let sink_ident = syn::Ident::new(
@@ -639,7 +628,7 @@ impl DeployExternal {
 }
 
 impl<'a> RegisterPort<'a, HydroDeploy> for DeployExternal {
-    fn register(&self, external_port_id: ExternalPortId, port: <HydroDeploy as Deploy>::Port) {
+    fn register(&self, external_port_id: ExternalPortId, port: Self::Port) {
         assert!(
             self.allocated_ports
                 .borrow_mut()


### PR DESCRIPTION
For the simulator, replaces `usize` with `SimNodePort`/`SimExternalPort`

Rearranges the `Deploy` trait to use the corresponding `Node`'s port type and `next_port()` method rather than custom methods.

BREAKING CHANGE: `Deploy`, `Node` traits, public API port types