### PR TITLE
feat(hydro_lang): introduce `Weaker{Ordering/Retries}Than` to simplify stream weakening

### DIFF
--- a/hydro_lang/src/live_collections/keyed_singleton.rs
+++ b/hydro_lang/src/live_collections/keyed_singleton.rs
@@ -1017,7 +1017,9 @@ impl<'a, K: Hash + Eq, V, L: Location<'a>> KeyedSingleton<K, V, Tick<L>, Bounded
         V2: Clone,
     {
         let lookup_result = self.clone().get_many_if_present(requests.clone());
-        let missing_keys = requests.filter_key_not_in(self.keys()).weakest_ordering();
+        let missing_keys = requests
+            .filter_key_not_in(self.keys())
+            .weaken_ordering::<NoOrder>();
 
         lookup_result
             .map(q!(|(v, v2)| (Some(v), v2)))

--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -20,7 +20,9 @@ use crate::compile::ir::{
 use crate::forward_handle::{CycleCollection, ReceiverComplete};
 use crate::forward_handle::{ForwardRef, TickCycle};
 use crate::live_collections::batch_atomic::BatchAtomic;
-use crate::live_collections::stream::{AtLeastOnce, Ordering, Retries};
+use crate::live_collections::stream::{
+    AtLeastOnce, Ordering, Retries, WeakerOrderingThan, WeakerRetryThan,
+};
 #[cfg(stageleft_runtime)]
 use crate::location::dynamic::{DynLocation, LocationId};
 use crate::location::tick::DeferTick;
@@ -90,7 +92,7 @@ where
     L: Location<'a>,
 {
     fn from(stream: KeyedStream<K, V, L, B, TotalOrder, R>) -> KeyedStream<K, V, L, B, NoOrder, R> {
-        stream.weakest_ordering()
+        stream.weaken_ordering()
     }
 }
 
@@ -314,11 +316,18 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
         }
     }
 
+    #[deprecated = "use `weaken_ordering::<NoOrder>()` instead"]
     /// Weakens the ordering guarantee provided by the stream to [`NoOrder`],
     /// which is always safe because that is the weakest possible guarantee.
     pub fn weakest_ordering(self) -> KeyedStream<K, V, L, B, NoOrder, R> {
+        self.weaken_ordering::<NoOrder>()
+    }
+
+    /// Weakens the ordering guarantee provided by the stream to `O2`, with the type-system
+    /// enforcing that `O2` is weaker than the input ordering guarantee.
+    pub fn weaken_ordering<O2: WeakerOrderingThan<O>>(self) -> KeyedStream<K, V, L, B, O2, R> {
         let nondet = nondet!(/** this is a weaker ordering guarantee, so it is safe to assume */);
-        self.assume_ordering::<NoOrder>(nondet)
+        self.assume_ordering::<O2>(nondet)
     }
 
     /// Explicitly "casts" the keyed stream to a type with a different retries
@@ -357,11 +366,18 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
         }
     }
 
+    #[deprecated = "use `weaker_retries::<AtLeastOnce>()` instead"]
     /// Weakens the retries guarantee provided by the stream to [`AtLeastOnce`],
     /// which is always safe because that is the weakest possible guarantee.
     pub fn weakest_retries(self) -> KeyedStream<K, V, L, B, O, AtLeastOnce> {
+        self.weaker_retries::<AtLeastOnce>()
+    }
+
+    /// Weakens the retries guarantee provided by the stream to `R2`, with the type-system
+    /// enforcing that `R2` is weaker than the input retries guarantee.
+    pub fn weaker_retries<R2: WeakerRetryThan<R>>(self) -> KeyedStream<K, V, L, B, O, R2> {
         let nondet = nondet!(/** this is a weaker retries guarantee, so it is safe to assume */);
-        self.assume_retries::<AtLeastOnce>(nondet)
+        self.assume_retries::<R2>(nondet)
     }
 
     /// Flattens the keyed stream into an unordered stream of key-value pairs.
@@ -1257,11 +1273,11 @@ impl<'a, K, V, L: Location<'a> + NoTick, O: Ordering, R: Retries>
         // Because the outputs are unordered, we can interleave batches from both streams.
         let nondet_batch_interleaving = nondet!(/** output stream is NoOrder, can interleave */);
         self.batch(&tick, nondet_batch_interleaving)
-            .weakest_ordering()
+            .weaken_ordering::<NoOrder>()
             .chain(
                 other
                     .batch(&tick, nondet_batch_interleaving)
-                    .weakest_ordering(),
+                    .weaken_ordering::<NoOrder>(),
             )
             .all_ticks()
     }
