### PR TITLE
docs(hydro_lang): inline code snippets

### DIFF
--- a/docs/docs/hydro/learn/quickstart/concurrent-clients.mdx
+++ b/docs/docs/hydro/learn/quickstart/concurrent-clients.mdx
@@ -34,7 +34,15 @@ Hydro provides [`KeyedStream`](../../reference/live-collections/keyed-streams.md
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/concurrent_clients.rs">src/concurrent_clients.rs</Link>
-} showLineNumbers={6}>{getLines(concurrentClientsSrc, 6, 12)}</CodeBlock>
+} showLineNumbers={6}>{getLines(concurrentClientsSrc, 6, 12, `
+pub fn concurrent_counter_service<'a>(
+    increment_requests: KeyedStream<u32, (), Process<'a, CounterServer>>,
+    get_requests: KeyedStream<u32, (), Process<'a, CounterServer>>,
+) -> (
+    KeyedStream<u32, (), Process<'a, CounterServer>>, // increment acknowledgments
+    KeyedStream<u32, usize, Process<'a, CounterServer>>, // get responses
+) {
+`)}</CodeBlock>
 
 The service now takes `KeyedStream<u32, ()>` instead of `Stream<()>`. Each request is tagged with a client ID, so when client 1 sends an increment request, it appears as a keyed stream element with key `1` and value `()`.
 
@@ -44,7 +52,11 @@ The counter still maintains a single global count across all clients. Since the 
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/concurrent_clients.rs">src/concurrent_clients.rs</Link>
-} showLineNumbers={13}>{getLines(concurrentClientsSrc, 13, 15)}</CodeBlock>
+} showLineNumbers={13}>{getLines(concurrentClientsSrc, 13, 15, `
+let atomic_tick = increment_requests.location().tick();
+let increment_request_processing = increment_requests.atomic(&atomic_tick);
+let current_count = increment_request_processing.clone().values().count();
+`)}</CodeBlock>
 
 The `.values()` method extracts just the values from the keyed stream, discarding the client IDs since they're irrelevant for computing the global count. This produces a regular `Stream<()>` containing all increment requests from all clients. 
 
@@ -60,13 +72,21 @@ The rest of the implementation follows the same pattern as the single client cou
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/concurrent_clients.rs">src/concurrent_clients.rs</Link>
-} showLineNumbers={16}>{getLines(concurrentClientsSrc, 16, 16)}</CodeBlock>
+} showLineNumbers={16}>{getLines(concurrentClientsSrc, 16, 16, `
+let increment_ack = increment_request_processing.end_atomic();
+`)}</CodeBlock>
 
 And get responses use `cross_singleton` which pairs the count with each client's request while preserving the client ID key:
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/concurrent_clients.rs">src/concurrent_clients.rs</Link>
-} showLineNumbers={18}>{getLines(concurrentClientsSrc, 18, 23)}</CodeBlock>
+} showLineNumbers={18}>{getLines(concurrentClientsSrc, 18, 23, `
+let get_response = sliced! {
+    let request_batch = use(get_requests, nondet!(/** we never observe batch boundaries */));
+    let count_snapshot = use::atomic(current_count, nondet!(/** atomicity guarantees consistency wrt increments */));
+    request_batch.cross_singleton(count_snapshot).map(q!(|(_, count)| count))
+};
+`)}</CodeBlock>
 
 ## Testing Multiple Concurrent Clients
 
@@ -74,7 +94,34 @@ Let's write a test where two different clients increment the counter and both re
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/concurrent_clients.rs">src/concurrent_clients.rs</Link>
-} showLineNumbers={34}>{getLines(concurrentClientsSrc, 34, 67)}</CodeBlock>
+} showLineNumbers={34}>{getLines(concurrentClientsSrc, 34, 67, `
+#[test]
+fn test_concurrent_clients() {
+    let mut flow = FlowBuilder::new();
+    let process = flow.process();
+    let (inc_in_port, inc_requests) = process.sim_input();
+    let inc_requests = inc_requests.into_keyed();
+    let (get_in_port, get_requests) = process.sim_input();
+    let get_requests = get_requests.into_keyed();
+    let (inc_acks, get_responses) = concurrent_counter_service(inc_requests, get_requests);
+    let inc_out_port = inc_acks.entries().sim_output();
+    let get_out_port = get_responses.entries().sim_output();
+    flow.sim().exhaustive(async || {
+        // Client 1 increments
+        inc_in_port.send((1, ()));
+        inc_out_port.assert_yields_unordered([(1, ())]).await;
+        // Client 2 increments
+        inc_in_port.send((2, ()));
+        inc_out_port.assert_yields_unordered([(2, ())]).await;
+        // Client 1 reads - should see 2
+        get_in_port.send((1, ()));
+        get_out_port.assert_yields_unordered([(1, 2)]).await;
+        // Client 2 reads - should also see 2
+        get_in_port.send((2, ()));
+        get_out_port.assert_yields_unordered([(2, 2)]).await;
+    });
+}
+`)}</CodeBlock>
 
 The test uses `.into_keyed()` to convert regular streams into keyed streams for input, and `.entries()` to convert keyed streams back to regular streams of `(key, value)` tuples for output. This is necessary because the simulator currently only supports `Stream` as inputs and outputs.
 

--- a/docs/docs/hydro/learn/quickstart/index.mdx
+++ b/docs/docs/hydro/learn/quickstart/index.mdx
@@ -55,13 +55,23 @@ Hydro projects are typically organized into two folders:
 Let's take a look at the initial Hydro code in `src/lib.rs`, which implements an echo server. The top of the file initializes the project (this only needs to be done once, in `lib.rs`) and imports the Hydro prelude, which includes common Hydro APIs (you will want to do this in each file):
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/template/hydro/src/lib.rs">src/lib.rs</Link>
-} showLineNumbers={1}>{getLines(libRsSrc, 1, 4)}</CodeBlock>
+} showLineNumbers={1}>{getLines(libRsSrc, 1, 4, `
+#[cfg(stageleft_runtime)]
+hydro_lang::setup!();
+
+use hydro_lang::prelude::*;
+`)}</CodeBlock>
 
 Next, the template defines the echo server function. The server takes in a stream of requests and responds with the text of each request capitalized. Hydro uses a stream programming model, which means that instead of the server taking a single request as a parameter, it takes in a _stream_ of requests that arrive over time. Similarly, the responses are sent back as a stream of values.
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/template/hydro/src/lib.rs">src/lib.rs</Link>
-} showLineNumbers={6}>{getLines(libRsSrc, 6, 9)}</CodeBlock>
+} showLineNumbers={6}>{getLines(libRsSrc, 6, 9, `
+pub struct EchoServer;
+pub fn echo_capitalize<'a>(
+    input: Stream<String, Process<'a, EchoServer>>,
+) -> Stream<String, Process<'a, EchoServer>> {
+`)}</CodeBlock>
 
 Let's dive into the parameters of this function. The input is a [`Stream`](../../reference/live-collections/streams.md), a [**Live Collection**](../../reference/live-collections/index.md) where new incoming requests arrive over time. The first type parameter, `String`, tells us that each incoming request will appear as a `String` element.
 
