### PR TITLE
feat(hydro_lang): support top-level `assume_ordering` in the simulator

### DIFF
--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -2434,7 +2434,7 @@ mod tests {
     use hydro_deploy::Deployment;
     #[cfg(feature = "deploy")]
     use serde::{Deserialize, Serialize};
-    #[cfg(feature = "deploy")]
+    #[cfg(any(feature = "deploy", feature = "sim"))]
     use stageleft::q;
 
     #[cfg(any(feature = "deploy", feature = "sim"))]
@@ -3001,5 +3001,141 @@ mod tests {
             instance_count,
             16 // 2^4, { 0, 1, 2, 3 } can be a snapshot and 4 is always included
         )
+    }
+
+    #[cfg(feature = "sim")]
+    #[test]
+    fn sim_top_level_assume_ordering() {
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<()>();
+
+        let (in_send, input) = node.sim_input::<_, NoOrder, _>();
+
+        let out_recv = input
+            .assume_ordering::<TotalOrder>(nondet!(/** test */))
+            .sim_output();
+
+        let instance_count = flow.sim().exhaustive(async || {
+            in_send.send_many_unordered([1, 2, 3]);
+            let mut out = out_recv.collect::<Vec<_>>().await;
+            out.sort();
+            assert_eq!(out, vec![1, 2, 3]);
+        });
+
+        assert_eq!(instance_count, 6)
+    }
+
+    #[cfg(feature = "sim")]
+    #[test]
+    fn sim_top_level_assume_ordering_cycle_back() {
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<()>();
+
+        let (in_send, input) = node.sim_input::<_, NoOrder, _>();
+
+        let (complete_cycle_back, cycle_back) =
+            node.forward_ref::<super::Stream<_, _, _, NoOrder>>();
+        let ordered = input
+            .interleave(cycle_back)
+            .assume_ordering::<TotalOrder>(nondet!(/** test */));
+        complete_cycle_back.complete(
+            ordered
+                .clone()
+                .map(q!(|v| v + 1))
+                .filter(q!(|v| v % 2 == 1)),
+        );
+
+        let out_recv = ordered.sim_output();
+
+        let mut saw = false;
+        let instance_count = flow.sim().exhaustive(async || {
+            in_send.send_many_unordered([0, 2]);
+            let out = out_recv.collect::<Vec<_>>().await;
+
+            if out.starts_with(&[0, 1, 2]) {
+                saw = true;
+            }
+        });
+
+        assert!(saw, "did not see an instance with 0, 1, 2 in order");
+        assert_eq!(instance_count, 6)
+    }
+
+    #[cfg(feature = "sim")]
+    #[test]
+    fn sim_top_level_assume_ordering_cycle_back_tick() {
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<()>();
+
+        let (in_send, input) = node.sim_input::<_, NoOrder, _>();
+
+        let (complete_cycle_back, cycle_back) =
+            node.forward_ref::<super::Stream<_, _, _, NoOrder>>();
+        let ordered = input
+            .interleave(cycle_back)
+            .assume_ordering::<TotalOrder>(nondet!(/** test */));
+        complete_cycle_back.complete(
+            ordered
+                .clone()
+                .batch(&node.tick(), nondet!(/** test */))
+                .all_ticks()
+                .map(q!(|v| v + 1))
+                .filter(q!(|v| v % 2 == 1)),
+        );
+
+        let out_recv = ordered.sim_output();
+
+        let mut saw = false;
+        let instance_count = flow.sim().exhaustive(async || {
+            in_send.send_many_unordered([0, 2]);
+            let out = out_recv.collect::<Vec<_>>().await;
+
+            if out.starts_with(&[0, 1, 2]) {
+                saw = true;
+            }
+        });
+
+        assert!(saw, "did not see an instance with 0, 1, 2 in order");
+        assert_eq!(instance_count, 58)
+    }
+
+    #[cfg(feature = "sim")]
+    #[test]
+    fn sim_top_level_assume_ordering_multiple() {
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<()>();
+
+        let (in_send, input) = node.sim_input::<_, NoOrder, _>();
+        let (_, input2) = node.sim_input::<_, NoOrder, _>();
+
+        let (complete_cycle_back, cycle_back) =
+            node.forward_ref::<super::Stream<_, _, _, NoOrder>>();
+        let input1_ordered = input
+            .clone()
+            .interleave(cycle_back)
+            .assume_ordering::<TotalOrder>(nondet!(/** test */));
+        let foo = input1_ordered
+            .clone()
+            .map(q!(|v| v + 3))
+            .weaken_ordering::<NoOrder>()
+            .interleave(input2)
+            .assume_ordering::<TotalOrder>(nondet!(/** test */));
+
+        complete_cycle_back.complete(foo.filter(q!(|v| *v == 3)));
+
+        let out_recv = input1_ordered.sim_output();
+
+        let mut saw = false;
+        let instance_count = flow.sim().exhaustive(async || {
+            in_send.send_many_unordered([0, 1]);
+            let out = out_recv.collect::<Vec<_>>().await;
+
+            if out.starts_with(&[0, 3, 1]) {
+                saw = true;
+            }
+        });
+
+        assert!(saw, "did not see an instance with 0, 3, 1 in order");
+        assert_eq!(instance_count, 24)
     }
 }