@@ -2464,7 +2480,7 @@ mod tests {
         let input = node
             .source_iter(q!([(1, 1), (1, 2), (2, 3)]))
             .into_keyed()
-            .weakest_ordering();
+            .weaken_ordering::<NoOrder>();
 
         let tick = node.tick();
         let out_recv = input

--- a/hydro_lang/src/live_collections/optional.rs
+++ b/hydro_lang/src/live_collections/optional.rs
@@ -1089,7 +1089,7 @@ where
         L: NoTick,
     {
         let tick = self.location.tick();
-        self.snapshot(&tick, nondet).all_ticks().weakest_retries()
+        self.snapshot(&tick, nondet).all_ticks().weaken_retries()
     }
 
     /// Given a time interval, returns a stream corresponding to snapshots of the optional
@@ -1115,7 +1115,7 @@ where
         self.snapshot(&tick, nondet)
             .filter_if_some(samples.batch(&tick, nondet).first())
             .all_ticks()
-            .weakest_retries()
+            .weaken_retries()
     }
 }
 

--- a/hydro_lang/src/live_collections/singleton.rs
+++ b/hydro_lang/src/live_collections/singleton.rs
@@ -806,7 +806,7 @@ where
             let snapshot = use(self, nondet);
             snapshot.into_stream()
         }
-        .weakest_retries()
+        .weaken_retries()
     }
 
     /// Given a time interval, returns a stream corresponding to snapshots of the singleton
@@ -833,7 +833,7 @@ where
 
             snapshot.filter_if_some(sample_batch.first()).into_stream()
         }
-        .weakest_retries()
+        .weaken_retries()
     }
 }
 

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -63,6 +63,14 @@ impl Ordering for NoOrder {
     const ORDERING_KIND: StreamOrder = StreamOrder::NoOrder;
 }
 