@@ -72,7 +82,14 @@ Locations are **tagged** with a type to distinguish them at compile-time. In the
 Finally, let us take a look at the function body:
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/template/hydro/src/lib.rs">src/lib.rs</Link>
-} showLineNumbers={7}>{getLines(highlightLines(libRsSrc, [10]), 7, 12)}</CodeBlock>
+} showLineNumbers={7}>{getLines(highlightLines(libRsSrc, [10]), 7, 12, `
+pub fn echo_capitalize<'a>(
+    input: Stream<String, Process<'a, EchoServer>>,
+) -> Stream<String, Process<'a, EchoServer>> {
+    // highlight-next-line
+    input.map(q!(|s| s.to_uppercase()))
+}
+`)}</CodeBlock>
 
 To process incoming requests, you use the APIs available on live collections. This example uses `Stream::map`, which transforms each element of the incoming requests into a element of the outgoing responses. In Hydro, all values and closures passed to such APIs must be **quoted**. Quoting _captures_ the Rust code so that it can be run on a distributed node. To quote an expression, you wrap it with the `q!` macro.
 
@@ -94,7 +111,13 @@ The template includes a unit test for the echo server in the `tests` module. Whe
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/template/hydro/src/lib.rs">src/lib.rs</Link>
-} showLineNumbers={13}>{getLines(highlightLines(libRsSrc, []), 13, 18)}</CodeBlock>
+} showLineNumbers={13}>{getLines(highlightLines(libRsSrc, []), 13, 18, `
+#[cfg(test)]
+mod tests {
+    use hydro_lang::prelude::*;
+    #[test]
+    fn test_echo_capitalize() {
+`)}</CodeBlock>
 
 Next, let's take a look at the setup logic for the test, which:
 1. Creates the set of distributed locations involved in the test
@@ -106,19 +129,32 @@ To create locations, you must first create a `FlowBuilder`, which will track all
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/template/hydro/src/lib.rs">src/lib.rs</Link>
-} showLineNumbers={19}>{getLines(highlightLines(libRsSrc, []), 19, 21)}</CodeBlock>
+} showLineNumbers={19}>{getLines(highlightLines(libRsSrc, []), 19, 21, `
+let mut flow = FlowBuilder::new();
+let process = flow.process();
+`)}</CodeBlock>
 
 Now, you can create the echo server! You start by receiving inputs from the test client using `sim_input`. This returns a tuple with two values: a port handle that the test can use to send requests, and a `Stream` of the received requests. You can then pass this stream into `echo_capitalize`, which returns a stream of responses. To read the outputs from the test, you use `sim_output`. This function returns a port handle that the test can use to receive responses.
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/template/hydro/src/lib.rs">src/lib.rs</Link>
-} showLineNumbers={22}>{getLines(highlightLines(libRsSrc, []), 22, 24)}</CodeBlock>
+} showLineNumbers={22}>{getLines(highlightLines(libRsSrc, []), 22, 24, `
+let (in_port, requests) = process.sim_input();
+let responses = super::echo_capitalize(requests);
+let out_port = responses.sim_output();
+`)}</CodeBlock>
 
 Finally, you can write the functionality test. To create an **exhaustive** simulation test, which explores _all possible_ distributed executions, you invoke `flow.sim().exhaustive()`. This function takes in an async closure, which will be repeatedly invoked with different simulation instances, each testing a different distributed execution.
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/template/hydro/src/lib.rs">src/lib.rs</Link>
-} showLineNumbers={26}>{getLines(highlightLines(libRsSrc, []), 26, 31)}</CodeBlock>
+} showLineNumbers={26}>{getLines(highlightLines(libRsSrc, []), 26, 31, `
+flow.sim().exhaustive(async || {
+    in_port.send("hello".to_string());
+    in_port.send("world".to_string());
+    out_port.assert_yields_only(["HELLO", "WORLD"]).await;
+});
+`)}</CodeBlock>
 
 The included test sends the messages `"hello"` and `"world"` to the echo server using the `send()` method. Then, it uses `assert_yields_only` to check that the responses `"HELLO"` and `"WORLD"` are returned and that there are no additional responses. The APIs for receiving responses are async so you must use `.await` to wait for the assertion to complete.
 
@@ -138,13 +174,23 @@ Open `examples/echo_local.rs`. The script starts by setting up a deployment and 
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/template/hydro/examples/echo_local.rs">examples/echo_local.rs</Link>
-} showLineNumbers={7}>{getLines(echoLocalSrc, 7, 11)}</CodeBlock>
+} showLineNumbers={7}>{getLines(echoLocalSrc, 7, 11, `
+let mut deployment = Deployment::new();
+
+let mut flow = hydro_lang::compile::builder::FlowBuilder::new();
+let process = flow.process();
+let external = flow.external::<()>();
+`)}</CodeBlock>
 
 In a deployment script, you create a `Deployment` object which tracks the physical machines where your program will run. Then, you create a `FlowBuilder` just like in the simulator tests. However, instead of connecting to ports manually, you'll use `bind_single_client` to set up networking:
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/template/hydro/examples/echo_local.rs">examples/echo_local.rs</Link>
-} showLineNumbers={13}>{getLines(echoLocalSrc, 13, 15)}</CodeBlock>
+} showLineNumbers={13}>{getLines(echoLocalSrc, 13, 15, `
+    let (_port, input, output) =
+        process.bind_single_client::<_, _, LinesCodec>(&external, NetworkHint::TcpPort(Some(4000)));
+    output.complete(hydro_template::echo_capitalize(input));
+`)}</CodeBlock>
 
 The `bind_single_client` method creates a server that receives messages from a single external client. It returns a port handle, a stream of incoming messages, and a sink for sending responses. The method takes a codec (`LinesCodec`) that encodes and decodes the raw bytes (in this case, treating each line of text as a message). The `NetworkHint` specifies that the server should listen on port 4000.
 
