### PR TITLE
ci: remove `maximize-build-space` action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,12 +91,6 @@ jobs:
           - os: ${{ (((github.event_name != 'pull_request') || (github.event_name == 'pull_request' && (contains(github.event.pull_request.title, '[ci-full]') || contains(github.event.pull_request.body, '[ci-full]')))) && 'nothing') || 'macos-latest' }}
 
     steps:
-      - name: Maximize build space
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        uses: easimon/maximize-build-space@c28619d8999a147d5e09c1199f84ff6af6ad5794
-        with:
-          root-reserve-mb: 4096
-
       - name: Checkout sources
         uses: actions/checkout@v4
 

--- a/hydro_lang/src/sim/graph.rs
+++ b/hydro_lang/src/sim/graph.rs
@@ -627,10 +627,7 @@ fn compile_sim_graph_trybuild(
                 .unwrap();
 
         if is_test {
-            UseTestModeStaged {
-                crate_name,
-            }
-            .visit_expr_mut(&mut dfir_expr);
+            UseTestModeStaged { crate_name }.visit_expr_mut(&mut dfir_expr);
         }
 
         dfir_expr


### PR DESCRIPTION

GitHub is removing the `/mnt` path which this depends on.
