### PR TITLE
fix(hydro_test): don't add custom rustflags for chat example

### DIFF
--- a/hydro_test/examples/chat.rs
+++ b/hydro_test/examples/chat.rs
@@ -67,12 +67,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Box::new(move |_| -> Arc<dyn Host> { localhost.clone() })
     };
 
-    let rustflags = if args.gcp.is_some() || args.aws {
-        "-C opt-level=3 -C codegen-units=1 -C strip=none -C debuginfo=2 -C lto=off -C link-args=--no-rosegment"
-    } else {
-        "-C opt-level=3 -C codegen-units=1 -C strip=none -C debuginfo=2 -C lto=off"
-    };
-
     let flow = hydro_lang::compile::builder::FlowBuilder::new();
 
     let process = flow.process::<()>();
@@ -101,10 +95,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Now use the built flow for deployment with optimization
     let nodes = built
         .with_default_optimize()
-        .with_process(
-            &process,
-            TrybuildHost::new(create_host(&mut deployment)).rustflags(rustflags),
-        )
+        .with_process(&process, TrybuildHost::new(create_host(&mut deployment)))
         .with_external(&external, deployment.Localhost())
         .deploy(&mut deployment);
 


### PR DESCRIPTION

Unnecessarily slows down tests by re-compiling everything with `-O3`.