@@ -152,7 +198,18 @@ Next, you map the *logical locations* to *physical machines* using `with_process
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/template/hydro/examples/echo_local.rs">examples/echo_local.rs</Link>
-} showLineNumbers={17}>{getLines(echoLocalSrc, 17, 26)}</CodeBlock>
+} showLineNumbers={17}>{getLines(echoLocalSrc, 17, 26, `
+let _nodes = flow
+    .with_process(&process, deployment.Localhost())
+    .with_external(&external, deployment.Localhost())
+    .deploy(&mut deployment);
+
+deployment.deploy().await.unwrap();
+
+println!("Launched Echo Server! Run \`nc localhost 4000\` to connect.");
+
+deployment.start_ctrl_c().await.unwrap();
+`)}</CodeBlock>
 
 The `with_process` method assigns the `process` location to run on `deployment.Localhost()`, which represents your local machine. Similarly, `with_external` specifies where the external client will connect from (also localhost in this case). Finally, `deploy()` compiles the program, and `start_ctrl_c()` runs it.
 
@@ -182,14 +239,31 @@ Hydro Deploy includes APIs for configuring resources on AWS, Azure, and GCP. Ins
 <TabItem value="gcp" label="GCP">
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/template/hydro/examples/echo_gcp.rs">examples/echo_gcp.rs</Link>
-} showLineNumbers={27}>{getLines(echoGcpSrc, 27, 37)}</CodeBlock>
+} showLineNumbers={27}>{getLines(echoGcpSrc, 24, 34, `
+  .with_process(
+        &process,
+        deployment
+        .GcpComputeEngineHost()
+        .project(gcp_project.clone())
+        .machine_type("e2-micro")
+        .image("debian-cloud/debian-11")
+        .region("us-west1-a")
+        .network(vpc.clone())
+        .add(),
+    )
+`)}</CodeBlock>
 </TabItem>
 </Tabs>
 
 
 When deploying to the cloud, the port is assigned automatically. You can retrieve it after deployment:
 
-<CodeBlock language="rust" showLineNumbers={43}>{getLines(echoGcpSrc, 43, 47)}</CodeBlock>
+<CodeBlock language="rust" showLineNumbers={43}>{getLines(echoGcpSrc, 40, 43, `
+let raw_port = nodes.raw_port(port);
+let server_port = raw_port.server_port().await;
+
+println!("Please connect a client to port {:?}", server_port);
+`)}</CodeBlock>
 
 Finally, to launch the echo server in the cloud, we run the deploy script. Hydro Deploy will automatically provision the necessary cloud resources, launch your application, and forward the server port to your local machine:
 <Tabs groupId="cloud">

--- a/docs/docs/hydro/learn/quickstart/keyed-counter.mdx
+++ b/docs/docs/hydro/learn/quickstart/keyed-counter.mdx
@@ -54,13 +54,23 @@ Just like in the single counter, you'll establish consistency guarantees between
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/keyed_counter.rs">src/keyed_counter.rs</Link>
-} showLineNumbers={15}>{getLines(keyedCounterSrc, 15, 16)}</CodeBlock>
+} showLineNumbers={15}>{getLines(keyedCounterSrc, 15, 16, `
+let atomic_tick = increment_requests.location().tick();
+let increment_request_processing = increment_requests.atomic(&atomic_tick);
+`)}</CodeBlock>
 
 To track counts for multiple keys, you need to regroup the increment requests. Currently, they're keyed by client ID, but you need to count by key name. Regrouping a keyed stream is a common pattern in Hydro. You convert the keyed stream to entries (tuples of `(client_id, key_name)`), then map to swap the order to `(key_name, ())`. The `into_keyed()` method converts this back into a keyed stream, now keyed by key name:
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/keyed_counter.rs">src/keyed_counter.rs</Link>
-} showLineNumbers={17}>{getLines(keyedCounterSrc, 17, 22)}</CodeBlock>
+} showLineNumbers={17}>{getLines(keyedCounterSrc, 17, 22, `
+let current_count = increment_request_processing
+    .clone()
+    .entries()
+    .map(q!(|(_, key)| (key, ())))
+    .into_keyed()
+    .value_counts();
+`)}</CodeBlock>
 
 The `value_counts()` method creates a `KeyedSingleton<String, usize>` that tracks the count for each key.
 
@@ -74,7 +84,9 @@ Finally, you acknowledge the increments by ending the atomic block:
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/keyed_counter.rs">src/keyed_counter.rs</Link>
-} showLineNumbers={23}>{getLines(keyedCounterSrc, 23, 23)}</CodeBlock>
+} showLineNumbers={23}>{getLines(keyedCounterSrc, 23, 23, `
+let increment_ack = increment_request_processing.end_atomic();
+`)}</CodeBlock>
 
 
 Now you have a `KeyedSingleton` that maintains independent counts for each key, and acknowledgements are sent back to clients as increments are processed.
@@ -85,13 +97,24 @@ Get requests arrive keyed by client ID, but you need to look them up by key name
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/keyed_counter.rs">src/keyed_counter.rs</Link>
-} showLineNumbers={25}>{getLines(keyedCounterSrc, 25, 29)}</CodeBlock>
+} showLineNumbers={25}>{getLines(keyedCounterSrc, 25, 29, `
+let requests_regrouped = get_requests
+    .entries()
+    .map(q!(|(cid, key)| (key, cid)))
+    .into_keyed();
+`)}</CodeBlock>
 
 This swaps the key and value: `(client_id, key_name)` becomes `(key_name, client_id)`. Now the stream is keyed by key name, matching the structure of `current_count`. With both get requests and counts keyed by key name, you can perform lookups using `sliced!`:
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/keyed_counter.rs">src/keyed_counter.rs</Link>
-} showLineNumbers={30}>{getLines(keyedCounterSrc, 30, 36)}</CodeBlock>
+} showLineNumbers={30}>{getLines(keyedCounterSrc, 30, 36, `
+let get_lookup = sliced! {
+    let request_batch = use(requests_regrouped, nondet!(/** we never observe batch boundaries */));
+    let count_snapshot = use::atomic(current_count, nondet!(/** atomicity guarantees consistency wrt increments */));
+    count_snapshot.get_many_if_present(request_batch)
+};
+`)}</CodeBlock>
 
 Just like the previous tutorial, `use::atomic` ensures that count snapshots are consistent with increment acknowledgements. The `get_many_if_present()` method looks up the count for each key in the request batch, returning a keyed stream where each element contains the count and the client ID.
 
@@ -105,7 +128,12 @@ Finally, you need to regroup the responses by client ID so each client receives 
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/keyed_counter.rs">src/keyed_counter.rs</Link>
-} showLineNumbers={37}>{getLines(keyedCounterSrc, 37, 41)}</CodeBlock>
+} showLineNumbers={37}>{getLines(keyedCounterSrc, 37, 41, `
+let get_response = get_lookup
+    .entries()
+    .map(q!(|(key, (count, client))| (client, (key, count))))
+    .into_keyed();
+`)}</CodeBlock>
 
 The lookup results are keyed by key name with values `(count, client_id)`. You transform this to `(client_id, (key_name, count))` and regroup by client ID. This completes the data flow: requests arrive organized by client, get processed by key, and responses are routed back to the appropriate clients.
 
@@ -162,7 +190,30 @@ The test follows the same pattern as the single counter. Because the simulator c
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/keyed_counter.rs">src/keyed_counter.rs</Link>
-} showLineNumbers={51}>{getLines(keyedCounterSrc, 51, 77)}</CodeBlock>
+} showLineNumbers={51}>{getLines(keyedCounterSrc, 51, 77, `
+#[test]
+fn test_counter_read_after_write() {
+    let mut flow = FlowBuilder::new();
+    let process = flow.process::<CounterServer>();
+    let (inc_in_port, inc_requests) = process.sim_input();
+    let inc_requests = inc_requests.into_keyed();
+    let (get_in_port, get_requests) = process.sim_input();
+    let get_requests = get_requests.into_keyed();
+    let (inc_acks, get_responses) = keyed_counter_service(inc_requests, get_requests);
+    let inc_out_port = inc_acks.entries().sim_output();
+    let get_out_port = get_responses.entries().sim_output();
+    flow.sim().exhaustive(async || {
+        inc_in_port.send((1, "abc".to_string()));
+        inc_out_port
+            .assert_yields_unordered([(1, "abc".to_string())])
+            .await;
+        get_in_port.send((1, "abc".to_string()));
+        get_out_port
+            .assert_yields_only_unordered([(1, ("abc".to_string(), 1))])
+            .await;
+    });
+}
+`)}</CodeBlock>
 
 This test verifies that a client can increment a specific key ("abc") and then read back the correct count. The atomic consistency guarantees ensure that after receiving an acknowledgement, a subsequent get request observes the updated count.
 

--- a/docs/docs/hydro/learn/quickstart/partitioned-counter.mdx
+++ b/docs/docs/hydro/learn/quickstart/partitioned-counter.mdx
@@ -26,7 +26,15 @@ Before partitioning the counter, you need to make the `keyed_counter_service` fu
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/keyed_counter.rs">src/keyed_counter.rs</Link>
-} showLineNumbers={8}>{getLines(keyedCounterSrc, 8, 14)}</CodeBlock>
+} showLineNumbers={8}>{getLines(keyedCounterSrc, 8, 14, `
+pub fn keyed_counter_service<'a, L: Location<'a> + NoTick>(
+    increment_requests: KeyedStream<u32, String, L, Unbounded>,
+    get_requests: KeyedStream<u32, String, L, Unbounded>,
+) -> (
+    KeyedStream<u32, String, L, Unbounded>,
+    KeyedStream<u32, (String, usize), L, Unbounded, NoOrder>,
+) {
+`)}</CodeBlock>
 
 The `L: Location<'a> + NoTick` bound means the function works with any location that that is outside a `Tick` (like `Process` or `Cluster`). This lets you reuse the same counter logic whether it runs on a single process or several cluster members. The rest of the function body remains unchanged, it already works with any location type.
 
@@ -48,7 +56,17 @@ You'll build a sharded counter service that partitions keys across cluster membe
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/partitioned_counter.rs">src/partitioned_counter.rs</Link>
-} showLineNumbers={11}>{getLines(partitionedCounterSrc, 11, 19)}</CodeBlock>
+} showLineNumbers={11}>{getLines(partitionedCounterSrc, 11, 19, `
+pub fn sharded_counter_service<'a>(
+    leader: &Process<'a, CounterServer>,
+    shard_servers: &Cluster<'a, CounterShard>,
+    increment_requests: KeyedStream<u32, String, Process<'a, CounterServer>>,
+    get_requests: KeyedStream<u32, String, Process<'a, CounterServer>>,
+) -> (
+    KeyedStream<u32, String, Process<'a, CounterServer>, Unbounded, NoOrder>,
+    KeyedStream<u32, (String, usize), Process<'a, CounterServer>, Unbounded, NoOrder>,
+) {
+`)}</CodeBlock>
 
 Unlike the previous tutorials, this function takes references to both a leader `Process` and a `Cluster` of shard servers as parameters. This is necessary because the service will send data between these locations internally: requests arrive at the leader, get routed to the appropriate shard, and responses return to the leader.
 
