### PR TITLE
refactor(hydro_lang): remove assumption that `use` always has two parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1492,6 +1492,7 @@ name = "copy_span"
 version = "0.1.0"
 dependencies = [
  "proc-macro2",
+ "quote",
  "syn 2.0.111",
 ]
 

--- a/copy_span/Cargo.toml
+++ b/copy_span/Cargo.toml
@@ -17,3 +17,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.95"
 syn = { version = "2", features = [ "parsing", "extra-traits" ] }
+quote = "1"

--- a/copy_span/src/lib.rs
+++ b/copy_span/src/lib.rs
@@ -1,16 +1,26 @@
+use quote::ToTokens;
 use syn::spanned::Spanned;
 
 struct CopySpanInput {
-    source: syn::Expr,
+    sources: Vec<syn::Expr>,
     target: proc_macro2::TokenStream,
 }
 
 impl syn::parse::Parse for CopySpanInput {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-        let source: syn::Expr = input.parse()?;
-        input.parse::<syn::Token![,]>()?;
-        let target: proc_macro2::TokenStream = input.parse()?;
-        Ok(CopySpanInput { source, target })
+        let mut sources = vec![];
+        loop {
+            let next_source: syn::Expr = input.parse()?;
+
+            if input.parse::<syn::Token![,]>().is_ok() {
+                sources.push(next_source);
+            } else {
+                return Ok(CopySpanInput {
+                    sources,
+                    target: next_source.to_token_stream(),
+                });
+            }
+        }
     }
 }
 
