### PR TITLE
fix: flag non-determinstic hashmap iterators, fix hydro_lang codegen nondeterminism fix #2464

### DIFF
--- a/benches/benches/reachability.rs
+++ b/benches/benches/reachability.rs
@@ -332,6 +332,10 @@ fn benchmark_hydroflow_surface_cheating(c: &mut Criterion) {
 
 fn benchmark_hydroflow_surface(c: &mut Criterion) {
     c.bench_function("reachability/dfir_rs/surface", |b| {
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "nondeterministic iteration order, ok for benchmarking"
+        )]
         let edges: Vec<_> = EDGES
             .iter()
             .flat_map(|(&k, v)| v.iter().map(move |v| (k, *v)))

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,23 @@
 upper-case-acronyms-aggressive = true
 avoid-breaking-exported-api = false
+disallowed-methods = [
+    { path = "slotmap::SparseSecondaryMap::drain", reason = "nondeterministic iteration order" },
+    { path = "slotmap::SparseSecondaryMap::iter_mut", reason = "nondeterministic iteration order" },
+    { path = "slotmap::SparseSecondaryMap::iter", reason = "nondeterministic iteration order" },
+    # { path = "slotmap::SparseSecondaryMap::into_iter", reason = "nondeterministic iteration order" }, // TODO(mingwei): https://github.com/rust-lang/rust-clippy/issues/8581
+    { path = "slotmap::SparseSecondaryMap::keys", reason = "nondeterministic iteration order" },
+    { path = "slotmap::SparseSecondaryMap::values_mut", reason = "nondeterministic iteration order" },
+    { path = "slotmap::SparseSecondaryMap::values", reason = "nondeterministic iteration order" },
+
+    { path = "std::collections::HashMap::drain", reason = "nondeterministic iteration order" },
+    { path = "std::collections::HashMap::iter_mut", reason = "nondeterministic iteration order" },
+    { path = "std::collections::HashMap::iter", reason = "nondeterministic iteration order" },
+    # { path = "std::collections::HashMap::into_iter", reason = "nondeterministic iteration order" }, // TODO(mingwei): https://github.com/rust-lang/rust-clippy/issues/8581
+    { path = "std::collections::HashMap::keys", reason = "nondeterministic iteration order" },
+    { path = "std::collections::HashMap::values_mut", reason = "nondeterministic iteration order" },
+    { path = "std::collections::HashMap::values", reason = "nondeterministic iteration order" },
+
+    { path = "std::collections::HashSet::drain", reason = "nondeterministic iteration order" },
+    { path = "std::collections::HashSet::iter", reason = "nondeterministic iteration order" },
+    # { path = "std::collections::HashSet::into_iter", reason = "nondeterministic iteration order" }, // TODO(mingwei): https://github.com/rust-lang/rust-clippy/issues/8581
+]

--- a/dfir_lang/src/graph/ops/fold_keyed.rs
+++ b/dfir_lang/src/graph/ops/fold_keyed.rs
@@ -184,6 +184,7 @@ pub const FOLD_KEYED: OperatorConstraints = OperatorConstraints {
                     let () = #work_fn_async(fut).await;
                 }
 
+                #[allow(clippy::disallowed_methods, reason = "FxHasher is deterministic")]
                 let #ident = #hashtable_ident
                     .iter()
                     .map(#[allow(suspicious_double_ref_op, clippy::clone_on_copy)] |(k, v)| (k.clone(), v.clone()));
@@ -253,6 +254,7 @@ pub const FOLD_KEYED: OperatorConstraints = OperatorConstraints {
                     let () = #work_fn_async(fut).await;
                 }
 
+                #[allow(clippy::disallowed_methods, reason = "FxHasher is deterministic")]
                 let #ident = #iter_expr;
                 let #ident = #root::futures::stream::iter(#ident);
             }

--- a/dfir_lang/src/graph/ops/join_fused.rs
+++ b/dfir_lang/src/graph/ops/join_fused.rs
@@ -160,6 +160,7 @@ pub const JOIN_FUSED: OperatorConstraints = OperatorConstraints {
 
                 // TODO: start the iterator with the smallest len() table rather than always picking rhs.
                 #[allow(suspicious_double_ref_op, clippy::clone_on_copy)]
+                #[allow(clippy::disallowed_methods, reason = "FxHasher is deterministic")]
                 let iter = #rhs_borrow
                     .iter()
                     .filter_map(|(k, v2)| {

--- a/dfir_lang/src/graph/ops/reduce_keyed.rs
+++ b/dfir_lang/src/graph/ops/reduce_keyed.rs
@@ -188,6 +188,7 @@ pub const REDUCE_KEYED: OperatorConstraints = OperatorConstraints {
                     let () = #work_fn_async(fut).await;
                 }
 
+                #[allow(clippy::disallowed_methods, reason = "FxHasher is deterministic")]
                 let #ident = #iter_expr;
                 let #ident = #root::futures::stream::iter(#ident);
             }

--- a/dfir_macro/build.rs
+++ b/dfir_macro/build.rs
@@ -66,6 +66,10 @@ fn update_book() -> Result<()> {
                     .map(|category| (category, op.name))
             })
             .into_group_map();
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "nondeterministic iteration order, sorted after"
+        )]
         let categories = category_operators
             .keys()
             .copied()

--- a/dfir_rs/examples/rga/main.rs
+++ b/dfir_rs/examples/rga/main.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use adjacency::rga_adjacency;
 use clap::{Parser, ValueEnum};
@@ -112,8 +112,8 @@ async fn write_to_dot(
     list_recv: &mut UnboundedReceiverStream<(Timestamp, Timestamp)>,
     w: &mut impl std::fmt::Write,
 ) {
-    let tree_edges: HashSet<_> = collect_ready_async(rga_recv).await;
-    let list_edges: HashMap<_, _> = collect_ready_async(list_recv).await;
+    let tree_edges: BTreeSet<_> = collect_ready_async(rga_recv).await;
+    let list_edges: BTreeMap<_, _> = collect_ready_async(list_recv).await;
     let node_names = tree_edges
         .iter()
         .map(|(c, _)| (c.ts, c.value))

--- a/dfir_rs/examples/rga/protocol.rs
+++ b/dfir_rs/examples/rga/protocol.rs
@@ -12,7 +12,7 @@ impl fmt::Display for Timestamp {
     }
 }
 
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Ord, PartialOrd)]
 pub(crate) struct Token {
     pub(crate) ts: Timestamp,
     pub(crate) value: char,

--- a/dfir_rs/src/compiled/pull/half_join_state/multiset.rs
+++ b/dfir_rs/src/compiled/pull/half_join_state/multiset.rs
@@ -98,6 +98,7 @@ where
         self.len
     }
     fn iter(&self) -> std::collections::hash_map::Iter<'_, Key, SmallVec<[ValBuild; 1]>> {