@@ -58,7 +76,15 @@ To partition data across the cluster, you need to assign each key to a specific 
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/partitioned_counter.rs">src/partitioned_counter.rs</Link>
-} showLineNumbers={20}>{getLines(partitionedCounterSrc, 20, 26)}</CodeBlock>
+} showLineNumbers={20}>{getLines(partitionedCounterSrc, 20, 26, `
+let sharded_increment_requests = increment_requests
+    .prefix_key(q!(|(_client, key)| {
+        let mut hasher = DefaultHasher::new();
+        key.hash(&mut hasher);
+        MemberId::from_raw_id(hasher.finish() as u32 % 5)
+    }))
+    .demux(shard_servers, TCP.bincode());
+`)}</CodeBlock>
 
 The `prefix_key` method adds a new key to the front of the keyed stream. Here, you compute a `MemberId` by hashing the key name and taking modulo 5 (assuming 5 shards). The result is a stream keyed by `(MemberId, client_id, key_name)`.
 
@@ -76,7 +102,23 @@ The `demux` method sends each element to the cluster member specified by the fir
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/partitioned_counter.rs">src/partitioned_counter.rs</Link>
-} showLineNumbers={20}>{highlightLines(getLines(partitionedCounterSrc, 20, 34), [7, 15])}</CodeBlock>
+} showLineNumbers={20}>{highlightLines(getLines(partitionedCounterSrc, 20, 34, `
+let sharded_increment_requests = increment_requests
+    .prefix_key(q!(|(_client, key)| {
+        let mut hasher = DefaultHasher::new();
+        key.hash(&mut hasher);
+        MemberId::from_raw_id(hasher.finish() as u32 % 5)
+    }))
+    .demux(shard_servers, TCP.bincode());
+
+let sharded_get_requests = get_requests
+    .prefix_key(q!(|(_client, key)| {
+        let mut hasher = DefaultHasher::new();
+        key.hash(&mut hasher);
+        MemberId::from_raw_id(hasher.finish() as u32 % 5)
+    }))
+    .demux(shard_servers, TCP.bincode());
+`), [7, 15])}</CodeBlock>
 
 After `demux`, the stream is now located at the cluster. The stream returned by a demux operator preserves the remaining keys after the `MemberId` is consumed for routing. In this case, we are left with a `KeyedStream<u32, String, Cluster<'a, CounterShard>>` - a stream keyed by client ID and key name, located on the cluster.
 
