### PR TITLE
fix(hydro_lang): support `assume_ordering` in atomic locations and block top-level bounded

### DIFF
--- a/hydro_lang/src/sim/builder.rs
+++ b/hydro_lang/src/sim/builder.rs
@@ -509,9 +509,24 @@ impl DfirBuilder for SimBuilder {
                 None,
                 None,
             );
-        } else if !location.is_top_level() {
+        } else if !location.is_root() || in_kind.is_bounded() {
+            // situations where all pending elements should be processed at once
+            if location.is_root() && in_kind.is_bounded() {
+                todo!(
+                    "observe_nondet with top-level bounded input not yet supported for kinds {:?} -> {:?}",
+                    in_kind,
+                    out_kind
+                )
+            }
+
             let (assume_location, line, caret) = location_for_op(op_meta);
             let root = get_this_crate();
+
+            let location = if let LocationId::Atomic(tick) = location {
+                tick.as_ref()
+            } else {
+                location
+            };
 
             match (in_kind, out_kind) {
                 (

--- a/hydro_lang/src/sim/runtime.rs
+++ b/hydro_lang/src/sim/runtime.rs
@@ -796,7 +796,7 @@ impl<T> SimInlineHook for StreamOrderHook<T> {
             if !to_release.is_empty() {
                 let (batch_location, line, caret_indent) = self.batch_location;
                 let note_str = format!(
-                    "^ ordered items: {:?}",
+                    "^ observed non-deterministic order: {:?}",
                     TruncatedVecDebug(RefCell::new(Some(to_release.iter())), 8, self.format_debug)
                 );
 
@@ -906,7 +906,7 @@ impl<K: Hash + Eq + Clone, V> SimInlineHook for KeyedStreamOrderHook<K, V> {
                     }
                     note_str.push_str(&entry_text);
                 }
-                note_str = format!("^ ordered items: {{ {} }}", note_str);
+                note_str = format!("^ observed non-deterministic order: {{ {} }}", note_str);
 
                 let _ = writeln!(
                     log_writer,


### PR DESCRIPTION

Will address top-level bounded collections in a later PR, but we need to disable support for now to avoid soundness bugs.
