### PR TITLE
feat(hydro_lang): add support for top-level `KeyedStream::assume_ordering`

### DIFF
--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -1270,17 +1270,21 @@ impl<'a, K, V, L: Location<'a> + NoTick, O: Ordering, R: Retries>
     where
         R: MinRetries<R2>,
     {
-        let tick = self.location.tick();
-        // Because the outputs are unordered, we can interleave batches from both streams.
-        let nondet_batch_interleaving = nondet!(/** output stream is NoOrder, can interleave */);
-        self.batch(&tick, nondet_batch_interleaving)
-            .weaken_ordering::<NoOrder>()
-            .chain(
-                other
-                    .batch(&tick, nondet_batch_interleaving)
-                    .weaken_ordering::<NoOrder>(),
-            )
-            .all_ticks()
+        KeyedStream::new(
+            self.location.clone(),
+            HydroNode::Chain {
+                first: Box::new(self.ir_node.into_inner()),
+                second: Box::new(other.ir_node.into_inner()),
+                metadata: self.location.new_node_metadata(KeyedStream::<
+                    K,
+                    V,
+                    L,
+                    Unbounded,
+                    NoOrder,
+                    <R as MinRetries<R2>>::Min,
+                >::collection_kind()),
+            },
+        )
     }
 }
 
@@ -2794,5 +2798,235 @@ mod tests {
         });
 
         assert_eq!(instance_count, 104); // too complicated to enumerate here, but less than stream equivalent
+    }
+
+    #[cfg(feature = "sim")]
+    #[test]
+    fn sim_top_level_assume_ordering() {
+        use std::collections::HashMap;
+
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<()>();
+
+        let (in_send, input) = node.sim_input::<_, NoOrder, _>();
+
+        let out_recv = input
+            .into_keyed()
+            .assume_ordering::<TotalOrder>(nondet!(/** test */))
+            .fold_early_stop(
+                q!(|| Vec::new()),
+                q!(|acc, v| {
+                    acc.push(v);
+                    acc.len() >= 2
+                }),
+            )
+            .entries()
+            .sim_output();
+
+        let instance_count = flow.sim().exhaustive(async || {
+            in_send.send_many_unordered([(1, 'a'), (1, 'b'), (2, 'c'), (2, 'd')]);
+            let out: HashMap<_, _> = out_recv
+                .collect_sorted::<Vec<_>>()
+                .await
+                .into_iter()
+                .collect();
+            // Each key accumulates its values; we get one entry per key
+            assert_eq!(out.len(), 2);
+        });
+
+        assert_eq!(instance_count, 24)
+    }
+
+    #[cfg(feature = "sim")]
+    #[test]
+    fn sim_top_level_assume_ordering_cycle_back() {
+        use std::collections::HashMap;
+
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<()>();
+
+        let (in_send, input) = node.sim_input::<_, NoOrder, _>();
+
+        let (complete_cycle_back, cycle_back) =
+            node.forward_ref::<super::KeyedStream<_, _, _, _, NoOrder>>();
+        let ordered = input
+            .into_keyed()
+            .interleave(cycle_back)
+            .assume_ordering::<TotalOrder>(nondet!(/** test */));
+        complete_cycle_back.complete(
+            ordered
+                .clone()
+                .map(q!(|v| v + 1))
+                .filter(q!(|v| v % 2 == 1)),
+        );
+
+        let out_recv = ordered
+            .fold_early_stop(
+                q!(|| Vec::new()),
+                q!(|acc, v| {
+                    acc.push(v);
+                    acc.len() >= 2
+                }),
+            )
+            .entries()
+            .sim_output();
+
+        let mut saw = false;
+        let instance_count = flow.sim().exhaustive(async || {
+            // Send (1, 0) and (1, 2). 0+1=1 is odd so cycles back.
+            // We want to see [0, 1] - the cycled back value interleaved
+            in_send.send_many_unordered([(1, 0), (1, 2)]);
+            let out: HashMap<_, _> = out_recv
+                .collect_sorted::<Vec<_>>()
+                .await
+                .into_iter()
+                .collect();
+
+            // We want to see an instance where key 1 gets: 0, then 1 (cycled back from 0+1)
+            if let Some(values) = out.get(&1)
+                && *values == vec![0, 1]
+            {
+                saw = true;
+            }
+        });
+
+        assert!(
+            saw,
+            "did not see an instance with key 1 having [0, 1] in order"
+        );
+        assert_eq!(instance_count, 6);
+    }
+
+    #[cfg(feature = "sim")]
+    #[test]
+    fn sim_top_level_assume_ordering_cross_key_cycle() {
+        use std::collections::HashMap;
+
+        // This test demonstrates why releasing one entry at a time is important:
+        // When one key's observed order cycles back into a different key, we need
+        // to be able to interleave the cycled-back entry with pending items for
+        // that other key.
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<()>();
+
+        let (in_send, input) = node.sim_input::<_, NoOrder, _>();
+
+        let (complete_cycle_back, cycle_back) =
+            node.forward_ref::<super::KeyedStream<_, _, _, _, NoOrder>>();
+        let ordered = input
+            .into_keyed()
+            .interleave(cycle_back)
+            .assume_ordering::<TotalOrder>(nondet!(/** test */));
+
+        // Cycle back: when we see (1, 10), emit (2, 100) to key 2
+        complete_cycle_back.complete(
+            ordered
+                .clone()
+                .filter(q!(|v| *v == 10))
+                .map(q!(|_| 100))
+                .entries()
+                .map(q!(|(_, v)| (2, v))) // Change key from 1 to 2
+                .into_keyed(),
+        );
+
+        let out_recv = ordered
+            .fold_early_stop(
+                q!(|| Vec::new()),
+                q!(|acc, v| {
+                    acc.push(v);
+                    acc.len() >= 2
+                }),
+            )
+            .entries()
+            .sim_output();
+
+        // We want to see an instance where:
+        // - (1, 10) is released first
+        // - This causes (2, 100) to be cycled back
+        // - (2, 100) is released BEFORE (2, 20) which was already pending
+        let mut saw_cross_key_interleave = false;
+        let instance_count = flow.sim().exhaustive(async || {
+            // Send (1, 10), (1, 11) for key 1, and (2, 20), (2, 21) for key 2
+            in_send.send_many_unordered([(1, 10), (1, 11), (2, 20), (2, 21)]);
+            let out: HashMap<_, _> = out_recv
+                .collect_sorted::<Vec<_>>()
+                .await
+                .into_iter()
+                .collect();
+
+            // Check if we see the cross-key interleaving:
+            // key 2 should have [100, 20] or [100, 21] - cycled back 100 before a pending item
+            if let Some(values) = out.get(&2)
+                && values.len() >= 2
+                && values[0] == 100
+            {
+                saw_cross_key_interleave = true;
+            }
+        });
+
+        assert!(
+            saw_cross_key_interleave,
+            "did not see an instance where cycled-back 100 was released before pending items for key 2"
+        );
+        assert_eq!(instance_count, 60);
+    }
+
+    #[cfg(feature = "sim")]
+    #[test]
+    fn sim_top_level_assume_ordering_cycle_back_tick() {
+        use std::collections::HashMap;
+
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<()>();
+
+        let (in_send, input) = node.sim_input::<_, NoOrder, _>();
+
+        let (complete_cycle_back, cycle_back) =
+            node.forward_ref::<super::KeyedStream<_, _, _, _, NoOrder>>();
+        let ordered = input
+            .into_keyed()
+            .interleave(cycle_back)
+            .assume_ordering::<TotalOrder>(nondet!(/** test */));
+        complete_cycle_back.complete(
+            ordered
+                .clone()
+                .batch(&node.tick(), nondet!(/** test */))
+                .all_ticks()
+                .map(q!(|v| v + 1))
+                .filter(q!(|v| v % 2 == 1)),
+        );
+
+        let out_recv = ordered
+            .fold_early_stop(
+                q!(|| Vec::new()),
+                q!(|acc, v| {
+                    acc.push(v);
+                    acc.len() >= 2
+                }),
+            )
+            .entries()
+            .sim_output();
+
+        let mut saw = false;
+        let instance_count = flow.sim().exhaustive(async || {
+            in_send.send_many_unordered([(1, 0), (1, 2)]);
+            let out: HashMap<_, _> = out_recv
+                .collect_sorted::<Vec<_>>()
+                .await
+                .into_iter()
+                .collect();
+
+            if let Some(values) = out.get(&1)
+                && *values == vec![0, 1]
+            {
+                saw = true;
+            }
+        });
+
+        assert!(
+            saw,
+            "did not see an instance with key 1 having [0, 1] in order"
+        );
+        assert_eq!(instance_count, 58);
     }
 }

--- a/hydro_lang/src/sim/builder.rs
+++ b/hydro_lang/src/sim/builder.rs
@@ -730,6 +730,64 @@ impl DfirBuilder for SimBuilder {
                         None,
                     );
                 }