@@ -86,7 +128,12 @@ Now you can call the generic `keyed_counter_service` function with the cluster-l
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/partitioned_counter.rs">src/partitioned_counter.rs</Link>
-} showLineNumbers={36}>{getLines(partitionedCounterSrc, 36, 39)}</CodeBlock>
+} showLineNumbers={36}>{getLines(partitionedCounterSrc, 36, 39, `
+let (sharded_increment_ack, sharded_get_response) = super::keyed_counter::keyed_counter_service(
+    sharded_increment_requests,
+    sharded_get_requests,
+);
+`)}</CodeBlock>
 
 Because `keyed_counter_service` is generic over the location type, it works seamlessly with `Cluster<'a, CounterShard>`. Each cluster member independently maintains its own keyed singleton for the keys it's responsible for.
 
@@ -94,7 +141,11 @@ Finally, you need to send the responses back to the leader process:
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/partitioned_counter.rs">src/partitioned_counter.rs</Link>
-} showLineNumbers={41}>{getLines(partitionedCounterSrc, 41, 44)}</CodeBlock>
+} showLineNumbers={41}>{getLines(partitionedCounterSrc, 41, 44, `
+let increment_ack = sharded_increment_ack
+    .send(leader, TCP.bincode())
+    .drop_key_prefix();
+`)}</CodeBlock>
 
 The `send` method sends data from the cluster to the leader process. When data moves from a cluster to a process, it arrives as a keyed stream with `MemberId` as the first key. The `drop_key_prefix` method removes this `MemberId` key, leaving just the original keys (client ID and response data).
 
@@ -106,7 +157,34 @@ The test is similar to the keyed counter test, but now you need to instantiate t
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/partitioned_counter.rs">src/partitioned_counter.rs</Link>
-} showLineNumbers={54}>{highlightLines(getLines(partitionedCounterSrc, 54, 84), [5, 20])}</CodeBlock>
+} showLineNumbers={54}>{highlightLines(getLines(partitionedCounterSrc, 54, 84, `
+use hydro_lang::prelude::*;
+
+use super::*;
+
+#[test]
+fn test_counter_read_after_write() {
+    let mut flow = FlowBuilder::new();
+    let process = flow.process();
+    let shards = flow.cluster();
+    let (inc_in_port, inc_requests) = process.sim_input();
+    let inc_requests = inc_requests.into_keyed();
+    let (get_in_port, get_requests) = process.sim_input();
+    let get_requests = get_requests.into_keyed();
+    let (inc_acks, get_responses) =
+        sharded_counter_service(&process, &shards, inc_requests, get_requests);
+    let inc_out_port = inc_acks.entries().sim_output();
+    let get_out_port = get_responses.entries().sim_output();
+    flow.sim()
+        .with_cluster_size(&shards, 5)
+        .exhaustive(async || {
+            inc_in_port.send((1, "abc".to_string()));
+            inc_out_port
+                .assert_yields_unordered([(1, "abc".to_string())])
+                .await;
+            get_in_port.send((1, "abc".to_string()));
+            get_out_port
+`), [5, 20])}</CodeBlock>
 
 The `with_cluster_size(&shards, 5)` method configures the simulator to create 5 cluster members. The test verifies that the partitioned counter behaves identically to the single-process version, even though the state is now distributed across multiple machines.
 

--- a/docs/docs/hydro/learn/quickstart/single-counter.mdx
+++ b/docs/docs/hydro/learn/quickstart/single-counter.mdx
@@ -38,7 +38,15 @@ The standard pattern in Hydro is to take in a separate parameter for each reques
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/single_client_counter.rs">src/single_client_counter.rs</Link>
-} showLineNumbers={5}>{getLines(singleClientCounterSrc, 5, 11)}</CodeBlock>
+} showLineNumbers={5}>{getLines(singleClientCounterSrc, 5, 11, `
+pub fn single_client_counter_service<'a>(
+    increment_requests: Stream<(), Process<'a, CounterServer>>,
+    get_requests: Stream<(), Process<'a, CounterServer>>,
+) -> (
+    Stream<(), Process<'a, CounterServer>>, // increment acknowledgments
+    Stream<usize, Process<'a, CounterServer>>, // get responses
+) {
+`)}</CodeBlock>
 
 ## Maintaining State with Singleton
 
@@ -48,7 +56,9 @@ You can create a singleton by counting the number of increment requests:
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/single_client_counter_buggy.rs">src/single_client_counter.rs</Link>
-} showLineNumbers={12}>{getLines(singleClientCounterBuggySrc, 12, 12)}</CodeBlock>
+} showLineNumbers={12}>{getLines(singleClientCounterBuggySrc, 12, 12, `
+let current_count = increment_requests.clone().count();
+`)}</CodeBlock>
 
 The `count()` method consumes the stream and returns a `Singleton<usize>` that tracks the total number of elements seen so far. Since you want to both count the requests and acknowledge them, you use `clone()` to create a copy of the stream.
 
@@ -56,7 +66,9 @@ For now, let's acknowledge increment requests immediately:
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/single_client_counter_buggy.rs">src/single_client_counter.rs</Link>
-} showLineNumbers={13}>{getLines(singleClientCounterBuggySrc, 13, 13)}</CodeBlock>
+} showLineNumbers={13}>{getLines(singleClientCounterBuggySrc, 13, 13, `
+let increment_ack = increment_requests;
+`)}</CodeBlock>
 
 ## Asynchronous State and Slices
 
