### PR TITLE
feat(hydro_lang): improve quality of error spans in `sliced!` macro

### DIFF
--- a/copy_span/src/lib.rs
+++ b/copy_span/src/lib.rs
@@ -40,6 +40,9 @@ fn recursively_set_span(token: &mut proc_macro2::TokenTree, span: proc_macro2::S
             new_group.set_span(span);
             *group = new_group;
         }
+        proc_macro2::TokenTree::Ident(i) if *i == "$crate" => {
+            token.set_span(span.resolved_at(token.span()));
+        }
         _ => {
             token.set_span(span);
         }

--- a/hydro_lang/tests/compile-fail-stable/sliced_missing_arg.rs
+++ b/hydro_lang/tests/compile-fail-stable/sliced_missing_arg.rs
@@ -1,0 +1,1 @@
+../compile-fail/sliced_missing_arg.rs

--- a/hydro_lang/tests/compile-fail-stable/sliced_missing_arg.stderr
+++ b/hydro_lang/tests/compile-fail-stable/sliced_missing_arg.stderr
@@ -1,0 +1,86 @@
+error[E0425]: cannot find value `fake` in this scope
+  --> tests/compile-fail-stable/sliced_missing_arg.rs:11:21
+   |
+11 |         let e = use(fake, nondet!(/** test */));
+   |                     ^^^^ not found in this scope
+
+error[E0425]: cannot find value `fake` in this scope
+  --> tests/compile-fail-stable/sliced_missing_arg.rs:12:29
+   |
+12 |         let f = use::atomic(fake, nondet!(/** test */));
+   |                             ^^^^ not found in this scope
+
+error[E0061]: this function takes 2 arguments but 1 argument was supplied
+  --> tests/compile-fail-stable/sliced_missing_arg.rs:7:21
+   |
+ 6 | /     sliced! {
+ 7 | |         let a = use(input);
+   | |                     ^^^^^
+ 8 | |         let b = use::atomic(input.atomic(&input.location().tick()));
+ 9 | |         let c = use(input, 123);
+...  |
+13 | |         let g = use::foobar();
+14 | |     }
+   | |_____- argument #2 of type `NonDet` is missing
+   |
+note: function defined here
+  --> src/live_collections/sliced/style.rs
+   |
+   | pub fn default<T>(t: T, nondet: NonDet) -> Default<T> {
+   |        ^^^^^^^
+help: provide the argument
+  --> src/live_collections/sliced/mod.rs
+   |
+   -             @uses [$($uses)* { $name, $crate::macro_support::copy_span::copy_span!($($args,)* default)($($args),*), $($args),* }]
+   +             @uses [$($uses)* { $name, (input, /* NonDet */), $($args),* }]
+   |
+
+error[E0061]: this function takes 2 arguments but 1 argument was supplied
+ --> tests/compile-fail-stable/sliced_missing_arg.rs:8:22
+  |
+8 |         let b = use::atomic(input.atomic(&input.location().tick()));
+  |                      ^^^^^^---------------------------------------- argument #2 of type `NonDet` is missing
+  |
+note: function defined here
+ --> src/live_collections/sliced/style.rs
+  |
+  | pub fn atomic<T>(t: T, nondet: NonDet) -> Atomic<T> {
+  |        ^^^^^^
+help: provide the argument
+  |
+8 |         let b = use::atomic(input.atomic(&input.location().tick()), /* NonDet */);
+  |                                                                   ++++++++++++++
+
+error[E0308]: mismatched types
+ --> tests/compile-fail-stable/sliced_missing_arg.rs:9:28
+  |
+9 |         let c = use(input, 123);
+  |                     -----  ^^^ expected `NonDet`, found integer
+  |                     |
+  |                     arguments to this function are incorrect
+  |
+note: function defined here
+ --> src/live_collections/sliced/style.rs
+  |
+  | pub fn default<T>(t: T, nondet: NonDet) -> Default<T> {
+  |        ^^^^^^^
+
+error[E0308]: mismatched types
+  --> tests/compile-fail-stable/sliced_missing_arg.rs:10:69
+   |
+10 |         let d = use::atomic(input.atomic(&input.location().tick()), 123);
+   |                      ------                                         ^^^ expected `NonDet`, found integer
+   |                      |
+   |                      arguments to this function are incorrect
+   |
+note: function defined here
+  --> src/live_collections/sliced/style.rs
+   |
+   | pub fn atomic<T>(t: T, nondet: NonDet) -> Atomic<T> {
+   |        ^^^^^^
+
+error[E0425]: cannot find function `foobar` in this scope
+  --> tests/compile-fail-stable/sliced_missing_arg.rs:13:22
+   |
+13 |         let g = use::foobar();
+   |                      ^^^^^^ not found in this scope

--- a/hydro_lang/tests/compile-fail/sliced_missing_arg.rs
+++ b/hydro_lang/tests/compile-fail/sliced_missing_arg.rs
@@ -1,0 +1,17 @@
+use hydro_lang::prelude::*;
+
+struct P1 {}
+
+fn test<'a>(input: Stream<u32, Process<'a, P1>>) {
+    sliced! {
+        let a = use(input);
+        let b = use::atomic(input.atomic(&input.location().tick()));
+        let c = use(input, 123);
+        let d = use::atomic(input.atomic(&input.location().tick()), 123);
+        let e = use(fake, nondet!(/** test */));
+        let f = use::atomic(fake, nondet!(/** test */));
+        let g = use::foobar();
+    }
+}
+
+fn main() {}

--- a/hydro_std/src/bench_client/mod.rs
+++ b/hydro_std/src/bench_client/mod.rs
@@ -67,7 +67,7 @@ where
 {
     let dummy = clients.singleton(q!(0));
     let new_payload_ids = sliced! {
-        let dummy_batched = use(dummy, nondet!(/** temp */));
+        let _dummy_batched = use(dummy, nondet!(/** temp */));
         let mut next_virtual_client = use::state(|l| Optional::from(l.singleton(q!((0u32, None)))));
 
         // Set up virtual clients - spawn new ones each tick until we reach the limit


### PR DESCRIPTION

Fixes #2509

With careful macro rules and span manipulation, we can dramatically improve the quality of errors when there is a malformed `use` call. Now missing args, non-existent "styles", argument errors, etc are spanned to the appropriate source location instead of the entire macro invocation.