--- a/hydro_lang/src/sim/builder.rs
+++ b/hydro_lang/src/sim/builder.rs
@@ -668,7 +668,76 @@ impl DfirBuilder for SimBuilder {
                 }
             }
         } else {
-            todo!("non-trusted observe_nondet not yet supported at top-level locations");
+            let (assume_location, line, caret) = location_for_op(op_meta);
+            let root = get_this_crate();
+
+            match (in_kind, out_kind) {
+                (
+                    CollectionKind::Stream {
+                        order: StreamOrder::NoOrder,
+                        retry: StreamRetry::ExactlyOnce,
+                        ..
+                    },
+                    CollectionKind::Stream {
+                        order: StreamOrder::TotalOrder,
+                        retry: StreamRetry::ExactlyOnce,
+                        ..
+                    },
+                ) => {
+                    let hoff_id = self.next_hoff_id;
+                    self.next_hoff_id += 1;
+
+                    let buffered_ident =
+                        syn::Ident::new(&format!("__buffered_{hoff_id}"), Span::call_site());
+                    let hoff_send_ident =
+                        syn::Ident::new(&format!("__hoff_send_{hoff_id}"), Span::call_site());
+                    let hoff_recv_ident =
+                        syn::Ident::new(&format!("__hoff_recv_{hoff_id}"), Span::call_site());
+
+                    self.add_extra_stmt_internal(location, syn::parse_quote! {
+                        let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unbounded_channel();
+                    });
+                    self.add_extra_stmt_internal(location, syn::parse_quote! {
+                        let #buffered_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(::std::collections::VecDeque::new()));
+                    });
+                    self.add_hook(
+                        location,
+                        location,
+                        syn::parse_quote!(
+                            Box::new(#root::sim::runtime::TopLevelStreamOrderHook::<_> {
+                                input: #buffered_ident.clone(),
+                                to_release: None,
+                                output: #hoff_send_ident,
+                                location: (#assume_location, #line, #caret),
+                                format_item_debug: #root::__maybe_debug__!(),
+                            })
+                        ),
+                    );
+
+                    self.get_dfir_mut(location).add_dfir(
+                        parse_quote! {
+                            #in_ident -> for_each(|v| #buffered_ident.borrow_mut().push_back(v));
+                        },
+                        None,
+                        None,
+                    );
+
+                    self.get_dfir_mut(location).add_dfir(
+                        parse_quote! {
+                            #out_ident = source_stream(#hoff_recv_ident);
+                        },
+                        None,
+                        None,
+                    );
+                }
+                _ => {
+                    todo!(
+                        "non-trusted observe_nondet not yet supported for kinds {:?} -> {:?} at top-level locations",
+                        in_kind,
+                        out_kind
+                    );
+                }
+            }
         }
     }
 