@@ -38,17 +48,30 @@ fn recursively_set_span(token: &mut proc_macro2::TokenTree, span: proc_macro2::S
 
 #[proc_macro]
 pub fn copy_span(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let CopySpanInput { source, target } = syn::parse_macro_input!(input as CopySpanInput);
+    let CopySpanInput { sources, target } = syn::parse_macro_input!(input as CopySpanInput);
 
-    let mut inner_source = source;
-    while let syn::Expr::Group(g) = inner_source {
-        inner_source = *g.expr;
+    let mut combined_span = None;
+    for mut inner_source in sources {
+        while let syn::Expr::Group(g) = inner_source {
+            inner_source = *g.expr;
+        }
+
+        if combined_span.is_none() {
+            combined_span = Some(inner_source.span());
+        } else {
+            combined_span = Some(
+                combined_span
+                    .unwrap()
+                    .join(inner_source.span())
+                    .unwrap_or(combined_span.unwrap()),
+            );
+        }
     }
 
     let output = target
         .into_iter()
         .fold(proc_macro2::TokenStream::new(), |mut acc, mut token| {
-            recursively_set_span(&mut token, inner_source.span());
+            recursively_set_span(&mut token, combined_span.unwrap());
             acc.extend(std::iter::once(token));
             acc
         });

--- a/hydro_lang/src/live_collections/sliced/style.rs
+++ b/hydro_lang/src/live_collections/sliced/style.rs
@@ -1,0 +1,399 @@
+//! Styled wrappers for live collections used with the `sliced!` macro.
+//!
+//! This module provides wrapper types that store both a collection and its associated
+//! non-determinism guard, allowing the nondet to be properly passed through during slicing.
+
+use super::Slicable;
+#[cfg(stageleft_runtime)]
+use crate::forward_handle::{CycleCollection, CycleCollectionWithInitial};
+use crate::forward_handle::{TickCycle, TickCycleHandle};
+use crate::live_collections::boundedness::{Bounded, Boundedness, Unbounded};
+use crate::live_collections::keyed_singleton::BoundedValue;
+use crate::live_collections::stream::{Ordering, Retries};
+use crate::location::tick::{DeferTick, Tick};
+use crate::location::{Location, NoTick};
+use crate::nondet::NonDet;
+
+/// Default style wrapper that stores a collection and its non-determinism guard.
+///
+/// This is used by the `sliced!` macro when no explicit style is specified.
+pub struct Default<T> {
+    pub(crate) collection: T,
+    pub(crate) nondet: NonDet,
+}
+
+impl<T> Default<T> {
+    /// Creates a new default-styled wrapper.
+    pub fn new(collection: T, nondet: NonDet) -> Self {
+        Self { collection, nondet }
+    }
+}
+
+/// Helper function for unstyled `use` in `sliced!` macro - wraps the collection in Default style.
+#[doc(hidden)]
+pub fn default<T>(t: T, nondet: NonDet) -> Default<T> {
+    Default::new(t, nondet)
+}
+
+/// Atomic style wrapper that stores a collection and its non-determinism guard.
+///
+/// This is used by the `sliced!` macro when `use::atomic(...)` is specified.
+pub struct Atomic<T> {
+    pub(crate) collection: T,
+    pub(crate) nondet: NonDet,
+}
+
+impl<T> Atomic<T> {
+    /// Creates a new atomic-styled wrapper.
+    pub fn new(collection: T, nondet: NonDet) -> Self {
+        Self { collection, nondet }
+    }
+}
+
+/// Wraps a live collection to be treated atomically during slicing.
+pub fn atomic<T>(t: T, nondet: NonDet) -> Atomic<T> {
+    Atomic::new(t, nondet)
+}
+
+/// Creates a stateful cycle with an initial value for use in `sliced!`.
+///
+/// The initial value is computed from a closure that receives the location
+/// for the body of the slice.
+///
+/// The initial value is used on the first iteration, and subsequent iterations receive
+/// the value assigned to the mutable binding at the end of the previous iteration.
+#[cfg(stageleft_runtime)]
+#[expect(
+    private_bounds,
+    reason = "only Hydro collections can implement CycleCollectionWithInitial"
+)]
+pub fn state<
+    'a,
+    S: CycleCollectionWithInitial<'a, TickCycle, Location = Tick<L>>,
+    L: Location<'a> + NoTick,
+>(
+    tick: &Tick<L>,
+    initial_fn: impl FnOnce(&Tick<L>) -> S,
+) -> (TickCycleHandle<'a, S>, S) {
+    let initial = initial_fn(tick);
+    tick.cycle_with_initial(initial)
+}
+
+/// Creates a stateful cycle without an initial value for use in `sliced!`.
+///
+/// On the first iteration, the state will be null/empty. Subsequent iterations receive
+/// the value assigned to the mutable binding at the end of the previous iteration.
+#[cfg(stageleft_runtime)]
+#[expect(
+    private_bounds,
+    reason = "only Hydro collections can implement CycleCollection"
+)]
+pub fn state_null<
+    'a,
+    S: CycleCollection<'a, TickCycle, Location = Tick<L>> + DeferTick,
+    L: Location<'a> + NoTick,
+>(
+    tick: &Tick<L>,
+) -> (TickCycleHandle<'a, S>, S) {
+    tick.cycle::<S>()
+}
+
+// ============================================================================
+// Default style Slicable implementations
+// ============================================================================
+
+impl<'a, T, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries> Slicable<'a, L>
+    for Default<crate::live_collections::Stream<T, L, B, O, R>>
+{
+    type Slice = crate::live_collections::Stream<T, Tick<L>, Bounded, O, R>;
+    type Backtrace = crate::compile::ir::backtrace::Backtrace;
+
+    fn get_location(&self) -> &L {
+        self.collection.location()
+    }
+
+    fn preferred_tick(&self) -> Option<Tick<L>> {
+        None
+    }
+
+    fn slice(self, tick: &Tick<L>, backtrace: Self::Backtrace) -> Self::Slice {
+        let out = self.collection.batch(tick, self.nondet);
+        out.ir_node.borrow_mut().op_metadata_mut().backtrace = backtrace;
+        out
+    }
+}
+
+impl<'a, T, L: Location<'a>, B: Boundedness> Slicable<'a, L>
+    for Default<crate::live_collections::Singleton<T, L, B>>
+{
+    type Slice = crate::live_collections::Singleton<T, Tick<L>, Bounded>;
+    type Backtrace = crate::compile::ir::backtrace::Backtrace;
+
+    fn get_location(&self) -> &L {
+        self.collection.location()
+    }
+
+    fn preferred_tick(&self) -> Option<Tick<L>> {
+        None
+    }
+
+    fn slice(self, tick: &Tick<L>, backtrace: Self::Backtrace) -> Self::Slice {
+        let out = self.collection.snapshot(tick, self.nondet);
+        out.ir_node.borrow_mut().op_metadata_mut().backtrace = backtrace;
+        out
+    }
+}
+
+impl<'a, T, L: Location<'a>, B: Boundedness> Slicable<'a, L>
+    for Default<crate::live_collections::Optional<T, L, B>>
+{
+    type Slice = crate::live_collections::Optional<T, Tick<L>, Bounded>;
+    type Backtrace = crate::compile::ir::backtrace::Backtrace;
+
+    fn get_location(&self) -> &L {
+        self.collection.location()
+    }
+
+    fn preferred_tick(&self) -> Option<Tick<L>> {
+        None
+    }
+
+    fn slice(self, tick: &Tick<L>, backtrace: Self::Backtrace) -> Self::Slice {
+        let out = self.collection.snapshot(tick, self.nondet);
+        out.ir_node.borrow_mut().op_metadata_mut().backtrace = backtrace;
+        out
+    }
+}
+
+impl<'a, K, V, L: Location<'a>, O: Ordering, R: Retries> Slicable<'a, L>
+    for Default<crate::live_collections::KeyedStream<K, V, L, Unbounded, O, R>>
+{
+    type Slice = crate::live_collections::KeyedStream<K, V, Tick<L>, Bounded, O, R>;
+    type Backtrace = crate::compile::ir::backtrace::Backtrace;
+
+    fn get_location(&self) -> &L {
+        self.collection.location()
+    }
+
+    fn preferred_tick(&self) -> Option<Tick<L>> {
+        None
+    }
+
+    fn slice(self, tick: &Tick<L>, backtrace: Self::Backtrace) -> Self::Slice {
+        let out = self.collection.batch(tick, self.nondet);
+        out.ir_node.borrow_mut().op_metadata_mut().backtrace = backtrace;
+        out
+    }
+}
+
+impl<'a, K, V, L: Location<'a>> Slicable<'a, L>
+    for Default<crate::live_collections::KeyedSingleton<K, V, L, Unbounded>>
+{
+    type Slice = crate::live_collections::KeyedSingleton<K, V, Tick<L>, Bounded>;
+    type Backtrace = crate::compile::ir::backtrace::Backtrace;
+
+    fn get_location(&self) -> &L {
+        self.collection.location()
+    }
+
+    fn preferred_tick(&self) -> Option<Tick<L>> {
+        None
+    }
+
+    fn slice(self, tick: &Tick<L>, backtrace: Self::Backtrace) -> Self::Slice {
+        let out = self.collection.snapshot(tick, self.nondet);
+        out.ir_node.borrow_mut().op_metadata_mut().backtrace = backtrace;
+        out
+    }
+}
+
+impl<'a, K, V, L: Location<'a> + NoTick> Slicable<'a, L>
+    for Default<crate::live_collections::KeyedSingleton<K, V, L, BoundedValue>>
+{
+    type Slice = crate::live_collections::KeyedSingleton<K, V, Tick<L>, Bounded>;
+    type Backtrace = crate::compile::ir::backtrace::Backtrace;
+
+    fn get_location(&self) -> &L {
+        self.collection.location()
+    }
+
+    fn preferred_tick(&self) -> Option<Tick<L>> {
+        None
+    }
+
+    fn slice(self, tick: &Tick<L>, backtrace: Self::Backtrace) -> Self::Slice {
+        let out = self.collection.batch(tick, self.nondet);
+        out.ir_node.borrow_mut().op_metadata_mut().backtrace = backtrace;
+        out
+    }
+}
+
+// ============================================================================
+// Atomic style Slicable implementations
+// ============================================================================
+
+impl<'a, T, L: Location<'a> + NoTick, O: Ordering, R: Retries> Slicable<'a, L>
+    for Atomic<crate::live_collections::Stream<T, crate::location::Atomic<L>, Unbounded, O, R>>
+{
+    type Slice = crate::live_collections::Stream<T, Tick<L>, Bounded, O, R>;
+    type Backtrace = crate::compile::ir::backtrace::Backtrace;
+
+    fn preferred_tick(&self) -> Option<Tick<L>> {
+        Some(self.collection.location().tick.clone())
+    }
+
+    fn get_location(&self) -> &L {
+        panic!("Atomic location has no accessible inner location")
+    }
+
+    fn slice(self, tick: &Tick<L>, backtrace: Self::Backtrace) -> Self::Slice {
+        assert_eq!(
+            self.collection.location().tick.id(),
+            tick.id(),
+            "Mismatched tick for atomic slicing"
+        );
+
+        let out = self.collection.batch_atomic(self.nondet);
+        out.ir_node.borrow_mut().op_metadata_mut().backtrace = backtrace;
+        out
+    }
+}
+
+impl<'a, T, L: Location<'a> + NoTick> Slicable<'a, L>
+    for Atomic<crate::live_collections::Singleton<T, crate::location::Atomic<L>, Unbounded>>
+{
+    type Slice = crate::live_collections::Singleton<T, Tick<L>, Bounded>;
+    type Backtrace = crate::compile::ir::backtrace::Backtrace;
+
+    fn preferred_tick(&self) -> Option<Tick<L>> {
+        Some(self.collection.location().tick.clone())
+    }
+
+    fn get_location(&self) -> &L {
+        panic!("Atomic location has no accessible inner location")
+    }
+
+    fn slice(self, tick: &Tick<L>, backtrace: Self::Backtrace) -> Self::Slice {
+        assert_eq!(
+            self.collection.location().tick.id(),
+            tick.id(),
+            "Mismatched tick for atomic slicing"
+        );
+
+        let out = self.collection.snapshot_atomic(self.nondet);
+        out.ir_node.borrow_mut().op_metadata_mut().backtrace = backtrace;
+        out
+    }
+}
+
+impl<'a, T, L: Location<'a> + NoTick> Slicable<'a, L>
+    for Atomic<crate::live_collections::Optional<T, crate::location::Atomic<L>, Unbounded>>
+{
+    type Slice = crate::live_collections::Optional<T, Tick<L>, Bounded>;
+    type Backtrace = crate::compile::ir::backtrace::Backtrace;
+
+    fn preferred_tick(&self) -> Option<Tick<L>> {
+        Some(self.collection.location().tick.clone())
+    }
+
+    fn get_location(&self) -> &L {
+        panic!("Atomic location has no accessible inner location")
+    }
+
+    fn slice(self, tick: &Tick<L>, backtrace: Self::Backtrace) -> Self::Slice {
+        assert_eq!(
+            self.collection.location().tick.id(),
+            tick.id(),
+            "Mismatched tick for atomic slicing"
+        );
+
+        let out = self.collection.snapshot_atomic(self.nondet);
+        out.ir_node.borrow_mut().op_metadata_mut().backtrace = backtrace;
+        out
+    }
+}
+
+impl<'a, K, V, L: Location<'a> + NoTick, O: Ordering, R: Retries> Slicable<'a, L>
+    for Atomic<
+        crate::live_collections::KeyedStream<K, V, crate::location::Atomic<L>, Unbounded, O, R>,
+    >
+{
+    type Slice = crate::live_collections::KeyedStream<K, V, Tick<L>, Bounded, O, R>;
+    type Backtrace = crate::compile::ir::backtrace::Backtrace;
+
+    fn preferred_tick(&self) -> Option<Tick<L>> {
+        Some(self.collection.location().tick.clone())
+    }
+
+    fn get_location(&self) -> &L {
+        panic!("Atomic location has no accessible inner location")
+    }
+
+    fn slice(self, tick: &Tick<L>, backtrace: Self::Backtrace) -> Self::Slice {
+        assert_eq!(
+            self.collection.location().tick.id(),
+            tick.id(),
+            "Mismatched tick for atomic slicing"
+        );
+
+        let out = self.collection.batch_atomic(self.nondet);
+        out.ir_node.borrow_mut().op_metadata_mut().backtrace = backtrace;
+        out
+    }
+}
+
+impl<'a, K, V, L: Location<'a> + NoTick> Slicable<'a, L>
+    for Atomic<crate::live_collections::KeyedSingleton<K, V, crate::location::Atomic<L>, Unbounded>>
+{
+    type Slice = crate::live_collections::KeyedSingleton<K, V, Tick<L>, Bounded>;
+    type Backtrace = crate::compile::ir::backtrace::Backtrace;
+
+    fn preferred_tick(&self) -> Option<Tick<L>> {
+        Some(self.collection.location().tick.clone())
+    }
+
+    fn get_location(&self) -> &L {
+        panic!("Atomic location has no accessible inner location")
+    }
+
+    fn slice(self, tick: &Tick<L>, backtrace: Self::Backtrace) -> Self::Slice {
+        assert_eq!(
+            self.collection.location().tick.id(),
+            tick.id(),
+            "Mismatched tick for atomic slicing"
+        );
+
+        let out = self.collection.snapshot_atomic(self.nondet);
+        out.ir_node.borrow_mut().op_metadata_mut().backtrace = backtrace;
+        out
+    }
+}
+
+impl<'a, K, V, L: Location<'a> + NoTick> Slicable<'a, L>
+    for Atomic<
+        crate::live_collections::KeyedSingleton<K, V, crate::location::Atomic<L>, BoundedValue>,
+    >
+{
+    type Slice = crate::live_collections::KeyedSingleton<K, V, Tick<L>, Bounded>;
+    type Backtrace = crate::compile::ir::backtrace::Backtrace;
+
+    fn preferred_tick(&self) -> Option<Tick<L>> {
+        Some(self.collection.location().tick.clone())
+    }
+
+    fn get_location(&self) -> &L {
+        panic!("Atomic location has no accessible inner location")
+    }
+
+    fn slice(self, tick: &Tick<L>, backtrace: Self::Backtrace) -> Self::Slice {
+        assert_eq!(
+            self.collection.location().tick.id(),
+            tick.id(),
+            "Mismatched tick for atomic slicing"
+        );
+
+        let out = self.collection.batch_atomic(self.nondet);
+        out.ir_node.borrow_mut().op_metadata_mut().backtrace = backtrace;
+        out
+    }
+}


### PR DESCRIPTION

Also includes some refactoring of the macro to simplify it.

Includes a change to `copy_span` to take several expressions to copy the span from.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydro-project/hydro/pull/2530).
* #2531
* __->__ #2530