### PR TITLE
fix(hydro_lang): mutate Stageleft `gen_staged` in-place to avoid AST copies during pretty-print

### DIFF
--- a/hydro_lang/src/compile/trybuild/generate.rs
+++ b/hydro_lang/src/compile/trybuild/generate.rs
@@ -87,24 +87,27 @@ pub fn create_graph_trybuild(
     );
 
     let inlined_staged = if is_test {
-        let gen_staged = stageleft_tool::gen_staged_trybuild(
+        let mut gen_staged = stageleft_tool::gen_staged_trybuild(
             &path!(source_dir / "src" / "lib.rs"),
             &path!(source_dir / "Cargo.toml"),
             crate_name.clone(),
             Some("hydro___test".to_string()),
         );
 
-        Some(prettyplease::unparse(&syn::parse_quote! {
-            #![allow(
-                unused,
-                ambiguous_glob_reexports,
-                clippy::suspicious_else_formatting,
-                unexpected_cfgs,
-                reason = "generated code"
-            )]
+        gen_staged.attrs.insert(
+            0,
+            syn::parse_quote! {
+                #![allow(
+                    unused,
+                    ambiguous_glob_reexports,
+                    clippy::suspicious_else_formatting,
+                    unexpected_cfgs,
+                    reason = "generated code"
+                )]
+            },
+        );
 
-            #gen_staged
-        }))
+        Some(prettyplease::unparse(&gen_staged))
     } else {
         None
     };

--- a/hydro_lang/src/sim/graph.rs
+++ b/hydro_lang/src/sim/graph.rs
@@ -529,7 +529,7 @@ pub(super) fn create_sim_graph_trybuild(
             .and_then(|lib| lib.get("path"))
             .and_then(|path| path.as_str());
 
-        let gen_staged = stageleft_tool::gen_staged_trybuild(
+        let mut gen_staged = stageleft_tool::gen_staged_trybuild(
             &maybe_custom_lib_path
                 .map(|s| path!(source_dir / s))
                 .unwrap_or_else(|| path!(source_dir / "src" / "lib.rs")),
@@ -538,17 +538,20 @@ pub(super) fn create_sim_graph_trybuild(
             Some("hydro___test".to_string()),
         );
 
-        Some(prettyplease::unparse(&syn::parse_quote! {
-            #![allow(
-                unused,
-                ambiguous_glob_reexports,
-                clippy::suspicious_else_formatting,
-                unexpected_cfgs,
-                reason = "generated code"
-            )]
+        gen_staged.attrs.insert(
+            0,
+            syn::parse_quote! {
+                #![allow(
+                    unused,
+                    ambiguous_glob_reexports,
+                    clippy::suspicious_else_formatting,
+                    unexpected_cfgs,
+                    reason = "generated code"
+                )]
+            },
+        );
 
-            #gen_staged
-        }))
+        Some(prettyplease::unparse(&gen_staged))
     } else {
         None
     };


### PR DESCRIPTION

Reduces time to pretty-print from ~350ms to ~80ms for `hydro_lang` crate.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydro-project/hydro/pull/2452).
* #2453
* #2457
* __->__ #2452