+        #[expect(clippy::disallowed_methods, reason = "FxHasher is deterministic")]
         self.table.iter()
     }
 }

--- a/dfir_rs/src/compiled/pull/half_join_state/set.rs
+++ b/dfir_rs/src/compiled/pull/half_join_state/set.rs
@@ -103,6 +103,7 @@ where
     }
 
     fn iter(&self) -> std::collections::hash_map::Iter<'_, Key, SmallVec<[ValBuild; 1]>> {
+        #[expect(clippy::disallowed_methods, reason = "FxHasher is deterministic")]
         self.table.iter()
     }
 }

--- a/dfir_rs/src/util/simulation.rs
+++ b/dfir_rs/src/util/simulation.rs
@@ -297,6 +297,10 @@ impl Fleet {
     pub async fn run_single_tick_all_hosts(&mut self) -> bool {
         let mut work_done: bool = false;
 
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "nondeterministic iteration order, TODO(mingwei)"
+        )]
         for (name, host) in self.hosts.iter_mut() {
             trace!("Running tick for host: {}", name);
             work_done |= host.run_tick().await;
@@ -315,6 +319,10 @@ impl Fleet {
         let mut all_messages: Vec<(Address, MessageWithAddress)> = Vec::new();
 
         // Collect all messages from all outboxes on all hosts.
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "nondeterministic iteration order, TODO(mingwei)"
+        )]
         for (name, host) in self.hosts.iter_mut() {
             for (interface, output) in host.output.iter_mut() {
                 let src_address = Address::new(name.clone(), interface.clone());

--- a/hydro_deploy/core/src/lib.rs
+++ b/hydro_deploy/core/src/lib.rs
@@ -1,5 +1,5 @@
 use std::any::Any;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -123,7 +123,7 @@ pub trait LaunchedHost: Send + Sync {
                 demux
                     .iter()
                     .map(|(key, underlying)| (*key, self.server_config(underlying)))
-                    .collect::<HashMap<_, _>>(),
+                    .collect(),
             ),
             ServerStrategy::Merge(merge) => ServerBindConfig::Merge(
                 merge
@@ -164,7 +164,7 @@ pub enum BaseServerStrategy {
 pub enum ServerStrategy {
     Direct(BaseServerStrategy),
     Many(BaseServerStrategy),
-    Demux(HashMap<u32, ServerStrategy>),
+    Demux(BTreeMap<u32, ServerStrategy>),
     /// AppendOnlyVec has a quite large inline array, so we box it.
     Merge(Box<AppendOnlyVec<ServerStrategy>>),
     Tagged(Box<ServerStrategy>, u32),

--- a/hydro_deploy/core/src/terraform.rs
+++ b/hydro_deploy/core/src/terraform.rs
@@ -97,6 +97,10 @@ impl TerraformPool {
 
 impl Drop for TerraformPool {
     fn drop(&mut self) {
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "nondeterministic iteration order, fine for assertions"
+        )]
         for (_, apply) in self.active_applies.drain() {
             debug_assert_eq!(Arc::strong_count(&apply), 1);
         }
@@ -176,6 +180,10 @@ impl TerraformBatch {
 
             let output = ProgressTracker::with_group(
                 "apply",
+                #[expect(
+                    clippy::disallowed_methods,
+                    reason = "nondeterministic iteration order, fine for addition"
+                )]
                 Some(self.resource.values().map(|r| r.len()).sum()),
                 || async { apply.write().await.output().await },
             )

--- a/hydro_deploy/hydro_deploy_integration/src/lib.rs
+++ b/hydro_deploy/hydro_deploy_integration/src/lib.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::marker::PhantomData;
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -55,7 +55,7 @@ type UnixListener = std::convert::Infallible;
 pub enum ServerPort {
     UnixSocket(PathBuf),
     TcpPort(SocketAddr),
-    Demux(HashMap<u32, ServerPort>),
+    Demux(BTreeMap<u32, ServerPort>),
     Merge(Vec<ServerPort>),
     Tagged(Box<ServerPort>, u32),
     Null,
@@ -94,10 +94,8 @@ impl ServerPort {
                     .iter()
                     .map(|(k, v)| async move { (*k, v.connect().await) })
                     .collect::<FuturesUnordered<_>>()
-                    .collect::<Vec<_>>()
-                    .await
-                    .into_iter()
-                    .collect(),
+                    .collect::<BTreeMap<_, _>>()
+                    .await,
             ),
             ServerPort::Merge(ports) => ClientConnection::Merge(
                 ports
@@ -105,9 +103,7 @@ impl ServerPort {
                     .map(|p| p.connect())
                     .collect::<FuturesUnordered<_>>()
                     .collect::<Vec<_>>()
-                    .await
-                    .into_iter()
-                    .collect(),
+                    .await,
             ),
             ServerPort::Tagged(port, tag) => {
                 ClientConnection::Tagged(Box::new(port.as_ref().connect().await), *tag)
@@ -125,7 +121,7 @@ impl ServerPort {
 pub enum ClientConnection {
     UnixSocket(UnixStream),
     TcpPort(TcpStream),
-    Demux(HashMap<u32, ClientConnection>),
+    Demux(BTreeMap<u32, ClientConnection>),
     Merge(Vec<ClientConnection>),
     Tagged(Box<ClientConnection>, u32),
     Null,
@@ -142,7 +138,7 @@ pub enum ServerBindConfig {
         /// If `None`, the port will be chosen automatically.
         Option<u16>,
     ),
-    Demux(HashMap<u32, ServerBindConfig>),
+    Demux(BTreeMap<u32, ServerBindConfig>),
     Merge(Vec<ServerBindConfig>),
     Tagged(Box<ServerBindConfig>, u32),
     MultiConnection(Box<ServerBindConfig>),
@@ -175,16 +171,16 @@ impl ServerBindConfig {
                 BoundServer::TcpPort(TcpListenerStream::new(listener), addr)
             }
             ServerBindConfig::Demux(bindings) => {
-                let mut demux = HashMap::new();
+                let mut demux = BTreeMap::new();
                 for (key, bind) in bindings {
-                    demux.insert(key, bind.bind().await);
+                    demux.insert(key, bind.bind().await); // TODO(mingwei): Do in parallel.
                 }
                 BoundServer::Demux(demux)
             }
             ServerBindConfig::Merge(bindings) => {
                 let mut merge = Vec::new();
                 for bind in bindings {
-                    merge.push(bind.bind().await);
+                    merge.push(bind.bind().await); // TODO(mingwei): Do in parallel.
                 }
                 BoundServer::Merge(merge)
             }
@@ -247,7 +243,7 @@ pub trait ConnectedSource {
 pub enum BoundServer {
     UnixSocket(UnixListener, TempDir),
     TcpPort(TcpListenerStream, SocketAddr),
-    Demux(HashMap<u32, BoundServer>),
+    Demux(BTreeMap<u32, BoundServer>),
     Merge(Vec<BoundServer>),
     Tagged(Box<BoundServer>, u32),
     MultiConnection(Box<BoundServer>),
@@ -258,7 +254,7 @@ pub enum BoundServer {
 pub enum AcceptedServer {
     UnixSocket(UnixStream, TempDir),
     TcpPort(TcpStream),
-    Demux(HashMap<u32, AcceptedServer>),
+    Demux(BTreeMap<u32, AcceptedServer>),
     Merge(Vec<AcceptedServer>),
     Tagged(Box<AcceptedServer>, u32),
     MultiConnection(Box<BoundServer>),
@@ -332,7 +328,7 @@ impl BoundServer {
             }
 
             BoundServer::Demux(bindings) => {
-                let mut demux = HashMap::new();
+                let mut demux = BTreeMap::new();
                 for (key, bind) in bindings {
                     demux.insert(*key, bind.server_port());
                 }

--- a/hydro_lang/src/deploy/deploy_runtime_containerized_ecs.rs
+++ b/hydro_lang/src/deploy/deploy_runtime_containerized_ecs.rs
@@ -428,6 +428,10 @@ fn ecs_membership_stream(
                     }
                 }
 
+                #[expect(
+                    clippy::disallowed_methods,
+                    reason = "nondeterministic iteration order, container events are not deterministically ordered"
+                )]
                 for container_id in known_tasks.iter() {
                     if !current_tasks.contains(container_id) {
                         trace!(name: "container_left", %container_id);

--- a/hydro_lang/src/live_collections/keyed_singleton.rs
+++ b/hydro_lang/src/live_collections/keyed_singleton.rs
@@ -549,7 +549,7 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound<ValueBound = Bounded>>
     /// Flattens the keyed singleton into an unordered stream of key-value pairs.
     ///
     /// The value for each key must be bounded, otherwise the resulting stream elements would be
-    /// non-determinstic. As new entries are added to the keyed singleton, they will be streamed
+    /// non-deterministic. As new entries are added to the keyed singleton, they will be streamed
     /// into the output.
     ///
     /// # Example
@@ -582,7 +582,7 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound<ValueBound = Bounded>>
     /// Flattens the keyed singleton into an unordered stream of just the values.
     ///
     /// The value for each key must be bounded, otherwise the resulting stream elements would be
-    /// non-determinstic. As new entries are added to the keyed singleton, they will be streamed
+    /// non-deterministic. As new entries are added to the keyed singleton, they will be streamed
     /// into the output.
     ///
     /// # Example

--- a/hydro_lang/src/sim/compiled.rs
+++ b/hydro_lang/src/sim/compiled.rs
@@ -731,7 +731,7 @@ impl<T: Serialize + DeserializeOwned, O: Ordering, R: Retries> SimSender<T, O, R
 
 impl<T: Serialize + DeserializeOwned, O: Ordering> SimSender<T, O, ExactlyOnce> {
     /// Sends several messages to the external bincode sink. The messages will be asynchronously
-    /// processed as part of the simulation, in non-determinstic order.
+    /// processed as part of the simulation, in non-deterministic order.
     pub fn send_many_unordered<I: IntoIterator<Item = T>>(&self, iter: I) {
         self.with_sink(|send| {
             for t in iter {

--- a/hydro_lang/src/sim/flow.rs
+++ b/hydro_lang/src/sim/flow.rs
@@ -175,6 +175,10 @@ impl<'a> SimFlow<'a> {
             })
             .collect::<BTreeMap<_, _>>();
 
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "nondeterministic iteration order, fine for checks"
+        )]
         for c in self.clusters.keys() {
             assert!(
                 self.cluster_max_sizes.contains_key(c),

--- a/hydro_lang/src/sim/graph.rs
+++ b/hydro_lang/src/sim/graph.rs
@@ -718,8 +718,14 @@ fn compile_sim_graph_trybuild(
         })
         .collect::<Vec<syn::Expr>>();
 
-    let cluster_ids_stmts = cluster_max_sizes
-        .iter()
+    // TODO(mingwei): https://github.com/rust-lang/rust-clippy/issues/8581
+    // #[expect(
+    //     clippy::disallowed_methods,
+    //     reason = "nondeterministic iteration order, will be sorted"
+    // )]
+    let mut cluster_max_sizes = cluster_max_sizes.into_iter().collect::<Vec<_>>();
+    cluster_max_sizes.sort();
+    let cluster_ids_stmts = cluster_max_sizes.into_iter()
         .map(|(loc_key, max_size)| {
             let ident = syn::Ident::new(
                 &format!(
@@ -729,7 +735,7 @@ fn compile_sim_graph_trybuild(
                 Span::call_site(),
             );
 
-            let elements = (0..*max_size as u32)
+            let elements = (0..max_size as u32)
                 .map(|i| syn::parse_quote! { #i })
                 .collect::<Vec<syn::Expr>>();
 

--- a/hydro_lang/src/sim/runtime.rs
+++ b/hydro_lang/src/sim/runtime.rs
@@ -275,6 +275,7 @@ impl<K: Hash + Eq + Clone, V> SimHook for KeyedStreamHook<K, V, TotalOrder> {
     }
 
     fn can_make_nontrivial_decision(&self) -> bool {
+        #[expect(clippy::disallowed_methods, reason = "FxHasher is deterministic")]
         !self.input.borrow().values().all(|q| q.is_empty())
     }
 
@@ -285,9 +286,11 @@ impl<K: Hash + Eq + Clone, V> SimHook for KeyedStreamHook<K, V, TotalOrder> {
     ) -> bool {
         let mut current_input = self.input.borrow_mut();
         self.to_release = Some(vec![]);
+        #[expect(clippy::disallowed_methods, reason = "FxHasher is deterministic")]
         let nonempty_key_count = current_input.values().filter(|q| !q.is_empty()).count();
 
         let mut remaining_nonempty_keys = nonempty_key_count;
+        #[expect(clippy::disallowed_methods, reason = "FxHasher is deterministic")]
         for (key, queue) in current_input.iter_mut() {
             if queue.is_empty() {
                 continue;
@@ -362,6 +365,7 @@ impl<K: Hash + Eq + Clone, V> SimHook for KeyedStreamHook<K, V, NoOrder> {
     }
 
     fn can_make_nontrivial_decision(&self) -> bool {
+        #[expect(clippy::disallowed_methods, reason = "FxHasher is deterministic")]
         !self.input.borrow().values().all(|q| q.is_empty())
     }
 
@@ -372,9 +376,11 @@ impl<K: Hash + Eq + Clone, V> SimHook for KeyedStreamHook<K, V, NoOrder> {
     ) -> bool {
         let mut current_input = self.input.borrow_mut();
         self.to_release = Some(vec![]);
+        #[expect(clippy::disallowed_methods, reason = "FxHasher is deterministic")]
         let nonempty_key_count = current_input.values().filter(|q| !q.is_empty()).count();
 
         let mut remaining_nonempty_keys = nonempty_key_count;
+        #[expect(clippy::disallowed_methods, reason = "FxHasher is deterministic")]
         for (key, queue) in current_input.iter_mut() {
             if queue.is_empty() {
                 continue;
@@ -615,6 +621,7 @@ impl<K: Hash + Eq + Clone, V: Clone> SimHook for KeyedSingletonHook<K, V> {
     }
 
     fn can_make_nontrivial_decision(&self) -> bool {
+        #[expect(clippy::disallowed_methods, reason = "FxHasher is deterministic")]
         !self.input.borrow().values().all(|q| q.is_empty())
     }
 
@@ -625,10 +632,12 @@ impl<K: Hash + Eq + Clone, V: Clone> SimHook for KeyedSingletonHook<K, V> {
     ) -> bool {
         let mut current_input = self.input.borrow_mut();
         self.to_release = Some(vec![]);
+        #[expect(clippy::disallowed_methods, reason = "FxHasher is deterministic")]
         let nonempty_key_count = current_input.values().filter(|q| !q.is_empty()).count();
 
         let mut remaining_nonempty_keys = nonempty_key_count;
         let mut any_nontrivial = false;
+        #[expect(clippy::disallowed_methods, reason = "FxHasher is deterministic")]
         for (key, queue) in current_input.iter_mut() {
             if queue.is_empty() {
                 self.to_release.as_mut().unwrap().push((

--- a/hydro_lang/src/viz/json.rs
+++ b/hydro_lang/src/viz/json.rs
@@ -421,6 +421,10 @@ where
         self.edge_count = self.edge_count.saturating_add(1);
 
         // Convert edge properties to semantic tags (string array)
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "nondeterministic iteration order, TODO(mingwei)"
+        )]
         let mut semantic_tags: Vec<String> = edge_properties
             .iter()
             .map(|p| Self::edge_type_to_string(*p))
@@ -748,6 +752,10 @@ impl<W> HydroJson<'_, W> {
         }
 
         // Remove nodes that already have backtrace assignments
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "nondeterministic iteration order, TODO(mingwei)"
+        )]
         for node_ids in path_to_node_assignments.values() {
             for node_id in node_ids {
                 nodes_without_backtrace.retain(|id| id != node_id);
@@ -814,6 +822,10 @@ impl<W> HydroJson<'_, W> {
         HashMap<String, String>,
     ) {
         // Assign IDs deterministically based on sorted path names
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "nondeterministic iteration order, TODO(mingwei)"
+        )]
         let mut keys: Vec<&String> = hierarchy_map.keys().collect();
         keys.sort();
         let mut path_to_id: HashMap<String, String> = HashMap::new();
@@ -822,6 +834,10 @@ impl<W> HydroJson<'_, W> {
         }
 
         // Find root items (depth 0) and sort by name
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "nondeterministic iteration order, TODO(mingwei)"
+        )]
         let mut roots: Vec<(String, String)> = hierarchy_map
             .iter()
             .filter_map(|(path, (name, depth, _))| {
@@ -849,6 +865,10 @@ impl<W> HydroJson<'_, W> {
 
         // Update path_to_id with remappings
         let mut updated_path_to_id = path_to_id.clone();
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "nondeterministic iteration order, TODO(mingwei)"
+        )]
         for (path, old_id) in path_to_id.iter() {
             if let Some(new_id) = id_remapping.get(old_id) {
                 updated_path_to_id.insert(path.clone(), new_id.clone());
@@ -868,6 +888,10 @@ impl<W> HydroJson<'_, W> {
         let current_id = path_to_id.get(current_path).unwrap().clone();
 
         // Find children (paths that have this path as parent)
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "nondeterministic iteration order, TODO(mingwei)"
+        )]
         let mut child_specs: Vec<(&String, &String)> = hierarchy_map
             .iter()
             .filter_map(|(child_path, (child_name, _, parent_path))| {

--- a/hydro_test/src/cluster/paxos.rs
+++ b/hydro_test/src/cluster/paxos.rs
@@ -448,7 +448,7 @@ fn p_leader_heartbeat<'a>(
                 )),
                 q!(Duration::from_secs(i_am_leader_check_timeout)),
                 nondet!(
-                    /// If the leader 'un-expires' due to non-determinstic delay, we return
+                    /// If the leader 'un-expires' due to non-deterministic delay, we return
                     /// to a stable leader state. If the leader remains expired, non-deterministic
                     /// delay is propagated to the non-determinism of which leader is elected.
                     nondet_reelection

--- a/lattices/src/algebra.rs
+++ b/lattices/src/algebra.rs
@@ -1060,6 +1060,10 @@ mod test {
                 &|x, y| {
                     let mut new_set = HashSet::new();
 
+                    #[expect(
+                        clippy::disallowed_methods,
+                        reason = "nondeterministic iteration order, fine to collect into set"
+                    )]
                     for a in x.iter() {
                         for b in y.iter() {
                             new_set.insert(format!("{a}{b}"));

--- a/lattices/src/ght/colt.rs
+++ b/lattices/src/ght/colt.rs
@@ -207,6 +207,10 @@ where
     }
 
     fn iter(&self) -> impl Iterator<Item = Self::Head> {
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "nondeterministic iteration order, TODO(mingwei)"
+        )]
         self.0.children.keys().cloned().chain(Rest::iter(&self.1))
     }
 }
@@ -241,6 +245,10 @@ where
     }
 
     fn iter(&self) -> impl Iterator<Item = Self::Head> {
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "nondeterministic iteration order, TODO(mingwei)"
+        )]
         self.0.children.keys().cloned().chain(Rest::iter(&self.1))
     }
 }
@@ -286,6 +294,10 @@ where
     }
 
     fn iter(&self) -> impl Iterator<Item = Self::Head> {
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "nondeterministic iteration order, TODO(mingwei)"
+        )]
         self.0.children.keys().cloned()
     }
 }

--- a/lattices/src/ght/lattice.rs
+++ b/lattices/src/ght/lattice.rs
@@ -93,6 +93,10 @@ where
         if self.children.is_empty() && other.children.is_empty() {
             Some(Equal)
         } else {
+            #[expect(
+                clippy::disallowed_methods,
+                reason = "nondeterministic iteration order, TODO(mingwei)"
+            )]
             for k in self.children.keys().chain(other.children.keys()) {
                 match (self.children.get(k), other.children.get(k)) {
                     (Some(self_value), Some(other_value)) => {
@@ -190,6 +194,10 @@ where
     Node: GeneralizedHashTrieNode + IsBot,
 {
     fn is_bot(&self) -> bool {
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "nondeterministic iteration order, TODO(mingwei)"
+        )]
         self.children.iter().all(|(_, v)| v.is_bot())
     }
 }

--- a/lattices/src/ght/mod.rs
+++ b/lattices/src/ght/mod.rs
@@ -158,6 +158,10 @@ where
     }
 
     fn recursive_iter(&self) -> impl Iterator<Item = <Self::Schema as VariadicExt>::AsRefVar<'_>> {
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "nondeterministic iteration order, TODO(mingwei)"
+        )]
         self.children
             .iter()
             .flat_map(|(_k, vs)| vs.recursive_iter())
@@ -425,6 +429,10 @@ where
     }
 
     fn iter(&self) -> impl Iterator<Item = Self::Head> {
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "nondeterministic iteration order, TODO(mingwei)"
+        )]
         self.children.keys().cloned()
     }
 

--- a/lattices/src/ght/test.rs
+++ b/lattices/src/ght/test.rs
@@ -209,6 +209,10 @@ mod tests {
             .map(|&(a, b, c)| var_expr!(a, b, c)),
         );
         let htrie = MyGht::new_from(input.clone());
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "nondeterministic iteration order, fine to collect into set"
+        )]
         let result = input.iter().map(|v| v.as_ref_var()).collect();
         let v: HashSet<ResultType> = htrie.recursive_iter().collect();
         assert_eq!(v, result);
@@ -241,6 +245,10 @@ mod tests {
         // let key = var_expr!(42u8).as_ref_var();
         let key = (); // (var_expr!().as_ref_var();)
         let v: HashSet<ResultType> = leaf.prefix_iter(key).collect();
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "nondeterministic iteration order, fine to collect into set"
+        )]
         let result = input
             .iter()
             // .filter(|t: &&InputType| t.0 == 42)
@@ -276,6 +284,10 @@ mod tests {
         assert_eq!(v, result);
 
         let v: HashSet<ResultType> = htrie.prefix_iter(var_expr!(42u8).as_ref_var()).collect();
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "nondeterministic iteration order, fine to collect into set"
+        )]
         let result = input
             .iter()
             .filter(|t: &&InputType| t.0 == 42)
@@ -317,6 +329,10 @@ mod tests {
         let v: HashSet<ResultType> = htrie
             .prefix_iter(var_expr!(true, 1, "hi").as_ref_var())
             .collect();
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "nondeterministic iteration order, fine to collect into set"
+        )]
         let result = input
             .iter()
             .filter(|t: &&InputType| t.0 && t.1.0 == 1 && t.1.1.0 == "hi")
@@ -326,6 +342,10 @@ mod tests {
         assert_eq!(v, result);
 
         let v: HashSet<ResultType> = htrie.prefix_iter(var_expr!(true).as_ref_var()).collect();
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "nondeterministic iteration order, fine to collect into set"
+        )]
         let result = input
             .iter()
             .filter(|t: &&InputType| t.0)
@@ -499,7 +519,7 @@ mod tests {
             ));
             let out = bim.call(&ght_a, &ght_b);
             let out: HashSet<ResultSchemaRefType> = out.recursive_iter().collect();
-            assert_eq!(out, result.iter().copied().collect());
+            assert_eq!(out, result);
         }
         {
             // Here we use DeepJoinLatticeBimorphism as a more compact representation of the
@@ -510,7 +530,7 @@ mod tests {
             let mut bim = <MyNodeBim as Default>::default();
             let out = bim.call(&ght_a, &ght_b);
             let out: HashSet<ResultSchemaRefType> = out.recursive_iter().collect();
-            assert_eq!(out, result.iter().copied().collect());
+            assert_eq!(out, result);
         }
     }
 

--- a/lattices/src/tombstone.rs
+++ b/lattices/src/tombstone.rs
@@ -322,6 +322,10 @@ where
 
     fn union_with(&mut self, other: &Self) -> usize {
         let old_len = self.len();
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "nondeterministic iteration order, fine to insert into set"
+        )]
         for item in other.iter() {
             self.insert(item.clone());
         }

--- a/sinktools/src/demux_map.rs
+++ b/sinktools/src/demux_map.rs
@@ -32,6 +32,10 @@ where
     type Error = Si::Error;
 
     fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "nondeterministic iteration order, the `try_fold` is not order-dependent"
+        )]
         self.get_mut()
             .sinks
             .values_mut()
