### PR TITLE
fix(hydro_lang): make backtrace resolution lazy to reduce graph compilation overhead

### DIFF
--- a/hydro_deploy/core/src/rust_crate/build.rs
+++ b/hydro_deploy/core/src/rust_crate/build.rs
@@ -108,7 +108,7 @@ pub async fn build_crate_memoized(params: BuildParams) -> Result<&'static BuildO
             ProgressTracker::rich_leaf("build", move |set_msg| async move {
                 tokio::task::spawn_blocking(move || {
                     let mut command = Command::new("cargo");
-                    command.args(["build", "--locked"]);
+                    command.args(["build", "--frozen"]);
 
                     if let Some(profile) = params.profile.as_ref() {
                         command.args(["--profile", profile]);

--- a/hydro_lang/src/compile/ir/backtrace.rs
+++ b/hydro_lang/src/compile/ir/backtrace.rs
@@ -5,6 +5,11 @@
 use std::cell::RefCell;
 #[cfg(feature = "build")]
 use std::fmt::Debug;
+#[cfg(feature = "build")]
+use std::sync::OnceLock;
+
+#[cfg(feature = "build")]
+use backtrace::BacktraceFrame;
 
 /// Strips `[hash]` patterns from nightly compiler symbol names.
 #[cfg(feature = "build")]
@@ -38,8 +43,7 @@ pub struct Backtrace;
 pub struct Backtrace {
     skip_count: usize,
     col_offset: usize, // whether this is from `sliced!` which requires an offset
-    inner: RefCell<backtrace::Backtrace>,
-    resolved: RefCell<Option<Vec<BacktraceElement>>>,
+    frames: Vec<(RefCell<Option<BacktraceFrame>>, OnceLock<BacktraceFrame>)>,
 }
 
 #[cfg(stageleft_runtime)]
@@ -62,11 +66,14 @@ impl Backtrace {
     #[inline(never)]
     pub(crate) fn get_backtrace(skip_count: usize) -> Backtrace {
         let backtrace = backtrace::Backtrace::new_unresolved();
+        let frames_vec: Vec<_> = backtrace.into();
         Backtrace {
             skip_count,
             col_offset: 0,
-            inner: RefCell::new(backtrace),
-            resolved: RefCell::new(None),
+            frames: frames_vec
+                .into_iter()
+                .map(|f| (RefCell::new(Some(f)), OnceLock::new()))
+                .collect(),
         }
     }
 
@@ -75,65 +82,62 @@ impl Backtrace {
         panic!();
     }
 
+    #[cfg(feature = "build")]
     /// Gets the elements of the backtrace including inlined frames.
     ///
     /// Excludes all backtrace elements up to the original `get_backtrace` call as
     /// well as additional skipped frames from that call. Also drops the suffix
     /// of frames from `__rust_begin_short_backtrace` onwards.
-    #[cfg(feature = "build")]
-    pub fn elements(&self) -> Vec<BacktraceElement> {
-        self.resolved
-            .borrow_mut()
-            .get_or_insert_with(|| {
-                let mut inner_borrow = self.inner.borrow_mut();
-                inner_borrow.resolve();
-                let mut collected: Vec<_> = inner_borrow
-                    .frames()
-                    .iter()
-                    .skip_while(|f| {
-                        !(std::ptr::eq(f.symbol_address(), Backtrace::get_backtrace as _)
-                            || f.symbols()
-                                .first()
-                                .and_then(|s| s.name())
-                                .and_then(|n| n.as_str())
-                                .is_some_and(|n| n.contains("get_backtrace")))
-                    })
-                    .skip(1)
-                    .take_while(|f| {
-                        !f.symbols()
-                            .last()
-                            .and_then(|s| s.name())
-                            .and_then(|n| n.as_str())
-                            .is_some_and(|n| n.contains("__rust_begin_short_backtrace"))
-                    })
-                    .flat_map(|frame| frame.symbols())
-                    .skip(self.skip_count)
-                    .map(|symbol| {
-                        let full_fn_name = strip_hash_brackets(&symbol.name().unwrap().to_string());
-                        BacktraceElement {
-                            fn_name: full_fn_name
-                                .rfind("::")
-                                .map(|idx| full_fn_name.split_at(idx).0.to_string())
-                                .unwrap_or(full_fn_name),
-                            filename: symbol.filename().map(|f| f.display().to_string()),
-                            lineno: symbol.lineno(),
-                            colno: symbol.colno(),
-                            addr: symbol.addr().map(|a| a as usize),
-                        }
-                    })
-                    .collect();
+    pub fn elements(&self) -> impl Iterator<Item = BacktraceElement> + '_ {
+        self.frames
+            .iter()
+            .map(|(frame_refcell, resolved_frame)| {
+                resolved_frame.get_or_init(|| {
+                    let mut gotten_frame = frame_refcell.borrow_mut().take().unwrap();
+                    gotten_frame.resolve();
+                    gotten_frame
+                })
+            })
+            .skip_while(|f| {
+                !(std::ptr::eq(f.symbol_address(), Backtrace::get_backtrace as _)
+                    || f.symbols()
+                        .first()
+                        .and_then(|s| s.name())
+                        .and_then(|n| n.as_str())
+                        .is_some_and(|n| n.contains("get_backtrace")))
+            })
+            .skip(1)
+            .take_while(|f| {
+                !f.symbols()
+                    .last()
+                    .and_then(|s| s.name())
+                    .and_then(|n| n.as_str())
+                    .is_some_and(|n| n.contains("__rust_begin_short_backtrace"))
+            })
+            .flat_map(move |frame| frame.symbols())
+            .skip(self.skip_count)
+            .enumerate()
+            .map(|(idx, symbol)| {
+                let full_fn_name = strip_hash_brackets(&symbol.name().unwrap().to_string());
+                let mut element = BacktraceElement {
+                    fn_name: full_fn_name
+                        .rfind("::")
+                        .map(|idx| full_fn_name.split_at(idx).0.to_string())
+                        .unwrap_or(full_fn_name),
+                    filename: symbol.filename().map(|f| f.display().to_string()),
+                    lineno: symbol.lineno(),
+                    colno: symbol.colno(),
+                    addr: symbol.addr().map(|a| a as usize),
+                };
 
-                if self.col_offset > 0
-                    && let Some(first) = collected.first_mut()
-                {
-                    first.colno = first
+                if self.col_offset > 0 && idx == 0 {
+                    element.colno = element
                         .colno
                         .map(|c| c.saturating_sub(self.col_offset as u32));
                 }
 
-                collected
+                element
             })
-            .clone()
     }
 }
 
@@ -180,6 +184,6 @@ mod tests {
         let backtrace = Backtrace::get_backtrace(0);
         let elements = backtrace.elements();
 
-        hydro_build_utils::assert_debug_snapshot!(elements);
+        hydro_build_utils::assert_debug_snapshot!(elements.collect::<Vec<_>>());
     }
 }

--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -3871,7 +3871,7 @@ mod test {
         ignore = "expects inclusion of feature-gated fields"
     )]
     fn hydro_node_size() {
-        assert_eq!(size_of::<HydroNode>(), 272);
+        assert_eq!(size_of::<HydroNode>(), 240);
     }
 
     #[test]
@@ -3880,7 +3880,7 @@ mod test {
         ignore = "expects inclusion of feature-gated fields"
     )]
     fn hydro_root_size() {
-        assert_eq!(size_of::<HydroRoot>(), 168);
+        assert_eq!(size_of::<HydroRoot>(), 136);
     }
 
     #[test]

--- a/hydro_lang/src/compile/ir/snapshots/backtrace.snap
+++ b/hydro_lang/src/compile/ir/snapshots/backtrace.snap
@@ -6,7 +6,7 @@ expression: elements
     BacktraceElement {
         fn_name: "hydro_lang::compile::ir::backtrace::tests::test_backtrace",
         lineno: Some(
-            180,
+            184,
         ),
         colno: Some(
             25,
@@ -15,7 +15,7 @@ expression: elements
     BacktraceElement {
         fn_name: "hydro_lang::compile::ir::backtrace::tests::test_backtrace::{{closure}}",
         lineno: Some(
-            172,
+            176,
         ),
         colno: Some(
             24,

--- a/hydro_lang/src/live_collections/stream/tests/backtrace_chained_ops.rs
+++ b/hydro_lang/src/live_collections/stream/tests/backtrace_chained_ops.rs
@@ -34,6 +34,8 @@ fn backtrace_chained_ops() {
     };
     let for_each_meta = finalized.ir()[0].op_metadata();
 
-    hydro_build_utils::assert_debug_snapshot!(source_meta.backtrace.elements());
-    hydro_build_utils::assert_debug_snapshot!(for_each_meta.backtrace.elements());
+    hydro_build_utils::assert_debug_snapshot!(source_meta.backtrace.elements().collect::<Vec<_>>());
+    hydro_build_utils::assert_debug_snapshot!(
+        for_each_meta.backtrace.elements().collect::<Vec<_>>()
+    );
 }

--- a/hydro_lang/src/sim/builder.rs
+++ b/hydro_lang/src/sim/builder.rs
@@ -369,7 +369,7 @@ impl DfirBuilder for SimBuilder {
                     );
                 }
                 _ => {
-                    eprintln!("{:?}", op_meta.backtrace.elements());
+                    eprintln!("{:?}", op_meta.backtrace.elements().collect::<Vec<_>>());
                     todo!("batch not implemented for kind {:?}", in_kind)
                 }
             }
@@ -974,7 +974,7 @@ fn location_for_op(op_meta: &HydroIrOpMetadata) -> (String, String, String) {
     op_meta
         .backtrace
         .elements()
-        .first()
+        .next()
         .and_then(|e| {
             let filename = e.filename.as_deref()?;
             let lineno = e.lineno?;

--- a/hydro_lang/src/sim/compiled.rs
+++ b/hydro_lang/src/sim/compiled.rs
@@ -141,7 +141,9 @@ impl CompiledSim {
 
         eprintln!(
             "backtrace: {:?}",
-            crate::compile::ir::backtrace::Backtrace::get_backtrace(0).elements()
+            crate::compile::ir::backtrace::Backtrace::get_backtrace(0)
+                .elements()
+                .collect::<Vec<_>>()
         );
 
         let caller_path = Path::new(&caller_fn.filename.unwrap()).to_path_buf();

--- a/hydro_lang/src/sim/graph.rs
+++ b/hydro_lang/src/sim/graph.rs
@@ -360,7 +360,7 @@ impl<'a> Deploy<'a> for SimDeploy {
 pub(super) fn compile_sim(bin: String, trybuild: TrybuildConfig) -> Result<TempPath, ()> {
     let mut command = Command::new("cargo");
     command.current_dir(&trybuild.project_dir);
-    command.args(["rustc", "--locked"]);
+    command.args(["rustc", "--frozen"]);
     command.args(["--example", "sim-dylib"]);
     command.args(["--target-dir", trybuild.target_dir.to_str().unwrap()]);
     if let Some(features) = &trybuild.features {

--- a/hydro_lang/src/viz/json.rs
+++ b/hydro_lang/src/viz/json.rs
@@ -249,7 +249,6 @@ impl<W> HydroJson<W> {
 
             // filter out obviously internal frames
             let relevant_frames: Vec<BacktraceFrame> = elements
-                .iter()
                 .map(|elem| {
                     // Truncate paths and function names for size
                     let short_filename = elem
@@ -697,7 +696,7 @@ impl<W> HydroJson<W> {
                 && let Ok(node_id) = node_id_str.parse::<VizNodeKey>()
                 && let Some(backtrace) = self.node_backtraces.get(&node_id)
             {
-                let elements = backtrace.elements();
+                let elements = backtrace.elements().collect::<Vec<_>>();
                 if elements.is_empty() {
                     continue;
                 }


### PR DESCRIPTION

Reduces latency of compiling a simulation graph (for `sim_batch_unordered_shuffles_count`) from ~270ms to ~200ms