@@ -66,7 +78,11 @@ Hydro provides the `sliced!` macro for this purpose. It allows you to perform co
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/single_client_counter_buggy.rs">src/single_client_counter.rs</Link>
-} showLineNumbers={15}>{getLines(singleClientCounterBuggySrc, 15, 17)}</CodeBlock>
+} showLineNumbers={15}>{getLines(singleClientCounterBuggySrc, 15, 17, `
+let get_response = sliced! {
+    let request_batch = use(get_requests, nondet!(/** we never observe batch boundaries */));
+    let count_snapshot = use(current_count, nondet!(/** intentional, based on when the request came in */));
+`)}</CodeBlock>
 
 The `sliced!` macro takes multiple `use` statements, using syntax inspired by React hooks. Each specifies a live collection to slice along with a non-determinism explanation, and returns the current slice. In this case:
 
@@ -88,7 +104,10 @@ After declaring the `use` statements, which must come at the top of the macro in
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/single_client_counter_buggy.rs">src/single_client_counter.rs</Link>
-} showLineNumbers={19}>{getLines(singleClientCounterBuggySrc, 19, 20)}</CodeBlock>
+} showLineNumbers={19}>{getLines(singleClientCounterBuggySrc, 19, 20, `
+    request_batch.cross_singleton(count_snapshot).map(q!(|(_, count)| count))
+};
+`)}</CodeBlock>
 
 The `cross_singleton` method pairs each element in the stream with the singleton value, creating tuples like `((), 5)`. Then you use `map` to extract just the count from the tuple with `map(q!(|(_, count)| count))`, converting `((), 5)` to just `5`.
 
@@ -98,7 +117,24 @@ Especially in code that involves `nondet!`, it is important to write simulation 
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/single_client_counter.rs">src/single_client_counter.rs</Link>
-} showLineNumbers={33}>{getLines(singleClientCounterSrc, 33, 52)}</CodeBlock>
+} showLineNumbers={33}>{getLines(singleClientCounterSrc, 33, 52, `
+#[test]
+fn test_counter_read_after_write() {
+    let mut flow = FlowBuilder::new();
+    let process = flow.process();
+    let (inc_in_port, inc_requests) = process.sim_input();
+    let (get_in_port, get_requests) = process.sim_input();
+    let (inc_acks, get_responses) = single_client_counter_service(inc_requests, get_requests);
+    let inc_out_port = inc_acks.sim_output();
+    let get_out_port = get_responses.sim_output();
+    flow.sim().exhaustive(async || {
+        inc_in_port.send(());
+        inc_out_port.assert_yields([()]).await;
+        get_in_port.send(());
+        get_out_port.assert_yields_only([1]).await;
+    });
+}
+`)}</CodeBlock>
 
 This test uses Hydro's exhaustive simulator to test a scenario where the client increments the counter and then reads it back. The test sends an increment request, waits for the acknowledgement, then sends a get request and expects to receive a count of 1.
 
@@ -133,19 +169,32 @@ Calling `atomic()` on a stream (which requires a `Tick` parameter) enables downs
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/single_client_counter.rs">src/single_client_counter.rs</Link>
-} showLineNumbers={12}>{getLines(singleClientCounterSrc, 12, 13)}</CodeBlock>
+} showLineNumbers={12}>{getLines(singleClientCounterSrc, 12, 13, `
+let atomic_tick = increment_requests.location().tick();
+let increment_request_processing = increment_requests.atomic(&atomic_tick);
+`)}</CodeBlock>
 
 Instead of counting the original stream, you now count using the atomic stream. This produces an atomic singleton that will allow you to take consistent snapshots later. The APIs on an atomic live collection are the same as on a regular live collection, so the counter code is unchanged:
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/single_client_counter.rs">src/single_client_counter.rs</Link>
-} showLineNumbers={14}>{getLines(singleClientCounterSrc, 14, 14)}</CodeBlock>
+} showLineNumbers={14}>{getLines(singleClientCounterSrc, 14, 14, `
+let current_count = increment_request_processing.clone().count();
+`)}</CodeBlock>
 
 Now, let's focus on the outputs of the counter service. It needs to release acknowledgements and process get requests, while ensuring that a read-after-write produces a consistent response:
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/single_client_counter.rs">src/single_client_counter.rs</Link>
-} showLineNumbers={15}>{getLines(singleClientCounterSrc, 15, 22)}</CodeBlock>
+} showLineNumbers={15}>{getLines(singleClientCounterSrc, 15, 22, `
+let increment_ack = increment_request_processing.end_atomic();
+
+let get_response = sliced! {
+    let request_batch = use(get_requests, nondet!(/** we never observe batch boundaries */));
+    let count_snapshot = use::atomic(current_count, nondet!(/** atomicity guarantees consistency wrt increments */));
+    request_batch.cross_singleton(count_snapshot).map(q!(|(_, count)| count))
+};
+`)}</CodeBlock>
 
 The `end_atomic()` call is one half of the consistency relationship. It marks the point where the acknowledgements are released to the client. The other half is `use::atomic`, which snapshots the count in a way that is **consistent with respect to** those acknowledgements. The `use::atomic` ensures that the count snapshot reflects all increments whose acknowledgements have been released.
 

