### PR TITLE
feat(hydro_lang): share target dir between main and trybuild

### DIFF
--- a/hydro_lang/src/compile/trybuild/generate.rs
+++ b/hydro_lang/src/compile/trybuild/generate.rs
@@ -629,7 +629,7 @@ members = ["dylib", "dylib-examples"]
 
     Ok((
         project.dir.as_ref().into(),
-        path!(project.target_dir / "hydro_trybuild"),
+        project.target_dir.as_ref().into(),
         project.features,
     ))
 }


### PR DESCRIPTION

This dramatically reduces disk usage (~50%) as well as first-test compilation latency since the vast majority (all crates outside this repo) of crate compilations are entirely shared between compiling the outer (regular) crate and the generated trybuild crate.

Fixes #2444