--- a/hydro_lang/src/sim/compiled.rs
+++ b/hydro_lang/src/sim/compiled.rs
@@ -28,6 +28,7 @@ use crate::compile::builder::ExternalPortId;
 use crate::live_collections::stream::{ExactlyOnce, NoOrder, Ordering, Retries, TotalOrder};
 use crate::location::dynamic::LocationId;
 use crate::sim::graph::{SimExternalPort, SimExternalPortRegistry};
+use crate::sim::runtime::SimHook;
 
 struct SimConnections {
     input_senders: HashMap<SimExternalPort, Rc<UnboundedSender<Bytes>>>,
@@ -429,6 +430,12 @@ impl<'a> CompiledSimInstance<'a> {
                 },
             )
         };
+
+        let not_ready_observation = async_dfirs
+            .iter()
+            .map(|(lid, c_id, _)| (serde_json::from_str(lid).unwrap(), *c_id))
+            .collect();
+
         let mut launched = LaunchedSim {
             async_dfirs: async_dfirs
                 .into_iter()
@@ -439,6 +446,8 @@ impl<'a> CompiledSimInstance<'a> {
                 .into_iter()
                 .map(|(lid, c_id, dfir)| (serde_json::from_str(lid).unwrap(), c_id, dfir))
                 .collect(),
+            possibly_ready_observation: vec![],
+            not_ready_observation,
             hooks: hooks
                 .into_iter()
                 .map(|((lid, cid), hs)| ((serde_json::from_str(lid).unwrap(), cid), hs))
@@ -785,6 +794,8 @@ struct LaunchedSim<W: std::io::Write> {
     async_dfirs: Vec<(LocationId, Option<u32>, Dfir<'static>)>,
     possibly_ready_ticks: Vec<(LocationId, Option<u32>, Dfir<'static>)>,
     not_ready_ticks: Vec<(LocationId, Option<u32>, Dfir<'static>)>,
+    possibly_ready_observation: Vec<(LocationId, Option<u32>)>,
+    not_ready_observation: Vec<(LocationId, Option<u32>)>,
     hooks: Hooks<LocationId>,
     inline_hooks: InlineHooks<LocationId>,
     log: LogKind<W>,
@@ -810,6 +821,14 @@ impl<W: std::io::Write> LaunchedSim<W> {
 
                     self.possibly_ready_ticks.extend(now_ready);
                     self.not_ready_ticks.extend(still_not_ready);
+
+                    let (now_ready_obs, still_not_ready_obs): (Vec<_>, Vec<_>) = self
+                        .not_ready_observation
+                        .drain(..)
+                        .partition(|(obs_loc, obs_c_id)| obs_loc == loc && obs_c_id == c_id);
+
+                    self.possibly_ready_observation.extend(now_ready_obs);
+                    self.not_ready_observation.extend(still_not_ready_obs);
                 }
             }
 
@@ -818,7 +837,7 @@ impl<W: std::io::Write> LaunchedSim<W> {
             } else {
                 use bolero::generator::*;
 
-                let (ready, mut not_ready): (Vec<_>, Vec<_>) = self
+                let (ready_tick, mut not_ready_tick): (Vec<_>, Vec<_>) = self
                     .possibly_ready_ticks
                     .drain(..)
                     .partition(|(name, cid, _)| {
@@ -832,119 +851,157 @@ impl<W: std::io::Write> LaunchedSim<W> {
                             })
                     });
 
-                self.possibly_ready_ticks = ready;
-                self.not_ready_ticks.append(&mut not_ready);
+                self.possibly_ready_ticks = ready_tick;
+                self.not_ready_ticks.append(&mut not_ready_tick);
 
-                if self.possibly_ready_ticks.is_empty() {
+                let (ready_obs, mut not_ready_obs): (Vec<_>, Vec<_>) = self
+                    .possibly_ready_observation
+                    .drain(..)
+                    .partition(|(name, cid)| {
+                        self.hooks
+                            .get(&(name.clone(), *cid))
+                            .into_iter()
+                            .flatten()
+                            .any(|hook| {
+                                hook.current_decision().unwrap_or(false)
+                                    || hook.can_make_nontrivial_decision()
+                            })
+                    });
+
+                self.possibly_ready_observation = ready_obs;
+                self.not_ready_observation.append(&mut not_ready_obs);
+
+                if self.possibly_ready_ticks.is_empty()
+                    && self.possibly_ready_observation.is_empty()
+                {
                     break;
                 } else {
-                    let next_tick = (0..self.possibly_ready_ticks.len()).any();
-                    let mut removed = self.possibly_ready_ticks.remove(next_tick);
+                    let next_tick_or_obs = (0..(self.possibly_ready_ticks.len()
+                        + self.possibly_ready_observation.len()))
+                        .any();
 
-                    match &mut self.log {
-                        LogKind::Null => {}
-                        LogKind::Stderr => {
-                            if let Some(cid) = &removed.1 {
-                                eprintln!(
-                                    "\n{}",
-                                    format!("Running Tick (Cluster Member {})", cid)
-                                        .color(colored::Color::Magenta)
-                                        .bold()
-                                )
-                            } else {
-                                eprintln!(
+                    if next_tick_or_obs < self.possibly_ready_ticks.len() {
+                        let next_tick = next_tick_or_obs;
+                        let mut removed = self.possibly_ready_ticks.remove(next_tick);
+
+                        match &mut self.log {
+                            LogKind::Null => {}
+                            LogKind::Stderr => {
+                                if let Some(cid) = &removed.1 {
+                                    eprintln!(
+                                        "\n{}",
+                                        format!("Running Tick (Cluster Member {})", cid)
+                                            .color(colored::Color::Magenta)
+                                            .bold()
+                                    )
+                                } else {
+                                    eprintln!(
+                                        "\n{}",
+                                        "Running Tick".color(colored::Color::Magenta).bold()
+                                    )
+                                }
+                            }
+                            LogKind::Custom(writer) => {
+                                writeln!(
+                                    writer,
                                     "\n{}",
                                     "Running Tick".color(colored::Color::Magenta).bold()
                                 )
+                                .unwrap();
                             }
                         }
-                        LogKind::Custom(writer) => {
-                            writeln!(
-                                writer,
-                                "\n{}",
-                                "Running Tick".color(colored::Color::Magenta).bold()
-                            )
-                            .unwrap();
-                        }
-                    }
 
-                    let mut asterisk_indenter = |_line_no, write: &mut dyn std::fmt::Write| {
-                        write.write_str(&"*".color(colored::Color::Magenta).bold())?;
-                        write.write_str(" ")
-                    };
+                        let mut asterisk_indenter = |_line_no, write: &mut dyn std::fmt::Write| {
+                            write.write_str(&"*".color(colored::Color::Magenta).bold())?;
+                            write.write_str(" ")
+                        };
 
-                    let mut tick_decision_writer =
-                        indenter::indented(&mut self.log).with_format(indenter::Format::Custom {
-                            inserter: &mut asterisk_indenter,
-                        });
+                        let mut tick_decision_writer = indenter::indented(&mut self.log)
+                            .with_format(indenter::Format::Custom {
+                                inserter: &mut asterisk_indenter,
+                            });
 
-                    let hooks = self.hooks.get_mut(&(removed.0.clone(), removed.1)).unwrap();
-                    let mut remaining_decision_count = hooks.len();
-                    let mut made_nontrivial_decision = false;
+                        let hooks = self.hooks.get_mut(&(removed.0.clone(), removed.1)).unwrap();
+                        run_hooks(&mut tick_decision_writer, hooks);
 
-                    bolero_generator::any::scope::borrow_with(|driver| {
-                        // first, scan manual decisions
-                        hooks.iter_mut().for_each(|hook| {
-                            if let Some(is_nontrivial) = hook.current_decision() {
-                                made_nontrivial_decision |= is_nontrivial;
-                                remaining_decision_count -= 1;
-                            } else if !hook.can_make_nontrivial_decision() {
-                                // if no nontrivial decision is possible, make a trivial one
-                                // (we need to do this in the first pass to force nontrivial decisions
-                                // on the remaining hooks)
-                                hook.autonomous_decision(driver, false);
-                                remaining_decision_count -= 1;
-                            }
-                        });
+                        let run_tick_future = removed.2.run_tick();
+                        if let Some(inline_hooks) =
+                            self.inline_hooks.get_mut(&(removed.0.clone(), removed.1))
+                        {
+                            let mut run_tick_future_pinned = pin!(run_tick_future);
 
-                        hooks.iter_mut().for_each(|hook| {
-                            if hook.current_decision().is_none() {
-                                made_nontrivial_decision |= hook.autonomous_decision(
-                                    driver,
-                                    !made_nontrivial_decision && remaining_decision_count == 1,
-                                );
-                                remaining_decision_count -= 1;
-                            }
+                            loop {
+                                tokio::select! {
+                                    biased;
+                                    r = &mut run_tick_future_pinned => {
+                                        assert!(r);
+                                        break;
+                                    }
+                                    _ = async {} => {
+                                        bolero_generator::any::scope::borrow_with(|driver| {
+                                            for hook in inline_hooks.iter_mut() {
+                                                if hook.pending_decision() {
+                                                    if !hook.has_decision() {
+                                                        hook.autonomous_decision(driver);
+                                                    }
 
-                            hook.release_decision(&mut tick_decision_writer);
-                        });
-                    });
-
-                    let run_tick_future = removed.2.run_tick();
-                    if let Some(inline_hooks) =
-                        self.inline_hooks.get_mut(&(removed.0.clone(), removed.1))
-                    {
-                        let mut run_tick_future_pinned = pin!(run_tick_future);
-
-                        loop {
-                            tokio::select! {
-                                biased;
-                                r = &mut run_tick_future_pinned => {
-                                    assert!(r);
-                                    break;
-                                }
-                                _ = async {} => {
-                                    bolero_generator::any::scope::borrow_with(|driver| {
-                                        for hook in inline_hooks.iter_mut() {
-                                            if hook.pending_decision() {
-                                                if !hook.has_decision() {
-                                                    hook.autonomous_decision(driver);
+                                                    hook.release_decision(&mut tick_decision_writer);
                                                 }
-
-                                                hook.release_decision(&mut tick_decision_writer);
                                             }
-                                        }
-                                    });
+                                        });
+                                    }
                                 }
                             }
+                        } else {
+                            assert!(run_tick_future.await);
                         }
-                    } else {
-                        assert!(run_tick_future.await);
-                    }
 
-                    self.possibly_ready_ticks.push(removed);
+                        self.possibly_ready_ticks.push(removed);
+                    } else {
+                        let next_obs = next_tick_or_obs - self.possibly_ready_ticks.len();
+                        let mut default_hooks = vec![];
+                        let hooks = self
+                            .hooks
+                            .get_mut(&self.possibly_ready_observation[next_obs])
+                            .unwrap_or(&mut default_hooks);
+
+                        run_hooks(&mut self.log, hooks);
+                    }
                 }
             }
         }
     }
+}
+
+fn run_hooks(tick_decision_writer: &mut impl std::fmt::Write, hooks: &mut Vec<Box<dyn SimHook>>) {
+    let mut remaining_decision_count = hooks.len();
+    let mut made_nontrivial_decision = false;
+
+    bolero::generator::bolero_generator::any::scope::borrow_with(|driver| {
+        // first, scan manual decisions
+        hooks.iter_mut().for_each(|hook| {
+            if let Some(is_nontrivial) = hook.current_decision() {
+                made_nontrivial_decision |= is_nontrivial;
+                remaining_decision_count -= 1;
+            } else if !hook.can_make_nontrivial_decision() {
+                // if no nontrivial decision is possible, make a trivial one
+                // (we need to do this in the first pass to force nontrivial decisions
+                // on the remaining hooks)
+                hook.autonomous_decision(driver, false);
+                remaining_decision_count -= 1;
+            }
+        });
+
+        hooks.iter_mut().for_each(|hook| {
+            if hook.current_decision().is_none() {
+                made_nontrivial_decision |= hook.autonomous_decision(
+                    driver,
+                    !made_nontrivial_decision && remaining_decision_count == 1,
+                );
+                remaining_decision_count -= 1;
+            }
+
+            hook.release_decision(tick_decision_writer);
+        });
+    });
 }

--- a/hydro_lang/src/sim/runtime.rs
+++ b/hydro_lang/src/sim/runtime.rs
@@ -938,3 +938,86 @@ impl<K: Hash + Eq + Clone, V> SimInlineHook for KeyedStreamOrderHook<K, V> {
         }
     }
 }
+
+pub struct TopLevelStreamOrderHook<T> {
+    pub input: Rc<RefCell<VecDeque<T>>>,
+    pub to_release: Option<Vec<T>>,
+    pub output: UnboundedSender<T>,
+    pub location: HookLocationMeta,
+    pub format_item_debug: fn(&T) -> Option<String>,
+}
+
+impl<T> SimHook for TopLevelStreamOrderHook<T> {
+    fn current_decision(&self) -> Option<bool> {
+        self.to_release.as_ref().map(|v| !v.is_empty())
+    }
+
+    fn can_make_nontrivial_decision(&self) -> bool {
+        !self.input.borrow().is_empty()
+    }
+
+    fn autonomous_decision<'a>(
+        &mut self,
+        driver: &mut Borrowed<'a>,
+        force_nontrivial: bool,
+    ) -> bool {
+        let mut current_input = self.input.borrow_mut();
+        let mut out = vec![];
+
+        // instead of a full shuffle, we only release one element at a time
+        // in order to handle possible feedback cycles
+        if !current_input.is_empty() {
+            let must_release = force_nontrivial && out.is_empty();
+            if !must_release && produce().generate(driver).unwrap() {
+                // don't release anything
+            } else {
+                let idx = (0..current_input.len()).generate(driver).unwrap();
+                let item = current_input.remove(idx).unwrap();
+                out.push(item);
+            }
+        }
+
+        let was_nontrivial = !out.is_empty();
+        self.to_release = Some(out);
+        was_nontrivial
+    }
+
+    fn release_decision(&mut self, log_writer: &mut dyn std::fmt::Write) {
+        if let Some(to_release) = self.to_release.take() {
+            if !to_release.is_empty() {
+                let (batch_location, line, caret_indent) = self.location;
+                let note_str = format!(
+                    "^ observered non-deterministic order: {:?}",
+                    TruncatedVecDebug(
+                        RefCell::new(Some(to_release.iter())),
+                        8,
+                        self.format_item_debug
+                    )
+                );
+
+                let _ = writeln!(
+                    log_writer,
+                    "\n{} {}",
+                    "-->".color(colored::Color::Blue),
+                    batch_location
+                );
+
+                let _ = writeln!(log_writer, " {}{}", "|".color(colored::Color::Blue), line);
+
+                let _ = writeln!(
+                    log_writer,
+                    " {}{}{}",
+                    "|".color(colored::Color::Blue),
+                    caret_indent,
+                    note_str.color(colored::Color::Green)
+                );
+            }
+
+            for item in to_release {
+                self.output.send(item).unwrap();
+            }
+        } else {
+            panic!("No decision to release");
+        }
+    }
+}


### PR DESCRIPTION

This resolves a major limitation of the simulator: the ability to handle `assume_ordering` for unbounded streams.

Simulating this operator is quite tricky. We cannot simply shuffle all of the pending unordered elements into an ordered output because the `assume_ordering` may participate in a feedback cycle, in which case such a naive simulation would skip over cases where an ordered output is cycled back into the unordered input and beats the other unordered inputs to being processed.

To handle it correctly, we only release one ordered element at a time and allow ticks to run in between ordering decisions. This currently results in somewhat verbose logs when the same `assume_ordering` releases several elements in a row. We will address this logging in a follow-up PR.

Because top-level operations like `assume_ordering` have their inputs and outputs in the same (non-Tick) location, we need to also add support for hooks (non-determinism simulators) placed at a top-level location. We call these "observation" hooks and add state management for them to the top-level simulator scheduler. When no top-level locations (the deterministic portions) can make progress, the simulator can now choose to run *either* a tick or an observation.
