### PR TITLE
feat(hydro_lang): bump Stageleft to reduce Trybuild prep latency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5640,9 +5640,9 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stageleft"
-version = "0.11.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d298ebe7d1c345ace8f9aa75de8e80dc11cf3c7263be203b3e1d3686eee073"
+checksum = "36eaefb60f9f46e22a155170c369356ce23f7f86f66e262247215a9d38a5b20a"
 dependencies = [
  "ctor 0.4.3",
  "proc-macro-crate 3.4.0",
@@ -5654,9 +5654,9 @@ dependencies = [
 
 [[package]]
 name = "stageleft_macro"
-version = "0.11.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75caa0673619e888064be2c6776d5d776333f07fff4d2c13e76570769f92766"
+checksum = "49d0693d2610bb355238fb72ff5ab1ad75523314cca9f5896338f75342715213"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -5667,9 +5667,9 @@ dependencies = [
 
 [[package]]
 name = "stageleft_tool"
-version = "0.11.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62dbaa8c42dbec00aa24188b6a8a568021e70b132fa1944f9c7f035510934f5a"
+checksum = "9c0507e668793592e373859d47549ce55b45fff3a475385ea1d9d2f42139a3d3"
 dependencies = [
  "prettyplease",
  "proc-macro-crate 3.4.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,5 +74,5 @@ uninlined_format_args = "allow"
 upper_case_acronyms = "warn"
 
 [workspace.dependencies]
-stageleft = "0.11.0"
-stageleft_tool = "0.11.0"
+stageleft = "0.13.0"
+stageleft_tool = "0.13.0"

--- a/hydro_lang/src/compile/trybuild/generate.rs
+++ b/hydro_lang/src/compile/trybuild/generate.rs
@@ -118,7 +118,7 @@ pub fn create_graph_trybuild(
                 .map(|s| path!(source_dir / s))
                 .unwrap_or_else(|| path!(source_dir / "src" / "lib.rs")),
             &path!(source_dir / "Cargo.toml"),
-            crate_name.clone(),
+            crate_name,
             Some("hydro___test".to_string()),
         );
 

--- a/hydro_lang/src/lib.rs
+++ b/hydro_lang/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![warn(missing_docs)]
+#![cfg_attr(not(stageleft_trybuild), warn(missing_docs))]
 
 //! Hydro is a high-level distributed programming framework for Rust.
 //! Hydro can help you quickly write scalable distributed services that are correct by construction.

--- a/hydro_lang/src/sim/graph.rs
+++ b/hydro_lang/src/sim/graph.rs
@@ -522,7 +522,7 @@ pub(super) fn create_sim_graph_trybuild(
                 .map(|s| path!(source_dir / s))
                 .unwrap_or_else(|| path!(source_dir / "src" / "lib.rs")),
             &path!(source_dir / "Cargo.toml"),
-            crate_name.clone(),
+            crate_name,
             Some("hydro___test".to_string()),
         );
 

--- a/template/hydro/Cargo.toml
+++ b/template/hydro/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2024"
 [dependencies]
 hydro_lang = { git = "{{ hydro_git | default: 'https://github.com/hydro-project/hydro.git' }}", branch = "{{ hydro_branch | default: 'main' }}" }
 hydro_std = { git = "{{ hydro_git | default: 'https://github.com/hydro-project/hydro.git' }}", branch = "{{ hydro_branch | default: 'main' }}" }
-stageleft = "0.11.0"
+stageleft = "0.13.0"
 
 [build-dependencies]
-stageleft_tool = "0.11.0"
+stageleft_tool = "0.13.0"
 
 [dev-dependencies]
 ctor = "0.2"


### PR DESCRIPTION

Avoids double-loading the crate tree and includes several fixes and optimizations to how the `__staged` module is generated.