+                (
+                    CollectionKind::KeyedStream {
+                        value_order: StreamOrder::NoOrder,
+                        value_retry: StreamRetry::ExactlyOnce,
+                        ..
+                    },
+                    CollectionKind::KeyedStream {
+                        value_order: StreamOrder::TotalOrder,
+                        value_retry: StreamRetry::ExactlyOnce,
+                        ..
+                    },
+                ) => {
+                    let hoff_id = self.next_hoff_id;
+                    self.next_hoff_id += 1;
+
+                    let buffered_ident =
+                        syn::Ident::new(&format!("__buffered_{hoff_id}"), Span::call_site());
+                    let hoff_send_ident =
+                        syn::Ident::new(&format!("__hoff_send_{hoff_id}"), Span::call_site());
+                    let hoff_recv_ident =
+                        syn::Ident::new(&format!("__hoff_recv_{hoff_id}"), Span::call_site());
+
+                    self.add_extra_stmt_internal(location, syn::parse_quote! {
+                        let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unbounded_channel();
+                    });
+                    self.add_extra_stmt_internal(location, syn::parse_quote! {
+                        let #buffered_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(__root_dfir_rs::rustc_hash::FxHashMap::default()));
+                    });
+                    self.add_hook(
+                        location,
+                        location,
+                        syn::parse_quote!(
+                            Box::new(#root::sim::runtime::TopLevelKeyedStreamOrderHook::<_, _> {
+                                input: #buffered_ident.clone(),
+                                to_release: None,
+                                output: #hoff_send_ident,
+                                location: (#assume_location, #line, #caret),
+                                format_item_debug: #root::__maybe_debug__!(),
+                            })
+                        ),
+                    );
+
+                    self.get_dfir_mut(location).add_dfir(
+                        parse_quote! {
+                            #in_ident -> for_each(|(k, v)| #buffered_ident.borrow_mut().entry(k).or_insert_with(::std::collections::VecDeque::new).push_back(v));
+                        },
+                        None,
+                        None,
+                    );
+
+                    self.get_dfir_mut(location).add_dfir(
+                        parse_quote! {
+                            #out_ident = source_stream(#hoff_recv_ident);
+                        },
+                        None,
+                        None,
+                    );
+                }
                 _ => {
                     todo!(
                         "non-trusted observe_nondet not yet supported for kinds {:?} -> {:?} at top-level locations",

--- a/hydro_test/src/cluster/snapshots/paxos_ir.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir.snap
@@ -279,7 +279,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(5, Cluster(loc1v1)),
+                                                            location_id: Tick(4, Cluster(loc1v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -301,7 +301,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(4, Cluster(loc1v1)),
+                                                                        location_id: Tick(3, Cluster(loc1v1)),
                                                                         collection_kind: Singleton {
                                                                             bound: Bounded,
                                                                             element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -325,7 +325,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(5, Cluster(loc1v1)),
+                                                            location_id: Tick(4, Cluster(loc1v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -333,7 +333,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(5, Cluster(loc1v1)),
+                                                        location_id: Tick(4, Cluster(loc1v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -357,7 +357,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(2, Cluster(loc1v1)),
+                                            location_id: Tick(1, Cluster(loc1v1)),
                                             collection_kind: Singleton {
                                                 bound: Bounded,
                                                 element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -365,7 +365,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Atomic(Tick(2, Cluster(loc1v1))),
+                                        location_id: Atomic(Tick(1, Cluster(loc1v1))),
                                         collection_kind: Singleton {
                                             bound: Unbounded,
                                             element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -373,7 +373,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(2, Cluster(loc1v1)),
+                                    location_id: Tick(1, Cluster(loc1v1)),
                                     collection_kind: Singleton {
                                         bound: Bounded,
                                         element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -381,7 +381,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(2, Cluster(loc1v1)),
+                                location_id: Tick(1, Cluster(loc1v1)),
                                 collection_kind: Singleton {
                                     bound: Bounded,
                                     element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -396,7 +396,7 @@ expression: built.ir()
                                             sym: cycle_8,
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(2, Cluster(loc1v1)),
+                                            location_id: Tick(1, Cluster(loc1v1)),
                                             collection_kind: Singleton {
                                                 bound: Bounded,
                                                 element_type: u32,
@@ -404,7 +404,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(2, Cluster(loc1v1)),
+                                        location_id: Tick(1, Cluster(loc1v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: u32,
@@ -415,7 +415,7 @@ expression: built.ir()
                                     inner: SingletonSource {
                                         value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; 0 },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(2, Cluster(loc1v1)),
+                                            location_id: Tick(1, Cluster(loc1v1)),
                                             collection_kind: Singleton {
                                                 bound: Bounded,
                                                 element_type: u32,
@@ -423,7 +423,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(2, Cluster(loc1v1)),
+                                        location_id: Tick(1, Cluster(loc1v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: u32,
@@ -431,7 +431,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(2, Cluster(loc1v1)),
+                                    location_id: Tick(1, Cluster(loc1v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: u32,
@@ -439,7 +439,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(2, Cluster(loc1v1)),
+                                location_id: Tick(1, Cluster(loc1v1)),
                                 collection_kind: Singleton {
                                     bound: Bounded,
                                     element_type: u32,
@@ -447,7 +447,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(2, Cluster(loc1v1)),
+                            location_id: Tick(1, Cluster(loc1v1)),
                             collection_kind: Optional {
                                 bound: Bounded,
                                 element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , u32),
@@ -455,7 +455,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(2, Cluster(loc1v1)),
+                        location_id: Tick(1, Cluster(loc1v1)),
                         collection_kind: Singleton {
                             bound: Bounded,
                             element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , u32),
@@ -463,7 +463,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(2, Cluster(loc1v1)),
+                    location_id: Tick(1, Cluster(loc1v1)),
                     collection_kind: Singleton {
                         bound: Bounded,
                         element_type: u32,
@@ -471,7 +471,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(2, Cluster(loc1v1)),
+                location_id: Tick(1, Cluster(loc1v1)),
                 collection_kind: Singleton {
                     bound: Bounded,
                     element_type: u32,
@@ -561,7 +561,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(7, Cluster(loc1v1)),
+                                                                        location_id: Tick(6, Cluster(loc1v1)),
                                                                         collection_kind: KeyedSingleton {
                                                                             bound: Bounded,
                                                                             key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
@@ -570,7 +570,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(7, Cluster(loc1v1)),
+                                                                    location_id: Tick(6, Cluster(loc1v1)),
                                                                     collection_kind: KeyedSingleton {
                                                                         bound: Bounded,
                                                                         key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
@@ -579,7 +579,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(7, Cluster(loc1v1)),
+                                                                location_id: Tick(6, Cluster(loc1v1)),
                                                                 collection_kind: KeyedStream {
                                                                     bound: Bounded,
                                                                     value_order: TotalOrder,
@@ -590,7 +590,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(7, Cluster(loc1v1)),
+                                                            location_id: Tick(6, Cluster(loc1v1)),
                                                             collection_kind: Stream {
                                                                 bound: Bounded,
                                                                 order: NoOrder,
@@ -600,7 +600,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(7, Cluster(loc1v1)),
+                                                        location_id: Tick(6, Cluster(loc1v1)),
                                                         collection_kind: Stream {
                                                             bound: Bounded,
                                                             order: NoOrder,
@@ -610,7 +610,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(7, Cluster(loc1v1)),
+                                                    location_id: Tick(6, Cluster(loc1v1)),
                                                     collection_kind: Stream {
                                                         bound: Bounded,
                                                         order: NoOrder,
@@ -621,7 +621,7 @@ expression: built.ir()
                                             },
                                             trusted: true,
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(7, Cluster(loc1v1)),
+                                                location_id: Tick(6, Cluster(loc1v1)),
                                                 collection_kind: Stream {
                                                     bound: Bounded,
                                                     order: TotalOrder,
@@ -651,7 +651,7 @@ expression: built.ir()
                                                                                                     input: Tee {
                                                                                                         inner: <tee 1>,
                                                                                                         metadata: HydroIrMetadata {
-                                                                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                                                                             collection_kind: Singleton {
                                                                                                                 bound: Bounded,
                                                                                                                 element_type: u32,
@@ -659,7 +659,7 @@ expression: built.ir()
                                                                                                         },
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
-                                                                                                        location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                        location_id: Tick(1, Cluster(loc1v1)),
                                                                                                         collection_kind: Singleton {
                                                                                                             bound: Bounded,
                                                                                                             element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -667,7 +667,7 @@ expression: built.ir()
                                                                                                     },
                                                                                                 },
                                                                                                 metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                                                                     collection_kind: Singleton {
                                                                                                         bound: Bounded,
                                                                                                         element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -675,7 +675,7 @@ expression: built.ir()
                                                                                                 },
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
-                                                                                                location_id: Atomic(Tick(2, Cluster(loc1v1))),
+                                                                                                location_id: Atomic(Tick(1, Cluster(loc1v1))),
                                                                                                 collection_kind: Singleton {
                                                                                                     bound: Unbounded,
                                                                                                     element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -683,7 +683,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                                                             collection_kind: Singleton {
                                                                                                 bound: Bounded,
                                                                                                 element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -691,7 +691,7 @@ expression: built.ir()
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(2, Cluster(loc1v1)),
+                                                                                        location_id: Tick(1, Cluster(loc1v1)),
                                                                                         collection_kind: Singleton {
                                                                                             bound: Bounded,
                                                                                             element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -706,7 +706,7 @@ expression: built.ir()
                                                                                                 sym: cycle_7,
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                location_id: Tick(1, Cluster(loc1v1)),
                                                                                                 collection_kind: Optional {
                                                                                                     bound: Bounded,
                                                                                                     element_type: (),
@@ -714,7 +714,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                                                             collection_kind: Optional {
                                                                                                 bound: Bounded,
                                                                                                 element_type: (),
@@ -722,7 +722,7 @@ expression: built.ir()
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(2, Cluster(loc1v1)),
+                                                                                        location_id: Tick(1, Cluster(loc1v1)),
                                                                                         collection_kind: Optional {
                                                                                             bound: Bounded,
                                                                                             element_type: (),
@@ -730,7 +730,7 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                                                     collection_kind: Optional {
                                                                                         bound: Bounded,
                                                                                         element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , ()),
@@ -738,7 +738,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                                                location_id: Tick(1, Cluster(loc1v1)),
                                                                                 collection_kind: Optional {
                                                                                     bound: Bounded,
                                                                                     element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -754,7 +754,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(6, Cluster(loc1v1)),
+                                                                        location_id: Tick(5, Cluster(loc1v1)),
                                                                         collection_kind: Optional {
                                                                             bound: Bounded,
                                                                             element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -781,7 +781,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(6, Cluster(loc1v1)),
+                                                                                location_id: Tick(5, Cluster(loc1v1)),
                                                                                 collection_kind: Stream {
                                                                                     bound: Bounded,
                                                                                     order: TotalOrder,
@@ -791,7 +791,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(6, Cluster(loc1v1)),
+                                                                            location_id: Tick(5, Cluster(loc1v1)),
                                                                             collection_kind: Optional {
                                                                                 bound: Bounded,
                                                                                 element_type: hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
@@ -799,7 +799,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(6, Cluster(loc1v1)),
+                                                                        location_id: Tick(5, Cluster(loc1v1)),
                                                                         collection_kind: Optional {
                                                                             bound: Bounded,
                                                                             element_type: (),
@@ -807,7 +807,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(6, Cluster(loc1v1)),
+                                                                    location_id: Tick(5, Cluster(loc1v1)),
                                                                     collection_kind: Optional {
                                                                         bound: Bounded,
                                                                         element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , ()),
@@ -815,7 +815,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(6, Cluster(loc1v1)),
+                                                                location_id: Tick(5, Cluster(loc1v1)),
                                                                 collection_kind: Optional {
                                                                     bound: Bounded,
                                                                     element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -823,7 +823,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(6, Cluster(loc1v1)),
+                                                            location_id: Tick(5, Cluster(loc1v1)),
                                                             collection_kind: Stream {
                                                                 bound: Bounded,
                                                                 order: TotalOrder,
@@ -853,7 +853,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(7, Cluster(loc1v1)),
+                                                location_id: Tick(6, Cluster(loc1v1)),
                                                 collection_kind: Stream {
                                                     bound: Bounded,
                                                     order: TotalOrder,
@@ -863,7 +863,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(7, Cluster(loc1v1)),
+                                            location_id: Tick(6, Cluster(loc1v1)),
                                             collection_kind: Stream {
                                                 bound: Bounded,
                                                 order: TotalOrder,
@@ -873,7 +873,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(7, Cluster(loc1v1)),
+                                        location_id: Tick(6, Cluster(loc1v1)),
                                         collection_kind: KeyedStream {
                                             bound: Bounded,
                                             value_order: TotalOrder,
@@ -960,7 +960,7 @@ expression: built.ir()
                                 sym: cycle_9,
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(10, Cluster(loc1v1)),
+                                location_id: Tick(9, Cluster(loc1v1)),
                                 collection_kind: Stream {
                                     bound: Bounded,
                                     order: NoOrder,
@@ -970,7 +970,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(10, Cluster(loc1v1)),
+                            location_id: Tick(9, Cluster(loc1v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -1079,7 +1079,7 @@ expression: built.ir()
                                                                                                                                     },
                                                                                                                                 },
                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                    location_id: Tick(9, Cluster(loc1v1)),
+                                                                                                                                    location_id: Tick(8, Cluster(loc1v1)),
                                                                                                                                     collection_kind: KeyedSingleton {
                                                                                                                                         bound: Bounded,
                                                                                                                                         key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
@@ -1088,7 +1088,7 @@ expression: built.ir()
                                                                                                                                 },
                                                                                                                             },
                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                location_id: Tick(9, Cluster(loc1v1)),
+                                                                                                                                location_id: Tick(8, Cluster(loc1v1)),
                                                                                                                                 collection_kind: KeyedSingleton {
                                                                                                                                     bound: Bounded,
                                                                                                                                     key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
@@ -1097,7 +1097,7 @@ expression: built.ir()
                                                                                                                             },
                                                                                                                         },
                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                            location_id: Tick(9, Cluster(loc1v1)),
+                                                                                                                            location_id: Tick(8, Cluster(loc1v1)),
                                                                                                                             collection_kind: KeyedStream {
                                                                                                                                 bound: Bounded,
                                                                                                                                 value_order: TotalOrder,
@@ -1108,7 +1108,7 @@ expression: built.ir()
                                                                                                                         },
                                                                                                                     },
                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                        location_id: Tick(9, Cluster(loc1v1)),
+                                                                                                                        location_id: Tick(8, Cluster(loc1v1)),
                                                                                                                         collection_kind: Stream {
                                                                                                                             bound: Bounded,
                                                                                                                             order: NoOrder,
@@ -1118,7 +1118,7 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                 },
                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(9, Cluster(loc1v1)),
+                                                                                                                    location_id: Tick(8, Cluster(loc1v1)),
                                                                                                                     collection_kind: Stream {
                                                                                                                         bound: Bounded,
                                                                                                                         order: NoOrder,
@@ -1129,7 +1129,7 @@ expression: built.ir()
                                                                                                             },
                                                                                                             trusted: true,
                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                location_id: Tick(9, Cluster(loc1v1)),
+                                                                                                                location_id: Tick(8, Cluster(loc1v1)),
                                                                                                                 collection_kind: Stream {
                                                                                                                     bound: Bounded,
                                                                                                                     order: TotalOrder,
@@ -1149,7 +1149,7 @@ expression: built.ir()
                                                                                                                                 left: Tee {
                                                                                                                                     inner: <tee 4>,
                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                        location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                        location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                         collection_kind: Singleton {
                                                                                                                                             bound: Bounded,
                                                                                                                                             element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -1217,7 +1217,7 @@ expression: built.ir()
                                                                                                                                                                         },
                                                                                                                                                                     },
                                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                                        location_id: Tick(8, Cluster(loc1v1)),
+                                                                                                                                                                        location_id: Tick(7, Cluster(loc1v1)),
                                                                                                                                                                         collection_kind: Singleton {
                                                                                                                                                                             bound: Bounded,
                                                                                                                                                                             element_type: core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant >,
@@ -1225,7 +1225,7 @@ expression: built.ir()
                                                                                                                                                                     },
                                                                                                                                                                 },
                                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                                    location_id: Tick(8, Cluster(loc1v1)),
+                                                                                                                                                                    location_id: Tick(7, Cluster(loc1v1)),
                                                                                                                                                                     collection_kind: Optional {
                                                                                                                                                                         bound: Bounded,
                                                                                                                                                                         element_type: (),
@@ -1241,7 +1241,7 @@ expression: built.ir()
                                                                                                                                                             },
                                                                                                                                                         },
                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                             collection_kind: Optional {
                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                 element_type: (),
@@ -1261,7 +1261,7 @@ expression: built.ir()
                                                                                                                                                                             input: Tee {
                                                                                                                                                                                 inner: <tee 6>,
                                                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                                                     collection_kind: Optional {
                                                                                                                                                                                         bound: Bounded,
                                                                                                                                                                                         element_type: (),
@@ -1269,7 +1269,7 @@ expression: built.ir()
                                                                                                                                                                                 },
                                                                                                                                                                             },
                                                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                                                location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                                                 collection_kind: Optional {
                                                                                                                                                                                     bound: Bounded,
                                                                                                                                                                                     element_type: (),
@@ -1277,7 +1277,7 @@ expression: built.ir()
                                                                                                                                                                             },
                                                                                                                                                                         },
                                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                                             collection_kind: Optional {
                                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                                 element_type: core :: option :: Option < () >,
@@ -1288,7 +1288,7 @@ expression: built.ir()
                                                                                                                                                                         inner: SingletonSource {
                                                                                                                                                                             value: :: std :: option :: Option :: None,
                                                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                                                location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                                                 collection_kind: Singleton {
                                                                                                                                                                                     bound: Bounded,
                                                                                                                                                                                     element_type: core :: option :: Option < () >,
@@ -1296,7 +1296,7 @@ expression: built.ir()
                                                                                                                                                                             },
                                                                                                                                                                         },
                                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                                             collection_kind: Optional {
                                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                                 element_type: core :: option :: Option < () >,
@@ -1304,7 +1304,7 @@ expression: built.ir()
                                                                                                                                                                         },
                                                                                                                                                                     },
                                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                                        location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                                        location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                                         collection_kind: Optional {
                                                                                                                                                                             bound: Bounded,
                                                                                                                                                                             element_type: core :: option :: Option < () >,
@@ -1312,7 +1312,7 @@ expression: built.ir()
                                                                                                                                                                     },
                                                                                                                                                                 },
                                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                                     collection_kind: Singleton {
                                                                                                                                                                         bound: Bounded,
                                                                                                                                                                         element_type: core :: option :: Option < () >,
@@ -1320,7 +1320,7 @@ expression: built.ir()
                                                                                                                                                                 },
                                                                                                                                                             },
                                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                                location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                                 collection_kind: Optional {
                                                                                                                                                                     bound: Bounded,
                                                                                                                                                                     element_type: core :: option :: Option < () >,
@@ -1328,7 +1328,7 @@ expression: built.ir()
                                                                                                                                                             },
                                                                                                                                                         },
                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                             collection_kind: Optional {
                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                 element_type: (),
@@ -1336,7 +1336,7 @@ expression: built.ir()
                                                                                                                                                         },
                                                                                                                                                     },
                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                        location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                        location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                         collection_kind: Optional {
                                                                                                                                                             bound: Bounded,
                                                                                                                                                             element_type: (() , ()),
@@ -1344,7 +1344,7 @@ expression: built.ir()
                                                                                                                                                     },
                                                                                                                                                 },
                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                     collection_kind: Optional {
                                                                                                                                                         bound: Bounded,
                                                                                                                                                         element_type: (),
@@ -1371,7 +1371,7 @@ expression: built.ir()
                                                                                                                                                             },
                                                                                                                                                         },
                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                             collection_kind: Stream {
                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                 order: TotalOrder,
@@ -1381,7 +1381,7 @@ expression: built.ir()
                                                                                                                                                         },
                                                                                                                                                     },
                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                        location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                        location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                         collection_kind: Optional {
                                                                                                                                                             bound: Bounded,
                                                                                                                                                             element_type: hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
@@ -1389,7 +1389,7 @@ expression: built.ir()
                                                                                                                                                     },
                                                                                                                                                 },
                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                     collection_kind: Optional {
                                                                                                                                                         bound: Bounded,
                                                                                                                                                         element_type: (),
@@ -1397,7 +1397,7 @@ expression: built.ir()
                                                                                                                                                 },
                                                                                                                                             },
                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                 collection_kind: Optional {
                                                                                                                                                     bound: Bounded,
                                                                                                                                                     element_type: (() , ()),
@@ -1405,7 +1405,7 @@ expression: built.ir()
                                                                                                                                             },
                                                                                                                                         },
                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                             collection_kind: Optional {
                                                                                                                                                 bound: Bounded,
                                                                                                                                                 element_type: (),
@@ -1413,7 +1413,7 @@ expression: built.ir()
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                        location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                        location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                         collection_kind: Optional {
                                                                                                                                             bound: Bounded,
                                                                                                                                             element_type: (),
@@ -1421,7 +1421,7 @@ expression: built.ir()
                                                                                                                                     },
                                                                                                                                 },
                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                     collection_kind: Optional {
                                                                                                                                         bound: Bounded,
                                                                                                                                         element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , ()),
@@ -1429,7 +1429,7 @@ expression: built.ir()
                                                                                                                                 },
                                                                                                                             },
                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                 collection_kind: Optional {
                                                                                                                                     bound: Bounded,
                                                                                                                                     element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -1437,7 +1437,7 @@ expression: built.ir()
                                                                                                                             },
                                                                                                                         },
                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                             collection_kind: Stream {
                                                                                                                                 bound: Bounded,
                                                                                                                                 order: TotalOrder,
@@ -1467,7 +1467,7 @@ expression: built.ir()
                                                                                                                 },
                                                                                                             },
                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                location_id: Tick(9, Cluster(loc1v1)),
+                                                                                                                location_id: Tick(8, Cluster(loc1v1)),
                                                                                                                 collection_kind: Stream {
                                                                                                                     bound: Bounded,
                                                                                                                     order: TotalOrder,
@@ -1477,7 +1477,7 @@ expression: built.ir()
                                                                                                             },
                                                                                                         },
                                                                                                         metadata: HydroIrMetadata {
-                                                                                                            location_id: Tick(9, Cluster(loc1v1)),
+                                                                                                            location_id: Tick(8, Cluster(loc1v1)),
                                                                                                             collection_kind: Stream {
                                                                                                                 bound: Bounded,
                                                                                                                 order: TotalOrder,
@@ -1487,7 +1487,7 @@ expression: built.ir()
                                                                                                         },
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
-                                                                                                        location_id: Tick(9, Cluster(loc1v1)),
+                                                                                                        location_id: Tick(8, Cluster(loc1v1)),
                                                                                                         collection_kind: KeyedStream {
                                                                                                             bound: Bounded,
                                                                                                             value_order: TotalOrder,
@@ -1550,7 +1550,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(3, Cluster(loc2v1)),
+                                                                                location_id: Tick(2, Cluster(loc2v1)),
                                                                                 collection_kind: Stream {
                                                                                     bound: Bounded,
                                                                                     order: NoOrder,
@@ -1560,7 +1560,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(3, Cluster(loc2v1)),
+                                                                            location_id: Tick(2, Cluster(loc2v1)),
                                                                             collection_kind: Stream {
                                                                                 bound: Bounded,
                                                                                 order: NoOrder,
@@ -1583,7 +1583,7 @@ expression: built.ir()
                                                                                                         input: Tee {
                                                                                                             inner: <tee 9>,
                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                location_id: Tick(3, Cluster(loc2v1)),
+                                                                                                                location_id: Tick(2, Cluster(loc2v1)),
                                                                                                                 collection_kind: Stream {
                                                                                                                     bound: Bounded,
                                                                                                                     order: NoOrder,
@@ -1593,7 +1593,7 @@ expression: built.ir()
                                                                                                             },
                                                                                                         },
                                                                                                         metadata: HydroIrMetadata {
-                                                                                                            location_id: Tick(3, Cluster(loc2v1)),
+                                                                                                            location_id: Tick(2, Cluster(loc2v1)),
                                                                                                             collection_kind: Stream {
                                                                                                                 bound: Bounded,
                                                                                                                 order: NoOrder,
@@ -1603,7 +1603,7 @@ expression: built.ir()
                                                                                                         },
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
-                                                                                                        location_id: Atomic(Tick(3, Cluster(loc2v1))),
+                                                                                                        location_id: Atomic(Tick(2, Cluster(loc2v1))),
                                                                                                         collection_kind: Stream {
                                                                                                             bound: Unbounded,
                                                                                                             order: NoOrder,
@@ -1614,7 +1614,7 @@ expression: built.ir()
                                                                                                 },
                                                                                                 trusted: false,
                                                                                                 metadata: HydroIrMetadata {
-                                                                                                    location_id: Atomic(Tick(3, Cluster(loc2v1))),
+                                                                                                    location_id: Atomic(Tick(2, Cluster(loc2v1))),
                                                                                                     collection_kind: Stream {
                                                                                                         bound: Unbounded,
                                                                                                         order: TotalOrder,
@@ -1624,7 +1624,7 @@ expression: built.ir()
                                                                                                 },
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
-                                                                                                location_id: Atomic(Tick(3, Cluster(loc2v1))),
+                                                                                                location_id: Atomic(Tick(2, Cluster(loc2v1))),
                                                                                                 collection_kind: Optional {
                                                                                                     bound: Unbounded,
                                                                                                     element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -1632,7 +1632,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(3, Cluster(loc2v1)),
+                                                                                            location_id: Tick(2, Cluster(loc2v1)),
                                                                                             collection_kind: Optional {
                                                                                                 bound: Bounded,
                                                                                                 element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -1643,7 +1643,7 @@ expression: built.ir()
                                                                                         inner: SingletonSource {
                                                                                             value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; Ballot { num : 0 , proposer_id : MemberId :: from_raw_id (0) } },
                                                                                             metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(3, Cluster(loc2v1)),
+                                                                                                location_id: Tick(2, Cluster(loc2v1)),
                                                                                                 collection_kind: Singleton {
                                                                                                     bound: Bounded,
                                                                                                     element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -1651,7 +1651,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(3, Cluster(loc2v1)),
+                                                                                            location_id: Tick(2, Cluster(loc2v1)),
                                                                                             collection_kind: Optional {
                                                                                                 bound: Bounded,
                                                                                                 element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -1659,7 +1659,7 @@ expression: built.ir()
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(3, Cluster(loc2v1)),
+                                                                                        location_id: Tick(2, Cluster(loc2v1)),
                                                                                         collection_kind: Optional {
                                                                                             bound: Bounded,
                                                                                             element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -1667,7 +1667,7 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(3, Cluster(loc2v1)),
+                                                                                    location_id: Tick(2, Cluster(loc2v1)),
                                                                                     collection_kind: Singleton {
                                                                                         bound: Bounded,
                                                                                         element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -1675,7 +1675,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(3, Cluster(loc2v1)),
+                                                                                location_id: Tick(2, Cluster(loc2v1)),
                                                                                 collection_kind: Singleton {
                                                                                     bound: Bounded,
                                                                                     element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -1683,7 +1683,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(3, Cluster(loc2v1)),
+                                                                            location_id: Tick(2, Cluster(loc2v1)),
                                                                             collection_kind: Optional {
                                                                                 bound: Bounded,
                                                                                 element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -1691,7 +1691,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(3, Cluster(loc2v1)),
+                                                                        location_id: Tick(2, Cluster(loc2v1)),
                                                                         collection_kind: Stream {
                                                                             bound: Bounded,
                                                                             order: NoOrder,
@@ -1706,7 +1706,7 @@ expression: built.ir()
                                                                             sym: cycle_4,
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(3, Cluster(loc2v1)),
+                                                                            location_id: Tick(2, Cluster(loc2v1)),
                                                                             collection_kind: Singleton {
                                                                                 bound: Bounded,
                                                                                 element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
@@ -1714,7 +1714,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(3, Cluster(loc2v1)),
+                                                                        location_id: Tick(2, Cluster(loc2v1)),
                                                                         collection_kind: Optional {
                                                                             bound: Bounded,
                                                                             element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
@@ -1722,7 +1722,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(3, Cluster(loc2v1)),
+                                                                    location_id: Tick(2, Cluster(loc2v1)),
                                                                     collection_kind: Stream {
                                                                         bound: Bounded,
                                                                         order: NoOrder,
@@ -1732,7 +1732,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(3, Cluster(loc2v1)),
+                                                                location_id: Tick(2, Cluster(loc2v1)),
                                                                 collection_kind: Stream {
                                                                     bound: Bounded,
                                                                     order: NoOrder,
@@ -1824,7 +1824,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(10, Cluster(loc1v1)),
+                            location_id: Tick(9, Cluster(loc1v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -1834,7 +1834,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(10, Cluster(loc1v1)),
+                        location_id: Tick(9, Cluster(loc1v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: NoOrder,
@@ -1844,7 +1844,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(10, Cluster(loc1v1)),
+                    location_id: Tick(9, Cluster(loc1v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -1869,7 +1869,7 @@ expression: built.ir()
                                                 inner: Tee {
                                                     inner: <tee 7>,
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(10, Cluster(loc1v1)),
+                                                        location_id: Tick(9, Cluster(loc1v1)),
                                                         collection_kind: Stream {
                                                             bound: Bounded,
                                                             order: NoOrder,
@@ -1879,7 +1879,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(10, Cluster(loc1v1)),
+                                                    location_id: Tick(9, Cluster(loc1v1)),
                                                     collection_kind: KeyedStream {
                                                         bound: Bounded,
                                                         value_order: NoOrder,
@@ -1891,7 +1891,7 @@ expression: built.ir()
                                             },
                                             trusted: false,
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(10, Cluster(loc1v1)),
+                                                location_id: Tick(9, Cluster(loc1v1)),
                                                 collection_kind: KeyedStream {
                                                     bound: Bounded,
                                                     value_order: TotalOrder,
@@ -1902,7 +1902,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(10, Cluster(loc1v1)),
+                                            location_id: Tick(9, Cluster(loc1v1)),
                                             collection_kind: KeyedSingleton {
                                                 bound: Bounded,
                                                 key_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -1911,7 +1911,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(10, Cluster(loc1v1)),
+                                        location_id: Tick(9, Cluster(loc1v1)),
                                         collection_kind: KeyedSingleton {
                                             bound: Bounded,
                                             key_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -1920,7 +1920,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(10, Cluster(loc1v1)),
+                                    location_id: Tick(9, Cluster(loc1v1)),
                                     collection_kind: KeyedSingleton {
                                         bound: Bounded,
                                         key_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -1929,7 +1929,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(10, Cluster(loc1v1)),
+                                location_id: Tick(9, Cluster(loc1v1)),
                                 collection_kind: KeyedStream {
                                     bound: Bounded,
                                     value_order: TotalOrder,
@@ -1940,7 +1940,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(10, Cluster(loc1v1)),
+                            location_id: Tick(9, Cluster(loc1v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -1950,7 +1950,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(10, Cluster(loc1v1)),
+                        location_id: Tick(9, Cluster(loc1v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: NoOrder,
@@ -1960,7 +1960,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(10, Cluster(loc1v1)),
+                    location_id: Tick(9, Cluster(loc1v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -1970,7 +1970,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(10, Cluster(loc1v1)),
+                location_id: Tick(9, Cluster(loc1v1)),
                 collection_kind: Stream {
                     bound: Bounded,
                     order: NoOrder,
@@ -1995,7 +1995,7 @@ expression: built.ir()
                             input: Tee {
                                 inner: <tee 12>,
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(10, Cluster(loc1v1)),
+                                    location_id: Tick(9, Cluster(loc1v1)),
                                     collection_kind: KeyedSingleton {
                                         bound: Bounded,
                                         key_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -2004,7 +2004,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(10, Cluster(loc1v1)),
+                                location_id: Tick(9, Cluster(loc1v1)),
                                 collection_kind: KeyedSingleton {
                                     bound: Bounded,
                                     key_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -2013,7 +2013,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(10, Cluster(loc1v1)),
+                            location_id: Tick(9, Cluster(loc1v1)),
                             collection_kind: KeyedStream {
                                 bound: Bounded,
                                 value_order: TotalOrder,
@@ -2024,7 +2024,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(10, Cluster(loc1v1)),
+                        location_id: Tick(9, Cluster(loc1v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: NoOrder,
@@ -2034,7 +2034,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(10, Cluster(loc1v1)),
+                    location_id: Tick(9, Cluster(loc1v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -2046,7 +2046,7 @@ expression: built.ir()
             neg: Tee {
                 inner: <tee 11>,
                 metadata: HydroIrMetadata {
-                    location_id: Tick(10, Cluster(loc1v1)),
+                    location_id: Tick(9, Cluster(loc1v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -2056,7 +2056,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(10, Cluster(loc1v1)),
+                location_id: Tick(9, Cluster(loc1v1)),
                 collection_kind: Stream {
                     bound: Bounded,
                     order: NoOrder,
@@ -2103,7 +2103,7 @@ expression: built.ir()
                                                                                             pos: Tee {
                                                                                                 inner: <tee 7>,
                                                                                                 metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(10, Cluster(loc1v1)),
+                                                                                                    location_id: Tick(9, Cluster(loc1v1)),
                                                                                                     collection_kind: Stream {
                                                                                                         bound: Bounded,
                                                                                                         order: NoOrder,
@@ -2121,7 +2121,7 @@ expression: built.ir()
                                                                                                             input: Tee {
                                                                                                                 inner: <tee 12>,
                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(10, Cluster(loc1v1)),
+                                                                                                                    location_id: Tick(9, Cluster(loc1v1)),
                                                                                                                     collection_kind: KeyedSingleton {
                                                                                                                         bound: Bounded,
                                                                                                                         key_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -2130,7 +2130,7 @@ expression: built.ir()
                                                                                                                 },
                                                                                                             },
                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                location_id: Tick(10, Cluster(loc1v1)),
+                                                                                                                location_id: Tick(9, Cluster(loc1v1)),
                                                                                                                 collection_kind: KeyedSingleton {
                                                                                                                     bound: Bounded,
                                                                                                                     key_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -2139,7 +2139,7 @@ expression: built.ir()
                                                                                                             },
                                                                                                         },
                                                                                                         metadata: HydroIrMetadata {
-                                                                                                            location_id: Tick(10, Cluster(loc1v1)),
+                                                                                                            location_id: Tick(9, Cluster(loc1v1)),
                                                                                                             collection_kind: KeyedStream {
                                                                                                                 bound: Bounded,
                                                                                                                 value_order: TotalOrder,
@@ -2150,7 +2150,7 @@ expression: built.ir()
                                                                                                         },
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
-                                                                                                        location_id: Tick(10, Cluster(loc1v1)),
+                                                                                                        location_id: Tick(9, Cluster(loc1v1)),
                                                                                                         collection_kind: Stream {
                                                                                                             bound: Bounded,
                                                                                                             order: NoOrder,
@@ -2160,7 +2160,7 @@ expression: built.ir()
                                                                                                     },
                                                                                                 },
                                                                                                 metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(10, Cluster(loc1v1)),
+                                                                                                    location_id: Tick(9, Cluster(loc1v1)),
                                                                                                     collection_kind: Stream {
                                                                                                         bound: Bounded,
                                                                                                         order: NoOrder,
@@ -2170,7 +2170,7 @@ expression: built.ir()
                                                                                                 },
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(10, Cluster(loc1v1)),
+                                                                                                location_id: Tick(9, Cluster(loc1v1)),
                                                                                                 collection_kind: Stream {
                                                                                                     bound: Bounded,
                                                                                                     order: NoOrder,
@@ -2185,7 +2185,7 @@ expression: built.ir()
                                                                                                     sym: cycle_10,
                                                                                                 },
                                                                                                 metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(10, Cluster(loc1v1)),
+                                                                                                    location_id: Tick(9, Cluster(loc1v1)),
                                                                                                     collection_kind: Stream {
                                                                                                         bound: Bounded,
                                                                                                         order: NoOrder,
@@ -2195,7 +2195,7 @@ expression: built.ir()
                                                                                                 },
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(10, Cluster(loc1v1)),
+                                                                                                location_id: Tick(9, Cluster(loc1v1)),
                                                                                                 collection_kind: Stream {
                                                                                                     bound: Bounded,
                                                                                                     order: NoOrder,
@@ -2205,7 +2205,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(10, Cluster(loc1v1)),
+                                                                                            location_id: Tick(9, Cluster(loc1v1)),
                                                                                             collection_kind: Stream {
                                                                                                 bound: Bounded,
                                                                                                 order: NoOrder,
@@ -2215,7 +2215,7 @@ expression: built.ir()
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(10, Cluster(loc1v1)),
+                                                                                        location_id: Tick(9, Cluster(loc1v1)),
                                                                                         collection_kind: Stream {
                                                                                             bound: Bounded,
                                                                                             order: NoOrder,
@@ -2328,7 +2328,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(2, Cluster(loc1v1)),
+                                            location_id: Tick(1, Cluster(loc1v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >),
@@ -2339,7 +2339,7 @@ expression: built.ir()
                                         inner: Tee {
                                             inner: <tee 4>,
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                location_id: Tick(1, Cluster(loc1v1)),
                                                 collection_kind: Singleton {
                                                     bound: Bounded,
                                                     element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -2347,7 +2347,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(2, Cluster(loc1v1)),
+                                            location_id: Tick(1, Cluster(loc1v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -2355,7 +2355,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(2, Cluster(loc1v1)),
+                                        location_id: Tick(1, Cluster(loc1v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: ((hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >) , hydro_test :: __staged :: cluster :: paxos :: Ballot),
@@ -2363,7 +2363,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(2, Cluster(loc1v1)),
+                                    location_id: Tick(1, Cluster(loc1v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >,
@@ -2371,7 +2371,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(2, Cluster(loc1v1)),
+                                location_id: Tick(1, Cluster(loc1v1)),
                                 collection_kind: Optional {
                                     bound: Bounded,
                                     element_type: std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >,
@@ -2379,7 +2379,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(2, Cluster(loc1v1)),
+                            location_id: Tick(1, Cluster(loc1v1)),
                             collection_kind: Optional {
                                 bound: Bounded,
                                 element_type: (),
@@ -2400,7 +2400,7 @@ expression: built.ir()
                                                     left: Tee {
                                                         inner: <tee 2>,
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                             collection_kind: Singleton {
                                                                 bound: Bounded,
                                                                 element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -2410,7 +2410,7 @@ expression: built.ir()
                                                     right: Tee {
                                                         inner: <tee 5>,
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                             collection_kind: Singleton {
                                                                 bound: Bounded,
                                                                 element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -2418,7 +2418,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(2, Cluster(loc1v1)),
+                                                        location_id: Tick(1, Cluster(loc1v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot),
@@ -2426,7 +2426,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                     collection_kind: Singleton {
                                                         bound: Bounded,
                                                         element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot),
@@ -2434,7 +2434,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                location_id: Tick(1, Cluster(loc1v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot),
@@ -2442,7 +2442,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(2, Cluster(loc1v1)),
+                                            location_id: Tick(1, Cluster(loc1v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: (),
@@ -2450,7 +2450,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Atomic(Tick(2, Cluster(loc1v1))),
+                                        location_id: Atomic(Tick(1, Cluster(loc1v1))),
                                         collection_kind: Optional {
                                             bound: Unbounded,
                                             element_type: (),
@@ -2458,7 +2458,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(2, Cluster(loc1v1)),
+                                    location_id: Tick(1, Cluster(loc1v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: (),
@@ -2466,7 +2466,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(2, Cluster(loc1v1)),
+                                location_id: Tick(1, Cluster(loc1v1)),
                                 collection_kind: Optional {
                                     bound: Bounded,
                                     element_type: (),
@@ -2474,7 +2474,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(2, Cluster(loc1v1)),
+                            location_id: Tick(1, Cluster(loc1v1)),
                             collection_kind: Optional {
                                 bound: Bounded,
                                 element_type: (),
@@ -2482,7 +2482,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(2, Cluster(loc1v1)),
+                        location_id: Tick(1, Cluster(loc1v1)),
                         collection_kind: Optional {
                             bound: Bounded,
                             element_type: (() , ()),
@@ -2490,7 +2490,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(2, Cluster(loc1v1)),
+                    location_id: Tick(1, Cluster(loc1v1)),
                     collection_kind: Optional {
                         bound: Bounded,
                         element_type: (),
@@ -2498,7 +2498,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(2, Cluster(loc1v1)),
+                location_id: Tick(1, Cluster(loc1v1)),
                 collection_kind: Optional {
                     bound: Bounded,
                     element_type: (),
@@ -2564,7 +2564,7 @@ expression: built.ir()
                                     sym: cycle_11,
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(12, Cluster(loc3v1)),
+                                    location_id: Tick(11, Cluster(loc3v1)),
                                     collection_kind: Stream {
                                         bound: Bounded,
                                         order: TotalOrder,
@@ -2574,7 +2574,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(12, Cluster(loc3v1)),
+                                location_id: Tick(11, Cluster(loc3v1)),
                                 collection_kind: Stream {
                                     bound: Bounded,
                                     order: TotalOrder,
@@ -2591,111 +2591,35 @@ expression: built.ir()
                                         inner: Tee {
                                             inner: <tee 17>: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , core :: option :: Option < i32 >) , (u32 , i32) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < i32 > , i32 > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; move | payload | { if let Some (counter) = payload { counter + 1 } else { 0 } } }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
-                                                input: YieldConcat {
-                                                    inner: Chain {
-                                                        first: Cast {
-                                                            inner: Batch {
-                                                                inner: YieldConcat {
-                                                                    inner: Cast {
-                                                                        inner: Cast {
-                                                                            inner: Tee {
-                                                                                inner: <tee 0>,
-                                                                                metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(0, Cluster(loc3v1)),
-                                                                                    collection_kind: Optional {
-                                                                                        bound: Bounded,
-                                                                                        element_type: (u32 , core :: option :: Option < i32 >),
-                                                                                    },
-                                                                                },
-                                                                            },
-                                                                            metadata: HydroIrMetadata {
-                                                                                location_id: Tick(0, Cluster(loc3v1)),
-                                                                                collection_kind: Stream {
-                                                                                    bound: Bounded,
-                                                                                    order: TotalOrder,
-                                                                                    retry: ExactlyOnce,
-                                                                                    element_type: (u32 , core :: option :: Option < i32 >),
-                                                                                },
-                                                                            },
-                                                                        },
-                                                                        metadata: HydroIrMetadata {
-                                                                            location_id: Tick(0, Cluster(loc3v1)),
-                                                                            collection_kind: KeyedStream {
-                                                                                bound: Bounded,
-                                                                                value_order: TotalOrder,
-                                                                                value_retry: ExactlyOnce,
-                                                                                key_type: u32,
-                                                                                value_type: core :: option :: Option < i32 >,
-                                                                            },
-                                                                        },
-                                                                    },
+                                                input: Chain {
+                                                    first: YieldConcat {
+                                                        inner: Cast {
+                                                            inner: Cast {
+                                                                inner: Tee {
+                                                                    inner: <tee 0>,
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Cluster(loc3v1),
-                                                                        collection_kind: KeyedStream {
-                                                                            bound: Unbounded,
-                                                                            value_order: TotalOrder,
-                                                                            value_retry: ExactlyOnce,
-                                                                            key_type: u32,
-                                                                            value_type: core :: option :: Option < i32 >,
+                                                                        location_id: Tick(0, Cluster(loc3v1)),
+                                                                        collection_kind: Optional {
+                                                                            bound: Bounded,
+                                                                            element_type: (u32 , core :: option :: Option < i32 >),
                                                                         },
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(1, Cluster(loc3v1)),
-                                                                    collection_kind: KeyedStream {
+                                                                    location_id: Tick(0, Cluster(loc3v1)),
+                                                                    collection_kind: Stream {
                                                                         bound: Bounded,
-                                                                        value_order: TotalOrder,
-                                                                        value_retry: ExactlyOnce,
-                                                                        key_type: u32,
-                                                                        value_type: core :: option :: Option < i32 >,
+                                                                        order: TotalOrder,
+                                                                        retry: ExactlyOnce,
+                                                                        element_type: (u32 , core :: option :: Option < i32 >),
                                                                     },
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(1, Cluster(loc3v1)),
+                                                                location_id: Tick(0, Cluster(loc3v1)),
                                                                 collection_kind: KeyedStream {
                                                                     bound: Bounded,
-                                                                    value_order: NoOrder,
-                                                                    value_retry: ExactlyOnce,
-                                                                    key_type: u32,
-                                                                    value_type: core :: option :: Option < i32 >,
-                                                                },
-                                                            },
-                                                        },
-                                                        second: Batch {
-                                                            inner: Map {
-                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , i32) , (u32 , core :: option :: Option < i32 >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < i32 , core :: option :: Option < i32 > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | payload | Some (payload) }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
-                                                                input: CycleSource {
-                                                                    ident: Ident {
-                                                                        sym: cycle_1,
-                                                                    },
-                                                                    metadata: HydroIrMetadata {
-                                                                        location_id: Cluster(loc3v1),
-                                                                        collection_kind: KeyedStream {
-                                                                            bound: Unbounded,
-                                                                            value_order: NoOrder,
-                                                                            value_retry: ExactlyOnce,
-                                                                            key_type: u32,
-                                                                            value_type: i32,
-                                                                        },
-                                                                    },
-                                                                },
-                                                                metadata: HydroIrMetadata {
-                                                                    location_id: Cluster(loc3v1),
-                                                                    collection_kind: KeyedStream {
-                                                                        bound: Unbounded,
-                                                                        value_order: NoOrder,
-                                                                        value_retry: ExactlyOnce,
-                                                                        key_type: u32,
-                                                                        value_type: core :: option :: Option < i32 >,
-                                                                    },
-                                                                },
-                                                            },
-                                                            metadata: HydroIrMetadata {
-                                                                location_id: Tick(1, Cluster(loc3v1)),
-                                                                collection_kind: KeyedStream {
-                                                                    bound: Bounded,
-                                                                    value_order: NoOrder,
+                                                                    value_order: TotalOrder,
                                                                     value_retry: ExactlyOnce,
                                                                     key_type: u32,
                                                                     value_type: core :: option :: Option < i32 >,
@@ -2703,9 +2627,37 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(1, Cluster(loc3v1)),
+                                                            location_id: Cluster(loc3v1),
                                                             collection_kind: KeyedStream {
-                                                                bound: Bounded,
+                                                                bound: Unbounded,
+                                                                value_order: TotalOrder,
+                                                                value_retry: ExactlyOnce,
+                                                                key_type: u32,
+                                                                value_type: core :: option :: Option < i32 >,
+                                                            },
+                                                        },
+                                                    },
+                                                    second: Map {
+                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , i32) , (u32 , core :: option :: Option < i32 >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < i32 , core :: option :: Option < i32 > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | payload | Some (payload) }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
+                                                        input: CycleSource {
+                                                            ident: Ident {
+                                                                sym: cycle_1,
+                                                            },
+                                                            metadata: HydroIrMetadata {
+                                                                location_id: Cluster(loc3v1),
+                                                                collection_kind: KeyedStream {
+                                                                    bound: Unbounded,
+                                                                    value_order: NoOrder,
+                                                                    value_retry: ExactlyOnce,
+                                                                    key_type: u32,
+                                                                    value_type: i32,
+                                                                },
+                                                            },
+                                                        },
+                                                        metadata: HydroIrMetadata {
+                                                            location_id: Cluster(loc3v1),
+                                                            collection_kind: KeyedStream {
+                                                                bound: Unbounded,
                                                                 value_order: NoOrder,
                                                                 value_retry: ExactlyOnce,
                                                                 key_type: u32,
@@ -2778,7 +2730,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(12, Cluster(loc3v1)),
+                                location_id: Tick(11, Cluster(loc3v1)),
                                 collection_kind: Stream {
                                     bound: Bounded,
                                     order: TotalOrder,
@@ -2788,7 +2740,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(12, Cluster(loc3v1)),
+                            location_id: Tick(11, Cluster(loc3v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: TotalOrder,
@@ -2798,7 +2750,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(12, Cluster(loc3v1)),
+                        location_id: Tick(11, Cluster(loc3v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: TotalOrder,
@@ -2901,7 +2853,7 @@ expression: built.ir()
                                                                                                                         },
                                                                                                                     },
                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                        location_id: Tick(11, Cluster(loc1v1)),
+                                                                                                                        location_id: Tick(10, Cluster(loc1v1)),
                                                                                                                         collection_kind: KeyedSingleton {
                                                                                                                             bound: Bounded,
                                                                                                                             key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >,
@@ -2910,7 +2862,7 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                 },
                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(11, Cluster(loc1v1)),
+                                                                                                                    location_id: Tick(10, Cluster(loc1v1)),
                                                                                                                     collection_kind: KeyedSingleton {
                                                                                                                         bound: Bounded,
                                                                                                                         key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >,
@@ -2919,7 +2871,7 @@ expression: built.ir()
                                                                                                                 },
                                                                                                             },
                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                location_id: Tick(11, Cluster(loc1v1)),
+                                                                                                                location_id: Tick(10, Cluster(loc1v1)),
                                                                                                                 collection_kind: KeyedStream {
                                                                                                                     bound: Bounded,
                                                                                                                     value_order: TotalOrder,
@@ -2930,7 +2882,7 @@ expression: built.ir()
                                                                                                             },
                                                                                                         },
                                                                                                         metadata: HydroIrMetadata {
-                                                                                                            location_id: Tick(11, Cluster(loc1v1)),
+                                                                                                            location_id: Tick(10, Cluster(loc1v1)),
                                                                                                             collection_kind: Stream {
                                                                                                                 bound: Bounded,
                                                                                                                 order: NoOrder,
@@ -2940,7 +2892,7 @@ expression: built.ir()
                                                                                                         },
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
-                                                                                                        location_id: Tick(11, Cluster(loc1v1)),
+                                                                                                        location_id: Tick(10, Cluster(loc1v1)),
                                                                                                         collection_kind: Stream {
                                                                                                             bound: Bounded,
                                                                                                             order: NoOrder,
@@ -2951,7 +2903,7 @@ expression: built.ir()
                                                                                                 },
                                                                                                 trusted: true,
                                                                                                 metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(11, Cluster(loc1v1)),
+                                                                                                    location_id: Tick(10, Cluster(loc1v1)),
                                                                                                     collection_kind: Stream {
                                                                                                         bound: Bounded,
                                                                                                         order: TotalOrder,
@@ -2969,7 +2921,7 @@ expression: built.ir()
                                                                                                                 left: Tee {
                                                                                                                     inner: <tee 4>,
                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                        location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                        location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                         collection_kind: Singleton {
                                                                                                                             bound: Bounded,
                                                                                                                             element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -2985,7 +2937,7 @@ expression: built.ir()
                                                                                                                                 left: Tee {
                                                                                                                                     inner: <tee 13>,
                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                        location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                        location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                         collection_kind: Optional {
                                                                                                                                             bound: Bounded,
                                                                                                                                             element_type: (),
@@ -3006,7 +2958,7 @@ expression: built.ir()
                                                                                                                                                             input: Tee {
                                                                                                                                                                 inner: <tee 13>,
                                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                                     collection_kind: Optional {
                                                                                                                                                                         bound: Bounded,
                                                                                                                                                                         element_type: (),
@@ -3014,7 +2966,7 @@ expression: built.ir()
                                                                                                                                                                 },
                                                                                                                                                             },
                                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                                location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                                 collection_kind: Optional {
                                                                                                                                                                     bound: Bounded,
                                                                                                                                                                     element_type: (),
@@ -3022,7 +2974,7 @@ expression: built.ir()
                                                                                                                                                             },
                                                                                                                                                         },
                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                             collection_kind: Optional {
                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                 element_type: (),
@@ -3030,7 +2982,7 @@ expression: built.ir()
                                                                                                                                                         },
                                                                                                                                                     },
                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                        location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                        location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                         collection_kind: Optional {
                                                                                                                                                             bound: Bounded,
                                                                                                                                                             element_type: core :: option :: Option < () >,
@@ -3041,7 +2993,7 @@ expression: built.ir()
                                                                                                                                                     inner: SingletonSource {
                                                                                                                                                         value: :: std :: option :: Option :: None,
                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                             collection_kind: Singleton {
                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                 element_type: core :: option :: Option < () >,
@@ -3049,7 +3001,7 @@ expression: built.ir()
                                                                                                                                                         },
                                                                                                                                                     },
                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                        location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                        location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                         collection_kind: Optional {
                                                                                                                                                             bound: Bounded,
                                                                                                                                                             element_type: core :: option :: Option < () >,
@@ -3057,7 +3009,7 @@ expression: built.ir()
                                                                                                                                                     },
                                                                                                                                                 },
                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                     collection_kind: Optional {
                                                                                                                                                         bound: Bounded,
                                                                                                                                                         element_type: core :: option :: Option < () >,
@@ -3065,7 +3017,7 @@ expression: built.ir()
                                                                                                                                                 },
                                                                                                                                             },
                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                 collection_kind: Singleton {
                                                                                                                                                     bound: Bounded,
                                                                                                                                                     element_type: core :: option :: Option < () >,
@@ -3073,7 +3025,7 @@ expression: built.ir()
                                                                                                                                             },
                                                                                                                                         },
                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                             collection_kind: Optional {
                                                                                                                                                 bound: Bounded,
                                                                                                                                                 element_type: core :: option :: Option < () >,
@@ -3081,7 +3033,7 @@ expression: built.ir()
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                        location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                        location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                         collection_kind: Optional {
                                                                                                                                             bound: Bounded,
                                                                                                                                             element_type: (),
@@ -3089,7 +3041,7 @@ expression: built.ir()
                                                                                                                                     },
                                                                                                                                 },
                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                     collection_kind: Optional {
                                                                                                                                         bound: Bounded,
                                                                                                                                         element_type: (() , ()),
@@ -3097,7 +3049,7 @@ expression: built.ir()
                                                                                                                                 },
                                                                                                                             },
                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                 collection_kind: Optional {
                                                                                                                                     bound: Bounded,
                                                                                                                                     element_type: (),
@@ -3105,7 +3057,7 @@ expression: built.ir()
                                                                                                                             },
                                                                                                                         },
                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                             collection_kind: Optional {
                                                                                                                                 bound: Bounded,
                                                                                                                                 element_type: (),
@@ -3113,7 +3065,7 @@ expression: built.ir()
                                                                                                                         },
                                                                                                                     },
                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                        location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                        location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                         collection_kind: Optional {
                                                                                                                             bound: Bounded,
                                                                                                                             element_type: (),
@@ -3121,7 +3073,7 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                 },
                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                     collection_kind: Optional {
                                                                                                                         bound: Bounded,
                                                                                                                         element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , ()),
@@ -3129,7 +3081,7 @@ expression: built.ir()
                                                                                                                 },
                                                                                                             },
                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                 collection_kind: Optional {
                                                                                                                     bound: Bounded,
                                                                                                                     element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -3137,7 +3089,7 @@ expression: built.ir()
                                                                                                             },
                                                                                                         },
                                                                                                         metadata: HydroIrMetadata {
-                                                                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                                                                             collection_kind: Stream {
                                                                                                                 bound: Bounded,
                                                                                                                 order: TotalOrder,
@@ -3157,7 +3109,7 @@ expression: built.ir()
                                                                                                     },
                                                                                                 },
                                                                                                 metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(11, Cluster(loc1v1)),
+                                                                                                    location_id: Tick(10, Cluster(loc1v1)),
                                                                                                     collection_kind: Stream {
                                                                                                         bound: Bounded,
                                                                                                         order: TotalOrder,
@@ -3167,7 +3119,7 @@ expression: built.ir()
                                                                                                 },
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(11, Cluster(loc1v1)),
+                                                                                                location_id: Tick(10, Cluster(loc1v1)),
                                                                                                 collection_kind: Stream {
                                                                                                     bound: Bounded,
                                                                                                     order: TotalOrder,
@@ -3177,7 +3129,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(11, Cluster(loc1v1)),
+                                                                                            location_id: Tick(10, Cluster(loc1v1)),
                                                                                             collection_kind: KeyedStream {
                                                                                                 bound: Bounded,
                                                                                                 value_order: TotalOrder,
@@ -3277,7 +3229,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(12, Cluster(loc3v1)),
+                                                    location_id: Tick(11, Cluster(loc3v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
@@ -3285,7 +3237,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(12, Cluster(loc3v1)),
+                                                location_id: Tick(11, Cluster(loc3v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
@@ -3293,7 +3245,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(12, Cluster(loc3v1)),
+                                            location_id: Tick(11, Cluster(loc3v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: (),
@@ -3301,7 +3253,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(12, Cluster(loc3v1)),
+                                        location_id: Tick(11, Cluster(loc3v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: core :: option :: Option < () >,
@@ -3312,7 +3264,7 @@ expression: built.ir()
                                     inner: SingletonSource {
                                         value: :: std :: option :: Option :: None,
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(12, Cluster(loc3v1)),
+                                            location_id: Tick(11, Cluster(loc3v1)),
                                             collection_kind: Singleton {
                                                 bound: Bounded,
                                                 element_type: core :: option :: Option < () >,
@@ -3320,7 +3272,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(12, Cluster(loc3v1)),
+                                        location_id: Tick(11, Cluster(loc3v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: core :: option :: Option < () >,
@@ -3328,7 +3280,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(12, Cluster(loc3v1)),
+                                    location_id: Tick(11, Cluster(loc3v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: core :: option :: Option < () >,
@@ -3336,7 +3288,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(12, Cluster(loc3v1)),
+                                location_id: Tick(11, Cluster(loc3v1)),
                                 collection_kind: Singleton {
                                     bound: Bounded,
                                     element_type: core :: option :: Option < () >,
@@ -3344,7 +3296,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(12, Cluster(loc3v1)),
+                            location_id: Tick(11, Cluster(loc3v1)),
                             collection_kind: Optional {
                                 bound: Bounded,
                                 element_type: core :: option :: Option < () >,
@@ -3352,7 +3304,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(12, Cluster(loc3v1)),
+                        location_id: Tick(11, Cluster(loc3v1)),
                         collection_kind: Optional {
                             bound: Bounded,
                             element_type: (),
@@ -3360,7 +3312,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(12, Cluster(loc3v1)),
+                    location_id: Tick(11, Cluster(loc3v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: TotalOrder,
@@ -3370,7 +3322,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(12, Cluster(loc3v1)),
+                location_id: Tick(11, Cluster(loc3v1)),
                 collection_kind: Stream {
                     bound: Bounded,
                     order: TotalOrder,
@@ -3426,7 +3378,7 @@ expression: built.ir()
                                                                                                     left: Tee {
                                                                                                         inner: <tee 16>,
                                                                                                         metadata: HydroIrMetadata {
-                                                                                                            location_id: Tick(12, Cluster(loc3v1)),
+                                                                                                            location_id: Tick(11, Cluster(loc3v1)),
                                                                                                             collection_kind: Stream {
                                                                                                                 bound: Bounded,
                                                                                                                 order: TotalOrder,
@@ -3438,7 +3390,7 @@ expression: built.ir()
                                                                                                     right: Tee {
                                                                                                         inner: <tee 18>,
                                                                                                         metadata: HydroIrMetadata {
-                                                                                                            location_id: Tick(12, Cluster(loc3v1)),
+                                                                                                            location_id: Tick(11, Cluster(loc3v1)),
                                                                                                             collection_kind: Optional {
                                                                                                                 bound: Bounded,
                                                                                                                 element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
@@ -3446,7 +3398,7 @@ expression: built.ir()
                                                                                                         },
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
-                                                                                                        location_id: Tick(12, Cluster(loc3v1)),
+                                                                                                        location_id: Tick(11, Cluster(loc3v1)),
                                                                                                         collection_kind: Stream {
                                                                                                             bound: Bounded,
                                                                                                             order: TotalOrder,
@@ -3539,7 +3491,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                                     collection_kind: Stream {
                                                                         bound: Bounded,
                                                                         order: TotalOrder,
@@ -3553,7 +3505,7 @@ expression: built.ir()
                                                                 input: Tee {
                                                                     inner: <tee 13>,
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(2, Cluster(loc1v1)),
+                                                                        location_id: Tick(1, Cluster(loc1v1)),
                                                                         collection_kind: Optional {
                                                                             bound: Bounded,
                                                                             element_type: (),
@@ -3561,7 +3513,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                                     collection_kind: Optional {
                                                                         bound: Bounded,
                                                                         element_type: (),
@@ -3569,7 +3521,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                                location_id: Tick(1, Cluster(loc1v1)),
                                                                 collection_kind: Stream {
                                                                     bound: Bounded,
                                                                     order: TotalOrder,
@@ -3579,7 +3531,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                             collection_kind: Stream {
                                                                 bound: Bounded,
                                                                 order: TotalOrder,
@@ -3589,7 +3541,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Atomic(Tick(2, Cluster(loc1v1))),
+                                                        location_id: Atomic(Tick(1, Cluster(loc1v1))),
                                                         collection_kind: Stream {
                                                             bound: Unbounded,
                                                             order: TotalOrder,
@@ -3599,7 +3551,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                     collection_kind: Stream {
                                                         bound: Bounded,
                                                         order: TotalOrder,
@@ -3609,7 +3561,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                location_id: Tick(1, Cluster(loc1v1)),
                                                 collection_kind: Stream {
                                                     bound: Bounded,
                                                     order: TotalOrder,
@@ -3652,7 +3604,7 @@ expression: built.ir()
                                                                                                                                 input: Tee {
                                                                                                                                     inner: <tee 14>,
                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                        location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                        location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                         collection_kind: Optional {
                                                                                                                                             bound: Bounded,
                                                                                                                                             element_type: std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >,
@@ -3660,7 +3612,7 @@ expression: built.ir()
                                                                                                                                     },
                                                                                                                                 },
                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                     collection_kind: Stream {
                                                                                                                                         bound: Bounded,
                                                                                                                                         order: NoOrder,
@@ -3670,7 +3622,7 @@ expression: built.ir()
                                                                                                                                 },
                                                                                                                             },
                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                 collection_kind: Stream {
                                                                                                                                     bound: Bounded,
                                                                                                                                     order: NoOrder,
@@ -3680,7 +3632,7 @@ expression: built.ir()
                                                                                                                             },
                                                                                                                         },
                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                             collection_kind: Stream {
                                                                                                                                 bound: Bounded,
                                                                                                                                 order: NoOrder,
@@ -3690,7 +3642,7 @@ expression: built.ir()
                                                                                                                         },
                                                                                                                     },
                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                        location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                        location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                         collection_kind: Stream {
                                                                                                                             bound: Bounded,
                                                                                                                             order: NoOrder,
@@ -3700,7 +3652,7 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                 },
                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                     collection_kind: KeyedStream {
                                                                                                                         bound: Bounded,
                                                                                                                         value_order: NoOrder,
@@ -3712,7 +3664,7 @@ expression: built.ir()
                                                                                                             },
                                                                                                             trusted: false,
                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                 collection_kind: KeyedStream {
                                                                                                                     bound: Bounded,
                                                                                                                     value_order: TotalOrder,
@@ -3723,7 +3675,7 @@ expression: built.ir()
                                                                                                             },
                                                                                                         },
                                                                                                         metadata: HydroIrMetadata {
-                                                                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                                                                             collection_kind: KeyedSingleton {
                                                                                                                 bound: Bounded,
                                                                                                                 key_type: usize,
@@ -3732,7 +3684,7 @@ expression: built.ir()
                                                                                                         },
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
-                                                                                                        location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                        location_id: Tick(1, Cluster(loc1v1)),
                                                                                                         collection_kind: KeyedSingleton {
                                                                                                             bound: Bounded,
                                                                                                             key_type: usize,
@@ -3741,7 +3693,7 @@ expression: built.ir()
                                                                                                     },
                                                                                                 },
                                                                                                 metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                                                                     collection_kind: KeyedSingleton {
                                                                                                         bound: Bounded,
                                                                                                         key_type: usize,
@@ -3750,7 +3702,7 @@ expression: built.ir()
                                                                                                 },
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                location_id: Tick(1, Cluster(loc1v1)),
                                                                                                 collection_kind: KeyedStream {
                                                                                                     bound: Bounded,
                                                                                                     value_order: TotalOrder,
@@ -3761,7 +3713,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                                                             collection_kind: Stream {
                                                                                                 bound: Bounded,
                                                                                                 order: NoOrder,
@@ -3771,7 +3723,7 @@ expression: built.ir()
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(2, Cluster(loc1v1)),
+                                                                                        location_id: Tick(1, Cluster(loc1v1)),
                                                                                         collection_kind: Stream {
                                                                                             bound: Bounded,
                                                                                             order: NoOrder,
@@ -3782,7 +3734,7 @@ expression: built.ir()
                                                                                 },
                                                                                 trusted: true,
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                                                     collection_kind: Stream {
                                                                                         bound: Bounded,
                                                                                         order: TotalOrder,
@@ -3792,7 +3744,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                                                location_id: Tick(1, Cluster(loc1v1)),
                                                                                 collection_kind: Optional {
                                                                                     bound: Bounded,
                                                                                     element_type: usize,
@@ -3800,7 +3752,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                                             collection_kind: Optional {
                                                                                 bound: Bounded,
                                                                                 element_type: usize,
@@ -3808,7 +3760,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Atomic(Tick(2, Cluster(loc1v1))),
+                                                                        location_id: Atomic(Tick(1, Cluster(loc1v1))),
                                                                         collection_kind: Optional {
                                                                             bound: Unbounded,
                                                                             element_type: usize,
@@ -3816,7 +3768,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                                     collection_kind: Optional {
                                                                         bound: Bounded,
                                                                         element_type: usize,
@@ -3824,7 +3776,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                                location_id: Tick(1, Cluster(loc1v1)),
                                                                 collection_kind: Optional {
                                                                     bound: Bounded,
                                                                     element_type: usize,
@@ -3840,7 +3792,7 @@ expression: built.ir()
                                                                                 sym: cycle_12,
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                                                location_id: Tick(1, Cluster(loc1v1)),
                                                                                 collection_kind: Singleton {
                                                                                     bound: Bounded,
                                                                                     element_type: usize,
@@ -3848,7 +3800,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                                             collection_kind: Optional {
                                                                                 bound: Bounded,
                                                                                 element_type: usize,
@@ -3859,7 +3811,7 @@ expression: built.ir()
                                                                         inner: SingletonSource {
                                                                             value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; 0 },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                                                location_id: Tick(1, Cluster(loc1v1)),
                                                                                 collection_kind: Singleton {
                                                                                     bound: Bounded,
                                                                                     element_type: usize,
@@ -3867,7 +3819,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                                             collection_kind: Optional {
                                                                                 bound: Bounded,
                                                                                 element_type: usize,
@@ -3875,7 +3827,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(2, Cluster(loc1v1)),
+                                                                        location_id: Tick(1, Cluster(loc1v1)),
                                                                         collection_kind: Optional {
                                                                             bound: Bounded,
                                                                             element_type: usize,
@@ -3883,7 +3835,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                                     collection_kind: Singleton {
                                                                         bound: Bounded,
                                                                         element_type: usize,
@@ -3891,7 +3843,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                                location_id: Tick(1, Cluster(loc1v1)),
                                                                 collection_kind: Optional {
                                                                     bound: Bounded,
                                                                     element_type: usize,
@@ -3899,7 +3851,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: usize,
@@ -3907,7 +3859,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(2, Cluster(loc1v1)),
+                                                        location_id: Tick(1, Cluster(loc1v1)),
                                                         collection_kind: Singleton {
                                                             bound: Bounded,
                                                             element_type: usize,
@@ -3915,7 +3867,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                     collection_kind: Singleton {
                                                         bound: Bounded,
                                                         element_type: usize,
@@ -3923,7 +3875,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                location_id: Tick(1, Cluster(loc1v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: usize,
@@ -3931,7 +3883,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(2, Cluster(loc1v1)),
+                                            location_id: Tick(1, Cluster(loc1v1)),
                                             collection_kind: Stream {
                                                 bound: Bounded,
                                                 order: TotalOrder,
@@ -3941,7 +3893,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(2, Cluster(loc1v1)),
+                                        location_id: Tick(1, Cluster(loc1v1)),
                                         collection_kind: Stream {
                                             bound: Bounded,
                                             order: TotalOrder,
@@ -3951,7 +3903,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(2, Cluster(loc1v1)),
+                                    location_id: Tick(1, Cluster(loc1v1)),
                                     collection_kind: Stream {
                                         bound: Bounded,
                                         order: TotalOrder,
@@ -3961,7 +3913,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(2, Cluster(loc1v1)),
+                                location_id: Tick(1, Cluster(loc1v1)),
                                 collection_kind: Singleton {
                                     bound: Bounded,
                                     element_type: usize,
@@ -3969,7 +3921,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(2, Cluster(loc1v1)),
+                            location_id: Tick(1, Cluster(loc1v1)),
                             collection_kind: Singleton {
                                 bound: Bounded,
                                 element_type: usize,
@@ -3979,7 +3931,7 @@ expression: built.ir()
                     right: Tee {
                         inner: <tee 22>,
                         metadata: HydroIrMetadata {
-                            location_id: Tick(2, Cluster(loc1v1)),
+                            location_id: Tick(1, Cluster(loc1v1)),
                             collection_kind: Singleton {
                                 bound: Bounded,
                                 element_type: usize,
@@ -3987,7 +3939,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(2, Cluster(loc1v1)),
+                        location_id: Tick(1, Cluster(loc1v1)),
                         collection_kind: Optional {
                             bound: Bounded,
                             element_type: (usize , usize),
@@ -3995,7 +3947,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(2, Cluster(loc1v1)),
+                    location_id: Tick(1, Cluster(loc1v1)),
                     collection_kind: Singleton {
                         bound: Bounded,
                         element_type: (usize , usize),
@@ -4003,7 +3955,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(2, Cluster(loc1v1)),
+                location_id: Tick(1, Cluster(loc1v1)),
                 collection_kind: Singleton {
                     bound: Bounded,
                     element_type: usize,
@@ -4025,7 +3977,7 @@ expression: built.ir()
                                 sym: cycle_13,
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(14, Cluster(loc1v1)),
+                                location_id: Tick(13, Cluster(loc1v1)),
                                 collection_kind: Stream {
                                     bound: Bounded,
                                     order: NoOrder,
@@ -4035,7 +3987,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(14, Cluster(loc1v1)),
+                            location_id: Tick(13, Cluster(loc1v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -4141,7 +4093,7 @@ expression: built.ir()
                                                                                                                             },
                                                                                                                         },
                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                            location_id: Tick(13, Cluster(loc1v1)),
+                                                                                                                            location_id: Tick(12, Cluster(loc1v1)),
                                                                                                                             collection_kind: KeyedSingleton {
                                                                                                                                 bound: Bounded,
                                                                                                                                 key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
@@ -4150,7 +4102,7 @@ expression: built.ir()
                                                                                                                         },
                                                                                                                     },
                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                        location_id: Tick(13, Cluster(loc1v1)),
+                                                                                                                        location_id: Tick(12, Cluster(loc1v1)),
                                                                                                                         collection_kind: KeyedSingleton {
                                                                                                                             bound: Bounded,
                                                                                                                             key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
@@ -4159,7 +4111,7 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                 },
                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(13, Cluster(loc1v1)),
+                                                                                                                    location_id: Tick(12, Cluster(loc1v1)),
                                                                                                                     collection_kind: KeyedStream {
                                                                                                                         bound: Bounded,
                                                                                                                         value_order: TotalOrder,
@@ -4170,7 +4122,7 @@ expression: built.ir()
                                                                                                                 },
                                                                                                             },
                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                location_id: Tick(13, Cluster(loc1v1)),
+                                                                                                                location_id: Tick(12, Cluster(loc1v1)),
                                                                                                                 collection_kind: Stream {
                                                                                                                     bound: Bounded,
                                                                                                                     order: NoOrder,
@@ -4180,7 +4132,7 @@ expression: built.ir()
                                                                                                             },
                                                                                                         },
                                                                                                         metadata: HydroIrMetadata {
-                                                                                                            location_id: Tick(13, Cluster(loc1v1)),
+                                                                                                            location_id: Tick(12, Cluster(loc1v1)),
                                                                                                             collection_kind: Stream {
                                                                                                                 bound: Bounded,
                                                                                                                 order: NoOrder,
@@ -4191,7 +4143,7 @@ expression: built.ir()
                                                                                                     },
                                                                                                     trusted: true,
                                                                                                     metadata: HydroIrMetadata {
-                                                                                                        location_id: Tick(13, Cluster(loc1v1)),
+                                                                                                        location_id: Tick(12, Cluster(loc1v1)),
                                                                                                         collection_kind: Stream {
                                                                                                             bound: Bounded,
                                                                                                             order: TotalOrder,
@@ -4218,7 +4170,7 @@ expression: built.ir()
                                                                                                                                                 inner: Tee {
                                                                                                                                                     inner: <tee 21>,
                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                        location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                        location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                         collection_kind: Stream {
                                                                                                                                                             bound: Bounded,
                                                                                                                                                             order: TotalOrder,
@@ -4228,7 +4180,7 @@ expression: built.ir()
                                                                                                                                                     },
                                                                                                                                                 },
                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                    location_id: Atomic(Tick(2, Cluster(loc1v1))),
+                                                                                                                                                    location_id: Atomic(Tick(1, Cluster(loc1v1))),
                                                                                                                                                     collection_kind: Stream {
                                                                                                                                                         bound: Unbounded,
                                                                                                                                                         order: TotalOrder,
@@ -4238,7 +4190,7 @@ expression: built.ir()
                                                                                                                                                 },
                                                                                                                                             },
                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                 collection_kind: Stream {
                                                                                                                                                     bound: Bounded,
                                                                                                                                                     order: TotalOrder,
@@ -4251,7 +4203,7 @@ expression: built.ir()
                                                                                                                                             inner: Tee {
                                                                                                                                                 inner: <tee 4>,
                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                     collection_kind: Singleton {
                                                                                                                                                         bound: Bounded,
                                                                                                                                                         element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -4259,7 +4211,7 @@ expression: built.ir()
                                                                                                                                                 },
                                                                                                                                             },
                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                 collection_kind: Optional {
                                                                                                                                                     bound: Bounded,
                                                                                                                                                     element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -4267,7 +4219,7 @@ expression: built.ir()
                                                                                                                                             },
                                                                                                                                         },
                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                             collection_kind: Stream {
                                                                                                                                                 bound: Bounded,
                                                                                                                                                 order: TotalOrder,
@@ -4277,7 +4229,7 @@ expression: built.ir()
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                        location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                        location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                         collection_kind: Stream {
                                                                                                                                             bound: Bounded,
                                                                                                                                             order: TotalOrder,
@@ -4296,7 +4248,7 @@ expression: built.ir()
                                                                                                                                                         inner: Tee {
                                                                                                                                                             inner: <tee 24>,
                                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                                location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                                 collection_kind: KeyedSingleton {
                                                                                                                                                                     bound: Bounded,
                                                                                                                                                                     key_type: usize,
@@ -4305,7 +4257,7 @@ expression: built.ir()
                                                                                                                                                             },
                                                                                                                                                         },
                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                             collection_kind: KeyedStream {
                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                 value_order: TotalOrder,
@@ -4316,7 +4268,7 @@ expression: built.ir()
                                                                                                                                                         },
                                                                                                                                                     },
                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                        location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                        location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                         collection_kind: Stream {
                                                                                                                                                             bound: Bounded,
                                                                                                                                                             order: NoOrder,
@@ -4329,7 +4281,7 @@ expression: built.ir()
                                                                                                                                                     inner: Tee {
                                                                                                                                                         inner: <tee 4>,
                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                             collection_kind: Singleton {
                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                 element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -4337,7 +4289,7 @@ expression: built.ir()
                                                                                                                                                         },
                                                                                                                                                     },
                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                        location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                        location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                         collection_kind: Optional {
                                                                                                                                                             bound: Bounded,
                                                                                                                                                             element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -4345,7 +4297,7 @@ expression: built.ir()
                                                                                                                                                     },
                                                                                                                                                 },
                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                     collection_kind: Stream {
                                                                                                                                                         bound: Bounded,
                                                                                                                                                         order: NoOrder,
@@ -4368,7 +4320,7 @@ expression: built.ir()
                                                                                                                                                                             input: Tee {
                                                                                                                                                                                 inner: <tee 25>,
                                                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                                                     collection_kind: Stream {
                                                                                                                                                                                         bound: Bounded,
                                                                                                                                                                                         order: NoOrder,
@@ -4378,7 +4330,7 @@ expression: built.ir()
                                                                                                                                                                                 },
                                                                                                                                                                             },
                                                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                                                location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                                                 collection_kind: Stream {
                                                                                                                                                                                     bound: Bounded,
                                                                                                                                                                                     order: NoOrder,
@@ -4389,7 +4341,7 @@ expression: built.ir()
                                                                                                                                                                         },
                                                                                                                                                                         trusted: true,
                                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                                             collection_kind: Stream {
                                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                                 order: TotalOrder,
@@ -4399,7 +4351,7 @@ expression: built.ir()
                                                                                                                                                                         },
                                                                                                                                                                     },
                                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                                        location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                                        location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                                         collection_kind: Optional {
                                                                                                                                                                             bound: Bounded,
                                                                                                                                                                             element_type: usize,
@@ -4407,7 +4359,7 @@ expression: built.ir()
                                                                                                                                                                     },
                                                                                                                                                                 },
                                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                                     collection_kind: Optional {
                                                                                                                                                                         bound: Bounded,
                                                                                                                                                                         element_type: core :: option :: Option < usize >,
@@ -4418,7 +4370,7 @@ expression: built.ir()
                                                                                                                                                                 inner: SingletonSource {
                                                                                                                                                                     value: :: std :: option :: Option :: None,
                                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                                        location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                                        location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                                         collection_kind: Singleton {
                                                                                                                                                                             bound: Bounded,
                                                                                                                                                                             element_type: core :: option :: Option < usize >,
@@ -4426,7 +4378,7 @@ expression: built.ir()
                                                                                                                                                                     },
                                                                                                                                                                 },
                                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                                     collection_kind: Optional {
                                                                                                                                                                         bound: Bounded,
                                                                                                                                                                         element_type: core :: option :: Option < usize >,
@@ -4434,7 +4386,7 @@ expression: built.ir()
                                                                                                                                                                 },
                                                                                                                                                             },
                                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                                location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                                 collection_kind: Optional {
                                                                                                                                                                     bound: Bounded,
                                                                                                                                                                     element_type: core :: option :: Option < usize >,
@@ -4442,7 +4394,7 @@ expression: built.ir()
                                                                                                                                                             },
                                                                                                                                                         },
                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                             collection_kind: Singleton {
                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                 element_type: core :: option :: Option < usize >,
@@ -4450,7 +4402,7 @@ expression: built.ir()
                                                                                                                                                         },
                                                                                                                                                     },
                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                        location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                        location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                         collection_kind: Singleton {
                                                                                                                                                             bound: Bounded,
                                                                                                                                                             element_type: core :: option :: Option < usize >,
@@ -4458,7 +4410,7 @@ expression: built.ir()
                                                                                                                                                     },
                                                                                                                                                 },
                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                     collection_kind: Optional {
                                                                                                                                                         bound: Bounded,
                                                                                                                                                         element_type: core :: option :: Option < usize >,
@@ -4466,7 +4418,7 @@ expression: built.ir()
                                                                                                                                                 },
                                                                                                                                             },
                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                 collection_kind: Stream {
                                                                                                                                                     bound: Bounded,
                                                                                                                                                     order: NoOrder,
@@ -4476,7 +4428,7 @@ expression: built.ir()
                                                                                                                                             },
                                                                                                                                         },
                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                             collection_kind: Stream {
                                                                                                                                                 bound: Bounded,
                                                                                                                                                 order: NoOrder,
@@ -4495,7 +4447,7 @@ expression: built.ir()
                                                                                                                                                         left: Tee {
                                                                                                                                                             inner: <tee 23>,
                                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                                location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                                 collection_kind: Optional {
                                                                                                                                                                     bound: Bounded,
                                                                                                                                                                     element_type: usize,
@@ -4506,7 +4458,7 @@ expression: built.ir()
                                                                                                                                                             inner: Tee {
                                                                                                                                                                 inner: <tee 30>,
                                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                                     collection_kind: Singleton {
                                                                                                                                                                         bound: Bounded,
                                                                                                                                                                         element_type: core :: option :: Option < usize >,
@@ -4514,7 +4466,7 @@ expression: built.ir()
                                                                                                                                                                 },
                                                                                                                                                             },
                                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                                location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                                 collection_kind: Optional {
                                                                                                                                                                     bound: Bounded,
                                                                                                                                                                     element_type: core :: option :: Option < usize >,
@@ -4522,7 +4474,7 @@ expression: built.ir()
                                                                                                                                                             },
                                                                                                                                                         },
                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                             collection_kind: Optional {
                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                 element_type: (usize , core :: option :: Option < usize >),
@@ -4530,7 +4482,7 @@ expression: built.ir()
                                                                                                                                                         },
                                                                                                                                                     },
                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                        location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                        location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                         collection_kind: Stream {
                                                                                                                                                             bound: Bounded,
                                                                                                                                                             order: TotalOrder,
@@ -4546,7 +4498,7 @@ expression: built.ir()
                                                                                                                                                             inner: Tee {
                                                                                                                                                                 inner: <tee 24>,
                                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                                     collection_kind: KeyedSingleton {
                                                                                                                                                                         bound: Bounded,
                                                                                                                                                                         key_type: usize,
@@ -4555,7 +4507,7 @@ expression: built.ir()
                                                                                                                                                                 },
                                                                                                                                                             },
                                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                                location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                                 collection_kind: KeyedStream {
                                                                                                                                                                     bound: Bounded,
                                                                                                                                                                     value_order: TotalOrder,
@@ -4566,7 +4518,7 @@ expression: built.ir()
                                                                                                                                                             },
                                                                                                                                                         },
                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                             collection_kind: Stream {
                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                 order: NoOrder,
@@ -4576,7 +4528,7 @@ expression: built.ir()
                                                                                                                                                         },
                                                                                                                                                     },
                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                        location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                        location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                         collection_kind: Stream {
                                                                                                                                                             bound: Bounded,
                                                                                                                                                             order: NoOrder,
@@ -4586,7 +4538,7 @@ expression: built.ir()
                                                                                                                                                     },
                                                                                                                                                 },
                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                     collection_kind: Stream {
                                                                                                                                                         bound: Bounded,
                                                                                                                                                         order: TotalOrder,
@@ -4599,7 +4551,7 @@ expression: built.ir()
                                                                                                                                                 inner: Tee {
                                                                                                                                                     inner: <tee 4>,
                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                        location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                        location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                         collection_kind: Singleton {
                                                                                                                                                             bound: Bounded,
                                                                                                                                                             element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -4607,7 +4559,7 @@ expression: built.ir()
                                                                                                                                                     },
                                                                                                                                                 },
                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                     collection_kind: Optional {
                                                                                                                                                         bound: Bounded,
                                                                                                                                                         element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -4615,7 +4567,7 @@ expression: built.ir()
                                                                                                                                                 },
                                                                                                                                             },
                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                                location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                 collection_kind: Stream {
                                                                                                                                                     bound: Bounded,
                                                                                                                                                     order: TotalOrder,
@@ -4625,7 +4577,7 @@ expression: built.ir()
                                                                                                                                             },
                                                                                                                                         },
                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                             collection_kind: Stream {
                                                                                                                                                 bound: Bounded,
                                                                                                                                                 order: TotalOrder,
@@ -4635,7 +4587,7 @@ expression: built.ir()
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                        location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                        location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                         collection_kind: Stream {
                                                                                                                                             bound: Bounded,
                                                                                                                                             order: NoOrder,
@@ -4645,7 +4597,7 @@ expression: built.ir()
                                                                                                                                     },
                                                                                                                                 },
                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                     collection_kind: Stream {
                                                                                                                                         bound: Bounded,
                                                                                                                                         order: NoOrder,
@@ -4659,7 +4611,7 @@ expression: built.ir()
                                                                                                                                 input: Tee {
                                                                                                                                     inner: <tee 13>,
                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                        location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                        location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                         collection_kind: Optional {
                                                                                                                                             bound: Bounded,
                                                                                                                                             element_type: (),
@@ -4667,7 +4619,7 @@ expression: built.ir()
                                                                                                                                     },
                                                                                                                                 },
                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                     collection_kind: Optional {
                                                                                                                                         bound: Bounded,
                                                                                                                                         element_type: (),
@@ -4675,7 +4627,7 @@ expression: built.ir()
                                                                                                                                 },
                                                                                                                             },
                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                                location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                 collection_kind: Stream {
                                                                                                                                     bound: Bounded,
                                                                                                                                     order: NoOrder,
@@ -4685,7 +4637,7 @@ expression: built.ir()
                                                                                                                             },
                                                                                                                         },
                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                             collection_kind: Stream {
                                                                                                                                 bound: Bounded,
                                                                                                                                 order: NoOrder,
@@ -4695,7 +4647,7 @@ expression: built.ir()
                                                                                                                         },
                                                                                                                     },
                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                        location_id: Atomic(Tick(2, Cluster(loc1v1))),
+                                                                                                                        location_id: Atomic(Tick(1, Cluster(loc1v1))),
                                                                                                                         collection_kind: Stream {
                                                                                                                             bound: Unbounded,
                                                                                                                             order: NoOrder,
@@ -4705,7 +4657,7 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                 },
                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                    location_id: Atomic(Tick(2, Cluster(loc1v1))),
+                                                                                                                    location_id: Atomic(Tick(1, Cluster(loc1v1))),
                                                                                                                     collection_kind: Stream {
                                                                                                                         bound: Unbounded,
                                                                                                                         order: NoOrder,
@@ -4735,7 +4687,7 @@ expression: built.ir()
                                                                                                         },
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
-                                                                                                        location_id: Tick(13, Cluster(loc1v1)),
+                                                                                                        location_id: Tick(12, Cluster(loc1v1)),
                                                                                                         collection_kind: Stream {
                                                                                                             bound: Bounded,
                                                                                                             order: NoOrder,
@@ -4745,7 +4697,7 @@ expression: built.ir()
                                                                                                     },
                                                                                                 },
                                                                                                 metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(13, Cluster(loc1v1)),
+                                                                                                    location_id: Tick(12, Cluster(loc1v1)),
                                                                                                     collection_kind: Stream {
                                                                                                         bound: Bounded,
                                                                                                         order: NoOrder,
@@ -4755,7 +4707,7 @@ expression: built.ir()
                                                                                                 },
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(13, Cluster(loc1v1)),
+                                                                                                location_id: Tick(12, Cluster(loc1v1)),
                                                                                                 collection_kind: KeyedStream {
                                                                                                     bound: Bounded,
                                                                                                     value_order: NoOrder,
@@ -4818,7 +4770,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(3, Cluster(loc2v1)),
+                                                                        location_id: Tick(2, Cluster(loc2v1)),
                                                                         collection_kind: Stream {
                                                                             bound: Bounded,
                                                                             order: NoOrder,
@@ -4828,7 +4780,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(3, Cluster(loc2v1)),
+                                                                    location_id: Tick(2, Cluster(loc2v1)),
                                                                     collection_kind: Stream {
                                                                         bound: Bounded,
                                                                         order: NoOrder,
@@ -4841,7 +4793,7 @@ expression: built.ir()
                                                                 inner: Tee {
                                                                     inner: <tee 10>,
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(3, Cluster(loc2v1)),
+                                                                        location_id: Tick(2, Cluster(loc2v1)),
                                                                         collection_kind: Singleton {
                                                                             bound: Bounded,
                                                                             element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -4849,7 +4801,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(3, Cluster(loc2v1)),
+                                                                    location_id: Tick(2, Cluster(loc2v1)),
                                                                     collection_kind: Optional {
                                                                         bound: Bounded,
                                                                         element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -4857,7 +4809,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(3, Cluster(loc2v1)),
+                                                                location_id: Tick(2, Cluster(loc2v1)),
                                                                 collection_kind: Stream {
                                                                     bound: Bounded,
                                                                     order: NoOrder,
@@ -4867,7 +4819,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(3, Cluster(loc2v1)),
+                                                            location_id: Tick(2, Cluster(loc2v1)),
                                                             collection_kind: Stream {
                                                                 bound: Bounded,
                                                                 order: NoOrder,
@@ -4949,7 +4901,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(14, Cluster(loc1v1)),
+                            location_id: Tick(13, Cluster(loc1v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -4959,7 +4911,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(14, Cluster(loc1v1)),
+                        location_id: Tick(13, Cluster(loc1v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: NoOrder,
@@ -4969,7 +4921,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(14, Cluster(loc1v1)),
+                    location_id: Tick(13, Cluster(loc1v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -4994,7 +4946,7 @@ expression: built.ir()
                                                 inner: Tee {
                                                     inner: <tee 26>,
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(14, Cluster(loc1v1)),
+                                                        location_id: Tick(13, Cluster(loc1v1)),
                                                         collection_kind: Stream {
                                                             bound: Bounded,
                                                             order: NoOrder,
@@ -5004,7 +4956,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(14, Cluster(loc1v1)),
+                                                    location_id: Tick(13, Cluster(loc1v1)),
                                                     collection_kind: KeyedStream {
                                                         bound: Bounded,
                                                         value_order: NoOrder,
@@ -5016,7 +4968,7 @@ expression: built.ir()
                                             },
                                             trusted: false,
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(14, Cluster(loc1v1)),
+                                                location_id: Tick(13, Cluster(loc1v1)),
                                                 collection_kind: KeyedStream {
                                                     bound: Bounded,
                                                     value_order: TotalOrder,
@@ -5027,7 +4979,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(14, Cluster(loc1v1)),
+                                            location_id: Tick(13, Cluster(loc1v1)),
                                             collection_kind: KeyedSingleton {
                                                 bound: Bounded,
                                                 key_type: (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot),
@@ -5036,7 +4988,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(14, Cluster(loc1v1)),
+                                        location_id: Tick(13, Cluster(loc1v1)),
                                         collection_kind: KeyedSingleton {
                                             bound: Bounded,
                                             key_type: (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot),
@@ -5045,7 +4997,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(14, Cluster(loc1v1)),
+                                    location_id: Tick(13, Cluster(loc1v1)),
                                     collection_kind: KeyedSingleton {
                                         bound: Bounded,
                                         key_type: (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot),
@@ -5054,7 +5006,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(14, Cluster(loc1v1)),
+                                location_id: Tick(13, Cluster(loc1v1)),
                                 collection_kind: KeyedStream {
                                     bound: Bounded,
                                     value_order: TotalOrder,
@@ -5065,7 +5017,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(14, Cluster(loc1v1)),
+                            location_id: Tick(13, Cluster(loc1v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -5075,7 +5027,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(14, Cluster(loc1v1)),
+                        location_id: Tick(13, Cluster(loc1v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: NoOrder,
@@ -5085,7 +5037,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(14, Cluster(loc1v1)),
+                    location_id: Tick(13, Cluster(loc1v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -5095,7 +5047,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(14, Cluster(loc1v1)),
+                location_id: Tick(13, Cluster(loc1v1)),
                 collection_kind: Stream {
                     bound: Bounded,
                     order: NoOrder,
@@ -5119,7 +5071,7 @@ expression: built.ir()
                             inner: Tee {
                                 inner: <tee 32>,
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(14, Cluster(loc1v1)),
+                                    location_id: Tick(13, Cluster(loc1v1)),
                                     collection_kind: KeyedSingleton {
                                         bound: Bounded,
                                         key_type: (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot),
@@ -5128,7 +5080,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(14, Cluster(loc1v1)),
+                                location_id: Tick(13, Cluster(loc1v1)),
                                 collection_kind: KeyedStream {
                                     bound: Bounded,
                                     value_order: TotalOrder,
@@ -5139,7 +5091,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(14, Cluster(loc1v1)),
+                            location_id: Tick(13, Cluster(loc1v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -5149,7 +5101,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(14, Cluster(loc1v1)),
+                        location_id: Tick(13, Cluster(loc1v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: NoOrder,
@@ -5159,7 +5111,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(14, Cluster(loc1v1)),
+                    location_id: Tick(13, Cluster(loc1v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -5171,7 +5123,7 @@ expression: built.ir()
             neg: Tee {
                 inner: <tee 31>,
                 metadata: HydroIrMetadata {
-                    location_id: Tick(14, Cluster(loc1v1)),
+                    location_id: Tick(13, Cluster(loc1v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -5181,7 +5133,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(14, Cluster(loc1v1)),
+                location_id: Tick(13, Cluster(loc1v1)),
                 collection_kind: Stream {
                     bound: Bounded,
                     order: NoOrder,
@@ -5205,7 +5157,7 @@ expression: built.ir()
                                 sym: cycle_15,
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(2, Cluster(loc1v1)),
+                                location_id: Tick(1, Cluster(loc1v1)),
                                 collection_kind: Stream {
                                     bound: Bounded,
                                     order: NoOrder,
@@ -5215,7 +5167,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(2, Cluster(loc1v1)),
+                            location_id: Tick(1, Cluster(loc1v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -5230,7 +5182,7 @@ expression: built.ir()
                                 inner: Tee {
                                     inner: <tee 29>,
                                     metadata: HydroIrMetadata {
-                                        location_id: Atomic(Tick(2, Cluster(loc1v1))),
+                                        location_id: Atomic(Tick(1, Cluster(loc1v1))),
                                         collection_kind: Stream {
                                             bound: Unbounded,
                                             order: NoOrder,
@@ -5240,7 +5192,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(2, Cluster(loc1v1)),
+                                    location_id: Tick(1, Cluster(loc1v1)),
                                     collection_kind: Stream {
                                         bound: Bounded,
                                         order: NoOrder,
@@ -5250,7 +5202,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Atomic(Tick(2, Cluster(loc1v1))),
+                                location_id: Atomic(Tick(1, Cluster(loc1v1))),
                                 collection_kind: Stream {
                                     bound: Unbounded,
                                     order: NoOrder,
@@ -5260,7 +5212,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(2, Cluster(loc1v1)),
+                            location_id: Tick(1, Cluster(loc1v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -5270,7 +5222,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(2, Cluster(loc1v1)),
+                        location_id: Tick(1, Cluster(loc1v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: NoOrder,
@@ -5280,7 +5232,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(2, Cluster(loc1v1)),
+                    location_id: Tick(1, Cluster(loc1v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -5300,7 +5252,7 @@ expression: built.ir()
                                     pos: Tee {
                                         inner: <tee 33>,
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(14, Cluster(loc1v1)),
+                                            location_id: Tick(13, Cluster(loc1v1)),
                                             collection_kind: Stream {
                                                 bound: Bounded,
                                                 order: NoOrder,
@@ -5315,7 +5267,7 @@ expression: built.ir()
                                                 sym: cycle_14,
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(14, Cluster(loc1v1)),
+                                                location_id: Tick(13, Cluster(loc1v1)),
                                                 collection_kind: Stream {
                                                     bound: Bounded,
                                                     order: NoOrder,
@@ -5325,7 +5277,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(14, Cluster(loc1v1)),
+                                            location_id: Tick(13, Cluster(loc1v1)),
                                             collection_kind: Stream {
                                                 bound: Bounded,
                                                 order: NoOrder,
@@ -5335,7 +5287,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(14, Cluster(loc1v1)),
+                                        location_id: Tick(13, Cluster(loc1v1)),
                                         collection_kind: Stream {
                                             bound: Bounded,
                                             order: NoOrder,
@@ -5365,7 +5317,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(2, Cluster(loc1v1)),
+                            location_id: Tick(1, Cluster(loc1v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -5375,7 +5327,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(2, Cluster(loc1v1)),
+                        location_id: Tick(1, Cluster(loc1v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: NoOrder,
@@ -5385,7 +5337,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(2, Cluster(loc1v1)),
+                    location_id: Tick(1, Cluster(loc1v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -5395,7 +5347,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(2, Cluster(loc1v1)),
+                location_id: Tick(1, Cluster(loc1v1)),
                 collection_kind: Stream {
                     bound: Bounded,
                     order: NoOrder,
@@ -5433,7 +5385,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(3, Cluster(loc2v1)),
+                                                location_id: Tick(2, Cluster(loc2v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: usize,
@@ -5441,7 +5393,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(3, Cluster(loc2v1)),
+                                            location_id: Tick(2, Cluster(loc2v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: usize,
@@ -5449,7 +5401,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(3, Cluster(loc2v1)),
+                                        location_id: Tick(2, Cluster(loc2v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: core :: option :: Option < usize >,
@@ -5460,7 +5412,7 @@ expression: built.ir()
                                     inner: SingletonSource {
                                         value: :: std :: option :: Option :: None,
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(3, Cluster(loc2v1)),
+                                            location_id: Tick(2, Cluster(loc2v1)),
                                             collection_kind: Singleton {
                                                 bound: Bounded,
                                                 element_type: core :: option :: Option < usize >,
@@ -5468,7 +5420,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(3, Cluster(loc2v1)),
+                                        location_id: Tick(2, Cluster(loc2v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: core :: option :: Option < usize >,
@@ -5476,7 +5428,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(3, Cluster(loc2v1)),
+                                    location_id: Tick(2, Cluster(loc2v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: core :: option :: Option < usize >,
@@ -5484,7 +5436,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(3, Cluster(loc2v1)),
+                                location_id: Tick(2, Cluster(loc2v1)),
                                 collection_kind: Singleton {
                                     bound: Bounded,
                                     element_type: core :: option :: Option < usize >,
@@ -5509,7 +5461,7 @@ expression: built.ir()
                                                                     left: Tee {
                                                                         inner: <tee 28>,
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(3, Cluster(loc2v1)),
+                                                                            location_id: Tick(2, Cluster(loc2v1)),
                                                                             collection_kind: Stream {
                                                                                 bound: Bounded,
                                                                                 order: NoOrder,
@@ -5522,7 +5474,7 @@ expression: built.ir()
                                                                         inner: Tee {
                                                                             inner: <tee 10>,
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(3, Cluster(loc2v1)),
+                                                                                location_id: Tick(2, Cluster(loc2v1)),
                                                                                 collection_kind: Singleton {
                                                                                     bound: Bounded,
                                                                                     element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -5530,7 +5482,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(3, Cluster(loc2v1)),
+                                                                            location_id: Tick(2, Cluster(loc2v1)),
                                                                             collection_kind: Optional {
                                                                                 bound: Bounded,
                                                                                 element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -5538,7 +5490,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(3, Cluster(loc2v1)),
+                                                                        location_id: Tick(2, Cluster(loc2v1)),
                                                                         collection_kind: Stream {
                                                                             bound: Bounded,
                                                                             order: NoOrder,
@@ -5548,7 +5500,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(3, Cluster(loc2v1)),
+                                                                    location_id: Tick(2, Cluster(loc2v1)),
                                                                     collection_kind: Stream {
                                                                         bound: Bounded,
                                                                         order: NoOrder,
@@ -5558,7 +5510,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Atomic(Tick(3, Cluster(loc2v1))),
+                                                                location_id: Atomic(Tick(2, Cluster(loc2v1))),
                                                                 collection_kind: Stream {
                                                                     bound: Unbounded,
                                                                     order: NoOrder,
@@ -5568,7 +5520,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Atomic(Tick(3, Cluster(loc2v1))),
+                                                            location_id: Atomic(Tick(2, Cluster(loc2v1))),
                                                             collection_kind: KeyedStream {
                                                                 bound: Unbounded,
                                                                 value_order: NoOrder,
@@ -5580,7 +5532,7 @@ expression: built.ir()
                                                     },
                                                     trusted: false,
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Atomic(Tick(3, Cluster(loc2v1))),
+                                                        location_id: Atomic(Tick(2, Cluster(loc2v1))),
                                                         collection_kind: KeyedStream {
                                                             bound: Unbounded,
                                                             value_order: TotalOrder,
@@ -5593,7 +5545,7 @@ expression: built.ir()
                                                 watermark: Tee {
                                                     inner: <tee 36>,
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(3, Cluster(loc2v1)),
+                                                        location_id: Tick(2, Cluster(loc2v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: usize,
@@ -5601,7 +5553,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Atomic(Tick(3, Cluster(loc2v1))),
+                                                    location_id: Atomic(Tick(2, Cluster(loc2v1))),
                                                     collection_kind: KeyedSingleton {
                                                         bound: Unbounded,
                                                         key_type: usize,
@@ -5610,7 +5562,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(3, Cluster(loc2v1)),
+                                                location_id: Tick(2, Cluster(loc2v1)),
                                                 collection_kind: KeyedSingleton {
                                                     bound: Bounded,
                                                     key_type: usize,
@@ -5619,7 +5571,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(3, Cluster(loc2v1)),
+                                            location_id: Tick(2, Cluster(loc2v1)),
                                             collection_kind: KeyedStream {
                                                 bound: Bounded,
                                                 value_order: TotalOrder,
@@ -5630,7 +5582,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(3, Cluster(loc2v1)),
+                                        location_id: Tick(2, Cluster(loc2v1)),
                                         collection_kind: Stream {
                                             bound: Bounded,
                                             order: NoOrder,
@@ -5641,7 +5593,7 @@ expression: built.ir()
                                 },
                                 trusted: false,
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(3, Cluster(loc2v1)),
+                                    location_id: Tick(2, Cluster(loc2v1)),
                                     collection_kind: Stream {
                                         bound: Bounded,
                                         order: TotalOrder,
@@ -5651,7 +5603,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(3, Cluster(loc2v1)),
+                                location_id: Tick(2, Cluster(loc2v1)),
                                 collection_kind: Singleton {
                                     bound: Bounded,
                                     element_type: std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >,
@@ -5659,7 +5611,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(3, Cluster(loc2v1)),
+                            location_id: Tick(2, Cluster(loc2v1)),
                             collection_kind: Optional {
                                 bound: Bounded,
                                 element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
@@ -5667,7 +5619,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(3, Cluster(loc2v1)),
+                        location_id: Tick(2, Cluster(loc2v1)),
                         collection_kind: Singleton {
                             bound: Bounded,
                             element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
@@ -5675,7 +5627,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Atomic(Tick(3, Cluster(loc2v1))),
+                    location_id: Atomic(Tick(2, Cluster(loc2v1))),
                     collection_kind: Singleton {
                         bound: Unbounded,
                         element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
@@ -5683,7 +5635,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(3, Cluster(loc2v1)),
+                location_id: Tick(2, Cluster(loc2v1)),
                 collection_kind: Singleton {
                     bound: Bounded,
                     element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
@@ -5826,7 +5778,7 @@ expression: built.ir()
                                                                                                     },
                                                                                                 },
                                                                                                 metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                    location_id: Tick(14, Cluster(loc1v1)),
                                                                                                     collection_kind: KeyedSingleton {
                                                                                                         bound: Bounded,
                                                                                                         key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica >,
@@ -5835,7 +5787,7 @@ expression: built.ir()
                                                                                                 },
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                location_id: Tick(14, Cluster(loc1v1)),
                                                                                                 collection_kind: KeyedSingleton {
                                                                                                     bound: Bounded,
                                                                                                     key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica >,
@@ -5844,7 +5796,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                            location_id: Tick(14, Cluster(loc1v1)),
                                                                                             collection_kind: KeyedStream {
                                                                                                 bound: Bounded,
                                                                                                 value_order: TotalOrder,
@@ -5855,7 +5807,7 @@ expression: built.ir()
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                        location_id: Tick(14, Cluster(loc1v1)),
                                                                                         collection_kind: Stream {
                                                                                             bound: Bounded,
                                                                                             order: NoOrder,
@@ -5865,7 +5817,7 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                    location_id: Tick(14, Cluster(loc1v1)),
                                                                                     collection_kind: Stream {
                                                                                         bound: Bounded,
                                                                                         order: NoOrder,
@@ -5876,7 +5828,7 @@ expression: built.ir()
                                                                             },
                                                                             trusted: true,
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                location_id: Tick(14, Cluster(loc1v1)),
                                                                                 collection_kind: Stream {
                                                                                     bound: Bounded,
                                                                                     order: TotalOrder,
@@ -5895,7 +5847,7 @@ expression: built.ir()
                                                                                             left: Tee {
                                                                                                 inner: <tee 34>,
                                                                                                 metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                                                                     collection_kind: Stream {
                                                                                                         bound: Bounded,
                                                                                                         order: NoOrder,
@@ -5907,7 +5859,7 @@ expression: built.ir()
                                                                                             right: Tee {
                                                                                                 inner: <tee 35>,
                                                                                                 metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                    location_id: Tick(1, Cluster(loc1v1)),
                                                                                                     collection_kind: Stream {
                                                                                                         bound: Bounded,
                                                                                                         order: NoOrder,
@@ -5917,7 +5869,7 @@ expression: built.ir()
                                                                                                 },
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(2, Cluster(loc1v1)),
+                                                                                                location_id: Tick(1, Cluster(loc1v1)),
                                                                                                 collection_kind: Stream {
                                                                                                     bound: Bounded,
                                                                                                     order: NoOrder,
@@ -5927,7 +5879,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(2, Cluster(loc1v1)),
+                                                                                            location_id: Tick(1, Cluster(loc1v1)),
                                                                                             collection_kind: Stream {
                                                                                                 bound: Bounded,
                                                                                                 order: NoOrder,
@@ -5957,7 +5909,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                location_id: Tick(14, Cluster(loc1v1)),
                                                                                 collection_kind: Stream {
                                                                                     bound: Bounded,
                                                                                     order: NoOrder,
@@ -5967,7 +5919,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                            location_id: Tick(14, Cluster(loc1v1)),
                                                                             collection_kind: Stream {
                                                                                 bound: Bounded,
                                                                                 order: NoOrder,
@@ -5977,7 +5929,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                        location_id: Tick(14, Cluster(loc1v1)),
                                                                         collection_kind: KeyedStream {
                                                                             bound: Bounded,
                                                                             value_order: NoOrder,
@@ -6060,7 +6012,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(16, Cluster(loc5v1)),
+                                        location_id: Tick(15, Cluster(loc5v1)),
                                         collection_kind: Stream {
                                             bound: Bounded,
                                             order: NoOrder,
@@ -6075,7 +6027,7 @@ expression: built.ir()
                                             sym: cycle_16,
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(16, Cluster(loc5v1)),
+                                            location_id: Tick(15, Cluster(loc5v1)),
                                             collection_kind: Stream {
                                                 bound: Bounded,
                                                 order: TotalOrder,
@@ -6085,7 +6037,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(16, Cluster(loc5v1)),
+                                        location_id: Tick(15, Cluster(loc5v1)),
                                         collection_kind: Stream {
                                             bound: Bounded,
                                             order: TotalOrder,
@@ -6095,7 +6047,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(16, Cluster(loc5v1)),
+                                    location_id: Tick(15, Cluster(loc5v1)),
                                     collection_kind: Stream {
                                         bound: Bounded,
                                         order: NoOrder,
@@ -6105,7 +6057,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(16, Cluster(loc5v1)),
+                                location_id: Tick(15, Cluster(loc5v1)),
                                 collection_kind: Stream {
                                     bound: Bounded,
                                     order: TotalOrder,
@@ -6115,7 +6067,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(16, Cluster(loc5v1)),
+                            location_id: Tick(15, Cluster(loc5v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: TotalOrder,
@@ -6133,7 +6085,7 @@ expression: built.ir()
                                     left: Tee {
                                         inner: <tee 37>,
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(16, Cluster(loc5v1)),
+                                            location_id: Tick(15, Cluster(loc5v1)),
                                             collection_kind: Stream {
                                                 bound: Bounded,
                                                 order: TotalOrder,
@@ -6152,7 +6104,7 @@ expression: built.ir()
                                                                 sym: cycle_17,
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(16, Cluster(loc5v1)),
+                                                                location_id: Tick(15, Cluster(loc5v1)),
                                                                 collection_kind: Singleton {
                                                                     bound: Bounded,
                                                                     element_type: usize,
@@ -6160,7 +6112,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(16, Cluster(loc5v1)),
+                                                            location_id: Tick(15, Cluster(loc5v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: usize,
@@ -6171,7 +6123,7 @@ expression: built.ir()
                                                         inner: SingletonSource {
                                                             value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; 0 },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(16, Cluster(loc5v1)),
+                                                                location_id: Tick(15, Cluster(loc5v1)),
                                                                 collection_kind: Singleton {
                                                                     bound: Bounded,
                                                                     element_type: usize,
@@ -6179,7 +6131,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(16, Cluster(loc5v1)),
+                                                            location_id: Tick(15, Cluster(loc5v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: usize,
@@ -6187,7 +6139,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(16, Cluster(loc5v1)),
+                                                        location_id: Tick(15, Cluster(loc5v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: usize,
@@ -6195,7 +6147,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(16, Cluster(loc5v1)),
+                                                    location_id: Tick(15, Cluster(loc5v1)),
                                                     collection_kind: Singleton {
                                                         bound: Bounded,
                                                         element_type: usize,
@@ -6203,7 +6155,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(16, Cluster(loc5v1)),
+                                                location_id: Tick(15, Cluster(loc5v1)),
                                                 collection_kind: Singleton {
                                                     bound: Bounded,
                                                     element_type: usize,
@@ -6211,7 +6163,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(16, Cluster(loc5v1)),
+                                            location_id: Tick(15, Cluster(loc5v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: usize,
@@ -6219,7 +6171,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(16, Cluster(loc5v1)),
+                                        location_id: Tick(15, Cluster(loc5v1)),
                                         collection_kind: Stream {
                                             bound: Bounded,
                                             order: TotalOrder,
@@ -6229,7 +6181,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(16, Cluster(loc5v1)),
+                                    location_id: Tick(15, Cluster(loc5v1)),
                                     collection_kind: Singleton {
                                         bound: Bounded,
                                         element_type: usize,
@@ -6237,7 +6189,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(16, Cluster(loc5v1)),
+                                location_id: Tick(15, Cluster(loc5v1)),
                                 collection_kind: Singleton {
                                     bound: Bounded,
                                     element_type: usize,
@@ -6245,7 +6197,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(16, Cluster(loc5v1)),
+                            location_id: Tick(15, Cluster(loc5v1)),
                             collection_kind: Optional {
                                 bound: Bounded,
                                 element_type: usize,
@@ -6253,7 +6205,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(16, Cluster(loc5v1)),
+                        location_id: Tick(15, Cluster(loc5v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: TotalOrder,
@@ -6263,7 +6215,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(16, Cluster(loc5v1)),
+                    location_id: Tick(15, Cluster(loc5v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: TotalOrder,
@@ -6273,7 +6225,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(16, Cluster(loc5v1)),
+                location_id: Tick(15, Cluster(loc5v1)),
                 collection_kind: Stream {
                     bound: Bounded,
                     order: TotalOrder,
@@ -6305,7 +6257,7 @@ expression: built.ir()
                                             left: Tee {
                                                 inner: <tee 37>,
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(16, Cluster(loc5v1)),
+                                                    location_id: Tick(15, Cluster(loc5v1)),
                                                     collection_kind: Stream {
                                                         bound: Bounded,
                                                         order: TotalOrder,
@@ -6318,7 +6270,7 @@ expression: built.ir()
                                                 inner: Tee {
                                                     inner: <tee 38>,
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(16, Cluster(loc5v1)),
+                                                        location_id: Tick(15, Cluster(loc5v1)),
                                                         collection_kind: Singleton {
                                                             bound: Bounded,
                                                             element_type: usize,
@@ -6326,7 +6278,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(16, Cluster(loc5v1)),
+                                                    location_id: Tick(15, Cluster(loc5v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: usize,
@@ -6334,7 +6286,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(16, Cluster(loc5v1)),
+                                                location_id: Tick(15, Cluster(loc5v1)),
                                                 collection_kind: Stream {
                                                     bound: Bounded,
                                                     order: TotalOrder,
@@ -6344,7 +6296,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(16, Cluster(loc5v1)),
+                                            location_id: Tick(15, Cluster(loc5v1)),
                                             collection_kind: Stream {
                                                 bound: Bounded,
                                                 order: TotalOrder,
@@ -6354,7 +6306,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(16, Cluster(loc5v1)),
+                                        location_id: Tick(15, Cluster(loc5v1)),
                                         collection_kind: Stream {
                                             bound: Bounded,
                                             order: TotalOrder,
@@ -6364,7 +6316,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(16, Cluster(loc5v1)),
+                                    location_id: Tick(15, Cluster(loc5v1)),
                                     collection_kind: Stream {
                                         bound: Bounded,
                                         order: TotalOrder,
@@ -6374,7 +6326,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Atomic(Tick(16, Cluster(loc5v1))),
+                                location_id: Atomic(Tick(15, Cluster(loc5v1))),
                                 collection_kind: Stream {
                                     bound: Unbounded,
                                     order: TotalOrder,
@@ -6384,7 +6336,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Atomic(Tick(16, Cluster(loc5v1))),
+                            location_id: Atomic(Tick(15, Cluster(loc5v1))),
                             collection_kind: Singleton {
                                 bound: Unbounded,
                                 element_type: (std :: collections :: hash_map :: HashMap < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize),
@@ -6392,7 +6344,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(16, Cluster(loc5v1)),
+                        location_id: Tick(15, Cluster(loc5v1)),
                         collection_kind: Singleton {
                             bound: Bounded,
                             element_type: (std :: collections :: hash_map :: HashMap < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize),
@@ -6400,7 +6352,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(16, Cluster(loc5v1)),
+                    location_id: Tick(15, Cluster(loc5v1)),
                     collection_kind: Singleton {
                         bound: Bounded,
                         element_type: usize,
@@ -6408,7 +6360,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(16, Cluster(loc5v1)),
+                location_id: Tick(15, Cluster(loc5v1)),
                 collection_kind: Singleton {
                     bound: Bounded,
                     element_type: usize,
@@ -6441,7 +6393,7 @@ expression: built.ir()
                                                                 sym: cycle_18,
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(16, Cluster(loc5v1)),
+                                                                location_id: Tick(15, Cluster(loc5v1)),
                                                                 collection_kind: Optional {
                                                                     bound: Bounded,
                                                                     element_type: usize,
@@ -6449,7 +6401,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(16, Cluster(loc5v1)),
+                                                            location_id: Tick(15, Cluster(loc5v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: usize,
@@ -6457,7 +6409,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(16, Cluster(loc5v1)),
+                                                        location_id: Tick(15, Cluster(loc5v1)),
                                                         collection_kind: Stream {
                                                             bound: Bounded,
                                                             order: TotalOrder,
@@ -6467,7 +6419,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Atomic(Tick(16, Cluster(loc5v1))),
+                                                    location_id: Atomic(Tick(15, Cluster(loc5v1))),
                                                     collection_kind: Stream {
                                                         bound: Unbounded,
                                                         order: TotalOrder,
@@ -6477,7 +6429,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Atomic(Tick(16, Cluster(loc5v1))),
+                                                location_id: Atomic(Tick(15, Cluster(loc5v1))),
                                                 collection_kind: Optional {
                                                     bound: Unbounded,
                                                     element_type: usize,
@@ -6485,7 +6437,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(16, Cluster(loc5v1)),
+                                            location_id: Tick(15, Cluster(loc5v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: usize,
@@ -6493,7 +6445,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(16, Cluster(loc5v1)),
+                                        location_id: Tick(15, Cluster(loc5v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: core :: option :: Option < usize >,
@@ -6504,7 +6456,7 @@ expression: built.ir()
                                     inner: SingletonSource {
                                         value: :: std :: option :: Option :: None,
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(16, Cluster(loc5v1)),
+                                            location_id: Tick(15, Cluster(loc5v1)),
                                             collection_kind: Singleton {
                                                 bound: Bounded,
                                                 element_type: core :: option :: Option < usize >,
@@ -6512,7 +6464,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(16, Cluster(loc5v1)),
+                                        location_id: Tick(15, Cluster(loc5v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: core :: option :: Option < usize >,
@@ -6520,7 +6472,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(16, Cluster(loc5v1)),
+                                    location_id: Tick(15, Cluster(loc5v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: core :: option :: Option < usize >,
@@ -6528,7 +6480,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(16, Cluster(loc5v1)),
+                                location_id: Tick(15, Cluster(loc5v1)),
                                 collection_kind: Singleton {
                                     bound: Bounded,
                                     element_type: core :: option :: Option < usize >,
@@ -6542,7 +6494,7 @@ expression: built.ir()
                                         inner: Tee {
                                             inner: <tee 40>,
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(16, Cluster(loc5v1)),
+                                                location_id: Tick(15, Cluster(loc5v1)),
                                                 collection_kind: Singleton {
                                                     bound: Bounded,
                                                     element_type: usize,
@@ -6550,7 +6502,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(16, Cluster(loc5v1)),
+                                            location_id: Tick(15, Cluster(loc5v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: usize,
@@ -6558,7 +6510,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(16, Cluster(loc5v1)),
+                                        location_id: Tick(15, Cluster(loc5v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: usize,
@@ -6569,7 +6521,7 @@ expression: built.ir()
                                     inner: SingletonSource {
                                         value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; 0 },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(16, Cluster(loc5v1)),
+                                            location_id: Tick(15, Cluster(loc5v1)),
                                             collection_kind: Singleton {
                                                 bound: Bounded,
                                                 element_type: usize,
@@ -6577,7 +6529,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(16, Cluster(loc5v1)),
+                                        location_id: Tick(15, Cluster(loc5v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: usize,
@@ -6585,7 +6537,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(16, Cluster(loc5v1)),
+                                    location_id: Tick(15, Cluster(loc5v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: usize,
@@ -6593,7 +6545,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(16, Cluster(loc5v1)),
+                                location_id: Tick(15, Cluster(loc5v1)),
                                 collection_kind: Singleton {
                                     bound: Bounded,
                                     element_type: usize,
@@ -6601,7 +6553,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(16, Cluster(loc5v1)),
+                            location_id: Tick(15, Cluster(loc5v1)),
                             collection_kind: Optional {
                                 bound: Bounded,
                                 element_type: (core :: option :: Option < usize > , usize),
@@ -6609,7 +6561,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(16, Cluster(loc5v1)),
+                        location_id: Tick(15, Cluster(loc5v1)),
                         collection_kind: Singleton {
                             bound: Bounded,
                             element_type: (core :: option :: Option < usize > , usize),
@@ -6617,7 +6569,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(16, Cluster(loc5v1)),
+                    location_id: Tick(15, Cluster(loc5v1)),
                     collection_kind: Optional {
                         bound: Bounded,
                         element_type: usize,
@@ -6625,7 +6577,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(16, Cluster(loc5v1)),
+                location_id: Tick(15, Cluster(loc5v1)),
                 collection_kind: Optional {
                     bound: Bounded,
                     element_type: usize,
@@ -6725,7 +6677,7 @@ expression: built.ir()
                                                                                                     },
                                                                                                 },
                                                                                                 metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(17, Cluster(loc5v1)),
+                                                                                                    location_id: Tick(16, Cluster(loc5v1)),
                                                                                                     collection_kind: KeyedSingleton {
                                                                                                         bound: Bounded,
                                                                                                         key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
@@ -6734,7 +6686,7 @@ expression: built.ir()
                                                                                                 },
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(17, Cluster(loc5v1)),
+                                                                                                location_id: Tick(16, Cluster(loc5v1)),
                                                                                                 collection_kind: KeyedSingleton {
                                                                                                     bound: Bounded,
                                                                                                     key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
@@ -6743,7 +6695,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(17, Cluster(loc5v1)),
+                                                                                            location_id: Tick(16, Cluster(loc5v1)),
                                                                                             collection_kind: KeyedStream {
                                                                                                 bound: Bounded,
                                                                                                 value_order: TotalOrder,
@@ -6754,7 +6706,7 @@ expression: built.ir()
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(17, Cluster(loc5v1)),
+                                                                                        location_id: Tick(16, Cluster(loc5v1)),
                                                                                         collection_kind: Stream {
                                                                                             bound: Bounded,
                                                                                             order: NoOrder,
@@ -6764,7 +6716,7 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(17, Cluster(loc5v1)),
+                                                                                    location_id: Tick(16, Cluster(loc5v1)),
                                                                                     collection_kind: Stream {
                                                                                         bound: Bounded,
                                                                                         order: NoOrder,
@@ -6775,7 +6727,7 @@ expression: built.ir()
                                                                             },
                                                                             trusted: true,
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(17, Cluster(loc5v1)),
+                                                                                location_id: Tick(16, Cluster(loc5v1)),
                                                                                 collection_kind: Stream {
                                                                                     bound: Bounded,
                                                                                     order: TotalOrder,
@@ -6790,7 +6742,7 @@ expression: built.ir()
                                                                                     inner: Tee {
                                                                                         inner: <tee 42>,
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(16, Cluster(loc5v1)),
+                                                                                            location_id: Tick(15, Cluster(loc5v1)),
                                                                                             collection_kind: Optional {
                                                                                                 bound: Bounded,
                                                                                                 element_type: usize,
@@ -6798,7 +6750,7 @@ expression: built.ir()
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(16, Cluster(loc5v1)),
+                                                                                        location_id: Tick(15, Cluster(loc5v1)),
                                                                                         collection_kind: Stream {
                                                                                             bound: Bounded,
                                                                                             order: TotalOrder,
@@ -6818,7 +6770,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(17, Cluster(loc5v1)),
+                                                                                location_id: Tick(16, Cluster(loc5v1)),
                                                                                 collection_kind: Stream {
                                                                                     bound: Bounded,
                                                                                     order: TotalOrder,
@@ -6828,7 +6780,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(17, Cluster(loc5v1)),
+                                                                            location_id: Tick(16, Cluster(loc5v1)),
                                                                             collection_kind: Stream {
                                                                                 bound: Bounded,
                                                                                 order: TotalOrder,
@@ -6838,7 +6790,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(17, Cluster(loc5v1)),
+                                                                        location_id: Tick(16, Cluster(loc5v1)),
                                                                         collection_kind: KeyedStream {
                                                                             bound: Bounded,
                                                                             value_order: TotalOrder,
@@ -6890,7 +6842,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(18, Cluster(loc2v1)),
+                                                    location_id: Tick(17, Cluster(loc2v1)),
                                                     collection_kind: KeyedSingleton {
                                                         bound: Bounded,
                                                         key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica >,
@@ -6899,7 +6851,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(18, Cluster(loc2v1)),
+                                                location_id: Tick(17, Cluster(loc2v1)),
                                                 collection_kind: KeyedSingleton {
                                                     bound: Bounded,
                                                     key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica >,
@@ -6908,7 +6860,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(18, Cluster(loc2v1)),
+                                            location_id: Tick(17, Cluster(loc2v1)),
                                             collection_kind: KeyedStream {
                                                 bound: Bounded,
                                                 value_order: TotalOrder,
@@ -6919,7 +6871,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(18, Cluster(loc2v1)),
+                                        location_id: Tick(17, Cluster(loc2v1)),
                                         collection_kind: Stream {
                                             bound: Bounded,
                                             order: NoOrder,
@@ -6941,7 +6893,7 @@ expression: built.ir()
                                                         inner: Tee {
                                                             inner: <tee 43>,
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(18, Cluster(loc2v1)),
+                                                                location_id: Tick(17, Cluster(loc2v1)),
                                                                 collection_kind: KeyedSingleton {
                                                                     bound: Bounded,
                                                                     key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica >,
@@ -6950,7 +6902,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(18, Cluster(loc2v1)),
+                                                            location_id: Tick(17, Cluster(loc2v1)),
                                                             collection_kind: KeyedStream {
                                                                 bound: Bounded,
                                                                 value_order: TotalOrder,
@@ -6961,7 +6913,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(18, Cluster(loc2v1)),
+                                                        location_id: Tick(17, Cluster(loc2v1)),
                                                         collection_kind: Stream {
                                                             bound: Bounded,
                                                             order: NoOrder,
@@ -6972,7 +6924,7 @@ expression: built.ir()
                                                 },
                                                 trusted: true,
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(18, Cluster(loc2v1)),
+                                                    location_id: Tick(17, Cluster(loc2v1)),
                                                     collection_kind: Stream {
                                                         bound: Bounded,
                                                         order: TotalOrder,
@@ -6982,7 +6934,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(18, Cluster(loc2v1)),
+                                                location_id: Tick(17, Cluster(loc2v1)),
                                                 collection_kind: Singleton {
                                                     bound: Bounded,
                                                     element_type: usize,
@@ -6990,7 +6942,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(18, Cluster(loc2v1)),
+                                            location_id: Tick(17, Cluster(loc2v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: bool,
@@ -6998,7 +6950,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(18, Cluster(loc2v1)),
+                                        location_id: Tick(17, Cluster(loc2v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: (),
@@ -7006,7 +6958,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(18, Cluster(loc2v1)),
+                                    location_id: Tick(17, Cluster(loc2v1)),
                                     collection_kind: Stream {
                                         bound: Bounded,
                                         order: NoOrder,
@@ -7016,7 +6968,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(18, Cluster(loc2v1)),
+                                location_id: Tick(17, Cluster(loc2v1)),
                                 collection_kind: Stream {
                                     bound: Bounded,
                                     order: NoOrder,
@@ -7026,7 +6978,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(18, Cluster(loc2v1)),
+                            location_id: Tick(17, Cluster(loc2v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -7037,7 +6989,7 @@ expression: built.ir()
                     },
                     trusted: true,
                     metadata: HydroIrMetadata {
-                        location_id: Tick(18, Cluster(loc2v1)),
+                        location_id: Tick(17, Cluster(loc2v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: TotalOrder,
@@ -7047,7 +6999,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(18, Cluster(loc2v1)),
+                    location_id: Tick(17, Cluster(loc2v1)),
                     collection_kind: Optional {
                         bound: Bounded,
                         element_type: usize,
@@ -7077,7 +7029,7 @@ expression: built.ir()
                                 sym: cycle_19,
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(19, Cluster(loc3v1)),
+                                location_id: Tick(18, Cluster(loc3v1)),
                                 collection_kind: Stream {
                                     bound: Bounded,
                                     order: NoOrder,
@@ -7087,7 +7039,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(19, Cluster(loc3v1)),
+                            location_id: Tick(18, Cluster(loc3v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -7120,7 +7072,7 @@ expression: built.ir()
                                                             input: Tee {
                                                                 inner: <tee 41>,
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(16, Cluster(loc5v1)),
+                                                                    location_id: Tick(15, Cluster(loc5v1)),
                                                                     collection_kind: Stream {
                                                                         bound: Bounded,
                                                                         order: TotalOrder,
@@ -7130,7 +7082,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(16, Cluster(loc5v1)),
+                                                                location_id: Tick(15, Cluster(loc5v1)),
                                                                 collection_kind: Stream {
                                                                     bound: Bounded,
                                                                     order: TotalOrder,
@@ -7222,7 +7174,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(19, Cluster(loc3v1)),
+                            location_id: Tick(18, Cluster(loc3v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -7232,7 +7184,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(19, Cluster(loc3v1)),
+                        location_id: Tick(18, Cluster(loc3v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: NoOrder,
@@ -7242,7 +7194,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(19, Cluster(loc3v1)),
+                    location_id: Tick(18, Cluster(loc3v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -7265,7 +7217,7 @@ expression: built.ir()
                                             inner: Tee {
                                                 inner: <tee 44>,
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(19, Cluster(loc3v1)),
+                                                    location_id: Tick(18, Cluster(loc3v1)),
                                                     collection_kind: Stream {
                                                         bound: Bounded,
                                                         order: NoOrder,
@@ -7275,7 +7227,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(19, Cluster(loc3v1)),
+                                                location_id: Tick(18, Cluster(loc3v1)),
                                                 collection_kind: KeyedStream {
                                                     bound: Bounded,
                                                     value_order: NoOrder,
@@ -7287,7 +7239,7 @@ expression: built.ir()
                                         },
                                         trusted: false,
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(19, Cluster(loc3v1)),
+                                            location_id: Tick(18, Cluster(loc3v1)),
                                             collection_kind: KeyedStream {
                                                 bound: Bounded,
                                                 value_order: TotalOrder,
@@ -7298,7 +7250,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(19, Cluster(loc3v1)),
+                                        location_id: Tick(18, Cluster(loc3v1)),
                                         collection_kind: KeyedSingleton {
                                             bound: Bounded,
                                             key_type: (u32 , i32),
@@ -7307,7 +7259,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(19, Cluster(loc3v1)),
+                                    location_id: Tick(18, Cluster(loc3v1)),
                                     collection_kind: KeyedSingleton {
                                         bound: Bounded,
                                         key_type: (u32 , i32),
@@ -7316,7 +7268,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(19, Cluster(loc3v1)),
+                                location_id: Tick(18, Cluster(loc3v1)),
                                 collection_kind: KeyedStream {
                                     bound: Bounded,
                                     value_order: TotalOrder,
@@ -7327,7 +7279,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(19, Cluster(loc3v1)),
+                            location_id: Tick(18, Cluster(loc3v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -7337,7 +7289,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(19, Cluster(loc3v1)),
+                        location_id: Tick(18, Cluster(loc3v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: NoOrder,
@@ -7347,7 +7299,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(19, Cluster(loc3v1)),
+                    location_id: Tick(18, Cluster(loc3v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -7357,7 +7309,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(19, Cluster(loc3v1)),
+                location_id: Tick(18, Cluster(loc3v1)),
                 collection_kind: Stream {
                     bound: Bounded,
                     order: NoOrder,
@@ -7378,7 +7330,7 @@ expression: built.ir()
                     sym: cycle_20,
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(19, Cluster(loc3v1)),
+                    location_id: Tick(18, Cluster(loc3v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -7388,7 +7340,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(19, Cluster(loc3v1)),
+                location_id: Tick(18, Cluster(loc3v1)),
                 collection_kind: Stream {
                     bound: Bounded,
                     order: NoOrder,
@@ -7409,7 +7361,7 @@ expression: built.ir()
                     inner: Tee {
                         inner: <tee 46>,
                         metadata: HydroIrMetadata {
-                            location_id: Tick(19, Cluster(loc3v1)),
+                            location_id: Tick(18, Cluster(loc3v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -7529,7 +7481,7 @@ expression: built.ir()
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(22, Process(loc4v1)),
+                                                                                        location_id: Tick(21, Process(loc4v1)),
                                                                                         collection_kind: KeyedSingleton {
                                                                                             bound: Bounded,
                                                                                             key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >,
@@ -7538,7 +7490,7 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(22, Process(loc4v1)),
+                                                                                    location_id: Tick(21, Process(loc4v1)),
                                                                                     collection_kind: KeyedSingleton {
                                                                                         bound: Bounded,
                                                                                         key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >,
@@ -7547,7 +7499,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(22, Process(loc4v1)),
+                                                                                location_id: Tick(21, Process(loc4v1)),
                                                                                 collection_kind: KeyedStream {
                                                                                     bound: Bounded,
                                                                                     value_order: TotalOrder,
@@ -7558,7 +7510,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(22, Process(loc4v1)),
+                                                                            location_id: Tick(21, Process(loc4v1)),
                                                                             collection_kind: Stream {
                                                                                 bound: Bounded,
                                                                                 order: NoOrder,
@@ -7569,7 +7521,7 @@ expression: built.ir()
                                                                     },
                                                                     trusted: true,
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(22, Process(loc4v1)),
+                                                                        location_id: Tick(21, Process(loc4v1)),
                                                                         collection_kind: Stream {
                                                                             bound: Bounded,
                                                                             order: TotalOrder,
@@ -7579,7 +7531,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(22, Process(loc4v1)),
+                                                                    location_id: Tick(21, Process(loc4v1)),
                                                                     collection_kind: Singleton {
                                                                         bound: Bounded,
                                                                         element_type: usize,
@@ -7587,7 +7539,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(22, Process(loc4v1)),
+                                                                location_id: Tick(21, Process(loc4v1)),
                                                                 collection_kind: Singleton {
                                                                     bound: Bounded,
                                                                     element_type: usize,
@@ -7703,7 +7655,7 @@ expression: built.ir()
                                                                                                                                                                                                                         },
                                                                                                                                                                                                                     },
                                                                                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                                                                                        location_id: Tick(20, Cluster(loc3v1)),
+                                                                                                                                                                                                                        location_id: Tick(19, Cluster(loc3v1)),
                                                                                                                                                                                                                         collection_kind: KeyedSingleton {
                                                                                                                                                                                                                             bound: Bounded,
                                                                                                                                                                                                                             key_type: u32,
@@ -7712,7 +7664,7 @@ expression: built.ir()
                                                                                                                                                                                                                     },
                                                                                                                                                                                                                 },
                                                                                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                                                                                    location_id: Tick(20, Cluster(loc3v1)),
+                                                                                                                                                                                                                    location_id: Tick(19, Cluster(loc3v1)),
                                                                                                                                                                                                                     collection_kind: KeyedStream {
                                                                                                                                                                                                                         bound: Bounded,
                                                                                                                                                                                                                         value_order: TotalOrder,
@@ -7723,7 +7675,7 @@ expression: built.ir()
                                                                                                                                                                                                                 },
                                                                                                                                                                                                             },
                                                                                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                                                                                location_id: Tick(20, Cluster(loc3v1)),
+                                                                                                                                                                                                                location_id: Tick(19, Cluster(loc3v1)),
                                                                                                                                                                                                                 collection_kind: Stream {
                                                                                                                                                                                                                     bound: Bounded,
                                                                                                                                                                                                                     order: NoOrder,
@@ -7754,7 +7706,7 @@ expression: built.ir()
                                                                                                                                                                                                                                     },
                                                                                                                                                                                                                                 },
                                                                                                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                                                                                                    location_id: Tick(20, Cluster(loc3v1)),
+                                                                                                                                                                                                                                    location_id: Tick(19, Cluster(loc3v1)),
                                                                                                                                                                                                                                     collection_kind: KeyedStream {
                                                                                                                                                                                                                                         bound: Bounded,
                                                                                                                                                                                                                                         value_order: NoOrder,
@@ -7766,7 +7718,7 @@ expression: built.ir()
                                                                                                                                                                                                                             },
                                                                                                                                                                                                                             trusted: false,
                                                                                                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                                                                                                location_id: Tick(20, Cluster(loc3v1)),
+                                                                                                                                                                                                                                location_id: Tick(19, Cluster(loc3v1)),
                                                                                                                                                                                                                                 collection_kind: KeyedStream {
                                                                                                                                                                                                                                     bound: Bounded,
                                                                                                                                                                                                                                     value_order: TotalOrder,
@@ -7777,7 +7729,7 @@ expression: built.ir()
                                                                                                                                                                                                                             },
                                                                                                                                                                                                                         },
                                                                                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                                                                                            location_id: Tick(20, Cluster(loc3v1)),
+                                                                                                                                                                                                                            location_id: Tick(19, Cluster(loc3v1)),
                                                                                                                                                                                                                             collection_kind: KeyedSingleton {
                                                                                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                                                                                 key_type: u32,
@@ -7786,7 +7738,7 @@ expression: built.ir()
                                                                                                                                                                                                                         },
                                                                                                                                                                                                                     },
                                                                                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                                                                                        location_id: Tick(20, Cluster(loc3v1)),
+                                                                                                                                                                                                                        location_id: Tick(19, Cluster(loc3v1)),
                                                                                                                                                                                                                         collection_kind: KeyedSingleton {
                                                                                                                                                                                                                             bound: Bounded,
                                                                                                                                                                                                                             key_type: u32,
@@ -7795,7 +7747,7 @@ expression: built.ir()
                                                                                                                                                                                                                     },
                                                                                                                                                                                                                 },
                                                                                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                                                                                    location_id: Tick(20, Cluster(loc3v1)),
+                                                                                                                                                                                                                    location_id: Tick(19, Cluster(loc3v1)),
                                                                                                                                                                                                                     collection_kind: KeyedStream {
                                                                                                                                                                                                                         bound: Bounded,
                                                                                                                                                                                                                         value_order: TotalOrder,
@@ -7806,7 +7758,7 @@ expression: built.ir()
                                                                                                                                                                                                                 },
                                                                                                                                                                                                             },
                                                                                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                                                                                location_id: Tick(20, Cluster(loc3v1)),
+                                                                                                                                                                                                                location_id: Tick(19, Cluster(loc3v1)),
                                                                                                                                                                                                                 collection_kind: Stream {
                                                                                                                                                                                                                     bound: Bounded,
                                                                                                                                                                                                                     order: NoOrder,
@@ -7816,7 +7768,7 @@ expression: built.ir()
                                                                                                                                                                                                             },
                                                                                                                                                                                                         },
                                                                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                                                                            location_id: Tick(20, Cluster(loc3v1)),
+                                                                                                                                                                                                            location_id: Tick(19, Cluster(loc3v1)),
                                                                                                                                                                                                             collection_kind: Stream {
                                                                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                                                                 order: NoOrder,
@@ -7826,7 +7778,7 @@ expression: built.ir()
                                                                                                                                                                                                         },
                                                                                                                                                                                                     },
                                                                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                                                                        location_id: Tick(20, Cluster(loc3v1)),
+                                                                                                                                                                                                        location_id: Tick(19, Cluster(loc3v1)),
                                                                                                                                                                                                         collection_kind: KeyedStream {
                                                                                                                                                                                                             bound: Bounded,
                                                                                                                                                                                                             value_order: NoOrder,
@@ -7837,7 +7789,7 @@ expression: built.ir()
                                                                                                                                                                                                     },
                                                                                                                                                                                                 },
                                                                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                                                                    location_id: Tick(20, Cluster(loc3v1)),
+                                                                                                                                                                                                    location_id: Tick(19, Cluster(loc3v1)),
                                                                                                                                                                                                     collection_kind: KeyedSingleton {
                                                                                                                                                                                                         bound: Bounded,
                                                                                                                                                                                                         key_type: u32,
@@ -7846,7 +7798,7 @@ expression: built.ir()
                                                                                                                                                                                                 },
                                                                                                                                                                                             },
                                                                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                                                                location_id: Tick(20, Cluster(loc3v1)),
+                                                                                                                                                                                                location_id: Tick(19, Cluster(loc3v1)),
                                                                                                                                                                                                 collection_kind: KeyedSingleton {
                                                                                                                                                                                                     bound: Bounded,
                                                                                                                                                                                                     key_type: u32,
@@ -7855,7 +7807,7 @@ expression: built.ir()
                                                                                                                                                                                             },
                                                                                                                                                                                         },
                                                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                                                            location_id: Tick(20, Cluster(loc3v1)),
+                                                                                                                                                                                            location_id: Tick(19, Cluster(loc3v1)),
                                                                                                                                                                                             collection_kind: KeyedStream {
                                                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                                                 value_order: TotalOrder,
@@ -7866,7 +7818,7 @@ expression: built.ir()
                                                                                                                                                                                         },
                                                                                                                                                                                     },
                                                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                                                        location_id: Tick(20, Cluster(loc3v1)),
+                                                                                                                                                                                        location_id: Tick(19, Cluster(loc3v1)),
                                                                                                                                                                                         collection_kind: KeyedStream {
                                                                                                                                                                                             bound: Bounded,
                                                                                                                                                                                             value_order: NoOrder,
@@ -7918,7 +7870,7 @@ expression: built.ir()
                                                                                                                                                                     },
                                                                                                                                                                 },
                                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                                    location_id: Tick(21, Cluster(loc3v1)),
+                                                                                                                                                                    location_id: Tick(20, Cluster(loc3v1)),
                                                                                                                                                                     collection_kind: Stream {
                                                                                                                                                                         bound: Bounded,
                                                                                                                                                                         order: NoOrder,
@@ -7929,7 +7881,7 @@ expression: built.ir()
                                                                                                                                                             },
                                                                                                                                                             trusted: true,
                                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                                location_id: Tick(21, Cluster(loc3v1)),
+                                                                                                                                                                location_id: Tick(20, Cluster(loc3v1)),
                                                                                                                                                                 collection_kind: Stream {
                                                                                                                                                                     bound: Bounded,
                                                                                                                                                                     order: TotalOrder,
@@ -7939,7 +7891,7 @@ expression: built.ir()
                                                                                                                                                             },
                                                                                                                                                         },
                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(21, Cluster(loc3v1)),
+                                                                                                                                                            location_id: Tick(20, Cluster(loc3v1)),
                                                                                                                                                             collection_kind: Singleton {
                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                 element_type: usize,
@@ -7947,7 +7899,7 @@ expression: built.ir()
                                                                                                                                                         },
                                                                                                                                                     },
                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                        location_id: Tick(21, Cluster(loc3v1)),
+                                                                                                                                                        location_id: Tick(20, Cluster(loc3v1)),
                                                                                                                                                         collection_kind: Stream {
                                                                                                                                                             bound: Bounded,
                                                                                                                                                             order: TotalOrder,
@@ -8029,7 +7981,7 @@ expression: built.ir()
                                                                                                                                 },
                                                                                                                             },
                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                location_id: Tick(23, Cluster(loc3v1)),
+                                                                                                                                location_id: Tick(22, Cluster(loc3v1)),
                                                                                                                                 collection_kind: Singleton {
                                                                                                                                     bound: Bounded,
                                                                                                                                     element_type: hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage,
@@ -8056,7 +8008,7 @@ expression: built.ir()
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                        location_id: Tick(23, Cluster(loc3v1)),
+                                                                                                                                        location_id: Tick(22, Cluster(loc3v1)),
                                                                                                                                         collection_kind: Stream {
                                                                                                                                             bound: Bounded,
                                                                                                                                             order: TotalOrder,
@@ -8066,7 +8018,7 @@ expression: built.ir()
                                                                                                                                     },
                                                                                                                                 },
                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                    location_id: Tick(23, Cluster(loc3v1)),
+                                                                                                                                    location_id: Tick(22, Cluster(loc3v1)),
                                                                                                                                     collection_kind: Optional {
                                                                                                                                         bound: Bounded,
                                                                                                                                         element_type: hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
@@ -8074,7 +8026,7 @@ expression: built.ir()
                                                                                                                                 },
                                                                                                                             },
                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                location_id: Tick(23, Cluster(loc3v1)),
+                                                                                                                                location_id: Tick(22, Cluster(loc3v1)),
                                                                                                                                 collection_kind: Optional {
                                                                                                                                     bound: Bounded,
                                                                                                                                     element_type: (),
@@ -8082,7 +8034,7 @@ expression: built.ir()
                                                                                                                             },
                                                                                                                         },
                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                            location_id: Tick(23, Cluster(loc3v1)),
+                                                                                                                            location_id: Tick(22, Cluster(loc3v1)),
                                                                                                                             collection_kind: Optional {
                                                                                                                                 bound: Bounded,
                                                                                                                                 element_type: (hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage , ()),
@@ -8090,7 +8042,7 @@ expression: built.ir()
                                                                                                                         },
                                                                                                                     },
                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                        location_id: Tick(23, Cluster(loc3v1)),
+                                                                                                                        location_id: Tick(22, Cluster(loc3v1)),
                                                                                                                         collection_kind: Optional {
                                                                                                                             bound: Bounded,
                                                                                                                             element_type: hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage,
@@ -8098,7 +8050,7 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                 },
                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(23, Cluster(loc3v1)),
+                                                                                                                    location_id: Tick(22, Cluster(loc3v1)),
                                                                                                                     collection_kind: Stream {
                                                                                                                         bound: Bounded,
                                                                                                                         order: TotalOrder,
@@ -8179,7 +8131,7 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(22, Process(loc4v1)),
+                                                                                    location_id: Tick(21, Process(loc4v1)),
                                                                                     collection_kind: KeyedSingleton {
                                                                                         bound: Bounded,
                                                                                         key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >,
@@ -8188,7 +8140,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(22, Process(loc4v1)),
+                                                                                location_id: Tick(21, Process(loc4v1)),
                                                                                 collection_kind: KeyedSingleton {
                                                                                     bound: Bounded,
                                                                                     key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >,
@@ -8197,7 +8149,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(22, Process(loc4v1)),
+                                                                            location_id: Tick(21, Process(loc4v1)),
                                                                             collection_kind: KeyedStream {
                                                                                 bound: Bounded,
                                                                                 value_order: TotalOrder,
@@ -8208,7 +8160,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(22, Process(loc4v1)),
+                                                                        location_id: Tick(21, Process(loc4v1)),
                                                                         collection_kind: Stream {
                                                                             bound: Bounded,
                                                                             order: NoOrder,
@@ -8219,7 +8171,7 @@ expression: built.ir()
                                                                 },
                                                                 trusted: true,
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(22, Process(loc4v1)),
+                                                                    location_id: Tick(21, Process(loc4v1)),
                                                                     collection_kind: Stream {
                                                                         bound: Bounded,
                                                                         order: TotalOrder,
@@ -8229,7 +8181,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(22, Process(loc4v1)),
+                                                                location_id: Tick(21, Process(loc4v1)),
                                                                 collection_kind: Singleton {
                                                                     bound: Bounded,
                                                                     element_type: usize,
@@ -8237,7 +8189,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(22, Process(loc4v1)),
+                                                            location_id: Tick(21, Process(loc4v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: (usize , usize),
@@ -8245,7 +8197,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(22, Process(loc4v1)),
+                                                        location_id: Tick(21, Process(loc4v1)),
                                                         collection_kind: Singleton {
                                                             bound: Bounded,
                                                             element_type: (usize , usize),
@@ -8253,7 +8205,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(22, Process(loc4v1)),
+                                                    location_id: Tick(21, Process(loc4v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: usize,
@@ -8261,7 +8213,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(22, Process(loc4v1)),
+                                                location_id: Tick(21, Process(loc4v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: usize,
@@ -8269,7 +8221,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(22, Process(loc4v1)),
+                                            location_id: Tick(21, Process(loc4v1)),
                                             collection_kind: Stream {
                                                 bound: Bounded,
                                                 order: TotalOrder,
@@ -8289,7 +8241,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(24, Process(loc4v1)),
+                                    location_id: Tick(23, Process(loc4v1)),
                                     collection_kind: Stream {
                                         bound: Bounded,
                                         order: TotalOrder,
@@ -8318,7 +8270,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(24, Process(loc4v1)),
+                                            location_id: Tick(23, Process(loc4v1)),
                                             collection_kind: Stream {
                                                 bound: Bounded,
                                                 order: TotalOrder,
@@ -8328,7 +8280,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(24, Process(loc4v1)),
+                                        location_id: Tick(23, Process(loc4v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
@@ -8336,7 +8288,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(24, Process(loc4v1)),
+                                    location_id: Tick(23, Process(loc4v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: (),
@@ -8344,7 +8296,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(24, Process(loc4v1)),
+                                location_id: Tick(23, Process(loc4v1)),
                                 collection_kind: Stream {
                                     bound: Bounded,
                                     order: TotalOrder,
@@ -8354,7 +8306,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(24, Process(loc4v1)),
+                            location_id: Tick(23, Process(loc4v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: TotalOrder,
@@ -8431,7 +8383,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(25, Process(loc4v1)),
+                                                                                location_id: Tick(24, Process(loc4v1)),
                                                                                 collection_kind: KeyedSingleton {
                                                                                     bound: Bounded,
                                                                                     key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >,
@@ -8440,7 +8392,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(25, Process(loc4v1)),
+                                                                            location_id: Tick(24, Process(loc4v1)),
                                                                             collection_kind: Stream {
                                                                                 bound: Bounded,
                                                                                 order: NoOrder,
@@ -8451,7 +8403,7 @@ expression: built.ir()
                                                                     },
                                                                     trusted: false,
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(25, Process(loc4v1)),
+                                                                        location_id: Tick(24, Process(loc4v1)),
                                                                         collection_kind: Stream {
                                                                             bound: Bounded,
                                                                             order: TotalOrder,
@@ -8461,7 +8413,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(25, Process(loc4v1)),
+                                                                    location_id: Tick(24, Process(loc4v1)),
                                                                     collection_kind: Optional {
                                                                         bound: Bounded,
                                                                         element_type: hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage,
@@ -8477,7 +8429,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(26, Process(loc4v1)),
+                                                            location_id: Tick(25, Process(loc4v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage,
@@ -8504,7 +8456,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(26, Process(loc4v1)),
+                                                                    location_id: Tick(25, Process(loc4v1)),
                                                                     collection_kind: Stream {
                                                                         bound: Bounded,
                                                                         order: TotalOrder,
@@ -8514,7 +8466,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(26, Process(loc4v1)),
+                                                                location_id: Tick(25, Process(loc4v1)),
                                                                 collection_kind: Optional {
                                                                     bound: Bounded,
                                                                     element_type: hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
@@ -8522,7 +8474,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(26, Process(loc4v1)),
+                                                            location_id: Tick(25, Process(loc4v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: (),
@@ -8530,7 +8482,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(26, Process(loc4v1)),
+                                                        location_id: Tick(25, Process(loc4v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: (hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage , ()),
@@ -8538,7 +8490,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(26, Process(loc4v1)),
+                                                    location_id: Tick(25, Process(loc4v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage,
@@ -8546,7 +8498,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(26, Process(loc4v1)),
+                                                location_id: Tick(25, Process(loc4v1)),
                                                 collection_kind: Stream {
                                                     bound: Bounded,
                                                     order: TotalOrder,
@@ -8576,7 +8528,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(22, Process(loc4v1)),
+                                    location_id: Tick(21, Process(loc4v1)),
                                     collection_kind: Stream {
                                         bound: Bounded,
                                         order: TotalOrder,
@@ -8589,7 +8541,7 @@ expression: built.ir()
                                 inner: Tee {
                                     inner: <tee 50>,
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(22, Process(loc4v1)),
+                                        location_id: Tick(21, Process(loc4v1)),
                                         collection_kind: Singleton {
                                             bound: Bounded,
                                             element_type: usize,
@@ -8597,7 +8549,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(22, Process(loc4v1)),
+                                    location_id: Tick(21, Process(loc4v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: usize,
@@ -8605,7 +8557,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(22, Process(loc4v1)),
+                                location_id: Tick(21, Process(loc4v1)),
                                 collection_kind: Stream {
                                     bound: Bounded,
                                     order: TotalOrder,
@@ -8627,7 +8579,7 @@ expression: built.ir()
                                                 input: Tee {
                                                     inner: <tee 49>,
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(22, Process(loc4v1)),
+                                                        location_id: Tick(21, Process(loc4v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: usize,
@@ -8635,7 +8587,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(22, Process(loc4v1)),
+                                                    location_id: Tick(21, Process(loc4v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: (),
@@ -8643,7 +8595,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(22, Process(loc4v1)),
+                                                location_id: Tick(21, Process(loc4v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: core :: option :: Option < () >,
@@ -8654,7 +8606,7 @@ expression: built.ir()
                                             inner: SingletonSource {
                                                 value: :: std :: option :: Option :: None,
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(22, Process(loc4v1)),
+                                                    location_id: Tick(21, Process(loc4v1)),
                                                     collection_kind: Singleton {
                                                         bound: Bounded,
                                                         element_type: core :: option :: Option < () >,
@@ -8662,7 +8614,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(22, Process(loc4v1)),
+                                                location_id: Tick(21, Process(loc4v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: core :: option :: Option < () >,
@@ -8670,7 +8622,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(22, Process(loc4v1)),
+                                            location_id: Tick(21, Process(loc4v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: core :: option :: Option < () >,
@@ -8678,7 +8630,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(22, Process(loc4v1)),
+                                        location_id: Tick(21, Process(loc4v1)),
                                         collection_kind: Singleton {
                                             bound: Bounded,
                                             element_type: core :: option :: Option < () >,
@@ -8686,7 +8638,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(22, Process(loc4v1)),
+                                    location_id: Tick(21, Process(loc4v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: core :: option :: Option < () >,
@@ -8694,7 +8646,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(22, Process(loc4v1)),
+                                location_id: Tick(21, Process(loc4v1)),
                                 collection_kind: Optional {
                                     bound: Bounded,
                                     element_type: (),
@@ -8702,7 +8654,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(22, Process(loc4v1)),
+                            location_id: Tick(21, Process(loc4v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: TotalOrder,
@@ -8712,7 +8664,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(22, Process(loc4v1)),
+                        location_id: Tick(21, Process(loc4v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: TotalOrder,
@@ -8826,7 +8778,7 @@ expression: built.ir()
                                                                                                                             },
                                                                                                                         },
                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                            location_id: Tick(27, Cluster(loc3v1)),
+                                                                                                                            location_id: Tick(26, Cluster(loc3v1)),
                                                                                                                             collection_kind: Singleton {
                                                                                                                                 bound: Bounded,
                                                                                                                                 element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -8853,7 +8805,7 @@ expression: built.ir()
                                                                                                                                     },
                                                                                                                                 },
                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                    location_id: Tick(27, Cluster(loc3v1)),
+                                                                                                                                    location_id: Tick(26, Cluster(loc3v1)),
                                                                                                                                     collection_kind: Stream {
                                                                                                                                         bound: Bounded,
                                                                                                                                         order: TotalOrder,
@@ -8863,7 +8815,7 @@ expression: built.ir()
                                                                                                                                 },
                                                                                                                             },
                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                location_id: Tick(27, Cluster(loc3v1)),
+                                                                                                                                location_id: Tick(26, Cluster(loc3v1)),
                                                                                                                                 collection_kind: Optional {
                                                                                                                                     bound: Bounded,
                                                                                                                                     element_type: hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
@@ -8871,7 +8823,7 @@ expression: built.ir()
                                                                                                                             },
                                                                                                                         },
                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                            location_id: Tick(27, Cluster(loc3v1)),
+                                                                                                                            location_id: Tick(26, Cluster(loc3v1)),
                                                                                                                             collection_kind: Optional {
                                                                                                                                 bound: Bounded,
                                                                                                                                 element_type: (),
@@ -8879,7 +8831,7 @@ expression: built.ir()
                                                                                                                         },
                                                                                                                     },
                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                        location_id: Tick(27, Cluster(loc3v1)),
+                                                                                                                        location_id: Tick(26, Cluster(loc3v1)),
                                                                                                                         collection_kind: Optional {
                                                                                                                             bound: Bounded,
                                                                                                                             element_type: (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , ()),
@@ -8887,7 +8839,7 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                 },
                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(27, Cluster(loc3v1)),
+                                                                                                                    location_id: Tick(26, Cluster(loc3v1)),
                                                                                                                     collection_kind: Optional {
                                                                                                                         bound: Bounded,
                                                                                                                         element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -8895,7 +8847,7 @@ expression: built.ir()
                                                                                                                 },
                                                                                                             },
                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                location_id: Tick(27, Cluster(loc3v1)),
+                                                                                                                location_id: Tick(26, Cluster(loc3v1)),
                                                                                                                 collection_kind: Stream {
                                                                                                                     bound: Bounded,
                                                                                                                     order: TotalOrder,
@@ -8988,7 +8940,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(28, Process(loc4v1)),
+                                                                            location_id: Tick(27, Process(loc4v1)),
                                                                             collection_kind: KeyedSingleton {
                                                                                 bound: Bounded,
                                                                                 key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >,
@@ -8997,7 +8949,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(28, Process(loc4v1)),
+                                                                        location_id: Tick(27, Process(loc4v1)),
                                                                         collection_kind: Stream {
                                                                             bound: Bounded,
                                                                             order: NoOrder,
@@ -9008,7 +8960,7 @@ expression: built.ir()
                                                                 },
                                                                 trusted: false,
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(28, Process(loc4v1)),
+                                                                    location_id: Tick(27, Process(loc4v1)),
                                                                     collection_kind: Stream {
                                                                         bound: Bounded,
                                                                         order: TotalOrder,
@@ -9018,7 +8970,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(28, Process(loc4v1)),
+                                                                location_id: Tick(27, Process(loc4v1)),
                                                                 collection_kind: Optional {
                                                                     bound: Bounded,
                                                                     element_type: hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 >,
@@ -9034,7 +8986,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(29, Process(loc4v1)),
+                                                        location_id: Tick(28, Process(loc4v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 >,
@@ -9061,7 +9013,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(29, Process(loc4v1)),
+                                                                location_id: Tick(28, Process(loc4v1)),
                                                                 collection_kind: Stream {
                                                                     bound: Bounded,
                                                                     order: TotalOrder,
@@ -9071,7 +9023,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(29, Process(loc4v1)),
+                                                            location_id: Tick(28, Process(loc4v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
@@ -9079,7 +9031,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(29, Process(loc4v1)),
+                                                        location_id: Tick(28, Process(loc4v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: (),
@@ -9087,7 +9039,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(29, Process(loc4v1)),
+                                                    location_id: Tick(28, Process(loc4v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: (hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , ()),
@@ -9095,7 +9047,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(29, Process(loc4v1)),
+                                                location_id: Tick(28, Process(loc4v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 >,
@@ -9103,7 +9055,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(29, Process(loc4v1)),
+                                            location_id: Tick(28, Process(loc4v1)),
                                             collection_kind: Stream {
                                                 bound: Bounded,
                                                 order: TotalOrder,
@@ -9133,7 +9085,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(22, Process(loc4v1)),
+                                location_id: Tick(21, Process(loc4v1)),
                                 collection_kind: Stream {
                                     bound: Bounded,
                                     order: TotalOrder,
@@ -9155,7 +9107,7 @@ expression: built.ir()
                                                 input: Tee {
                                                     inner: <tee 49>,
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(22, Process(loc4v1)),
+                                                        location_id: Tick(21, Process(loc4v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: usize,
@@ -9163,7 +9115,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(22, Process(loc4v1)),
+                                                    location_id: Tick(21, Process(loc4v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: (),
@@ -9171,7 +9123,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(22, Process(loc4v1)),
+                                                location_id: Tick(21, Process(loc4v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: core :: option :: Option < () >,
@@ -9182,7 +9134,7 @@ expression: built.ir()
                                             inner: SingletonSource {
                                                 value: :: std :: option :: Option :: None,
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(22, Process(loc4v1)),
+                                                    location_id: Tick(21, Process(loc4v1)),
                                                     collection_kind: Singleton {
                                                         bound: Bounded,
                                                         element_type: core :: option :: Option < () >,
@@ -9190,7 +9142,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(22, Process(loc4v1)),
+                                                location_id: Tick(21, Process(loc4v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: core :: option :: Option < () >,
@@ -9198,7 +9150,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(22, Process(loc4v1)),
+                                            location_id: Tick(21, Process(loc4v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: core :: option :: Option < () >,
@@ -9206,7 +9158,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(22, Process(loc4v1)),
+                                        location_id: Tick(21, Process(loc4v1)),
                                         collection_kind: Singleton {
                                             bound: Bounded,
                                             element_type: core :: option :: Option < () >,
@@ -9214,7 +9166,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(22, Process(loc4v1)),
+                                    location_id: Tick(21, Process(loc4v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: core :: option :: Option < () >,
@@ -9222,7 +9174,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(22, Process(loc4v1)),
+                                location_id: Tick(21, Process(loc4v1)),
                                 collection_kind: Optional {
                                     bound: Bounded,
                                     element_type: (),
@@ -9230,7 +9182,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(22, Process(loc4v1)),
+                            location_id: Tick(21, Process(loc4v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: TotalOrder,
@@ -9240,7 +9192,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(22, Process(loc4v1)),
+                        location_id: Tick(21, Process(loc4v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: TotalOrder,

--- a/hydro_test/src/cluster/snapshots/paxos_ir@acceptor_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir@acceptor_mermaid.snap
@@ -130,8 +130,8 @@ subgraph var_cycle_4 ["var <tt>cycle_4</tt>"]
     style var_cycle_4 fill:transparent
     40v1
 end
-subgraph var_reduce_keyed_watermark_chain_505 ["var <tt>reduce_keyed_watermark_chain_505</tt>"]
-    style var_reduce_keyed_watermark_chain_505 fill:transparent
+subgraph var_reduce_keyed_watermark_chain_501 ["var <tt>reduce_keyed_watermark_chain_501</tt>"]
+    style var_reduce_keyed_watermark_chain_501 fill:transparent
     33v1
 end
 subgraph var_stream_137 ["var <tt>stream_137</tt>"]
@@ -184,103 +184,103 @@ subgraph var_stream_159 ["var <tt>stream_159</tt>"]
     style var_stream_159 fill:transparent
     15v1
 end
-subgraph var_stream_432 ["var <tt>stream_432</tt>"]
-    style var_stream_432 fill:transparent
+subgraph var_stream_428 ["var <tt>stream_428</tt>"]
+    style var_stream_428 fill:transparent
     18v1
     19v1
 end
-subgraph var_stream_435 ["var <tt>stream_435</tt>"]
-    style var_stream_435 fill:transparent
+subgraph var_stream_431 ["var <tt>stream_431</tt>"]
+    style var_stream_431 fill:transparent
     20v1
+end
+subgraph var_stream_433 ["var <tt>stream_433</tt>"]
+    style var_stream_433 fill:transparent
+    21v1
+end
+subgraph var_stream_436 ["var <tt>stream_436</tt>"]
+    style var_stream_436 fill:transparent
+    22v1
 end
 subgraph var_stream_437 ["var <tt>stream_437</tt>"]
     style var_stream_437 fill:transparent
-    21v1
-end
-subgraph var_stream_440 ["var <tt>stream_440</tt>"]
-    style var_stream_440 fill:transparent
-    22v1
-end
-subgraph var_stream_441 ["var <tt>stream_441</tt>"]
-    style var_stream_441 fill:transparent
     23v1
 end
-subgraph var_stream_490 ["var <tt>stream_490</tt>"]
-    style var_stream_490 fill:transparent
+subgraph var_stream_486 ["var <tt>stream_486</tt>"]
+    style var_stream_486 fill:transparent
     26v1
 end
-subgraph var_stream_491 ["var <tt>stream_491</tt>"]
-    style var_stream_491 fill:transparent
+subgraph var_stream_487 ["var <tt>stream_487</tt>"]
+    style var_stream_487 fill:transparent
     27v1
 end
-subgraph var_stream_492 ["var <tt>stream_492</tt>"]
-    style var_stream_492 fill:transparent
+subgraph var_stream_488 ["var <tt>stream_488</tt>"]
+    style var_stream_488 fill:transparent
     28v1
     29v1
 end
-subgraph var_stream_494 ["var <tt>stream_494</tt>"]
-    style var_stream_494 fill:transparent
+subgraph var_stream_490 ["var <tt>stream_490</tt>"]
+    style var_stream_490 fill:transparent
     30v1
 end
-subgraph var_stream_499 ["var <tt>stream_499</tt>"]
-    style var_stream_499 fill:transparent
+subgraph var_stream_495 ["var <tt>stream_495</tt>"]
+    style var_stream_495 fill:transparent
     31v1
 end
-subgraph var_stream_500 ["var <tt>stream_500</tt>"]
-    style var_stream_500 fill:transparent
+subgraph var_stream_496 ["var <tt>stream_496</tt>"]
+    style var_stream_496 fill:transparent
     32v1
 end
-subgraph var_stream_505 ["var <tt>stream_505</tt>"]
-    style var_stream_505 fill:transparent
+subgraph var_stream_501 ["var <tt>stream_501</tt>"]
+    style var_stream_501 fill:transparent
     36v1
     37v1
 end
-subgraph var_stream_510 ["var <tt>stream_510</tt>"]
-    style var_stream_510 fill:transparent
+subgraph var_stream_506 ["var <tt>stream_506</tt>"]
+    style var_stream_506 fill:transparent
     38v1
 end
-subgraph var_stream_511 ["var <tt>stream_511</tt>"]
-    style var_stream_511 fill:transparent
+subgraph var_stream_507 ["var <tt>stream_507</tt>"]
+    style var_stream_507 fill:transparent
     39v1
 end
-subgraph var_stream_617 ["var <tt>stream_617</tt>"]
-    style var_stream_617 fill:transparent
+subgraph var_stream_613 ["var <tt>stream_613</tt>"]
+    style var_stream_613 fill:transparent
     41v1
     42v1
 end
-subgraph var_stream_619 ["var <tt>stream_619</tt>"]
-    style var_stream_619 fill:transparent
+subgraph var_stream_615 ["var <tt>stream_615</tt>"]
+    style var_stream_615 fill:transparent
     43v1
 end
-subgraph var_stream_621 ["var <tt>stream_621</tt>"]
-    style var_stream_621 fill:transparent
+subgraph var_stream_617 ["var <tt>stream_617</tt>"]
+    style var_stream_617 fill:transparent
     44v1
+end
+subgraph var_stream_624 ["var <tt>stream_624</tt>"]
+    style var_stream_624 fill:transparent
+    45v1
+end
+subgraph var_stream_625 ["var <tt>stream_625</tt>"]
+    style var_stream_625 fill:transparent
+    46v1
+end
+subgraph var_stream_626 ["var <tt>stream_626</tt>"]
+    style var_stream_626 fill:transparent
+    47v1
+end
+subgraph var_stream_627 ["var <tt>stream_627</tt>"]
+    style var_stream_627 fill:transparent
+    48v1
 end
 subgraph var_stream_628 ["var <tt>stream_628</tt>"]
     style var_stream_628 fill:transparent
-    45v1
+    49v1
 end
 subgraph var_stream_629 ["var <tt>stream_629</tt>"]
     style var_stream_629 fill:transparent
-    46v1
-end
-subgraph var_stream_630 ["var <tt>stream_630</tt>"]
-    style var_stream_630 fill:transparent
-    47v1
+    50v1
 end
 subgraph var_stream_631 ["var <tt>stream_631</tt>"]
     style var_stream_631 fill:transparent
-    48v1
-end
-subgraph var_stream_632 ["var <tt>stream_632</tt>"]
-    style var_stream_632 fill:transparent
-    49v1
-end
-subgraph var_stream_633 ["var <tt>stream_633</tt>"]
-    style var_stream_633 fill:transparent
-    50v1
-end
-subgraph var_stream_635 ["var <tt>stream_635</tt>"]
-    style var_stream_635 fill:transparent
     51v1
 end

--- a/hydro_test/src/cluster/snapshots/paxos_ir@proposer_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir@proposer_mermaid.snap
@@ -848,240 +848,248 @@ subgraph var_stream_25 ["var <tt>stream_25</tt>"]
     style var_stream_25 fill:transparent
     6v1
 end
-subgraph var_stream_254 ["var <tt>stream_254</tt>"]
-    style var_stream_254 fill:transparent
+subgraph var_stream_250 ["var <tt>stream_250</tt>"]
+    style var_stream_250 fill:transparent
     115v1
+end
+subgraph var_stream_251 ["var <tt>stream_251</tt>"]
+    style var_stream_251 fill:transparent
+    116v1
+end
+subgraph var_stream_253 ["var <tt>stream_253</tt>"]
+    style var_stream_253 fill:transparent
+    117v1
 end
 subgraph var_stream_255 ["var <tt>stream_255</tt>"]
     style var_stream_255 fill:transparent
-    116v1
-end
-subgraph var_stream_257 ["var <tt>stream_257</tt>"]
-    style var_stream_257 fill:transparent
-    117v1
-end
-subgraph var_stream_259 ["var <tt>stream_259</tt>"]
-    style var_stream_259 fill:transparent
     118v1
+end
+subgraph var_stream_258 ["var <tt>stream_258</tt>"]
+    style var_stream_258 fill:transparent
+    119v1
 end
 subgraph var_stream_26 ["var <tt>stream_26</tt>"]
     style var_stream_26 fill:transparent
     7v1
 end
-subgraph var_stream_262 ["var <tt>stream_262</tt>"]
-    style var_stream_262 fill:transparent
-    119v1
-end
-subgraph var_stream_267 ["var <tt>stream_267</tt>"]
-    style var_stream_267 fill:transparent
+subgraph var_stream_263 ["var <tt>stream_263</tt>"]
+    style var_stream_263 fill:transparent
     120v1
 end
-subgraph var_stream_268 ["var <tt>stream_268</tt>"]
-    style var_stream_268 fill:transparent
+subgraph var_stream_264 ["var <tt>stream_264</tt>"]
+    style var_stream_264 fill:transparent
     121v1
 end
-subgraph var_stream_269 ["var <tt>stream_269</tt>"]
-    style var_stream_269 fill:transparent
+subgraph var_stream_265 ["var <tt>stream_265</tt>"]
+    style var_stream_265 fill:transparent
     122v1
 end
-subgraph var_stream_270 ["var <tt>stream_270</tt>"]
-    style var_stream_270 fill:transparent
+subgraph var_stream_266 ["var <tt>stream_266</tt>"]
+    style var_stream_266 fill:transparent
     123v1
     124v1
 end
-subgraph var_stream_272 ["var <tt>stream_272</tt>"]
-    style var_stream_272 fill:transparent
+subgraph var_stream_268 ["var <tt>stream_268</tt>"]
+    style var_stream_268 fill:transparent
     125v1
 end
-subgraph var_stream_274 ["var <tt>stream_274</tt>"]
-    style var_stream_274 fill:transparent
+subgraph var_stream_270 ["var <tt>stream_270</tt>"]
+    style var_stream_270 fill:transparent
     126v1
+end
+subgraph var_stream_271 ["var <tt>stream_271</tt>"]
+    style var_stream_271 fill:transparent
+    127v1
+end
+subgraph var_stream_272 ["var <tt>stream_272</tt>"]
+    style var_stream_272 fill:transparent
+    128v1
+end
+subgraph var_stream_273 ["var <tt>stream_273</tt>"]
+    style var_stream_273 fill:transparent
+    129v1
 end
 subgraph var_stream_275 ["var <tt>stream_275</tt>"]
     style var_stream_275 fill:transparent
-    127v1
+    131v1
 end
 subgraph var_stream_276 ["var <tt>stream_276</tt>"]
     style var_stream_276 fill:transparent
-    128v1
+    132v1
 end
 subgraph var_stream_277 ["var <tt>stream_277</tt>"]
     style var_stream_277 fill:transparent
-    129v1
-end
-subgraph var_stream_279 ["var <tt>stream_279</tt>"]
-    style var_stream_279 fill:transparent
-    131v1
-end
-subgraph var_stream_280 ["var <tt>stream_280</tt>"]
-    style var_stream_280 fill:transparent
-    132v1
+    133v1
 end
 subgraph var_stream_281 ["var <tt>stream_281</tt>"]
     style var_stream_281 fill:transparent
-    133v1
-end
-subgraph var_stream_285 ["var <tt>stream_285</tt>"]
-    style var_stream_285 fill:transparent
     134v1
 end
 subgraph var_stream_30 ["var <tt>stream_30</tt>"]
     style var_stream_30 fill:transparent
     8v1
 end
-subgraph var_stream_314 ["var <tt>stream_314</tt>"]
-    style var_stream_314 fill:transparent
+subgraph var_stream_310 ["var <tt>stream_310</tt>"]
+    style var_stream_310 fill:transparent
     138v1
     137v1
 end
-subgraph var_stream_317 ["var <tt>stream_317</tt>"]
-    style var_stream_317 fill:transparent
+subgraph var_stream_313 ["var <tt>stream_313</tt>"]
+    style var_stream_313 fill:transparent
     139v1
 end
-subgraph var_stream_321 ["var <tt>stream_321</tt>"]
-    style var_stream_321 fill:transparent
+subgraph var_stream_317 ["var <tt>stream_317</tt>"]
+    style var_stream_317 fill:transparent
     140v1
+end
+subgraph var_stream_318 ["var <tt>stream_318</tt>"]
+    style var_stream_318 fill:transparent
+    141v1
+end
+subgraph var_stream_319 ["var <tt>stream_319</tt>"]
+    style var_stream_319 fill:transparent
+    142v1
 end
 subgraph var_stream_322 ["var <tt>stream_322</tt>"]
     style var_stream_322 fill:transparent
-    141v1
+    143v1
 end
-subgraph var_stream_323 ["var <tt>stream_323</tt>"]
-    style var_stream_323 fill:transparent
-    142v1
+subgraph var_stream_324 ["var <tt>stream_324</tt>"]
+    style var_stream_324 fill:transparent
+    144v1
+end
+subgraph var_stream_325 ["var <tt>stream_325</tt>"]
+    style var_stream_325 fill:transparent
+    145v1
 end
 subgraph var_stream_326 ["var <tt>stream_326</tt>"]
     style var_stream_326 fill:transparent
-    143v1
+    146v1
 end
-subgraph var_stream_328 ["var <tt>stream_328</tt>"]
-    style var_stream_328 fill:transparent
-    144v1
-end
-subgraph var_stream_329 ["var <tt>stream_329</tt>"]
-    style var_stream_329 fill:transparent
-    145v1
+subgraph var_stream_327 ["var <tt>stream_327</tt>"]
+    style var_stream_327 fill:transparent
+    147v1
 end
 subgraph var_stream_330 ["var <tt>stream_330</tt>"]
     style var_stream_330 fill:transparent
-    146v1
+    148v1
 end
 subgraph var_stream_331 ["var <tt>stream_331</tt>"]
     style var_stream_331 fill:transparent
-    147v1
+    149v1
 end
-subgraph var_stream_334 ["var <tt>stream_334</tt>"]
-    style var_stream_334 fill:transparent
-    148v1
+subgraph var_stream_332 ["var <tt>stream_332</tt>"]
+    style var_stream_332 fill:transparent
+    150v1
 end
 subgraph var_stream_335 ["var <tt>stream_335</tt>"]
     style var_stream_335 fill:transparent
-    149v1
-end
-subgraph var_stream_336 ["var <tt>stream_336</tt>"]
-    style var_stream_336 fill:transparent
-    150v1
-end
-subgraph var_stream_339 ["var <tt>stream_339</tt>"]
-    style var_stream_339 fill:transparent
     151v1
+end
+subgraph var_stream_337 ["var <tt>stream_337</tt>"]
+    style var_stream_337 fill:transparent
+    152v1
+end
+subgraph var_stream_338 ["var <tt>stream_338</tt>"]
+    style var_stream_338 fill:transparent
+    153v1
 end
 subgraph var_stream_341 ["var <tt>stream_341</tt>"]
     style var_stream_341 fill:transparent
-    152v1
-end
-subgraph var_stream_342 ["var <tt>stream_342</tt>"]
-    style var_stream_342 fill:transparent
-    153v1
-end
-subgraph var_stream_345 ["var <tt>stream_345</tt>"]
-    style var_stream_345 fill:transparent
     154v1
 end
-subgraph var_stream_347 ["var <tt>stream_347</tt>"]
-    style var_stream_347 fill:transparent
+subgraph var_stream_343 ["var <tt>stream_343</tt>"]
+    style var_stream_343 fill:transparent
     155v1
 end
-subgraph var_stream_348 ["var <tt>stream_348</tt>"]
-    style var_stream_348 fill:transparent
+subgraph var_stream_344 ["var <tt>stream_344</tt>"]
+    style var_stream_344 fill:transparent
     156v1
     157v1
 end
-subgraph var_stream_350 ["var <tt>stream_350</tt>"]
-    style var_stream_350 fill:transparent
+subgraph var_stream_346 ["var <tt>stream_346</tt>"]
+    style var_stream_346 fill:transparent
     158v1
+end
+subgraph var_stream_349 ["var <tt>stream_349</tt>"]
+    style var_stream_349 fill:transparent
+    159v1
+end
+subgraph var_stream_351 ["var <tt>stream_351</tt>"]
+    style var_stream_351 fill:transparent
+    160v1
 end
 subgraph var_stream_353 ["var <tt>stream_353</tt>"]
     style var_stream_353 fill:transparent
-    159v1
+    161v1
+end
+subgraph var_stream_354 ["var <tt>stream_354</tt>"]
+    style var_stream_354 fill:transparent
+    162v1
 end
 subgraph var_stream_355 ["var <tt>stream_355</tt>"]
     style var_stream_355 fill:transparent
-    160v1
+    163v1
 end
-subgraph var_stream_357 ["var <tt>stream_357</tt>"]
-    style var_stream_357 fill:transparent
-    161v1
-end
-subgraph var_stream_358 ["var <tt>stream_358</tt>"]
-    style var_stream_358 fill:transparent
-    162v1
+subgraph var_stream_356 ["var <tt>stream_356</tt>"]
+    style var_stream_356 fill:transparent
+    164v1
 end
 subgraph var_stream_359 ["var <tt>stream_359</tt>"]
     style var_stream_359 fill:transparent
-    163v1
+    166v1
 end
 subgraph var_stream_36 ["var <tt>stream_36</tt>"]
     style var_stream_36 fill:transparent
     9v1
 end
-subgraph var_stream_360 ["var <tt>stream_360</tt>"]
-    style var_stream_360 fill:transparent
-    164v1
+subgraph var_stream_361 ["var <tt>stream_361</tt>"]
+    style var_stream_361 fill:transparent
+    167v1
 end
 subgraph var_stream_363 ["var <tt>stream_363</tt>"]
     style var_stream_363 fill:transparent
-    166v1
+    169v1
+end
+subgraph var_stream_364 ["var <tt>stream_364</tt>"]
+    style var_stream_364 fill:transparent
+    170v1
 end
 subgraph var_stream_365 ["var <tt>stream_365</tt>"]
     style var_stream_365 fill:transparent
-    167v1
+    171v1
 end
 subgraph var_stream_367 ["var <tt>stream_367</tt>"]
     style var_stream_367 fill:transparent
-    169v1
-end
-subgraph var_stream_368 ["var <tt>stream_368</tt>"]
-    style var_stream_368 fill:transparent
-    170v1
+    172v1
 end
 subgraph var_stream_369 ["var <tt>stream_369</tt>"]
     style var_stream_369 fill:transparent
-    171v1
-end
-subgraph var_stream_371 ["var <tt>stream_371</tt>"]
-    style var_stream_371 fill:transparent
-    172v1
-end
-subgraph var_stream_373 ["var <tt>stream_373</tt>"]
-    style var_stream_373 fill:transparent
     173v1
 end
-subgraph var_stream_376 ["var <tt>stream_376</tt>"]
-    style var_stream_376 fill:transparent
+subgraph var_stream_372 ["var <tt>stream_372</tt>"]
+    style var_stream_372 fill:transparent
     174v1
+end
+subgraph var_stream_379 ["var <tt>stream_379</tt>"]
+    style var_stream_379 fill:transparent
+    175v1
 end
 subgraph var_stream_38 ["var <tt>stream_38</tt>"]
     style var_stream_38 fill:transparent
     10v1
 end
-subgraph var_stream_383 ["var <tt>stream_383</tt>"]
-    style var_stream_383 fill:transparent
-    175v1
-end
-subgraph var_stream_384 ["var <tt>stream_384</tt>"]
-    style var_stream_384 fill:transparent
+subgraph var_stream_380 ["var <tt>stream_380</tt>"]
+    style var_stream_380 fill:transparent
     176v1
+end
+subgraph var_stream_386 ["var <tt>stream_386</tt>"]
+    style var_stream_386 fill:transparent
+    177v1
+end
+subgraph var_stream_388 ["var <tt>stream_388</tt>"]
+    style var_stream_388 fill:transparent
+    178v1
 end
 subgraph var_stream_39 ["var <tt>stream_39</tt>"]
     style var_stream_39 fill:transparent
@@ -1090,48 +1098,48 @@ subgraph var_stream_39 ["var <tt>stream_39</tt>"]
 end
 subgraph var_stream_390 ["var <tt>stream_390</tt>"]
     style var_stream_390 fill:transparent
-    177v1
+    179v1
+end
+subgraph var_stream_391 ["var <tt>stream_391</tt>"]
+    style var_stream_391 fill:transparent
+    180v1
 end
 subgraph var_stream_392 ["var <tt>stream_392</tt>"]
     style var_stream_392 fill:transparent
-    178v1
-end
-subgraph var_stream_394 ["var <tt>stream_394</tt>"]
-    style var_stream_394 fill:transparent
-    179v1
-end
-subgraph var_stream_395 ["var <tt>stream_395</tt>"]
-    style var_stream_395 fill:transparent
-    180v1
-end
-subgraph var_stream_396 ["var <tt>stream_396</tt>"]
-    style var_stream_396 fill:transparent
     181v1
     182v1
 end
-subgraph var_stream_398 ["var <tt>stream_398</tt>"]
-    style var_stream_398 fill:transparent
+subgraph var_stream_394 ["var <tt>stream_394</tt>"]
+    style var_stream_394 fill:transparent
     183v1
 end
-subgraph var_stream_400 ["var <tt>stream_400</tt>"]
-    style var_stream_400 fill:transparent
+subgraph var_stream_396 ["var <tt>stream_396</tt>"]
+    style var_stream_396 fill:transparent
     184v1
 end
-subgraph var_stream_402 ["var <tt>stream_402</tt>"]
-    style var_stream_402 fill:transparent
+subgraph var_stream_398 ["var <tt>stream_398</tt>"]
+    style var_stream_398 fill:transparent
     185v1
+end
+subgraph var_stream_399 ["var <tt>stream_399</tt>"]
+    style var_stream_399 fill:transparent
+    186v1
 end
 subgraph var_stream_403 ["var <tt>stream_403</tt>"]
     style var_stream_403 fill:transparent
-    186v1
-end
-subgraph var_stream_407 ["var <tt>stream_407</tt>"]
-    style var_stream_407 fill:transparent
     187v1
+end
+subgraph var_stream_404 ["var <tt>stream_404</tt>"]
+    style var_stream_404 fill:transparent
+    188v1
 end
 subgraph var_stream_408 ["var <tt>stream_408</tt>"]
     style var_stream_408 fill:transparent
-    188v1
+    189v1
+end
+subgraph var_stream_409 ["var <tt>stream_409</tt>"]
+    style var_stream_409 fill:transparent
+    190v1
 end
 subgraph var_stream_41 ["var <tt>stream_41</tt>"]
     style var_stream_41 fill:transparent
@@ -1139,215 +1147,207 @@ subgraph var_stream_41 ["var <tt>stream_41</tt>"]
 end
 subgraph var_stream_412 ["var <tt>stream_412</tt>"]
     style var_stream_412 fill:transparent
-    189v1
+    191v1
 end
 subgraph var_stream_413 ["var <tt>stream_413</tt>"]
     style var_stream_413 fill:transparent
-    190v1
+    192v1
 end
-subgraph var_stream_416 ["var <tt>stream_416</tt>"]
-    style var_stream_416 fill:transparent
-    191v1
+subgraph var_stream_414 ["var <tt>stream_414</tt>"]
+    style var_stream_414 fill:transparent
+    193v1
+end
+subgraph var_stream_415 ["var <tt>stream_415</tt>"]
+    style var_stream_415 fill:transparent
+    194v1
 end
 subgraph var_stream_417 ["var <tt>stream_417</tt>"]
     style var_stream_417 fill:transparent
-    192v1
+    195v1
 end
 subgraph var_stream_418 ["var <tt>stream_418</tt>"]
     style var_stream_418 fill:transparent
-    193v1
+    196v1
 end
 subgraph var_stream_419 ["var <tt>stream_419</tt>"]
     style var_stream_419 fill:transparent
-    194v1
+    197v1
 end
 subgraph var_stream_421 ["var <tt>stream_421</tt>"]
     style var_stream_421 fill:transparent
-    195v1
-end
-subgraph var_stream_422 ["var <tt>stream_422</tt>"]
-    style var_stream_422 fill:transparent
-    196v1
+    198v1
 end
 subgraph var_stream_423 ["var <tt>stream_423</tt>"]
     style var_stream_423 fill:transparent
-    197v1
+    199v1
 end
 subgraph var_stream_425 ["var <tt>stream_425</tt>"]
     style var_stream_425 fill:transparent
-    198v1
-end
-subgraph var_stream_427 ["var <tt>stream_427</tt>"]
-    style var_stream_427 fill:transparent
-    199v1
-end
-subgraph var_stream_429 ["var <tt>stream_429</tt>"]
-    style var_stream_429 fill:transparent
     200v1
 end
 subgraph var_stream_43 ["var <tt>stream_43</tt>"]
     style var_stream_43 fill:transparent
     14v1
 end
-subgraph var_stream_444 ["var <tt>stream_444</tt>"]
-    style var_stream_444 fill:transparent
+subgraph var_stream_440 ["var <tt>stream_440</tt>"]
+    style var_stream_440 fill:transparent
     203v1
     204v1
 end
-subgraph var_stream_447 ["var <tt>stream_447</tt>"]
-    style var_stream_447 fill:transparent
+subgraph var_stream_443 ["var <tt>stream_443</tt>"]
+    style var_stream_443 fill:transparent
     205v1
 end
-subgraph var_stream_448 ["var <tt>stream_448</tt>"]
-    style var_stream_448 fill:transparent
+subgraph var_stream_444 ["var <tt>stream_444</tt>"]
+    style var_stream_444 fill:transparent
     206v1
+end
+subgraph var_stream_446 ["var <tt>stream_446</tt>"]
+    style var_stream_446 fill:transparent
+    207v1
+end
+subgraph var_stream_447 ["var <tt>stream_447</tt>"]
+    style var_stream_447 fill:transparent
+    208v1
 end
 subgraph var_stream_45 ["var <tt>stream_45</tt>"]
     style var_stream_45 fill:transparent
     15v1
 end
-subgraph var_stream_450 ["var <tt>stream_450</tt>"]
-    style var_stream_450 fill:transparent
-    207v1
-end
 subgraph var_stream_451 ["var <tt>stream_451</tt>"]
     style var_stream_451 fill:transparent
-    208v1
-end
-subgraph var_stream_455 ["var <tt>stream_455</tt>"]
-    style var_stream_455 fill:transparent
     209v1
+end
+subgraph var_stream_452 ["var <tt>stream_452</tt>"]
+    style var_stream_452 fill:transparent
+    210v1
+end
+subgraph var_stream_453 ["var <tt>stream_453</tt>"]
+    style var_stream_453 fill:transparent
+    211v1
 end
 subgraph var_stream_456 ["var <tt>stream_456</tt>"]
     style var_stream_456 fill:transparent
-    210v1
+    212v1
 end
 subgraph var_stream_457 ["var <tt>stream_457</tt>"]
     style var_stream_457 fill:transparent
-    211v1
+    213v1
+end
+subgraph var_stream_458 ["var <tt>stream_458</tt>"]
+    style var_stream_458 fill:transparent
+    214v1
 end
 subgraph var_stream_46 ["var <tt>stream_46</tt>"]
     style var_stream_46 fill:transparent
     16v1
 end
-subgraph var_stream_460 ["var <tt>stream_460</tt>"]
-    style var_stream_460 fill:transparent
-    212v1
-end
-subgraph var_stream_461 ["var <tt>stream_461</tt>"]
-    style var_stream_461 fill:transparent
-    213v1
-end
 subgraph var_stream_462 ["var <tt>stream_462</tt>"]
     style var_stream_462 fill:transparent
-    214v1
-end
-subgraph var_stream_466 ["var <tt>stream_466</tt>"]
-    style var_stream_466 fill:transparent
     216v1
+end
+subgraph var_stream_463 ["var <tt>stream_463</tt>"]
+    style var_stream_463 fill:transparent
+    217v1
+end
+subgraph var_stream_465 ["var <tt>stream_465</tt>"]
+    style var_stream_465 fill:transparent
+    218v1
 end
 subgraph var_stream_467 ["var <tt>stream_467</tt>"]
     style var_stream_467 fill:transparent
-    217v1
-end
-subgraph var_stream_469 ["var <tt>stream_469</tt>"]
-    style var_stream_469 fill:transparent
-    218v1
+    220v1
 end
 subgraph var_stream_47 ["var <tt>stream_47</tt>"]
     style var_stream_47 fill:transparent
     18v1
 end
-subgraph var_stream_471 ["var <tt>stream_471</tt>"]
-    style var_stream_471 fill:transparent
-    220v1
+subgraph var_stream_472 ["var <tt>stream_472</tt>"]
+    style var_stream_472 fill:transparent
+    221v1
+end
+subgraph var_stream_473 ["var <tt>stream_473</tt>"]
+    style var_stream_473 fill:transparent
+    222v1
 end
 subgraph var_stream_476 ["var <tt>stream_476</tt>"]
     style var_stream_476 fill:transparent
-    221v1
+    223v1
 end
 subgraph var_stream_477 ["var <tt>stream_477</tt>"]
     style var_stream_477 fill:transparent
-    222v1
+    224v1
+end
+subgraph var_stream_479 ["var <tt>stream_479</tt>"]
+    style var_stream_479 fill:transparent
+    225v1
 end
 subgraph var_stream_48 ["var <tt>stream_48</tt>"]
     style var_stream_48 fill:transparent
     19v1
 end
-subgraph var_stream_480 ["var <tt>stream_480</tt>"]
-    style var_stream_480 fill:transparent
-    223v1
-end
 subgraph var_stream_481 ["var <tt>stream_481</tt>"]
     style var_stream_481 fill:transparent
-    224v1
+    226v1
+end
+subgraph var_stream_482 ["var <tt>stream_482</tt>"]
+    style var_stream_482 fill:transparent
+    227v1
 end
 subgraph var_stream_483 ["var <tt>stream_483</tt>"]
     style var_stream_483 fill:transparent
-    225v1
-end
-subgraph var_stream_485 ["var <tt>stream_485</tt>"]
-    style var_stream_485 fill:transparent
-    226v1
-end
-subgraph var_stream_486 ["var <tt>stream_486</tt>"]
-    style var_stream_486 fill:transparent
-    227v1
-end
-subgraph var_stream_487 ["var <tt>stream_487</tt>"]
-    style var_stream_487 fill:transparent
     228v1
 end
 subgraph var_stream_50 ["var <tt>stream_50</tt>"]
     style var_stream_50 fill:transparent
     20v1
 end
-subgraph var_stream_516 ["var <tt>stream_516</tt>"]
-    style var_stream_516 fill:transparent
+subgraph var_stream_512 ["var <tt>stream_512</tt>"]
+    style var_stream_512 fill:transparent
     230v1
+end
+subgraph var_stream_513 ["var <tt>stream_513</tt>"]
+    style var_stream_513 fill:transparent
+    231v1
+end
+subgraph var_stream_514 ["var <tt>stream_514</tt>"]
+    style var_stream_514 fill:transparent
+    233v1
+end
+subgraph var_stream_515 ["var <tt>stream_515</tt>"]
+    style var_stream_515 fill:transparent
+    234v1
 end
 subgraph var_stream_517 ["var <tt>stream_517</tt>"]
     style var_stream_517 fill:transparent
-    231v1
-end
-subgraph var_stream_518 ["var <tt>stream_518</tt>"]
-    style var_stream_518 fill:transparent
-    233v1
+    235v1
 end
 subgraph var_stream_519 ["var <tt>stream_519</tt>"]
     style var_stream_519 fill:transparent
-    234v1
+    236v1
 end
 subgraph var_stream_52 ["var <tt>stream_52</tt>"]
     style var_stream_52 fill:transparent
     21v1
 end
-subgraph var_stream_521 ["var <tt>stream_521</tt>"]
-    style var_stream_521 fill:transparent
-    235v1
-end
-subgraph var_stream_523 ["var <tt>stream_523</tt>"]
-    style var_stream_523 fill:transparent
-    236v1
+subgraph var_stream_522 ["var <tt>stream_522</tt>"]
+    style var_stream_522 fill:transparent
+    237v1
 end
 subgraph var_stream_526 ["var <tt>stream_526</tt>"]
     style var_stream_526 fill:transparent
-    237v1
-end
-subgraph var_stream_530 ["var <tt>stream_530</tt>"]
-    style var_stream_530 fill:transparent
     238v1
+end
+subgraph var_stream_527 ["var <tt>stream_527</tt>"]
+    style var_stream_527 fill:transparent
+    239v1
+end
+subgraph var_stream_529 ["var <tt>stream_529</tt>"]
+    style var_stream_529 fill:transparent
+    240v1
 end
 subgraph var_stream_531 ["var <tt>stream_531</tt>"]
     style var_stream_531 fill:transparent
-    239v1
-end
-subgraph var_stream_533 ["var <tt>stream_533</tt>"]
-    style var_stream_533 fill:transparent
-    240v1
-end
-subgraph var_stream_535 ["var <tt>stream_535</tt>"]
-    style var_stream_535 fill:transparent
     241v1
 end
 subgraph var_stream_55 ["var <tt>stream_55</tt>"]

--- a/hydro_test/src/cluster/snapshots/two_pc_ir.snap
+++ b/hydro_test/src/cluster/snapshots/two_pc_ir.snap
@@ -140,7 +140,7 @@ expression: built.ir()
                                 sym: cycle_2,
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(3, Process(loc1v1)),
+                                location_id: Tick(2, Process(loc1v1)),
                                 collection_kind: Stream {
                                     bound: Bounded,
                                     order: NoOrder,
@@ -150,7 +150,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(3, Process(loc1v1)),
+                            location_id: Tick(2, Process(loc1v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -247,7 +247,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(2, Process(loc1v1)),
+                                                                                            location_id: Tick(1, Process(loc1v1)),
                                                                                             collection_kind: KeyedSingleton {
                                                                                                 bound: Bounded,
                                                                                                 key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant >,
@@ -256,7 +256,7 @@ expression: built.ir()
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(2, Process(loc1v1)),
+                                                                                        location_id: Tick(1, Process(loc1v1)),
                                                                                         collection_kind: KeyedSingleton {
                                                                                             bound: Bounded,
                                                                                             key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant >,
@@ -265,7 +265,7 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(2, Process(loc1v1)),
+                                                                                    location_id: Tick(1, Process(loc1v1)),
                                                                                     collection_kind: KeyedStream {
                                                                                         bound: Bounded,
                                                                                         value_order: TotalOrder,
@@ -276,7 +276,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(2, Process(loc1v1)),
+                                                                                location_id: Tick(1, Process(loc1v1)),
                                                                                 collection_kind: Stream {
                                                                                     bound: Bounded,
                                                                                     order: NoOrder,
@@ -286,7 +286,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(2, Process(loc1v1)),
+                                                                            location_id: Tick(1, Process(loc1v1)),
                                                                             collection_kind: Stream {
                                                                                 bound: Bounded,
                                                                                 order: NoOrder,
@@ -297,7 +297,7 @@ expression: built.ir()
                                                                     },
                                                                     trusted: true,
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(2, Process(loc1v1)),
+                                                                        location_id: Tick(1, Process(loc1v1)),
                                                                         collection_kind: Stream {
                                                                             bound: Bounded,
                                                                             order: TotalOrder,
@@ -322,111 +322,35 @@ expression: built.ir()
                                                                                     inner: Tee {
                                                                                         inner: <tee 3>: Map {
                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , core :: option :: Option < i32 >) , (u32 , i32) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < i32 > , i32 > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; move | payload | { if let Some (counter) = payload { counter + 1 } else { 0 } } }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
-                                                                                            input: YieldConcat {
-                                                                                                inner: Chain {
-                                                                                                    first: Cast {
-                                                                                                        inner: Batch {
-                                                                                                            inner: YieldConcat {
-                                                                                                                inner: Cast {
-                                                                                                                    inner: Cast {
-                                                                                                                        inner: Tee {
-                                                                                                                            inner: <tee 0>,
-                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                location_id: Tick(0, Cluster(loc3v1)),
-                                                                                                                                collection_kind: Optional {
-                                                                                                                                    bound: Bounded,
-                                                                                                                                    element_type: (u32 , core :: option :: Option < i32 >),
-                                                                                                                                },
-                                                                                                                            },
-                                                                                                                        },
-                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                            location_id: Tick(0, Cluster(loc3v1)),
-                                                                                                                            collection_kind: Stream {
-                                                                                                                                bound: Bounded,
-                                                                                                                                order: TotalOrder,
-                                                                                                                                retry: ExactlyOnce,
-                                                                                                                                element_type: (u32 , core :: option :: Option < i32 >),
-                                                                                                                            },
-                                                                                                                        },
-                                                                                                                    },
-                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                        location_id: Tick(0, Cluster(loc3v1)),
-                                                                                                                        collection_kind: KeyedStream {
-                                                                                                                            bound: Bounded,
-                                                                                                                            value_order: TotalOrder,
-                                                                                                                            value_retry: ExactlyOnce,
-                                                                                                                            key_type: u32,
-                                                                                                                            value_type: core :: option :: Option < i32 >,
-                                                                                                                        },
-                                                                                                                    },
-                                                                                                                },
+                                                                                            input: Chain {
+                                                                                                first: YieldConcat {
+                                                                                                    inner: Cast {
+                                                                                                        inner: Cast {
+                                                                                                            inner: Tee {
+                                                                                                                inner: <tee 0>,
                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                    location_id: Cluster(loc3v1),
-                                                                                                                    collection_kind: KeyedStream {
-                                                                                                                        bound: Unbounded,
-                                                                                                                        value_order: TotalOrder,
-                                                                                                                        value_retry: ExactlyOnce,
-                                                                                                                        key_type: u32,
-                                                                                                                        value_type: core :: option :: Option < i32 >,
+                                                                                                                    location_id: Tick(0, Cluster(loc3v1)),
+                                                                                                                    collection_kind: Optional {
+                                                                                                                        bound: Bounded,
+                                                                                                                        element_type: (u32 , core :: option :: Option < i32 >),
                                                                                                                     },
                                                                                                                 },
                                                                                                             },
                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                location_id: Tick(1, Cluster(loc3v1)),
-                                                                                                                collection_kind: KeyedStream {
+                                                                                                                location_id: Tick(0, Cluster(loc3v1)),
+                                                                                                                collection_kind: Stream {
                                                                                                                     bound: Bounded,
-                                                                                                                    value_order: TotalOrder,
-                                                                                                                    value_retry: ExactlyOnce,
-                                                                                                                    key_type: u32,
-                                                                                                                    value_type: core :: option :: Option < i32 >,
+                                                                                                                    order: TotalOrder,
+                                                                                                                    retry: ExactlyOnce,
+                                                                                                                    element_type: (u32 , core :: option :: Option < i32 >),
                                                                                                                 },
                                                                                                             },
                                                                                                         },
                                                                                                         metadata: HydroIrMetadata {
-                                                                                                            location_id: Tick(1, Cluster(loc3v1)),
+                                                                                                            location_id: Tick(0, Cluster(loc3v1)),
                                                                                                             collection_kind: KeyedStream {
                                                                                                                 bound: Bounded,
-                                                                                                                value_order: NoOrder,
-                                                                                                                value_retry: ExactlyOnce,
-                                                                                                                key_type: u32,
-                                                                                                                value_type: core :: option :: Option < i32 >,
-                                                                                                            },
-                                                                                                        },
-                                                                                                    },
-                                                                                                    second: Batch {
-                                                                                                        inner: Map {
-                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , i32) , (u32 , core :: option :: Option < i32 >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < i32 , core :: option :: Option < i32 > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | payload | Some (payload) }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
-                                                                                                            input: CycleSource {
-                                                                                                                ident: Ident {
-                                                                                                                    sym: cycle_1,
-                                                                                                                },
-                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                    location_id: Cluster(loc3v1),
-                                                                                                                    collection_kind: KeyedStream {
-                                                                                                                        bound: Unbounded,
-                                                                                                                        value_order: NoOrder,
-                                                                                                                        value_retry: ExactlyOnce,
-                                                                                                                        key_type: u32,
-                                                                                                                        value_type: i32,
-                                                                                                                    },
-                                                                                                                },
-                                                                                                            },
-                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                location_id: Cluster(loc3v1),
-                                                                                                                collection_kind: KeyedStream {
-                                                                                                                    bound: Unbounded,
-                                                                                                                    value_order: NoOrder,
-                                                                                                                    value_retry: ExactlyOnce,
-                                                                                                                    key_type: u32,
-                                                                                                                    value_type: core :: option :: Option < i32 >,
-                                                                                                                },
-                                                                                                            },
-                                                                                                        },
-                                                                                                        metadata: HydroIrMetadata {
-                                                                                                            location_id: Tick(1, Cluster(loc3v1)),
-                                                                                                            collection_kind: KeyedStream {
-                                                                                                                bound: Bounded,
-                                                                                                                value_order: NoOrder,
+                                                                                                                value_order: TotalOrder,
                                                                                                                 value_retry: ExactlyOnce,
                                                                                                                 key_type: u32,
                                                                                                                 value_type: core :: option :: Option < i32 >,
@@ -434,9 +358,37 @@ expression: built.ir()
                                                                                                         },
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
-                                                                                                        location_id: Tick(1, Cluster(loc3v1)),
+                                                                                                        location_id: Cluster(loc3v1),
                                                                                                         collection_kind: KeyedStream {
-                                                                                                            bound: Bounded,
+                                                                                                            bound: Unbounded,
+                                                                                                            value_order: TotalOrder,
+                                                                                                            value_retry: ExactlyOnce,
+                                                                                                            key_type: u32,
+                                                                                                            value_type: core :: option :: Option < i32 >,
+                                                                                                        },
+                                                                                                    },
+                                                                                                },
+                                                                                                second: Map {
+                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , i32) , (u32 , core :: option :: Option < i32 >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < i32 , core :: option :: Option < i32 > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | payload | Some (payload) }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
+                                                                                                    input: CycleSource {
+                                                                                                        ident: Ident {
+                                                                                                            sym: cycle_1,
+                                                                                                        },
+                                                                                                        metadata: HydroIrMetadata {
+                                                                                                            location_id: Cluster(loc3v1),
+                                                                                                            collection_kind: KeyedStream {
+                                                                                                                bound: Unbounded,
+                                                                                                                value_order: NoOrder,
+                                                                                                                value_retry: ExactlyOnce,
+                                                                                                                key_type: u32,
+                                                                                                                value_type: i32,
+                                                                                                            },
+                                                                                                        },
+                                                                                                    },
+                                                                                                    metadata: HydroIrMetadata {
+                                                                                                        location_id: Cluster(loc3v1),
+                                                                                                        collection_kind: KeyedStream {
+                                                                                                            bound: Unbounded,
                                                                                                             value_order: NoOrder,
                                                                                                             value_retry: ExactlyOnce,
                                                                                                             key_type: u32,
@@ -519,7 +471,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(2, Process(loc1v1)),
+                                                                        location_id: Tick(1, Process(loc1v1)),
                                                                         collection_kind: Stream {
                                                                             bound: Bounded,
                                                                             order: NoOrder,
@@ -529,7 +481,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(2, Process(loc1v1)),
+                                                                    location_id: Tick(1, Process(loc1v1)),
                                                                     collection_kind: Stream {
                                                                         bound: Bounded,
                                                                         order: NoOrder,
@@ -539,7 +491,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(2, Process(loc1v1)),
+                                                                location_id: Tick(1, Process(loc1v1)),
                                                                 collection_kind: KeyedStream {
                                                                     bound: Bounded,
                                                                     value_order: NoOrder,
@@ -632,7 +584,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(3, Process(loc1v1)),
+                            location_id: Tick(2, Process(loc1v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -642,7 +594,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(3, Process(loc1v1)),
+                        location_id: Tick(2, Process(loc1v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: NoOrder,
@@ -652,7 +604,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(3, Process(loc1v1)),
+                    location_id: Tick(2, Process(loc1v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -675,7 +627,7 @@ expression: built.ir()
                                             inner: Tee {
                                                 inner: <tee 1>,
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(3, Process(loc1v1)),
+                                                    location_id: Tick(2, Process(loc1v1)),
                                                     collection_kind: Stream {
                                                         bound: Bounded,
                                                         order: NoOrder,
@@ -685,7 +637,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(3, Process(loc1v1)),
+                                                location_id: Tick(2, Process(loc1v1)),
                                                 collection_kind: KeyedStream {
                                                     bound: Bounded,
                                                     value_order: NoOrder,
@@ -697,7 +649,7 @@ expression: built.ir()
                                         },
                                         trusted: false,
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(3, Process(loc1v1)),
+                                            location_id: Tick(2, Process(loc1v1)),
                                             collection_kind: KeyedStream {
                                                 bound: Bounded,
                                                 value_order: TotalOrder,
@@ -708,7 +660,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(3, Process(loc1v1)),
+                                        location_id: Tick(2, Process(loc1v1)),
                                         collection_kind: KeyedSingleton {
                                             bound: Bounded,
                                             key_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)),
@@ -717,7 +669,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(3, Process(loc1v1)),
+                                    location_id: Tick(2, Process(loc1v1)),
                                     collection_kind: KeyedSingleton {
                                         bound: Bounded,
                                         key_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)),
@@ -726,7 +678,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(3, Process(loc1v1)),
+                                location_id: Tick(2, Process(loc1v1)),
                                 collection_kind: KeyedStream {
                                     bound: Bounded,
                                     value_order: TotalOrder,
@@ -737,7 +689,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(3, Process(loc1v1)),
+                            location_id: Tick(2, Process(loc1v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -747,7 +699,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(3, Process(loc1v1)),
+                        location_id: Tick(2, Process(loc1v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: NoOrder,
@@ -757,7 +709,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(3, Process(loc1v1)),
+                    location_id: Tick(2, Process(loc1v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -767,7 +719,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(3, Process(loc1v1)),
+                location_id: Tick(2, Process(loc1v1)),
                 collection_kind: Stream {
                     bound: Bounded,
                     order: NoOrder,
@@ -788,7 +740,7 @@ expression: built.ir()
                     sym: cycle_3,
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(3, Process(loc1v1)),
+                    location_id: Tick(2, Process(loc1v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -798,7 +750,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(3, Process(loc1v1)),
+                location_id: Tick(2, Process(loc1v1)),
                 collection_kind: Stream {
                     bound: Bounded,
                     order: NoOrder,
@@ -822,7 +774,7 @@ expression: built.ir()
                                 sym: cycle_4,
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(5, Process(loc1v1)),
+                                location_id: Tick(4, Process(loc1v1)),
                                 collection_kind: Stream {
                                     bound: Bounded,
                                     order: NoOrder,
@@ -832,7 +784,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(5, Process(loc1v1)),
+                            location_id: Tick(4, Process(loc1v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -929,7 +881,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(4, Process(loc1v1)),
+                                                                                            location_id: Tick(3, Process(loc1v1)),
                                                                                             collection_kind: KeyedSingleton {
                                                                                                 bound: Bounded,
                                                                                                 key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant >,
@@ -938,7 +890,7 @@ expression: built.ir()
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(4, Process(loc1v1)),
+                                                                                        location_id: Tick(3, Process(loc1v1)),
                                                                                         collection_kind: KeyedSingleton {
                                                                                             bound: Bounded,
                                                                                             key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant >,
@@ -947,7 +899,7 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(4, Process(loc1v1)),
+                                                                                    location_id: Tick(3, Process(loc1v1)),
                                                                                     collection_kind: KeyedStream {
                                                                                         bound: Bounded,
                                                                                         value_order: TotalOrder,
@@ -958,7 +910,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(4, Process(loc1v1)),
+                                                                                location_id: Tick(3, Process(loc1v1)),
                                                                                 collection_kind: Stream {
                                                                                     bound: Bounded,
                                                                                     order: NoOrder,
@@ -968,7 +920,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(4, Process(loc1v1)),
+                                                                            location_id: Tick(3, Process(loc1v1)),
                                                                             collection_kind: Stream {
                                                                                 bound: Bounded,
                                                                                 order: NoOrder,
@@ -979,7 +931,7 @@ expression: built.ir()
                                                                     },
                                                                     trusted: true,
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(4, Process(loc1v1)),
+                                                                        location_id: Tick(3, Process(loc1v1)),
                                                                         collection_kind: Stream {
                                                                             bound: Bounded,
                                                                             order: TotalOrder,
@@ -993,7 +945,7 @@ expression: built.ir()
                                                                         inner: Tee {
                                                                             inner: <tee 4>,
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(3, Process(loc1v1)),
+                                                                                location_id: Tick(2, Process(loc1v1)),
                                                                                 collection_kind: Stream {
                                                                                     bound: Bounded,
                                                                                     order: NoOrder,
@@ -1013,7 +965,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(4, Process(loc1v1)),
+                                                                        location_id: Tick(3, Process(loc1v1)),
                                                                         collection_kind: Stream {
                                                                             bound: Bounded,
                                                                             order: NoOrder,
@@ -1023,7 +975,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(4, Process(loc1v1)),
+                                                                    location_id: Tick(3, Process(loc1v1)),
                                                                     collection_kind: Stream {
                                                                         bound: Bounded,
                                                                         order: NoOrder,
@@ -1033,7 +985,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(4, Process(loc1v1)),
+                                                                location_id: Tick(3, Process(loc1v1)),
                                                                 collection_kind: KeyedStream {
                                                                     bound: Bounded,
                                                                     value_order: NoOrder,
@@ -1126,7 +1078,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(5, Process(loc1v1)),
+                            location_id: Tick(4, Process(loc1v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -1136,7 +1088,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(5, Process(loc1v1)),
+                        location_id: Tick(4, Process(loc1v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: NoOrder,
@@ -1146,7 +1098,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(5, Process(loc1v1)),
+                    location_id: Tick(4, Process(loc1v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -1169,7 +1121,7 @@ expression: built.ir()
                                             inner: Tee {
                                                 inner: <tee 6>,
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(5, Process(loc1v1)),
+                                                    location_id: Tick(4, Process(loc1v1)),
                                                     collection_kind: Stream {
                                                         bound: Bounded,
                                                         order: NoOrder,
@@ -1179,7 +1131,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(5, Process(loc1v1)),
+                                                location_id: Tick(4, Process(loc1v1)),
                                                 collection_kind: KeyedStream {
                                                     bound: Bounded,
                                                     value_order: NoOrder,
@@ -1191,7 +1143,7 @@ expression: built.ir()
                                         },
                                         trusted: false,
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(5, Process(loc1v1)),
+                                            location_id: Tick(4, Process(loc1v1)),
                                             collection_kind: KeyedStream {
                                                 bound: Bounded,
                                                 value_order: TotalOrder,
@@ -1202,7 +1154,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(5, Process(loc1v1)),
+                                        location_id: Tick(4, Process(loc1v1)),
                                         collection_kind: KeyedSingleton {
                                             bound: Bounded,
                                             key_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)),
@@ -1211,7 +1163,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(5, Process(loc1v1)),
+                                    location_id: Tick(4, Process(loc1v1)),
                                     collection_kind: KeyedSingleton {
                                         bound: Bounded,
                                         key_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)),
@@ -1220,7 +1172,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(5, Process(loc1v1)),
+                                location_id: Tick(4, Process(loc1v1)),
                                 collection_kind: KeyedStream {
                                     bound: Bounded,
                                     value_order: TotalOrder,
@@ -1231,7 +1183,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(5, Process(loc1v1)),
+                            location_id: Tick(4, Process(loc1v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -1241,7 +1193,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(5, Process(loc1v1)),
+                        location_id: Tick(4, Process(loc1v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: NoOrder,
@@ -1251,7 +1203,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(5, Process(loc1v1)),
+                    location_id: Tick(4, Process(loc1v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -1261,7 +1213,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(5, Process(loc1v1)),
+                location_id: Tick(4, Process(loc1v1)),
                 collection_kind: Stream {
                     bound: Bounded,
                     order: NoOrder,
@@ -1282,7 +1234,7 @@ expression: built.ir()
                     sym: cycle_5,
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(5, Process(loc1v1)),
+                    location_id: Tick(4, Process(loc1v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -1292,7 +1244,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(5, Process(loc1v1)),
+                location_id: Tick(4, Process(loc1v1)),
                 collection_kind: Stream {
                     bound: Bounded,
                     order: NoOrder,
@@ -1323,7 +1275,7 @@ expression: built.ir()
                             inner: Tee {
                                 inner: <tee 8>,
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(5, Process(loc1v1)),
+                                    location_id: Tick(4, Process(loc1v1)),
                                     collection_kind: Stream {
                                         bound: Bounded,
                                         order: NoOrder,
@@ -1464,7 +1416,7 @@ expression: built.ir()
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(8, Process(loc4v1)),
+                                                                                        location_id: Tick(7, Process(loc4v1)),
                                                                                         collection_kind: KeyedSingleton {
                                                                                             bound: Bounded,
                                                                                             key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client >,
@@ -1473,7 +1425,7 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(8, Process(loc4v1)),
+                                                                                    location_id: Tick(7, Process(loc4v1)),
                                                                                     collection_kind: KeyedSingleton {
                                                                                         bound: Bounded,
                                                                                         key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client >,
@@ -1482,7 +1434,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(8, Process(loc4v1)),
+                                                                                location_id: Tick(7, Process(loc4v1)),
                                                                                 collection_kind: KeyedStream {
                                                                                     bound: Bounded,
                                                                                     value_order: TotalOrder,
@@ -1493,7 +1445,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(8, Process(loc4v1)),
+                                                                            location_id: Tick(7, Process(loc4v1)),
                                                                             collection_kind: Stream {
                                                                                 bound: Bounded,
                                                                                 order: NoOrder,
@@ -1504,7 +1456,7 @@ expression: built.ir()
                                                                     },
                                                                     trusted: true,
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(8, Process(loc4v1)),
+                                                                        location_id: Tick(7, Process(loc4v1)),
                                                                         collection_kind: Stream {
                                                                             bound: Bounded,
                                                                             order: TotalOrder,
@@ -1514,7 +1466,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(8, Process(loc4v1)),
+                                                                    location_id: Tick(7, Process(loc4v1)),
                                                                     collection_kind: Singleton {
                                                                         bound: Bounded,
                                                                         element_type: usize,
@@ -1522,7 +1474,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(8, Process(loc4v1)),
+                                                                location_id: Tick(7, Process(loc4v1)),
                                                                 collection_kind: Singleton {
                                                                     bound: Bounded,
                                                                     element_type: usize,
@@ -1638,7 +1590,7 @@ expression: built.ir()
                                                                                                                                                                                                                         },
                                                                                                                                                                                                                     },
                                                                                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                                                                                        location_id: Tick(6, Cluster(loc3v1)),
+                                                                                                                                                                                                                        location_id: Tick(5, Cluster(loc3v1)),
                                                                                                                                                                                                                         collection_kind: KeyedSingleton {
                                                                                                                                                                                                                             bound: Bounded,
                                                                                                                                                                                                                             key_type: u32,
@@ -1647,7 +1599,7 @@ expression: built.ir()
                                                                                                                                                                                                                     },
                                                                                                                                                                                                                 },
                                                                                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                                                                                    location_id: Tick(6, Cluster(loc3v1)),
+                                                                                                                                                                                                                    location_id: Tick(5, Cluster(loc3v1)),
                                                                                                                                                                                                                     collection_kind: KeyedStream {
                                                                                                                                                                                                                         bound: Bounded,
                                                                                                                                                                                                                         value_order: TotalOrder,
@@ -1658,7 +1610,7 @@ expression: built.ir()
                                                                                                                                                                                                                 },
                                                                                                                                                                                                             },
                                                                                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                                                                                location_id: Tick(6, Cluster(loc3v1)),
+                                                                                                                                                                                                                location_id: Tick(5, Cluster(loc3v1)),
                                                                                                                                                                                                                 collection_kind: Stream {
                                                                                                                                                                                                                     bound: Bounded,
                                                                                                                                                                                                                     order: NoOrder,
@@ -1689,7 +1641,7 @@ expression: built.ir()
                                                                                                                                                                                                                                     },
                                                                                                                                                                                                                                 },
                                                                                                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                                                                                                    location_id: Tick(6, Cluster(loc3v1)),
+                                                                                                                                                                                                                                    location_id: Tick(5, Cluster(loc3v1)),
                                                                                                                                                                                                                                     collection_kind: KeyedStream {
                                                                                                                                                                                                                                         bound: Bounded,
                                                                                                                                                                                                                                         value_order: NoOrder,
@@ -1701,7 +1653,7 @@ expression: built.ir()
                                                                                                                                                                                                                             },
                                                                                                                                                                                                                             trusted: false,
                                                                                                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                                                                                                location_id: Tick(6, Cluster(loc3v1)),
+                                                                                                                                                                                                                                location_id: Tick(5, Cluster(loc3v1)),
                                                                                                                                                                                                                                 collection_kind: KeyedStream {
                                                                                                                                                                                                                                     bound: Bounded,
                                                                                                                                                                                                                                     value_order: TotalOrder,
@@ -1712,7 +1664,7 @@ expression: built.ir()
                                                                                                                                                                                                                             },
                                                                                                                                                                                                                         },
                                                                                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                                                                                            location_id: Tick(6, Cluster(loc3v1)),
+                                                                                                                                                                                                                            location_id: Tick(5, Cluster(loc3v1)),
                                                                                                                                                                                                                             collection_kind: KeyedSingleton {
                                                                                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                                                                                 key_type: u32,
@@ -1721,7 +1673,7 @@ expression: built.ir()
                                                                                                                                                                                                                         },
                                                                                                                                                                                                                     },
                                                                                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                                                                                        location_id: Tick(6, Cluster(loc3v1)),
+                                                                                                                                                                                                                        location_id: Tick(5, Cluster(loc3v1)),
                                                                                                                                                                                                                         collection_kind: KeyedSingleton {
                                                                                                                                                                                                                             bound: Bounded,
                                                                                                                                                                                                                             key_type: u32,
@@ -1730,7 +1682,7 @@ expression: built.ir()
                                                                                                                                                                                                                     },
                                                                                                                                                                                                                 },
                                                                                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                                                                                    location_id: Tick(6, Cluster(loc3v1)),
+                                                                                                                                                                                                                    location_id: Tick(5, Cluster(loc3v1)),
                                                                                                                                                                                                                     collection_kind: KeyedStream {
                                                                                                                                                                                                                         bound: Bounded,
                                                                                                                                                                                                                         value_order: TotalOrder,
@@ -1741,7 +1693,7 @@ expression: built.ir()
                                                                                                                                                                                                                 },
                                                                                                                                                                                                             },
                                                                                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                                                                                location_id: Tick(6, Cluster(loc3v1)),
+                                                                                                                                                                                                                location_id: Tick(5, Cluster(loc3v1)),
                                                                                                                                                                                                                 collection_kind: Stream {
                                                                                                                                                                                                                     bound: Bounded,
                                                                                                                                                                                                                     order: NoOrder,
@@ -1751,7 +1703,7 @@ expression: built.ir()
                                                                                                                                                                                                             },
                                                                                                                                                                                                         },
                                                                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                                                                            location_id: Tick(6, Cluster(loc3v1)),
+                                                                                                                                                                                                            location_id: Tick(5, Cluster(loc3v1)),
                                                                                                                                                                                                             collection_kind: Stream {
                                                                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                                                                 order: NoOrder,
@@ -1761,7 +1713,7 @@ expression: built.ir()
                                                                                                                                                                                                         },
                                                                                                                                                                                                     },
                                                                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                                                                        location_id: Tick(6, Cluster(loc3v1)),
+                                                                                                                                                                                                        location_id: Tick(5, Cluster(loc3v1)),
                                                                                                                                                                                                         collection_kind: KeyedStream {
                                                                                                                                                                                                             bound: Bounded,
                                                                                                                                                                                                             value_order: NoOrder,
@@ -1772,7 +1724,7 @@ expression: built.ir()
                                                                                                                                                                                                     },
                                                                                                                                                                                                 },
                                                                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                                                                    location_id: Tick(6, Cluster(loc3v1)),
+                                                                                                                                                                                                    location_id: Tick(5, Cluster(loc3v1)),
                                                                                                                                                                                                     collection_kind: KeyedSingleton {
                                                                                                                                                                                                         bound: Bounded,
                                                                                                                                                                                                         key_type: u32,
@@ -1781,7 +1733,7 @@ expression: built.ir()
                                                                                                                                                                                                 },
                                                                                                                                                                                             },
                                                                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                                                                location_id: Tick(6, Cluster(loc3v1)),
+                                                                                                                                                                                                location_id: Tick(5, Cluster(loc3v1)),
                                                                                                                                                                                                 collection_kind: KeyedSingleton {
                                                                                                                                                                                                     bound: Bounded,
                                                                                                                                                                                                     key_type: u32,
@@ -1790,7 +1742,7 @@ expression: built.ir()
                                                                                                                                                                                             },
                                                                                                                                                                                         },
                                                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                                                            location_id: Tick(6, Cluster(loc3v1)),
+                                                                                                                                                                                            location_id: Tick(5, Cluster(loc3v1)),
                                                                                                                                                                                             collection_kind: KeyedStream {
                                                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                                                 value_order: TotalOrder,
@@ -1801,7 +1753,7 @@ expression: built.ir()
                                                                                                                                                                                         },
                                                                                                                                                                                     },
                                                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                                                        location_id: Tick(6, Cluster(loc3v1)),
+                                                                                                                                                                                        location_id: Tick(5, Cluster(loc3v1)),
                                                                                                                                                                                         collection_kind: KeyedStream {
                                                                                                                                                                                             bound: Bounded,
                                                                                                                                                                                             value_order: NoOrder,
@@ -1853,7 +1805,7 @@ expression: built.ir()
                                                                                                                                                                     },
                                                                                                                                                                 },
                                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                                    location_id: Tick(7, Cluster(loc3v1)),
+                                                                                                                                                                    location_id: Tick(6, Cluster(loc3v1)),
                                                                                                                                                                     collection_kind: Stream {
                                                                                                                                                                         bound: Bounded,
                                                                                                                                                                         order: NoOrder,
@@ -1864,7 +1816,7 @@ expression: built.ir()
                                                                                                                                                             },
                                                                                                                                                             trusted: true,
                                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                                location_id: Tick(7, Cluster(loc3v1)),
+                                                                                                                                                                location_id: Tick(6, Cluster(loc3v1)),
                                                                                                                                                                 collection_kind: Stream {
                                                                                                                                                                     bound: Bounded,
                                                                                                                                                                     order: TotalOrder,
@@ -1874,7 +1826,7 @@ expression: built.ir()
                                                                                                                                                             },
                                                                                                                                                         },
                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(7, Cluster(loc3v1)),
+                                                                                                                                                            location_id: Tick(6, Cluster(loc3v1)),
                                                                                                                                                             collection_kind: Singleton {
                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                 element_type: usize,
@@ -1882,7 +1834,7 @@ expression: built.ir()
                                                                                                                                                         },
                                                                                                                                                     },
                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                        location_id: Tick(7, Cluster(loc3v1)),
+                                                                                                                                                        location_id: Tick(6, Cluster(loc3v1)),
                                                                                                                                                         collection_kind: Stream {
                                                                                                                                                             bound: Bounded,
                                                                                                                                                             order: TotalOrder,
@@ -1964,7 +1916,7 @@ expression: built.ir()
                                                                                                                                 },
                                                                                                                             },
                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                location_id: Tick(9, Cluster(loc3v1)),
+                                                                                                                                location_id: Tick(8, Cluster(loc3v1)),
                                                                                                                                 collection_kind: Singleton {
                                                                                                                                     bound: Bounded,
                                                                                                                                     element_type: hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage,
@@ -1991,7 +1943,7 @@ expression: built.ir()
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                        location_id: Tick(9, Cluster(loc3v1)),
+                                                                                                                                        location_id: Tick(8, Cluster(loc3v1)),
                                                                                                                                         collection_kind: Stream {
                                                                                                                                             bound: Bounded,
                                                                                                                                             order: TotalOrder,
@@ -2001,7 +1953,7 @@ expression: built.ir()
                                                                                                                                     },
                                                                                                                                 },
                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                    location_id: Tick(9, Cluster(loc3v1)),
+                                                                                                                                    location_id: Tick(8, Cluster(loc3v1)),
                                                                                                                                     collection_kind: Optional {
                                                                                                                                         bound: Bounded,
                                                                                                                                         element_type: hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
@@ -2009,7 +1961,7 @@ expression: built.ir()
                                                                                                                                 },
                                                                                                                             },
                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                location_id: Tick(9, Cluster(loc3v1)),
+                                                                                                                                location_id: Tick(8, Cluster(loc3v1)),
                                                                                                                                 collection_kind: Optional {
                                                                                                                                     bound: Bounded,
                                                                                                                                     element_type: (),
@@ -2017,7 +1969,7 @@ expression: built.ir()
                                                                                                                             },
                                                                                                                         },
                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                            location_id: Tick(9, Cluster(loc3v1)),
+                                                                                                                            location_id: Tick(8, Cluster(loc3v1)),
                                                                                                                             collection_kind: Optional {
                                                                                                                                 bound: Bounded,
                                                                                                                                 element_type: (hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage , ()),
@@ -2025,7 +1977,7 @@ expression: built.ir()
                                                                                                                         },
                                                                                                                     },
                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                        location_id: Tick(9, Cluster(loc3v1)),
+                                                                                                                        location_id: Tick(8, Cluster(loc3v1)),
                                                                                                                         collection_kind: Optional {
                                                                                                                             bound: Bounded,
                                                                                                                             element_type: hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage,
@@ -2033,7 +1985,7 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                 },
                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(9, Cluster(loc3v1)),
+                                                                                                                    location_id: Tick(8, Cluster(loc3v1)),
                                                                                                                     collection_kind: Stream {
                                                                                                                         bound: Bounded,
                                                                                                                         order: TotalOrder,
@@ -2114,7 +2066,7 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(8, Process(loc4v1)),
+                                                                                    location_id: Tick(7, Process(loc4v1)),
                                                                                     collection_kind: KeyedSingleton {
                                                                                         bound: Bounded,
                                                                                         key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client >,
@@ -2123,7 +2075,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(8, Process(loc4v1)),
+                                                                                location_id: Tick(7, Process(loc4v1)),
                                                                                 collection_kind: KeyedSingleton {
                                                                                     bound: Bounded,
                                                                                     key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client >,
@@ -2132,7 +2084,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(8, Process(loc4v1)),
+                                                                            location_id: Tick(7, Process(loc4v1)),
                                                                             collection_kind: KeyedStream {
                                                                                 bound: Bounded,
                                                                                 value_order: TotalOrder,
@@ -2143,7 +2095,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(8, Process(loc4v1)),
+                                                                        location_id: Tick(7, Process(loc4v1)),
                                                                         collection_kind: Stream {
                                                                             bound: Bounded,
                                                                             order: NoOrder,
@@ -2154,7 +2106,7 @@ expression: built.ir()
                                                                 },
                                                                 trusted: true,
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(8, Process(loc4v1)),
+                                                                    location_id: Tick(7, Process(loc4v1)),
                                                                     collection_kind: Stream {
                                                                         bound: Bounded,
                                                                         order: TotalOrder,
@@ -2164,7 +2116,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(8, Process(loc4v1)),
+                                                                location_id: Tick(7, Process(loc4v1)),
                                                                 collection_kind: Singleton {
                                                                     bound: Bounded,
                                                                     element_type: usize,
@@ -2172,7 +2124,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(8, Process(loc4v1)),
+                                                            location_id: Tick(7, Process(loc4v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: (usize , usize),
@@ -2180,7 +2132,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(8, Process(loc4v1)),
+                                                        location_id: Tick(7, Process(loc4v1)),
                                                         collection_kind: Singleton {
                                                             bound: Bounded,
                                                             element_type: (usize , usize),
@@ -2188,7 +2140,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(8, Process(loc4v1)),
+                                                    location_id: Tick(7, Process(loc4v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: usize,
@@ -2196,7 +2148,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(8, Process(loc4v1)),
+                                                location_id: Tick(7, Process(loc4v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: usize,
@@ -2204,7 +2156,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(8, Process(loc4v1)),
+                                            location_id: Tick(7, Process(loc4v1)),
                                             collection_kind: Stream {
                                                 bound: Bounded,
                                                 order: TotalOrder,
@@ -2224,7 +2176,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(10, Process(loc4v1)),
+                                    location_id: Tick(9, Process(loc4v1)),
                                     collection_kind: Stream {
                                         bound: Bounded,
                                         order: TotalOrder,
@@ -2253,7 +2205,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(10, Process(loc4v1)),
+                                            location_id: Tick(9, Process(loc4v1)),
                                             collection_kind: Stream {
                                                 bound: Bounded,
                                                 order: TotalOrder,
@@ -2263,7 +2215,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(10, Process(loc4v1)),
+                                        location_id: Tick(9, Process(loc4v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
@@ -2271,7 +2223,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(10, Process(loc4v1)),
+                                    location_id: Tick(9, Process(loc4v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: (),
@@ -2279,7 +2231,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(10, Process(loc4v1)),
+                                location_id: Tick(9, Process(loc4v1)),
                                 collection_kind: Stream {
                                     bound: Bounded,
                                     order: TotalOrder,
@@ -2289,7 +2241,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(10, Process(loc4v1)),
+                            location_id: Tick(9, Process(loc4v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: TotalOrder,
@@ -2366,7 +2318,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(11, Process(loc4v1)),
+                                                                                location_id: Tick(10, Process(loc4v1)),
                                                                                 collection_kind: KeyedSingleton {
                                                                                     bound: Bounded,
                                                                                     key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client >,
@@ -2375,7 +2327,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(11, Process(loc4v1)),
+                                                                            location_id: Tick(10, Process(loc4v1)),
                                                                             collection_kind: Stream {
                                                                                 bound: Bounded,
                                                                                 order: NoOrder,
@@ -2386,7 +2338,7 @@ expression: built.ir()
                                                                     },
                                                                     trusted: false,
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(11, Process(loc4v1)),
+                                                                        location_id: Tick(10, Process(loc4v1)),
                                                                         collection_kind: Stream {
                                                                             bound: Bounded,
                                                                             order: TotalOrder,
@@ -2396,7 +2348,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(11, Process(loc4v1)),
+                                                                    location_id: Tick(10, Process(loc4v1)),
                                                                     collection_kind: Optional {
                                                                         bound: Bounded,
                                                                         element_type: hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage,
@@ -2412,7 +2364,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(12, Process(loc4v1)),
+                                                            location_id: Tick(11, Process(loc4v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage,
@@ -2439,7 +2391,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(12, Process(loc4v1)),
+                                                                    location_id: Tick(11, Process(loc4v1)),
                                                                     collection_kind: Stream {
                                                                         bound: Bounded,
                                                                         order: TotalOrder,
@@ -2449,7 +2401,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(12, Process(loc4v1)),
+                                                                location_id: Tick(11, Process(loc4v1)),
                                                                 collection_kind: Optional {
                                                                     bound: Bounded,
                                                                     element_type: hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
@@ -2457,7 +2409,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(12, Process(loc4v1)),
+                                                            location_id: Tick(11, Process(loc4v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: (),
@@ -2465,7 +2417,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(12, Process(loc4v1)),
+                                                        location_id: Tick(11, Process(loc4v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: (hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage , ()),
@@ -2473,7 +2425,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(12, Process(loc4v1)),
+                                                    location_id: Tick(11, Process(loc4v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: rolling_average :: RollingAverage,
@@ -2481,7 +2433,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(12, Process(loc4v1)),
+                                                location_id: Tick(11, Process(loc4v1)),
                                                 collection_kind: Stream {
                                                     bound: Bounded,
                                                     order: TotalOrder,
@@ -2511,7 +2463,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(8, Process(loc4v1)),
+                                    location_id: Tick(7, Process(loc4v1)),
                                     collection_kind: Stream {
                                         bound: Bounded,
                                         order: TotalOrder,
@@ -2524,7 +2476,7 @@ expression: built.ir()
                                 inner: Tee {
                                     inner: <tee 12>,
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(8, Process(loc4v1)),
+                                        location_id: Tick(7, Process(loc4v1)),
                                         collection_kind: Singleton {
                                             bound: Bounded,
                                             element_type: usize,
@@ -2532,7 +2484,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(8, Process(loc4v1)),
+                                    location_id: Tick(7, Process(loc4v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: usize,
@@ -2540,7 +2492,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(8, Process(loc4v1)),
+                                location_id: Tick(7, Process(loc4v1)),
                                 collection_kind: Stream {
                                     bound: Bounded,
                                     order: TotalOrder,
@@ -2562,7 +2514,7 @@ expression: built.ir()
                                                 input: Tee {
                                                     inner: <tee 11>,
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(8, Process(loc4v1)),
+                                                        location_id: Tick(7, Process(loc4v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: usize,
@@ -2570,7 +2522,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(8, Process(loc4v1)),
+                                                    location_id: Tick(7, Process(loc4v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: (),
@@ -2578,7 +2530,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(8, Process(loc4v1)),
+                                                location_id: Tick(7, Process(loc4v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: core :: option :: Option < () >,
@@ -2589,7 +2541,7 @@ expression: built.ir()
                                             inner: SingletonSource {
                                                 value: :: std :: option :: Option :: None,
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(8, Process(loc4v1)),
+                                                    location_id: Tick(7, Process(loc4v1)),
                                                     collection_kind: Singleton {
                                                         bound: Bounded,
                                                         element_type: core :: option :: Option < () >,
@@ -2597,7 +2549,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(8, Process(loc4v1)),
+                                                location_id: Tick(7, Process(loc4v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: core :: option :: Option < () >,
@@ -2605,7 +2557,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(8, Process(loc4v1)),
+                                            location_id: Tick(7, Process(loc4v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: core :: option :: Option < () >,
@@ -2613,7 +2565,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(8, Process(loc4v1)),
+                                        location_id: Tick(7, Process(loc4v1)),
                                         collection_kind: Singleton {
                                             bound: Bounded,
                                             element_type: core :: option :: Option < () >,
@@ -2621,7 +2573,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(8, Process(loc4v1)),
+                                    location_id: Tick(7, Process(loc4v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: core :: option :: Option < () >,
@@ -2629,7 +2581,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(8, Process(loc4v1)),
+                                location_id: Tick(7, Process(loc4v1)),
                                 collection_kind: Optional {
                                     bound: Bounded,
                                     element_type: (),
@@ -2637,7 +2589,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(8, Process(loc4v1)),
+                            location_id: Tick(7, Process(loc4v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: TotalOrder,
@@ -2647,7 +2599,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(8, Process(loc4v1)),
+                        location_id: Tick(7, Process(loc4v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: TotalOrder,
@@ -2761,7 +2713,7 @@ expression: built.ir()
                                                                                                                             },
                                                                                                                         },
                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                            location_id: Tick(13, Cluster(loc3v1)),
+                                                                                                                            location_id: Tick(12, Cluster(loc3v1)),
                                                                                                                             collection_kind: Singleton {
                                                                                                                                 bound: Bounded,
                                                                                                                                 element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -2788,7 +2740,7 @@ expression: built.ir()
                                                                                                                                     },
                                                                                                                                 },
                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                    location_id: Tick(13, Cluster(loc3v1)),
+                                                                                                                                    location_id: Tick(12, Cluster(loc3v1)),
                                                                                                                                     collection_kind: Stream {
                                                                                                                                         bound: Bounded,
                                                                                                                                         order: TotalOrder,
@@ -2798,7 +2750,7 @@ expression: built.ir()
                                                                                                                                 },
                                                                                                                             },
                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                location_id: Tick(13, Cluster(loc3v1)),
+                                                                                                                                location_id: Tick(12, Cluster(loc3v1)),
                                                                                                                                 collection_kind: Optional {
                                                                                                                                     bound: Bounded,
                                                                                                                                     element_type: hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
@@ -2806,7 +2758,7 @@ expression: built.ir()
                                                                                                                             },
                                                                                                                         },
                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                            location_id: Tick(13, Cluster(loc3v1)),
+                                                                                                                            location_id: Tick(12, Cluster(loc3v1)),
                                                                                                                             collection_kind: Optional {
                                                                                                                                 bound: Bounded,
                                                                                                                                 element_type: (),
@@ -2814,7 +2766,7 @@ expression: built.ir()
                                                                                                                         },
                                                                                                                     },
                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                        location_id: Tick(13, Cluster(loc3v1)),
+                                                                                                                        location_id: Tick(12, Cluster(loc3v1)),
                                                                                                                         collection_kind: Optional {
                                                                                                                             bound: Bounded,
                                                                                                                             element_type: (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , ()),
@@ -2822,7 +2774,7 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                 },
                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(13, Cluster(loc3v1)),
+                                                                                                                    location_id: Tick(12, Cluster(loc3v1)),
                                                                                                                     collection_kind: Optional {
                                                                                                                         bound: Bounded,
                                                                                                                         element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -2830,7 +2782,7 @@ expression: built.ir()
                                                                                                                 },
                                                                                                             },
                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                location_id: Tick(13, Cluster(loc3v1)),
+                                                                                                                location_id: Tick(12, Cluster(loc3v1)),
                                                                                                                 collection_kind: Stream {
                                                                                                                     bound: Bounded,
                                                                                                                     order: TotalOrder,
@@ -2923,7 +2875,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(14, Process(loc4v1)),
+                                                                            location_id: Tick(13, Process(loc4v1)),
                                                                             collection_kind: KeyedSingleton {
                                                                                 bound: Bounded,
                                                                                 key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client >,
@@ -2932,7 +2884,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(14, Process(loc4v1)),
+                                                                        location_id: Tick(13, Process(loc4v1)),
                                                                         collection_kind: Stream {
                                                                             bound: Bounded,
                                                                             order: NoOrder,
@@ -2943,7 +2895,7 @@ expression: built.ir()
                                                                 },
                                                                 trusted: false,
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(14, Process(loc4v1)),
+                                                                    location_id: Tick(13, Process(loc4v1)),
                                                                     collection_kind: Stream {
                                                                         bound: Bounded,
                                                                         order: TotalOrder,
@@ -2953,7 +2905,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(14, Process(loc4v1)),
+                                                                location_id: Tick(13, Process(loc4v1)),
                                                                 collection_kind: Optional {
                                                                     bound: Bounded,
                                                                     element_type: hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 >,
@@ -2969,7 +2921,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(15, Process(loc4v1)),
+                                                        location_id: Tick(14, Process(loc4v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 >,
@@ -2996,7 +2948,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(15, Process(loc4v1)),
+                                                                location_id: Tick(14, Process(loc4v1)),
                                                                 collection_kind: Stream {
                                                                     bound: Bounded,
                                                                     order: TotalOrder,
@@ -3006,7 +2958,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(15, Process(loc4v1)),
+                                                            location_id: Tick(14, Process(loc4v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
@@ -3014,7 +2966,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(15, Process(loc4v1)),
+                                                        location_id: Tick(14, Process(loc4v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: (),
@@ -3022,7 +2974,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(15, Process(loc4v1)),
+                                                    location_id: Tick(14, Process(loc4v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: (hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , ()),
@@ -3030,7 +2982,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(15, Process(loc4v1)),
+                                                location_id: Tick(14, Process(loc4v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 >,
@@ -3038,7 +2990,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(15, Process(loc4v1)),
+                                            location_id: Tick(14, Process(loc4v1)),
                                             collection_kind: Stream {
                                                 bound: Bounded,
                                                 order: TotalOrder,
@@ -3068,7 +3020,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(8, Process(loc4v1)),
+                                location_id: Tick(7, Process(loc4v1)),
                                 collection_kind: Stream {
                                     bound: Bounded,
                                     order: TotalOrder,
@@ -3090,7 +3042,7 @@ expression: built.ir()
                                                 input: Tee {
                                                     inner: <tee 11>,
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(8, Process(loc4v1)),
+                                                        location_id: Tick(7, Process(loc4v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: usize,
@@ -3098,7 +3050,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(8, Process(loc4v1)),
+                                                    location_id: Tick(7, Process(loc4v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: (),
@@ -3106,7 +3058,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(8, Process(loc4v1)),
+                                                location_id: Tick(7, Process(loc4v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: core :: option :: Option < () >,
@@ -3117,7 +3069,7 @@ expression: built.ir()
                                             inner: SingletonSource {
                                                 value: :: std :: option :: Option :: None,
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(8, Process(loc4v1)),
+                                                    location_id: Tick(7, Process(loc4v1)),
                                                     collection_kind: Singleton {
                                                         bound: Bounded,
                                                         element_type: core :: option :: Option < () >,
@@ -3125,7 +3077,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(8, Process(loc4v1)),
+                                                location_id: Tick(7, Process(loc4v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: core :: option :: Option < () >,
@@ -3133,7 +3085,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(8, Process(loc4v1)),
+                                            location_id: Tick(7, Process(loc4v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: core :: option :: Option < () >,
@@ -3141,7 +3093,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(8, Process(loc4v1)),
+                                        location_id: Tick(7, Process(loc4v1)),
                                         collection_kind: Singleton {
                                             bound: Bounded,
                                             element_type: core :: option :: Option < () >,
@@ -3149,7 +3101,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(8, Process(loc4v1)),
+                                    location_id: Tick(7, Process(loc4v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: core :: option :: Option < () >,
@@ -3157,7 +3109,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(8, Process(loc4v1)),
+                                location_id: Tick(7, Process(loc4v1)),
                                 collection_kind: Optional {
                                     bound: Bounded,
                                     element_type: (),
@@ -3165,7 +3117,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(8, Process(loc4v1)),
+                            location_id: Tick(7, Process(loc4v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: TotalOrder,
@@ -3175,7 +3127,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(8, Process(loc4v1)),
+                        location_id: Tick(7, Process(loc4v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: TotalOrder,

--- a/hydro_test/src/cluster/snapshots/two_pc_ir@coordinator_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/two_pc_ir@coordinator_mermaid.snap
@@ -139,20 +139,12 @@ subgraph var_cycle_5 ["var <tt>cycle_5</tt>"]
     style var_cycle_5 fill:transparent
     50v1
 end
-subgraph var_stream_102 ["var <tt>stream_102</tt>"]
-    style var_stream_102 fill:transparent
-    45v1
-end
-subgraph var_stream_103 ["var <tt>stream_103</tt>"]
-    style var_stream_103 fill:transparent
-    46v1
-end
-subgraph var_stream_104 ["var <tt>stream_104</tt>"]
-    style var_stream_104 fill:transparent
+subgraph var_stream_100 ["var <tt>stream_100</tt>"]
+    style var_stream_100 fill:transparent
     47v1
 end
-subgraph var_stream_106 ["var <tt>stream_106</tt>"]
-    style var_stream_106 fill:transparent
+subgraph var_stream_102 ["var <tt>stream_102</tt>"]
+    style var_stream_102 fill:transparent
     49v1
 end
 subgraph var_stream_13 ["var <tt>stream_13</tt>"]
@@ -179,106 +171,114 @@ subgraph var_stream_22 ["var <tt>stream_22</tt>"]
     style var_stream_22 fill:transparent
     6v1
 end
-subgraph var_stream_38 ["var <tt>stream_38</tt>"]
-    style var_stream_38 fill:transparent
+subgraph var_stream_34 ["var <tt>stream_34</tt>"]
+    style var_stream_34 fill:transparent
     8v1
     7v1
 end
-subgraph var_stream_42 ["var <tt>stream_42</tt>"]
-    style var_stream_42 fill:transparent
+subgraph var_stream_38 ["var <tt>stream_38</tt>"]
+    style var_stream_38 fill:transparent
     9v1
 end
-subgraph var_stream_46 ["var <tt>stream_46</tt>"]
-    style var_stream_46 fill:transparent
+subgraph var_stream_42 ["var <tt>stream_42</tt>"]
+    style var_stream_42 fill:transparent
     13v1
     12v1
 end
+subgraph var_stream_45 ["var <tt>stream_45</tt>"]
+    style var_stream_45 fill:transparent
+    14v1
+end
+subgraph var_stream_46 ["var <tt>stream_46</tt>"]
+    style var_stream_46 fill:transparent
+    15v1
+end
 subgraph var_stream_49 ["var <tt>stream_49</tt>"]
     style var_stream_49 fill:transparent
-    14v1
+    17v1
 end
 subgraph var_stream_50 ["var <tt>stream_50</tt>"]
     style var_stream_50 fill:transparent
-    15v1
-end
-subgraph var_stream_53 ["var <tt>stream_53</tt>"]
-    style var_stream_53 fill:transparent
-    17v1
+    18v1
 end
 subgraph var_stream_54 ["var <tt>stream_54</tt>"]
     style var_stream_54 fill:transparent
-    18v1
+    19v1
 end
 subgraph var_stream_58 ["var <tt>stream_58</tt>"]
     style var_stream_58 fill:transparent
-    19v1
+    21v1
+end
+subgraph var_stream_59 ["var <tt>stream_59</tt>"]
+    style var_stream_59 fill:transparent
+    22v1
+end
+subgraph var_stream_60 ["var <tt>stream_60</tt>"]
+    style var_stream_60 fill:transparent
+    23v1
 end
 subgraph var_stream_62 ["var <tt>stream_62</tt>"]
     style var_stream_62 fill:transparent
-    21v1
-end
-subgraph var_stream_63 ["var <tt>stream_63</tt>"]
-    style var_stream_63 fill:transparent
-    22v1
+    25v1
 end
 subgraph var_stream_64 ["var <tt>stream_64</tt>"]
     style var_stream_64 fill:transparent
-    23v1
+    27v1
+end
+subgraph var_stream_65 ["var <tt>stream_65</tt>"]
+    style var_stream_65 fill:transparent
+    28v1
 end
 subgraph var_stream_66 ["var <tt>stream_66</tt>"]
     style var_stream_66 fill:transparent
-    25v1
+    29v1
 end
 subgraph var_stream_68 ["var <tt>stream_68</tt>"]
     style var_stream_68 fill:transparent
-    27v1
-end
-subgraph var_stream_69 ["var <tt>stream_69</tt>"]
-    style var_stream_69 fill:transparent
-    28v1
+    30v1
 end
 subgraph var_stream_70 ["var <tt>stream_70</tt>"]
     style var_stream_70 fill:transparent
-    29v1
-end
-subgraph var_stream_72 ["var <tt>stream_72</tt>"]
-    style var_stream_72 fill:transparent
-    30v1
-end
-subgraph var_stream_74 ["var <tt>stream_74</tt>"]
-    style var_stream_74 fill:transparent
     31v1
 end
-subgraph var_stream_77 ["var <tt>stream_77</tt>"]
-    style var_stream_77 fill:transparent
+subgraph var_stream_73 ["var <tt>stream_73</tt>"]
+    style var_stream_73 fill:transparent
     32v1
+end
+subgraph var_stream_78 ["var <tt>stream_78</tt>"]
+    style var_stream_78 fill:transparent
+    33v1
 end
 subgraph var_stream_82 ["var <tt>stream_82</tt>"]
     style var_stream_82 fill:transparent
-    33v1
-end
-subgraph var_stream_86 ["var <tt>stream_86</tt>"]
-    style var_stream_86 fill:transparent
     37v1
     36v1
 end
+subgraph var_stream_85 ["var <tt>stream_85</tt>"]
+    style var_stream_85 fill:transparent
+    38v1
+end
+subgraph var_stream_86 ["var <tt>stream_86</tt>"]
+    style var_stream_86 fill:transparent
+    39v1
+end
 subgraph var_stream_89 ["var <tt>stream_89</tt>"]
     style var_stream_89 fill:transparent
-    38v1
+    41v1
 end
 subgraph var_stream_90 ["var <tt>stream_90</tt>"]
     style var_stream_90 fill:transparent
-    39v1
-end
-subgraph var_stream_93 ["var <tt>stream_93</tt>"]
-    style var_stream_93 fill:transparent
-    41v1
+    42v1
 end
 subgraph var_stream_94 ["var <tt>stream_94</tt>"]
     style var_stream_94 fill:transparent
-    42v1
+    43v1
 end
 subgraph var_stream_98 ["var <tt>stream_98</tt>"]
     style var_stream_98 fill:transparent
-    43v1
+    45v1
+end
+subgraph var_stream_99 ["var <tt>stream_99</tt>"]
+    style var_stream_99 fill:transparent
+    46v1
 end

--- a/hydro_test/src/cluster/snapshots/two_pc_ir@participants_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/two_pc_ir@participants_mermaid.snap
@@ -26,13 +26,13 @@ linkStyle default stroke:#aaa
 4v1
 7v1
 8v1
-subgraph var_stream_45 ["var <tt>stream_45</tt>"]
-    style var_stream_45 fill:transparent
+subgraph var_stream_41 ["var <tt>stream_41</tt>"]
+    style var_stream_41 fill:transparent
     1v1
     2v1
 end
-subgraph var_stream_85 ["var <tt>stream_85</tt>"]
-    style var_stream_85 fill:transparent
+subgraph var_stream_81 ["var <tt>stream_81</tt>"]
+    style var_stream_81 fill:transparent
     5v1
     6v1
 end


### PR DESCRIPTION

Follows the same pattern as support for `Stream`. Because cross-key cycles are possible, we can only emit one entry at a time.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydro-project/hydro/pull/2523).
* #2526
* __->__ #2523