+/// Marker trait for an [`Ordering`] that is available when `Self` is a weaker guarantee than
+/// `Other`, which means that a stream with `Other` guarantees can be safely converted to
+/// have `Self` guarantees instead.
+#[sealed::sealed]
+pub trait WeakerOrderingThan<Other: ?Sized>: Ordering {}
+#[sealed::sealed]
+impl<O: Ordering, O2: Ordering> WeakerOrderingThan<O2> for O where O: MinOrder<O2, Min = O> {}
+
 /// Helper trait for determining the weakest of two orderings.
 #[sealed::sealed]
 pub trait MinOrder<Other: ?Sized> {
@@ -71,22 +79,12 @@ pub trait MinOrder<Other: ?Sized> {
 }
 
 #[sealed::sealed]
-impl MinOrder<NoOrder> for TotalOrder {
-    type Min = NoOrder;
+impl<O: Ordering> MinOrder<O> for TotalOrder {
+    type Min = O;
 }
 
 #[sealed::sealed]
-impl MinOrder<TotalOrder> for TotalOrder {
-    type Min = TotalOrder;
-}
-
-#[sealed::sealed]
-impl MinOrder<TotalOrder> for NoOrder {
-    type Min = NoOrder;
-}
-
-#[sealed::sealed]
-impl MinOrder<NoOrder> for NoOrder {
+impl<O: Ordering> MinOrder<O> for NoOrder {
     type Min = NoOrder;
 }
 
@@ -119,30 +117,28 @@ impl Retries for AtLeastOnce {
     const RETRIES_KIND: StreamRetry = StreamRetry::AtLeastOnce;
 }
 
+/// Marker trait for a [`Retries`] that is available when `Self` is a weaker guarantee than
+/// `Other`, which means that a stream with `Other` guarantees can be safely converted to
+/// have `Self` guarantees instead.
+#[sealed::sealed]
+pub trait WeakerRetryThan<Other: ?Sized>: Retries {}
+#[sealed::sealed]
+impl<R: Retries, R2: Retries> WeakerRetryThan<R2> for R where R: MinRetries<R2, Min = R> {}
+
 /// Helper trait for determining the weakest of two retry guarantees.
 #[sealed::sealed]
 pub trait MinRetries<Other: ?Sized> {
     /// The weaker of the two retry guarantees.
-    type Min: Retries;
+    type Min: Retries + WeakerRetryThan<Self> + WeakerRetryThan<Other>;
 }
 
 #[sealed::sealed]
-impl MinRetries<AtLeastOnce> for ExactlyOnce {
-    type Min = AtLeastOnce;
+impl<R: Retries> MinRetries<R> for ExactlyOnce {
+    type Min = R;
 }
 
 #[sealed::sealed]
-impl MinRetries<ExactlyOnce> for ExactlyOnce {
-    type Min = ExactlyOnce;
-}
-
-#[sealed::sealed]
-impl MinRetries<ExactlyOnce> for AtLeastOnce {
-    type Min = AtLeastOnce;
-}
-
-#[sealed::sealed]
-impl MinRetries<AtLeastOnce> for AtLeastOnce {
+impl<R: Retries> MinRetries<R> for AtLeastOnce {
     type Min = AtLeastOnce;
 }
 
@@ -1004,16 +1000,16 @@ where
         }
     }
 
+    #[deprecated = "use `weaken_ordering::<NoOrder>()` instead"]
     /// Weakens the ordering guarantee provided by the stream to [`NoOrder`],
     /// which is always safe because that is the weakest possible guarantee.
     pub fn weakest_ordering(self) -> Stream<T, L, B, NoOrder, R> {
-        let nondet = nondet!(/** this is a weaker ordering guarantee, so it is safe to assume */);
-        self.assume_ordering::<NoOrder>(nondet)
+        self.weaken_ordering::<NoOrder>()
     }
 
     /// Weakens the ordering guarantee provided by the stream to `O2`, with the type-system
     /// enforcing that `O2` is weaker than the input ordering guarantee.
-    pub fn weaken_ordering<O2: Ordering + MinOrder<O, Min = O2>>(self) -> Stream<T, L, B, O2, R> {
+    pub fn weaken_ordering<O2: WeakerOrderingThan<O>>(self) -> Stream<T, L, B, O2, R> {
         let nondet = nondet!(/** this is a weaker ordering guarantee, so it is safe to assume */);
         self.assume_ordering::<O2>(nondet)
     }
@@ -1084,16 +1080,16 @@ where
         }
     }
 
+    #[deprecated = "use `weaken_retries::<AtLeastOnce>()` instead"]
     /// Weakens the retries guarantee provided by the stream to [`AtLeastOnce`],
     /// which is always safe because that is the weakest possible guarantee.
     pub fn weakest_retries(self) -> Stream<T, L, B, O, AtLeastOnce> {
-        let nondet = nondet!(/** this is a weaker retry guarantee, so it is safe to assume */);
-        self.assume_retries::<AtLeastOnce>(nondet)
+        self.weaken_retries::<AtLeastOnce>()
     }
 
     /// Weakens the retries guarantee provided by the stream to `R2`, with the type-system
     /// enforcing that `R2` is weaker than the input retries guarantee.
-    pub fn weaken_retries<R2: Retries + MinRetries<R, Min = R2>>(self) -> Stream<T, L, B, O, R2> {
+    pub fn weaken_retries<R2: WeakerRetryThan<R>>(self) -> Stream<T, L, B, O, R2> {
         let nondet = nondet!(/** this is a weaker retry guarantee, so it is safe to assume */);
         self.assume_retries::<R2>(nondet)
     }
@@ -2129,7 +2125,7 @@ where
         self.batch(&tick, nondet)
             .filter_if_some(samples.batch(&tick, nondet).first())
             .all_ticks()
-            .weakest_retries()
+            .weaken_retries()
     }
 
     /// Given a timeout duration, returns an [`Optional`]  which will have a value if the

--- a/hydro_lang/src/location/mod.rs
+++ b/hydro_lang/src/location/mod.rs
@@ -1021,7 +1021,7 @@ mod tests {
             first_node
                 .source_iter::<(u64, ()), _>(q!([]))
                 .into_keyed()
-                .weakest_ordering(),
+                .weaken_ordering(),
         );
 
         let nodes = flow
@@ -1061,7 +1061,7 @@ mod tests {
             first_node
                 .source_iter::<(u64, ()), _>(q!([]))
                 .into_keyed()
-                .weakest_ordering(),
+                .weaken_ordering(),
         );
 
         let nodes = flow
@@ -1098,7 +1098,7 @@ mod tests {
             first_node
                 .source_iter(q!([]))
                 .into_keyed()
-                .weakest_ordering(),
+                .weaken_ordering(),
         );
 
         let nodes = flow

--- a/hydro_lang/tests/compile-fail-stable/non_commutative.stderr
+++ b/hydro_lang/tests/compile-fail-stable/non_commutative.stderr
@@ -1,8 +1,8 @@
 error[E0277]: Because the input stream has ordering `hydro_lang::live_collections::stream::NoOrder`, the closure must demonstrate commutativity with a `commutative = ...` annotation.
- --> tests/compile-fail-stable/non_commutative.rs:6:50
+ --> tests/compile-fail-stable/non_commutative.rs:9:10
   |
-6 |     p1.source_iter(q!(0..10)).weakest_ordering().fold(
-  |                                                  ^^^^ required for this call
+9 |         .fold(q!(|| 0), q!(|acc, x| *acc += x));
+  |          ^^^^ required for this call
   |
   = help: the trait `ValidCommutativityFor<hydro_lang::live_collections::stream::NoOrder>` is not implemented for `NotProved`
           but trait `ValidCommutativityFor<hydro_lang::live_collections::stream::TotalOrder>` is implemented for it

--- a/hydro_lang/tests/compile-fail/non_commutative.rs
+++ b/hydro_lang/tests/compile-fail/non_commutative.rs
@@ -1,12 +1,12 @@
+use hydro_lang::live_collections::stream::NoOrder;
 use hydro_lang::prelude::*;
 
 struct P1 {}
 
 fn test<'a>(p1: &Process<'a, P1>) {
-    p1.source_iter(q!(0..10)).weakest_ordering().fold(
-        q!(|| 0),
-        q!(|acc, x| *acc += x),
-    );
+    p1.source_iter(q!(0..10))
+        .weaken_ordering::<NoOrder>()
+        .fold(q!(|| 0), q!(|acc, x| *acc += x));
 }
 
 fn main() {}

--- a/hydro_std/src/bench_client/mod.rs
+++ b/hydro_std/src/bench_client/mod.rs
@@ -125,7 +125,7 @@ where
             .zip(end_times_and_output)
             .map(q!(|(start_time, (end_time, output))| (output, end_time.duration_since(start_time).unwrap())))
             .into_keyed_stream()
-            .weakest_ordering()
+            .weaken_ordering()
     }
 }
 

