### PR TITLE
refactor(hydro_deploy)!: extract profile folding into a feature

### DIFF
--- a/hydro_deploy/core/Cargo.toml
+++ b/hydro_deploy/core/Cargo.toml
@@ -11,6 +11,10 @@ license = { workspace = true }
 [lints]
 workspace = true
 
+[features]
+default = []
+profile-folding = ["dep:inferno", "dep:wholesym", "dep:itertools"]
+
 [dependencies]
 anyhow = { version = "1.0.82", features = ["backtrace"] }
 append-only-vec = "0.1.8"
@@ -26,7 +30,7 @@ dunce = "1.0.0"
 futures = "0.3.0"
 hydro_deploy_integration = { path = "../hydro_deploy_integration", version = "^0.15.0" }
 indicatif = "0.17.0"
-inferno = { version = "0.11.0", default-features = false }
+inferno = { version = "0.11.0", default-features = false, optional = true }
 memo-map = "0.3.0"
 nameof = "1.0.0"
 nanoid = "0.4.0"
@@ -40,5 +44,5 @@ tokio-stream = { version = "0.1.3", default-features = false, features = ["io-ut
 tokio-util = { version = "0.7.5", features = ["compat", "io-util"] }
 
 [target.'cfg(any(target_os = "macos", target_family = "windows"))'.dependencies]
-wholesym = "0.8.1"
-itertools = "0.13.0"
+wholesym = { version = "0.8.1", optional = true }
+itertools = { version = "0.13.0", optional = true }

--- a/hydro_deploy/core/src/lib.rs
+++ b/hydro_deploy/core/src/lib.rs
@@ -75,6 +75,7 @@ pub struct ResourceResult {
     _last_result: Option<Arc<ResourceResult>>,
 }
 
+#[cfg(feature = "profile-folding")]
 #[derive(Clone, Debug)]
 pub struct TracingResults {
     pub folded_data: Vec<u8>,
@@ -95,6 +96,7 @@ pub trait LaunchedBinary: Send + Sync {
     fn stdout_filter(&self, prefix: String) -> mpsc::UnboundedReceiver<String>;
     fn stderr_filter(&self, prefix: String) -> mpsc::UnboundedReceiver<String>;
 
+    #[cfg(feature = "profile-folding")]
     fn tracing_results(&self) -> Option<&TracingResults>;
 
     fn exit_code(&self) -> Option<i32>;

--- a/hydro_deploy/core/src/localhost/mod.rs
+++ b/hydro_deploy/core/src/localhost/mod.rs
@@ -17,6 +17,7 @@ use crate::{
 pub mod launched_binary;
 pub use launched_binary::*;
 
+#[cfg(feature = "profile-folding")]
 #[cfg(any(target_os = "macos", target_family = "windows"))]
 mod samply;
 

--- a/hydro_deploy/core/src/rust_crate/mod.rs
+++ b/hydro_deploy/core/src/rust_crate/mod.rs
@@ -14,6 +14,7 @@ pub mod ports;
 pub mod service;
 pub use service::*;
 
+#[cfg(feature = "profile-folding")]
 pub(crate) mod flamegraph;
 pub mod tracing_options;
 

--- a/hydro_deploy/core/src/rust_crate/service.rs
+++ b/hydro_deploy/core/src/rust_crate/service.rs
@@ -13,10 +13,12 @@ use tokio::sync::{OnceCell, RwLock, mpsc};
 use super::build::{BuildError, BuildOutput, BuildParams, build_crate_memoized};
 use super::ports::{self, RustCratePortConfig};
 use super::tracing_options::TracingOptions;
+#[cfg(feature = "profile-folding")]
+use crate::TracingResults;
 use crate::progress::ProgressTracker;
 use crate::{
     BaseServerStrategy, Host, LaunchedBinary, LaunchedHost, PortNetworkHint, ResourceBatch,
-    ResourceResult, ServerStrategy, Service, TracingResults,
+    ResourceResult, ServerStrategy, Service,
 };
 
 pub struct RustCrateService {
@@ -125,6 +127,7 @@ impl RustCrateService {
         self.launched_binary.get().unwrap().stderr_filter(prefix)
     }
 
+    #[cfg(feature = "profile-folding")]
     pub fn tracing_results(&self) -> Option<&TracingResults> {
         self.launched_binary.get().unwrap().tracing_results()
     }

--- a/hydro_deploy/core/src/rust_crate/tracing_options.rs
+++ b/hydro_deploy/core/src/rust_crate/tracing_options.rs
@@ -7,8 +7,10 @@
 use std::borrow::Cow;
 use std::path::PathBuf;
 
+#[cfg(feature = "profile-folding")]
 use inferno::collapse::perf::Options as PerfOptions;
 
+#[cfg(feature = "profile-folding")]
 type FlamegraphOptions = inferno::flamegraph::Options<'static>;
 
 /// `Cow<'static, str>`.
@@ -33,10 +35,12 @@ pub struct TracingOptions {
     // pub perf_script_outfile: Option<PathBuf>,
     /// If set, what the write the folded output to.
     pub fold_outfile: Option<PathBuf>,
+    #[cfg(feature = "profile-folding")]
     pub fold_perf_options: Option<PerfOptions>,
     /// If set, what to write the output flamegraph SVG file to.
     pub flamegraph_outfile: Option<PathBuf>,
     // This type is super annoying and isn't `clone` and has a lifetime... so wrap in fn pointer for now.
+    #[cfg(feature = "profile-folding")]
     pub flamegraph_options: Option<fn() -> FlamegraphOptions>,
 
     /// Command to setup tracing before running the command, i.e. to install `perf` or set kernel flags.

--- a/hydro_deploy/core/src/ssh.rs
+++ b/hydro_deploy/core/src/ssh.rs
@@ -1,6 +1,8 @@
 use std::net::SocketAddr;
 use std::path::PathBuf;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
+#[cfg(feature = "profile-folding")]
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use anyhow::{Context as _, Result};
@@ -11,23 +13,31 @@ use async_ssh2_russh::sftp::SftpError;
 use async_ssh2_russh::{AsyncChannel, AsyncSession, NoCheckHandler};
 use async_trait::async_trait;
 use hydro_deploy_integration::ServerBindConfig;
+#[cfg(feature = "profile-folding")]
 use inferno::collapse::Collapse;
+#[cfg(feature = "profile-folding")]
 use inferno::collapse::perf::Folder;
 use nanoid::nanoid;
 use tokio::fs::File;
-use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+#[cfg(feature = "profile-folding")]
+use tokio::io::BufReader;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio::sync::{mpsc, oneshot};
 use tokio_stream::StreamExt;
 use tokio_stream::wrappers::LinesStream;
+#[cfg(feature = "profile-folding")]
 use tokio_util::io::SyncIoBridge;
 
+#[cfg(feature = "profile-folding")]
+use crate::TracingResults;
 use crate::progress::ProgressTracker;
 use crate::rust_crate::build::BuildOutput;
+#[cfg(feature = "profile-folding")]
 use crate::rust_crate::flamegraph::handle_fold_data;
 use crate::rust_crate::tracing_options::TracingOptions;
 use crate::util::{PriorityBroadcast, async_retry, prioritized_broadcast};
-use crate::{BaseServerStrategy, LaunchedBinary, LaunchedHost, ResourceResult, TracingResults};
+use crate::{BaseServerStrategy, LaunchedBinary, LaunchedHost, ResourceResult};
 
 const PERF_OUTFILE: &str = "__profile.perf.data";
 
@@ -42,6 +52,7 @@ struct LaunchedSshBinary {
     stdout_broadcast: PriorityBroadcast,
     stderr_broadcast: PriorityBroadcast,
     tracing: Option<TracingOptions>,
+    #[cfg(feature = "profile-folding")]
     tracing_results: OnceLock<TracingResults>,
 }
 
@@ -71,6 +82,7 @@ impl LaunchedBinary for LaunchedSshBinary {
         self.stderr_broadcast.receive(Some(prefix))
     }
 
+    #[cfg(feature = "profile-folding")]
     fn tracing_results(&self) -> Option<&TracingResults> {
         self.tracing_results.get()
     }
@@ -103,6 +115,7 @@ impl LaunchedBinary for LaunchedSshBinary {
 
         // Run perf post-processing and download perf output.
         if let Some(tracing) = self.tracing.as_ref() {
+            #[cfg(feature = "profile-folding")]
             assert!(
                 self.tracing_results.get().is_none(),
                 "`tracing_results` already set! Was `stop()` called twice? This is a bug."
@@ -137,9 +150,12 @@ impl LaunchedBinary for LaunchedSshBinary {
                 .await?;
             }
 
+            #[cfg(feature = "profile-folding")]
             let script_channel = session.open_channel().await?;
+            #[cfg(feature = "profile-folding")]
             let mut fold_er = Folder::from(tracing.fold_perf_options.clone().unwrap_or_default());
 
+            #[cfg(feature = "profile-folding")]
             let fold_data = ProgressTracker::leaf("perf script & folding", async move {
                 let mut stderr_lines = script_channel.stderr().lines();
                 let stdout = script_channel.stdout();
@@ -177,12 +193,14 @@ impl LaunchedBinary for LaunchedSshBinary {
             })
             .await?;
 
+            #[cfg(feature = "profile-folding")]
             self.tracing_results
                 .set(TracingResults {
                     folded_data: fold_data.clone(),
                 })
                 .expect("`tracing_results` already set! This is a bug.");
 
+            #[cfg(feature = "profile-folding")]
             handle_fold_data(tracing, fold_data).await?;
         };
 
@@ -459,6 +477,7 @@ impl<T: LaunchedSshHost> LaunchedHost for T {
             stdout_broadcast,
             stderr_broadcast,
             tracing,
+            #[cfg(feature = "profile-folding")]
             tracing_results: OnceLock::new(),
         }))
     }

--- a/hydro_lang/src/deploy/deploy_graph.rs
+++ b/hydro_lang/src/deploy/deploy_graph.rs
@@ -15,7 +15,7 @@ use hydro_deploy::custom_service::CustomClientPort;
 use hydro_deploy::rust_crate::RustCrateService;
 use hydro_deploy::rust_crate::ports::{DemuxSink, RustCrateSink, RustCrateSource, TaggedSource};
 use hydro_deploy::rust_crate::tracing_options::TracingOptions;
-use hydro_deploy::{CustomService, Deployment, Host, RustCrate, TracingResults};
+use hydro_deploy::{CustomService, Deployment, Host, RustCrate};
 use hydro_deploy_integration::{ConnectedSink, ConnectedSource};
 use nameof::name_of;
 use proc_macro2::Span;
@@ -438,10 +438,6 @@ pub trait DeployCrateWrapper {
         prefix: impl Into<String>,
     ) -> tokio::sync::mpsc::UnboundedReceiver<String> {
         self.underlying().stderr_filter(prefix.into())
-    }
-
-    fn tracing_results(&self) -> Option<TracingResults> {
-        self.underlying().tracing_results().cloned()
     }
 }
 


### PR DESCRIPTION

BREAKING CHANGE: Hydro Deploy APIs for extracting folded profiles / flamegraphs now require the `profile-folding` feature.