--- a/docs/docs/hydro/reference/deploy/rust.mdx
+++ b/docs/docs/hydro/reference/deploy/rust.mdx
@@ -25,7 +25,14 @@ TODO(mingwei): Explain the details/nuances of the example and simple configurati
 `TrybuildHost` provides additional options for compiling your Hydro app, such as setting [`rustflags`](https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags),
 enabling [features](https://doc.rust-lang.org/cargo/reference/features.html), or setting up [performance profiling](#performance-profiling).
 
-<CodeBlock language="rust" title="hydro_test/examples/perf_compute_pi.rs">{getLines(perfComputePiSrc, "trybuildhost")}</CodeBlock>
+<CodeBlock language="rust" title="hydro_test/examples/perf_compute_pi.rs">{getLines(perfComputePiSrc, "trybuildhost", `
+.with_process(
+    &leader,
+    TrybuildHost::new(create_host(&mut deployment))
+        .rustflags(rustflags)
+        .additional_hydro_features(vec!["runtime_measure".to_string()])
+        // ...
+`)}</CodeBlock>
 
 TODO(mingwei)
 
@@ -36,7 +43,18 @@ code are taking the most time to execute.
 
 `TrybuildHost` provides a `tracing` method that will automatically generate a flamegraph after your app has run:
 
-<CodeBlock language="rust" title="hydro_test/examples/perf_compute_pi.rs">{getLines(perfComputePiSrc, "tracing")}</CodeBlock>
+<CodeBlock language="rust" title="hydro_test/examples/perf_compute_pi.rs">{getLines(perfComputePiSrc, "tracing", `
+.tracing(
+    TracingOptions::builder()
+        .perf_raw_outfile("leader.perf.data")
+        .samply_outfile("leader.profile")
+        .fold_outfile("leader.data.folded")
+        .flamegraph_outfile("leader.svg")
+        .frequency(frequency)
+        .setup_command(setup_command)
+        .build(),
+),
+`)}</CodeBlock>
 
 The `TracingOptions` builder has several options, such as sampling frequency, output file names, tracing options, and
 optionally a setup command to run before the profiling starts. The `setup_command` can be used to install the profiling,
@@ -44,7 +62,9 @@ in this case we use the provided `DEBIAN_PERF_SETUP_COMMAND` which installs `per
 enable tracing.
 
 You may need to use `TrybuildHost` to set the following `rustflags` to enable detailed performance profiling:
-<CodeBlock language="rust" title="hydro_test/examples/perf_compute_pi.rs">{getLines(perfComputePiSrc, "rustflags")}</CodeBlock>
+<CodeBlock language="rust" title="hydro_test/examples/perf_compute_pi.rs">{getLines(perfComputePiSrc, "rustflags", `
+rustflags = "-C opt-level=3 -C codegen-units=1 -C strip=none -C debuginfo=2 -C lto=off";
+`)}</CodeBlock>
 
 Different platforms require particular configuration to enable CPU profiling. Each platform uses a different tool to collect
 CPU profiling data, but Hydro Deploy will automatically process the resulting traces and download the resulting flamegraph:
@@ -54,4 +74,6 @@ CPU profiling data, but Hydro Deploy will automatically process the resulting tr
 * Windows: `samply` for CPU profiling
 
 For example, on GCP Linux machines, you may need to include additional `rustflags`:
-<CodeBlock language="rust" title="hydro_test/examples/perf_compute_pi.rs">{getLines(perfComputePiSrc, "rustflags_gcp")}</CodeBlock>
+<CodeBlock language="rust" title="hydro_test/examples/perf_compute_pi.rs">{getLines(perfComputePiSrc, "rustflags_gcp", `
+rustflags = "-C opt-level=3 -C codegen-units=1 -C strip=none -C debuginfo=2 -C lto=off -C link-args=--no-rosegment";
+`)}</CodeBlock>

--- a/docs/docs/hydro/reference/simulation/writing.mdx
+++ b/docs/docs/hydro/reference/simulation/writing.mdx
@@ -19,7 +19,24 @@ A simulation test has three parts: setup, execution, and assertions. The setup c
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/single_client_counter.rs">single_client_counter.rs</Link>
-} showLineNumbers={33}>{getLines(singleClientCounterSrc, 33, 52)}</CodeBlock>
+} showLineNumbers={33}>{getLines(singleClientCounterSrc, 33, 52, `
+#[test]
+fn test_counter_read_after_write() {
+    let mut flow = FlowBuilder::new();
+    let process = flow.process();
+    let (inc_in_port, inc_requests) = process.sim_input();
+    let (get_in_port, get_requests) = process.sim_input();
+    let (inc_acks, get_responses) = single_client_counter_service(inc_requests, get_requests);
+    let inc_out_port = inc_acks.sim_output();
+    let get_out_port = get_responses.sim_output();
+    flow.sim().exhaustive(async || {
+        inc_in_port.send(());
+        inc_out_port.assert_yields([()]).await;
+        get_in_port.send(());
+        get_out_port.assert_yields_only([1]).await;
+    });
+}
+`)}</CodeBlock>
 
 The execution happens inside the async closure passed to `exhaustive()`. This closure is called repeatedly—once for each distinct execution the simulator explores. Inside, you send messages using the input ports and make assertions about the outputs.
 

--- a/docs/src/util.ts
+++ b/docs/src/util.ts
@@ -8,49 +8,111 @@
 /// Sections are marked in the code with a start tag `//[mysection]//` and and end tag
 /// `//[/mysection]//`. The rest of these tag lines must be whitespace, and these tag lines are not
 /// included in the output. However they are included for line number _counting_.
-export function getLines(str: string, sectionName: string): string;
-export function getLines(str: string, lineStart: number, lineEnd?: number): string;
-export function getLines(str: string, lineStartOrSectionName: number | string, lineEnd?: number): string {
-    // `//[section]//` or `//[/section]//` (rest of line must be whitespace).
-    const SECTION_REGEX = /^\s*\/\/\[(\/?)(\S+)\]\/\/\s*$/;
-    let lines;
-    if ('string' === typeof lineStartOrSectionName) {
-        let inSection = false;
-        lines = str
-            .split('\n')
-            .filter(line => {
-                const match = SECTION_REGEX.exec(line);
-                if (null == match) {
-                    return inSection;
-                }
-                const [_, end, name] = match;
-                if (name == lineStartOrSectionName) {
-                    inSection = 0 === end.length;
-                }
-                return false;
-            })
+///
+/// An optional `expected` parameter can be provided as the last argument. If provided, the function
+/// will assert that the extracted content (after trimming whitespace) matches the expected string
+/// (also trimmed). This allows inlining code snippets in docs while ensuring they stay in sync
+/// with the source file.
+export function getLines(
+  str: string,
+  sectionName: string,
+  expected?: string,
+): string;
+export function getLines(
+  str: string,
+  lineStart: number,
+  lineEnd?: number,
+  expected?: string,
+): string;
+export function getLines(
+  str: string,
+  lineStartOrSectionName: number | string,
+  lineEndOrExpected?: number | string,
+  expected?: string,
+): string {
+  // `//[section]//` or `//[/section]//` (rest of line must be whitespace).
+  const SECTION_REGEX = /^\s*\/\/\[(\/?)(\S+)\]\/\/\s*$/;
+  let lines;
+  let lineEnd: number | undefined;
+  let expectedContent: string | undefined;
+
+  if ("string" === typeof lineStartOrSectionName) {
+    // Section name mode: getLines(str, sectionName, expected?)
+    expectedContent = lineEndOrExpected as string | undefined;
+    let inSection = false;
+    lines = str.split("\n").filter((line) => {
+      const match = SECTION_REGEX.exec(line);
+      if (null == match) {
+        return inSection;
+      }
+      const [_, end, name] = match;
+      if (name == lineStartOrSectionName) {
+        inSection = 0 === end.length;
+      }
+      return false;
+    });
+  } else {
+    // Line number mode: getLines(str, lineStart, lineEnd?, expected?)
+    if ("string" === typeof lineEndOrExpected) {
+      // getLines(str, lineStart, expected) - no lineEnd provided
+      expectedContent = lineEndOrExpected;
+      lineEnd = undefined;
+    } else {
+      lineEnd = lineEndOrExpected;
+      expectedContent = expected;
     }
-    else {
-        lines = str
-            .split('\n')
-            .slice(lineStartOrSectionName - 1, lineEnd || lineStartOrSectionName) // Select lines before removing section lines.
-            .filter(line => !SECTION_REGEX.test(line));
+    lines = str
+      .split("\n")
+      .slice(lineStartOrSectionName - 1, lineEnd || lineStartOrSectionName) // Select lines before removing section lines.
+      .filter((line) => !SECTION_REGEX.test(line));
+  }
+  const leadingWhitespace = Math.min(
+    ...lines
+      .filter((line) => 0 !== line.length)
+      .map((line) => line.search(/\S/))
+      .map(Number),
+  );
+  if (0 < leadingWhitespace) {
+    lines = lines.map((line) => line.slice(leadingWhitespace));
+  }
+  const result = lines.join("\n");
+
+  // If expected content is provided, assert it matches
+  if (expectedContent !== undefined) {
+    // Normalize by stripping leading whitespace from each line (MDX can mess with indentation)
+    const stripLeadingWhitespace = (s: string) =>
+      s
+        .trim()
+        .split("\n")
+        .map((line) => line.trimStart())
+        .join("");
+    const normalizedResult = stripLeadingWhitespace(result);
+    const normalizedExpected = stripLeadingWhitespace(expectedContent);
+    if (normalizedResult !== normalizedExpected) {
+      console.error("getLines assertion failed!");
+      console.error("Expected:\n", normalizedExpected);
+      console.error("Got:\n", normalizedResult);
+      throw new Error(
+        `getLines content mismatch. The inlined code snippet does not match the source file. ` +
+          `Update the expected string or check if the source file has changed.`,
+      );
     }
-    const leadingWhitespace = Math.min(...lines.filter(line => 0 !== line.length).map(line => line.search(/\S/)).map(Number));
-    if (0 < leadingWhitespace) {
-        lines = lines.map(line => line.slice(leadingWhitespace));
-    }
-    return lines.join('\n');
+  }
+
+  return result;
 }
 
 /// Adds `// highlight-next-line` annotations to the specified lines.
 export function highlightLines(code: string, lines: number[]): string {
-    return code.split('\n').map((line, i) => {
-        if (lines.includes(i + 1)) {
-            return `// highlight-next-line\n${line}`;
-        }
-        return line;
-    }).join('\n');
+  return code
+    .split("\n")
+    .map((line, i) => {
+      if (lines.includes(i + 1)) {
+        return `// highlight-next-line\n${line}`;
+      }
+      return line;
+    })
+    .join("\n");
 }
 
 /// Extract the output from the stdout snapshots created by `surface_examples.rs`.
@@ -60,21 +122,21 @@ export function highlightLines(code: string, lines: number[]): string {
 /// If `short` is false (default), will include code to show the `cargo run` console call.
 /// If `short` is true, returns only the stdout output.
 export function extractOutput(output: string, short = false): string {
-    const outputLines = output.replace(/\n$/, '').split('\n');
-    // Delete the first four lines, which are the snapshot front matter.
-    outputLines.splice(0, 4);
-    // Mermaid graph starts with double-percent signs.
-    if (outputLines[0].startsWith('%%')) {
-        // Continues until double newline (a blank line).
-        const count = outputLines.findIndex(line => 0 === line.length);
-        // Hide mermaid output.
-        outputLines.splice(0, count + 1, '<graph output>');
-    }
-    const stdOut = outputLines.join('\n');
-    if (short) {
-        return stdOut;
-    }
-    return `#shell-command-next-line
+  const outputLines = output.replace(/\n$/, "").split("\n");
+  // Delete the first four lines, which are the snapshot front matter.
+  outputLines.splice(0, 4);
+  // Mermaid graph starts with double-percent signs.
+  if (outputLines[0].startsWith("%%")) {
+    // Continues until double newline (a blank line).
+    const count = outputLines.findIndex((line) => 0 === line.length);
+    // Hide mermaid output.
+    outputLines.splice(0, count + 1, "<graph output>");
+  }
+  const stdOut = outputLines.join("\n");
+  if (short) {
+    return stdOut;
+  }
+  return `#shell-command-next-line
 cargo run
 <build output>
 ${stdOut}`;
@@ -82,15 +144,15 @@ ${stdOut}`;
 
 /// Extract the mermaid graph logged to stdout from the snapshots created by `surface_examples.rs`.
 export function extractMermaid(output: string): string {
-    const outputLines = output.split('\n');
-    // Delete the first four lines, which are the snapshot front matter.
-    outputLines.splice(0, 4);
-    // Mermaid graph starts with double-percent signs.
-    if (!outputLines[0].startsWith('%%')) {
-        console.error('Snapshot output may be missing mermaid graph.');
-    }
-    // Continues until double newline (a blank line).
-    const count = outputLines.findIndex(line => 0 === line.length);
-    outputLines.length = count;
-    return outputLines.join('\n');
+  const outputLines = output.split("\n");
+  // Delete the first four lines, which are the snapshot front matter.
+  outputLines.splice(0, 4);
+  // Mermaid graph starts with double-percent signs.
+  if (!outputLines[0].startsWith("%%")) {
+    console.error("Snapshot output may be missing mermaid graph.");
+  }
+  // Continues until double newline (a blank line).
+  const count = outputLines.findIndex((line) => 0 === line.length);
+  outputLines.length = count;
+  return outputLines.join("\n");
 }


### PR DESCRIPTION

It is helpful for AI agents to be able to see the code snippets inline with the docs, and also helps in situations where docs are available but not other pieces of the monorepo.

In order to prevent code drift, we still run assertions to make sure that the inlined snippet matches the actual code.