--- a/hydro_std/src/request_response.rs
+++ b/hydro_std/src/request_response.rs
@@ -64,10 +64,10 @@ mod tests {
         let metadata_ack = metadata_processing.clone().end_atomic();
         let metadata = metadata_processing
             .batch_atomic(nondet!(/** test */))
-            .weakest_ordering();
+            .weaken_ordering();
 
         // Join responses with metadata (weaken ordering for join_responses)
-        let joined = join_responses(responses.weakest_ordering(), metadata);
+        let joined = join_responses(responses.weaken_ordering(), metadata);
 
         // Set up outputs
         let metadata_ack_recv = metadata_ack.sim_output();
@@ -102,9 +102,9 @@ mod tests {
         let metadata_ack = metadata_processing.clone().end_atomic();
         let metadata = metadata_processing
             .batch_atomic(nondet!(/** test */))
-            .weakest_ordering();
+            .weaken_ordering();
 
-        let joined = join_responses(responses.weakest_ordering(), metadata);
+        let joined = join_responses(responses.weaken_ordering(), metadata);
 
         let metadata_ack_recv = metadata_ack.sim_output();
         let joined_recv = joined.sim_output();
@@ -139,9 +139,9 @@ mod tests {
         let metadata_ack = metadata_processing.clone().end_atomic();
         let metadata = metadata_processing
             .batch_atomic(nondet!(/** test */))
-            .weakest_ordering();
+            .weaken_ordering();
 
-        let joined = join_responses(responses.weakest_ordering(), metadata);
+        let joined = join_responses(responses.weaken_ordering(), metadata);
 
         let metadata_ack_recv = metadata_ack.sim_output();
         let joined_recv = joined.sim_output();
@@ -175,9 +175,9 @@ mod tests {
         let metadata_ack = metadata_processing.clone().end_atomic();
         let metadata = metadata_processing
             .batch_atomic(nondet!(/** test */))
-            .weakest_ordering();
+            .weaken_ordering();
 
-        let joined = join_responses(responses.weakest_ordering(), metadata);
+        let joined = join_responses(responses.weaken_ordering(), metadata);
 
         let metadata_ack_recv = metadata_ack.sim_output();
         let joined_recv = joined.sim_output();

--- a/hydro_test/src/distributed/distributed_echo.rs
+++ b/hydro_test/src/distributed/distributed_echo.rs
@@ -70,8 +70,7 @@ pub fn distributed_echo<'a>(
             (client_id, bytes::Bytes::from(json))
         }))
         .into_keyed()
-        .all_ticks()
-        .weakest_ordering();
+        .all_ticks();
 
     response_sink.complete(all_responses);
 


### PR DESCRIPTION

Previously, the `weaken_*` APIs required an asymmetric `MinX` trait implementation, which would cause trouble when trying to weaken the `Other` stream to the same weaker guarantee. We introduce a `WeakerXThan` pair of traits which are implemented in both directions automatically if there is a `MinX` implementation in one direction, which allows weakening all streams explicitly to `MinX::Min`.
