### PR TITLE
docs: remove border above "You will learn" header

### DIFF
--- a/docs/src/theme/Admonition/Types.js
+++ b/docs/src/theme/Admonition/Types.js
@@ -1,36 +1,52 @@
-import DefaultAdmonitionTypes from '@theme-original/Admonition/Types';
-import styles from '@docusaurus/theme-classic/src/theme/Admonition/Layout/styles.module.css';
-import {ThemeClassNames} from '@docusaurus/theme-common';
+import DefaultAdmonitionTypes from "@theme-original/Admonition/Types";
+import styles from "@docusaurus/theme-classic/src/theme/Admonition/Layout/styles.module.css";
+import { ThemeClassNames } from "@docusaurus/theme-common";
 
-import clsx from 'clsx';
+import clsx from "clsx";
 
 function LearnAdmonition(props) {
   const { children } = props;
-  return  <div
-    className={clsx(
-      ThemeClassNames.common.admonition,
-      ThemeClassNames.common.admonitionType("tip"),
-      styles.admonition,
-      "alert alert--success",
-    )} style={{
-      "--ifm-alert-background-color": "rgb(206 189 255 / 26%)",
-      "--ifm-alert-background-color-highlight": "rgb(35 0 164 / 15%)",
-      "--ifm-alert-border-left-width": "0px",
-      "--ifm-list-left-padding": "1.75rem"
-    }}>
-      <h3 style={{ fontFamily: "inherit", marginBottom: "10px" }}>You will learn</h3>
-      <div className={styles.admonitionContent} style={{
-        fontSize: "1.05em"
-      }}>
+  return (
+    <div
+      className={clsx(
+        ThemeClassNames.common.admonition,
+        ThemeClassNames.common.admonitionType("tip"),
+        styles.admonition,
+        "alert alert--success",
+      )}
+      style={{
+        "--ifm-alert-background-color": "rgb(206 189 255 / 26%)",
+        "--ifm-alert-background-color-highlight": "rgb(35 0 164 / 15%)",
+        "--ifm-alert-border-left-width": "0px",
+        "--ifm-list-left-padding": "1.75rem",
+      }}
+    >
+      <h3
+        style={{
+          fontFamily: "inherit",
+          marginBottom: "10px",
+          borderTop: "none",
+          paddingTop: "0px",
+        }}
+      >
+        You will learn
+      </h3>
+      <div
+        className={styles.admonitionContent}
+        style={{
+          fontSize: "1.05em",
+        }}
+      >
         {children}
       </div>
-  </div>
+    </div>
+  );
 }
 
 const AdmonitionTypes = {
   ...DefaultAdmonitionTypes,
 
-  'learn': LearnAdmonition,
+  learn: LearnAdmonition,
 };
 
 export default AdmonitionTypes;


### PR DESCRIPTION

Appears to have been added in a Docusaurus update, restores the original formatting.
