### PR TITLE
refactor(hydro_lang): remove RewriteIrFlowBuilder

### DIFF
--- a/hydro_lang/src/compile/builder.rs
+++ b/hydro_lang/src/compile/builder.rs
@@ -262,7 +262,8 @@ impl<'a> FlowBuilder<'a> {
         }
     }
 
-    pub fn force_roots(&mut self, roots: Vec<HydroRoot>) {
+    #[doc(hidden)] // TODO(mingwei): This is an unstable API for now
+    pub fn replace_ir(&mut self, roots: Vec<HydroRoot>) {
         self.flow_state.borrow_mut().roots = Some(roots);
     }
 }


### PR DESCRIPTION
I needed RewrittenIrFlowBuilder's thunk to pass a mutable FlowBuilder so I could add clusters within the thunk.
I then realized the thunk was kind of useless (I could have the thunk essentially do nothing, then manipulate the outputted FlowBuilder.
So I'm removing the whole wrapper.