@@ -51,6 +55,10 @@ where
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "nondeterministic iteration order, the `try_fold` is not order-dependent"
+        )]
         self.get_mut()
             .sinks
             .values_mut()
@@ -61,6 +69,10 @@ where
     }
 
     fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "nondeterministic iteration order, the `try_fold` is not order-dependent"
+        )]
         self.get_mut()
             .sinks
             .values_mut()

--- a/sinktools/src/demux_map_lazy.rs
+++ b/sinktools/src/demux_map_lazy.rs
@@ -35,6 +35,10 @@ where
     type Error = Si::Error;
 
     fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "nondeterministic iteration order, the `try_fold` is not order-dependent"
+        )]
         self.get_mut()
             .sinks
             .values_mut()
@@ -54,6 +58,10 @@ where
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "nondeterministic iteration order, the `try_fold` is not order-dependent"
+        )]
         self.get_mut()
             .sinks
             .values_mut()
@@ -64,6 +72,10 @@ where
     }
 
     fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "nondeterministic iteration order, the `try_fold` is not order-dependent"
+        )]
         self.get_mut()
             .sinks
             .values_mut()


### PR DESCRIPTION
Out of an abundance of caution, the `hydro_lang` IR `Demux` variants containing `HashMap<u32 ...>` have been replaced with `BTreeMap`