### PR TITLE
feat(hydro_lang): Jepsen / Maelstrom backend for Hydro

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,20 @@ jobs:
 
       - uses: taiki-e/install-action@nextest
 
+      - name: Install Java for Maelstrom
+        if: matrix.os != 'windows-latest'
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Download and setup Maelstrom
+        if: matrix.os != 'windows-latest'
+        run: |
+          curl -L -o maelstrom.tar.bz2 https://github.com/jepsen-io/maelstrom/releases/download/v0.2.4/maelstrom.tar.bz2
+          tar -xjf maelstrom.tar.bz2
+          echo "MAELSTROM_PATH=${{ github.workspace }}/maelstrom/maelstrom" >> $GITHUB_ENV
+
       - name: Enable Trybuild updating on nightly
         if: ${{ matrix.rust_release == 'latest-nightly' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
         uses: actions/github-script@v6

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ flamegraph.svg
 /release.log
 
 .fuzz-corpus/
+
+# Maelstrom
+store/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5857,6 +5857,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/hydro_lang/Cargo.toml
+++ b/hydro_lang/Cargo.toml
@@ -65,6 +65,11 @@ ecs_deploy = [
     "dep:anyhow",
 ]
 
+maelstrom = [
+    "trybuild",
+    "maelstrom_runtime",
+]
+
 # Dependencies needed to compile docker-targeted binaries with trybuild
 docker_runtime = [
     "deploy_integration",
@@ -79,6 +84,13 @@ ecs_runtime = [
     "dep:aws-config",
     "dep:aws-sdk-ecs",
     "dep:regex",
+]
+
+# Dependencies needed to compile maelstrom-targeted binaries with trybuild
+maelstrom_runtime = [
+    "deploy_integration",
+    "tokio-stream/sync",
+    "dep:serde_json",
 ]
 
 deploy_integration = ["dep:hydro_deploy_integration"]

--- a/hydro_lang/src/compile/trybuild/generate.rs
+++ b/hydro_lang/src/compile/trybuild/generate.rs
@@ -2,19 +2,15 @@ use std::fs::{self, File};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
-#[cfg(feature = "deploy")]
 use dfir_lang::graph::DfirGraph;
 use sha2::{Digest, Sha256};
-#[cfg(feature = "deploy")]
 use stageleft::internal::quote;
-#[cfg(feature = "deploy")]
 use syn::visit_mut::VisitMut;
 use trybuild_internals_api::cargo::{self, Metadata};
 use trybuild_internals_api::env::Update;
 use trybuild_internals_api::run::{PathDependency, Project};
 use trybuild_internals_api::{Runner, dependencies, features, path};
 
-#[cfg(feature = "deploy")]
 use super::rewriters::UseTestModeStaged;
 
 pub const HYDRO_RUNTIME_FEATURES: &[&str] = &[
@@ -22,16 +18,31 @@ pub const HYDRO_RUNTIME_FEATURES: &[&str] = &[
     "runtime_measure",
     "docker_runtime",
     "ecs_runtime",
+    "maelstrom_runtime",
 ];
 
-#[cfg(feature = "deploy")]
 /// Whether to use dynamic linking for the generated binary.
 /// - `Static`: Place in base crate examples (for remote/containerized deploys)
 /// - `Dynamic`: Place in dylib crate examples (for sim and localhost deploys)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LinkingMode {
     Static,
+    #[cfg(feature = "deploy")]
     Dynamic,
+}
+
+/// The deployment mode for code generation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeployMode {
+    #[cfg(feature = "deploy")]
+    /// Standard HydroDeploy
+    HydroDeploy,
+    #[cfg(any(feature = "docker_deploy", feature = "ecs_deploy"))]
+    /// Containerized deployment (Docker/ECS)
+    Containerized,
+    #[cfg(feature = "maelstrom")]
+    /// Maelstrom deployment with stdin/stdout JSON protocol
+    Maelstrom,
 }
 
 pub(crate) static IS_TEST: std::sync::atomic::AtomicBool =
@@ -56,7 +67,6 @@ pub fn init_test() {
     IS_TEST.store(true, std::sync::atomic::Ordering::Relaxed);
 }
 
-#[cfg(feature = "deploy")]
 fn clean_bin_name_prefix(bin_name_prefix: &str) -> String {
     bin_name_prefix
         .replace("::", "__")
@@ -80,13 +90,12 @@ pub struct TrybuildConfig {
     pub linking_mode: LinkingMode,
 }
 
-#[cfg(feature = "deploy")]
 pub fn create_graph_trybuild(
     graph: DfirGraph,
     extra_stmts: &[syn::Stmt],
     sidecars: &[syn::Expr],
     bin_name_prefix: Option<&str>,
-    is_containerized: bool,
+    deploy_mode: DeployMode,
     linking_mode: LinkingMode,
 ) -> (String, TrybuildConfig) {
     let source_dir = cargo::manifest_dir().unwrap();
@@ -101,7 +110,7 @@ pub fn create_graph_trybuild(
         sidecars,
         &crate_name,
         is_test,
-        is_containerized,
+        deploy_mode,
     );
 
     let inlined_staged = if is_test {
@@ -160,6 +169,7 @@ pub fn create_graph_trybuild(
     // Determine which crate's examples folder to use based on linking mode
     let examples_dir = match linking_mode {
         LinkingMode::Static => path!(project_dir / "examples"),
+        #[cfg(feature = "deploy")]
         LinkingMode::Dynamic => path!(project_dir / "dylib-examples" / "examples"),
     };
 
@@ -197,19 +207,19 @@ pub fn create_graph_trybuild(
             project_dir,
             target_dir,
             features: cur_bin_enabled_features,
+            #[cfg(feature = "deploy")]
             linking_mode,
         },
     )
 }
 
-#[cfg(feature = "deploy")]
 pub fn compile_graph_trybuild(
     partitioned_graph: DfirGraph,
     extra_stmts: &[syn::Stmt],
     sidecars: &[syn::Expr],
     crate_name: &str,
     is_test: bool,
-    is_containerized: bool,
+    deploy_mode: DeployMode,
 ) -> syn::File {
     use crate::staging_util::get_this_crate;
 
@@ -232,73 +242,119 @@ pub fn compile_graph_trybuild(
     let tokio_main_ident = format!("{}::runtime_support::tokio", root);
     let dfir_ident = quote::format_ident!("{}", crate::compile::DFIR_IDENT);
 
-    let source_ast: syn::File = if is_containerized {
-        syn::parse_quote! {
-            #![allow(unused_imports, unused_crate_dependencies, missing_docs, non_snake_case)]
-            use #trybuild_crate_name_ident::__root as #orig_crate_name;
-            use #trybuild_crate_name_ident::__staged::__deps::*;
-            use #root::prelude::*;
-            use #root::runtime_support::dfir_rs as __root_dfir_rs;
-            pub use #trybuild_crate_name_ident::__staged;
+    let source_ast: syn::File = match deploy_mode {
+        #[cfg(any(feature = "docker_deploy", feature = "ecs_deploy"))]
+        DeployMode::Containerized => {
+            syn::parse_quote! {
+                #![allow(unused_imports, unused_crate_dependencies, missing_docs, non_snake_case)]
+                use #trybuild_crate_name_ident::__root as #orig_crate_name;
+                use #trybuild_crate_name_ident::__staged::__deps::*;
+                use #root::prelude::*;
+                use #root::runtime_support::dfir_rs as __root_dfir_rs;
+                pub use #trybuild_crate_name_ident::__staged;
 
-            #[allow(unused)]
-            async fn __hydro_runtime<'a>() -> #root::runtime_support::dfir_rs::scheduled::graph::Dfir<'a> {
-                /// extra_stmts
-                #( #extra_stmts )*
+                #[allow(unused)]
+                async fn __hydro_runtime<'a>() -> #root::runtime_support::dfir_rs::scheduled::graph::Dfir<'a> {
+                    /// extra_stmts
+                    #( #extra_stmts )*
 
-                /// dfir_expr
-                #dfir_expr
-            }
+                    /// dfir_expr
+                    #dfir_expr
+                }
 
-            #[#root::runtime_support::tokio::main(crate = #tokio_main_ident, flavor = "current_thread")]
-            async fn main() {
-                #root::telemetry::initialize_tracing();
+                #[#root::runtime_support::tokio::main(crate = #tokio_main_ident, flavor = "current_thread")]
+                async fn main() {
+                    #root::telemetry::initialize_tracing();
 
-                let mut #dfir_ident = __hydro_runtime().await;
+                    let mut #dfir_ident = __hydro_runtime().await;
 
-                let local_set = #root::runtime_support::tokio::task::LocalSet::new();
-                #(
-                    let _ = local_set.spawn_local( #sidecars ); // Uses #dfir_ident
-                )*
+                    let local_set = #root::runtime_support::tokio::task::LocalSet::new();
+                    #(
+                        let _ = local_set.spawn_local( #sidecars ); // Uses #dfir_ident
+                    )*
 
-                let _ = local_set.run_until(#dfir_ident.run()).await;
+                    let _ = local_set.run_until(#dfir_ident.run()).await;
+                }
             }
         }
-    } else {
-        syn::parse_quote! {
-            #![allow(unused_imports, unused_crate_dependencies, missing_docs, non_snake_case)]
-            use #trybuild_crate_name_ident::__root as #orig_crate_name;
-            use #trybuild_crate_name_ident::__staged::__deps::*;
-            use #root::prelude::*;
-            use #root::runtime_support::dfir_rs as __root_dfir_rs;
-            pub use #trybuild_crate_name_ident::__staged;
+        #[cfg(feature = "deploy")]
+        DeployMode::HydroDeploy => {
+            syn::parse_quote! {
+                #![allow(unused_imports, unused_crate_dependencies, missing_docs, non_snake_case)]
+                use #trybuild_crate_name_ident::__root as #orig_crate_name;
+                use #trybuild_crate_name_ident::__staged::__deps::*;
+                use #root::prelude::*;
+                use #root::runtime_support::dfir_rs as __root_dfir_rs;
+                pub use #trybuild_crate_name_ident::__staged;
 
-            #[allow(unused)]
-            fn __hydro_runtime<'a>(
-                __hydro_lang_trybuild_cli: &'a #root::runtime_support::hydro_deploy_integration::DeployPorts<#root::__staged::deploy::deploy_runtime::HydroMeta>
-            )
-                -> #root::runtime_support::dfir_rs::scheduled::graph::Dfir<'a>
-            {
-                #( #extra_stmts )*
+                #[allow(unused)]
+                fn __hydro_runtime<'a>(
+                    __hydro_lang_trybuild_cli: &'a #root::runtime_support::hydro_deploy_integration::DeployPorts<#root::__staged::deploy::deploy_runtime::HydroMeta>
+                )
+                    -> #root::runtime_support::dfir_rs::scheduled::graph::Dfir<'a>
+                {
+                    #( #extra_stmts )*
 
-                #dfir_expr
+                    #dfir_expr
+                }
+
+                #[#root::runtime_support::tokio::main(crate = #tokio_main_ident, flavor = "current_thread")]
+                async fn main() {
+                    let ports = #root::runtime_support::launch::init_no_ack_start().await;
+                    let #dfir_ident = __hydro_runtime(&ports);
+                    println!("ack start");
+
+                    // TODO(mingwei): initialize `tracing` at this point in execution.
+                    // After "ack start" is when we can print whatever we want.
+
+                    let local_set = #root::runtime_support::tokio::task::LocalSet::new();
+                    #(
+                        let _ = local_set.spawn_local( #sidecars ); // Uses #dfir_ident
+                    )*
+
+                    let _ = local_set.run_until(#root::runtime_support::launch::run_stdin_commands(#dfir_ident)).await;
+                }
             }
+        }
+        #[cfg(feature = "maelstrom")]
+        DeployMode::Maelstrom => {
+            syn::parse_quote! {
+                #![allow(unused_imports, unused_crate_dependencies, missing_docs, non_snake_case)]
+                use #trybuild_crate_name_ident::__root as #orig_crate_name;
+                use #trybuild_crate_name_ident::__staged::__deps::*;
+                use #root::prelude::*;
+                use #root::runtime_support::dfir_rs as __root_dfir_rs;
+                pub use #trybuild_crate_name_ident::__staged;
 
-            #[#root::runtime_support::tokio::main(crate = #tokio_main_ident, flavor = "current_thread")]
-            async fn main() {
-                let ports = #root::runtime_support::launch::init_no_ack_start().await;
-                let #dfir_ident = __hydro_runtime(&ports);
-                println!("ack start");
+                #[allow(unused)]
+                fn __hydro_runtime<'a>(
+                    __hydro_lang_maelstrom_meta: &'a #root::__staged::deploy::maelstrom::deploy_runtime_maelstrom::MaelstromMeta
+                )
+                    -> #root::runtime_support::dfir_rs::scheduled::graph::Dfir<'a>
+                {
+                    #( #extra_stmts )*
 
-                // TODO(mingwei): initialize `tracing` at this point in execution.
-                // After "ack start" is when we can print whatever we want.
+                    #dfir_expr
+                }
 
-                let local_set = #root::runtime_support::tokio::task::LocalSet::new();
-                #(
-                    let _ = local_set.spawn_local( #sidecars ); // Uses #dfir_ident
-                )*
+                #[#root::runtime_support::tokio::main(crate = #tokio_main_ident, flavor = "current_thread")]
+                async fn main() {
+                    #root::telemetry::initialize_tracing();
 
-                let _ = local_set.run_until(#root::runtime_support::launch::run_stdin_commands(#dfir_ident)).await;
+                    // Initialize Maelstrom protocol - read init message and send init_ok
+                    let __hydro_lang_maelstrom_meta = #root::__staged::deploy::maelstrom::deploy_runtime_maelstrom::maelstrom_init();
+
+                    let mut #dfir_ident = __hydro_runtime(&__hydro_lang_maelstrom_meta);
+
+                    __hydro_lang_maelstrom_meta.start_receiving(); // start receiving messages after initializing subscribers
+
+                    let local_set = #root::runtime_support::tokio::task::LocalSet::new();
+                    #(
+                        let _ = local_set.spawn_local( #sidecars ); // Uses #dfir_ident
+                    )*
+
+                    let _ = local_set.run_until(#dfir_ident.run()).await;
+                }
             }
         }
     };

--- a/hydro_lang/src/deploy/deploy_graph.rs
+++ b/hydro_lang/src/deploy/deploy_graph.rs
@@ -830,7 +830,7 @@ impl Node for DeployNode {
                     extra_stmts,
                     sidecars,
                     trybuild.name_hint.as_deref(),
-                    false,
+                    crate::compile::trybuild::generate::DeployMode::HydroDeploy,
                     linking_mode,
                 );
                 let host = trybuild.host.clone();
@@ -935,7 +935,7 @@ impl Node for DeployCluster {
                 extra_stmts,
                 sidecars,
                 self.name_hint.as_deref(),
-                false,
+                crate::compile::trybuild::generate::DeployMode::HydroDeploy,
                 linking_mode,
             ))
         } else {

--- a/hydro_lang/src/deploy/deploy_graph_containerized.rs
+++ b/hydro_lang/src/deploy/deploy_graph_containerized.rs
@@ -107,7 +107,7 @@ impl Node for DockerDeployProcess {
             extra_stmts,
             sidecars,
             Some(&self.name),
-            true,
+            crate::compile::trybuild::generate::DeployMode::Containerized,
             LinkingMode::Static,
         );
 
@@ -182,7 +182,7 @@ impl Node for DockerDeployCluster {
             extra_stmts,
             sidecars,
             Some(&self.name),
-            true,
+            crate::compile::trybuild::generate::DeployMode::Containerized,
             LinkingMode::Static,
         );
 

--- a/hydro_lang/src/deploy/deploy_graph_containerized_ecs.rs
+++ b/hydro_lang/src/deploy/deploy_graph_containerized_ecs.rs
@@ -131,7 +131,7 @@ impl Node for EcsDeployProcess {
             extra_stmts,
             sidecars,
             Some(&self.name),
-            true,
+            crate::compile::trybuild::generate::DeployMode::Containerized,
             crate::compile::trybuild::generate::LinkingMode::Static,
         );
 
@@ -188,7 +188,7 @@ impl Node for EcsDeployCluster {
             extra_stmts,
             sidecars,
             Some(&self.name),
-            true,
+            crate::compile::trybuild::generate::DeployMode::Containerized,
             crate::compile::trybuild::generate::LinkingMode::Static,
         );
 

--- a/hydro_lang/src/deploy/maelstrom/deploy_maelstrom.rs
+++ b/hydro_lang/src/deploy/maelstrom/deploy_maelstrom.rs
@@ -1,0 +1,543 @@
+//! Deployment backend for Hydro that targets Maelstrom for distributed systems testing.
+//!
+//! Maelstrom is a workbench for learning distributed systems by writing your own.
+//! This backend compiles Hydro programs to binaries that communicate via Maelstrom's
+//! stdin/stdout JSON protocol.
+
+use std::cell::RefCell;
+use std::future::Future;
+use std::io::{BufRead, BufReader, Error};
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::process::Stdio;
+use std::rc::Rc;
+
+use bytes::{Bytes, BytesMut};
+use dfir_lang::graph::DfirGraph;
+use futures::{Sink, Stream};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use stageleft::{QuotedWithContext, RuntimeData};
+
+use super::deploy_runtime_maelstrom::*;
+use crate::compile::builder::ExternalPortId;
+use crate::compile::deploy_provider::{ClusterSpec, Deploy, Node, RegisterPort};
+use crate::compile::trybuild::generate::{LinkingMode, create_graph_trybuild};
+use crate::location::dynamic::LocationId;
+use crate::location::member_id::TaglessMemberId;
+use crate::location::{LocationKey, MembershipEvent, NetworkHint};
+
+/// Deployment backend that targets Maelstrom for distributed systems testing.
+///
+/// This backend compiles Hydro programs to binaries that communicate via Maelstrom's
+/// stdin/stdout JSON protocol. It is restricted to programs with:
+/// - Exactly one cluster (no processes)
+/// - A single external input channel for client communication
+pub enum MaelstromDeploy {}
+
+impl<'a> Deploy<'a> for MaelstromDeploy {
+    type Meta = ();
+    type InstantiateEnv = MaelstromDeployment;
+
+    type Process = MaelstromProcess;
+    type Cluster = MaelstromCluster;
+    type External = MaelstromExternal;
+
+    fn o2o_sink_source(
+        _p1: &Self::Process,
+        _p1_port: &<Self::Process as Node>::Port,
+        _p2: &Self::Process,
+        _p2_port: &<Self::Process as Node>::Port,
+    ) -> (syn::Expr, syn::Expr) {
+        panic!("Maelstrom deployment does not support processes, only clusters")
+    }
+
+    fn o2o_connect(
+        _p1: &Self::Process,
+        _p1_port: &<Self::Process as Node>::Port,
+        _p2: &Self::Process,
+        _p2_port: &<Self::Process as Node>::Port,
+    ) -> Box<dyn FnOnce()> {
+        panic!("Maelstrom deployment does not support processes, only clusters")
+    }
+
+    fn o2m_sink_source(
+        _p1: &Self::Process,
+        _p1_port: &<Self::Process as Node>::Port,
+        _c2: &Self::Cluster,
+        _c2_port: &<Self::Cluster as Node>::Port,
+    ) -> (syn::Expr, syn::Expr) {
+        panic!("Maelstrom deployment does not support processes, only clusters")
+    }
+
+    fn o2m_connect(
+        _p1: &Self::Process,
+        _p1_port: &<Self::Process as Node>::Port,
+        _c2: &Self::Cluster,
+        _c2_port: &<Self::Cluster as Node>::Port,
+    ) -> Box<dyn FnOnce()> {
+        panic!("Maelstrom deployment does not support processes, only clusters")
+    }
+
+    fn m2o_sink_source(
+        _c1: &Self::Cluster,
+        _c1_port: &<Self::Cluster as Node>::Port,
+        _p2: &Self::Process,
+        _p2_port: &<Self::Process as Node>::Port,
+    ) -> (syn::Expr, syn::Expr) {
+        panic!("Maelstrom deployment does not support processes, only clusters")
+    }
+
+    fn m2o_connect(
+        _c1: &Self::Cluster,
+        _c1_port: &<Self::Cluster as Node>::Port,
+        _p2: &Self::Process,
+        _p2_port: &<Self::Process as Node>::Port,
+    ) -> Box<dyn FnOnce()> {
+        panic!("Maelstrom deployment does not support processes, only clusters")
+    }
+
+    fn m2m_sink_source(
+        _c1: &Self::Cluster,
+        _c1_port: &<Self::Cluster as Node>::Port,
+        _c2: &Self::Cluster,
+        _c2_port: &<Self::Cluster as Node>::Port,
+    ) -> (syn::Expr, syn::Expr) {
+        deploy_maelstrom_m2m(RuntimeData::new("__hydro_lang_maelstrom_meta"))
+    }
+
+    fn m2m_connect(
+        _c1: &Self::Cluster,
+        _c1_port: &<Self::Cluster as Node>::Port,
+        _c2: &Self::Cluster,
+        _c2_port: &<Self::Cluster as Node>::Port,
+    ) -> Box<dyn FnOnce()> {
+        // No runtime connection needed for Maelstrom - all routing is via stdin/stdout
+        Box::new(|| {})
+    }
+
+    fn e2o_many_source(
+        _extra_stmts: &mut Vec<syn::Stmt>,
+        _p2: &Self::Process,
+        _p2_port: &<Self::Process as Node>::Port,
+        _codec_type: &syn::Type,
+        _shared_handle: String,
+    ) -> syn::Expr {
+        panic!("Maelstrom deployment does not support processes, only clusters")
+    }
+
+    fn e2o_many_sink(_shared_handle: String) -> syn::Expr {
+        panic!("Maelstrom deployment does not support processes, only clusters")
+    }
+
+    fn e2o_source(
+        _extra_stmts: &mut Vec<syn::Stmt>,
+        _p1: &Self::External,
+        _p1_port: &<Self::External as Node>::Port,
+        _p2: &Self::Process,
+        _p2_port: &<Self::Process as Node>::Port,
+        _codec_type: &syn::Type,
+        _shared_handle: String,
+    ) -> syn::Expr {
+        panic!("Maelstrom deployment does not support processes, only clusters")
+    }
+
+    fn e2o_connect(
+        _p1: &Self::External,
+        _p1_port: &<Self::External as Node>::Port,
+        _p2: &Self::Process,
+        _p2_port: &<Self::Process as Node>::Port,
+        _many: bool,
+        _server_hint: NetworkHint,
+    ) -> Box<dyn FnOnce()> {
+        panic!("Maelstrom deployment does not support processes, only clusters")
+    }
+
+    fn o2e_sink(
+        _p1: &Self::Process,
+        _p1_port: &<Self::Process as Node>::Port,
+        _p2: &Self::External,
+        _p2_port: &<Self::External as Node>::Port,
+        _shared_handle: String,
+    ) -> syn::Expr {
+        panic!("Maelstrom deployment does not support processes, only clusters")
+    }
+
+    fn cluster_ids(
+        _of_cluster: LocationKey,
+    ) -> impl QuotedWithContext<'a, &'a [TaglessMemberId], ()> + Clone + 'a {
+        cluster_members(RuntimeData::new("__hydro_lang_maelstrom_meta"), _of_cluster)
+    }
+
+    fn cluster_self_id() -> impl QuotedWithContext<'a, TaglessMemberId, ()> + Clone + 'a {
+        cluster_self_id(RuntimeData::new("__hydro_lang_maelstrom_meta"))
+    }
+
+    fn cluster_membership_stream(
+        location_id: &LocationId,
+    ) -> impl QuotedWithContext<'a, Box<dyn Stream<Item = (TaglessMemberId, MembershipEvent)> + Unpin>, ()>
+    {
+        cluster_membership_stream(location_id)
+    }
+}
+
+/// A dummy process type for Maelstrom (processes are not supported).
+#[derive(Clone)]
+pub struct MaelstromProcess {
+    _private: (),
+}
+
+impl Node for MaelstromProcess {
+    type Port = String;
+    type Meta = ();
+    type InstantiateEnv = MaelstromDeployment;
+
+    fn next_port(&self) -> Self::Port {
+        panic!("Maelstrom deployment does not support processes")
+    }
+
+    fn update_meta(&self, _meta: &Self::Meta) {}
+
+    fn instantiate(
+        &self,
+        _env: &mut Self::InstantiateEnv,
+        _meta: &mut Self::Meta,
+        _graph: DfirGraph,
+        _extra_stmts: &[syn::Stmt],
+        _sidecars: &[syn::Expr],
+    ) {
+        panic!("Maelstrom deployment does not support processes")
+    }
+}
+
+/// Represents a cluster in Maelstrom deployment.
+#[derive(Clone)]
+pub struct MaelstromCluster {
+    next_port: Rc<RefCell<usize>>,
+    name_hint: Option<String>,
+}
+
+impl Node for MaelstromCluster {
+    type Port = String;
+    type Meta = ();
+    type InstantiateEnv = MaelstromDeployment;
+
+    fn next_port(&self) -> Self::Port {
+        let next_port = *self.next_port.borrow();
+        *self.next_port.borrow_mut() += 1;
+        format!("port_{}", next_port)
+    }
+
+    fn update_meta(&self, _meta: &Self::Meta) {}
+
+    fn instantiate(
+        &self,
+        env: &mut Self::InstantiateEnv,
+        _meta: &mut Self::Meta,
+        graph: DfirGraph,
+        extra_stmts: &[syn::Stmt],
+        sidecars: &[syn::Expr],
+    ) {
+        let (bin_name, config) = create_graph_trybuild(
+            graph,
+            extra_stmts,
+            sidecars,
+            self.name_hint.as_deref(),
+            crate::compile::trybuild::generate::DeployMode::Maelstrom,
+            LinkingMode::Static,
+        );
+
+        env.bin_name = Some(bin_name);
+        env.project_dir = Some(config.project_dir);
+        env.target_dir = Some(config.target_dir);
+        env.features = config.features;
+    }
+}
+
+/// Represents an external client in Maelstrom deployment.
+#[derive(Clone)]
+pub enum MaelstromExternal {}
+
+impl Node for MaelstromExternal {
+    type Port = String;
+    type Meta = ();
+    type InstantiateEnv = MaelstromDeployment;
+
+    fn next_port(&self) -> Self::Port {
+        unreachable!()
+    }
+
+    fn update_meta(&self, _meta: &Self::Meta) {}
+
+    fn instantiate(
+        &self,
+        _env: &mut Self::InstantiateEnv,
+        _meta: &mut Self::Meta,
+        _graph: DfirGraph,
+        _extra_stmts: &[syn::Stmt],
+        _sidecars: &[syn::Expr],
+    ) {
+        unreachable!()
+    }
+}
+
+impl<'a> RegisterPort<'a, MaelstromDeploy> for MaelstromExternal {
+    fn register(&self, _external_port_id: ExternalPortId, _port: Self::Port) {
+        unreachable!()
+    }
+
+    #[expect(clippy::manual_async_fn, reason = "false positive, involves lifetimes")]
+    fn as_bytes_bidi(
+        &self,
+        _external_port_id: ExternalPortId,
+    ) -> impl Future<
+        Output = (
+            Pin<Box<dyn Stream<Item = Result<BytesMut, Error>>>>,
+            Pin<Box<dyn Sink<Bytes, Error = Error>>>,
+        ),
+    > + 'a {
+        async move { unreachable!() }
+    }
+
+    #[expect(clippy::manual_async_fn, reason = "false positive, involves lifetimes")]
+    fn as_bincode_bidi<InT, OutT>(
+        &self,
+        _external_port_id: ExternalPortId,
+    ) -> impl Future<
+        Output = (
+            Pin<Box<dyn Stream<Item = OutT>>>,
+            Pin<Box<dyn Sink<InT, Error = Error>>>,
+        ),
+    > + 'a
+    where
+        InT: Serialize + 'static,
+        OutT: DeserializeOwned + 'static,
+    {
+        async move { unreachable!() }
+    }
+
+    #[expect(clippy::manual_async_fn, reason = "false positive, involves lifetimes")]
+    fn as_bincode_sink<T: Serialize + 'static>(
+        &self,
+        _external_port_id: ExternalPortId,
+    ) -> impl Future<Output = Pin<Box<dyn Sink<T, Error = Error>>>> + 'a {
+        async move { unreachable!() }
+    }
+
+    #[expect(clippy::manual_async_fn, reason = "false positive, involves lifetimes")]
+    fn as_bincode_source<T: DeserializeOwned + 'static>(
+        &self,
+        _external_port_id: ExternalPortId,
+    ) -> impl Future<Output = Pin<Box<dyn Stream<Item = T>>>> + 'a {
+        async move { unreachable!() }
+    }
+}
+
+/// Specification for building a Maelstrom cluster.
+#[derive(Clone)]
+pub struct MaelstromClusterSpec;
+
+impl<'a> ClusterSpec<'a, MaelstromDeploy> for MaelstromClusterSpec {
+    fn build(self, key: LocationKey, name_hint: &str) -> MaelstromCluster {
+        assert_eq!(
+            key,
+            LocationKey::FIRST,
+            "there should only be one location for a Maelstrom deployment"
+        );
+        MaelstromCluster {
+            next_port: Rc::new(RefCell::new(0)),
+            name_hint: Some(name_hint.to_owned()),
+        }
+    }
+}
+
+/// The Maelstrom deployment environment.
+///
+/// This holds configuration for the Maelstrom run and accumulates
+/// compilation artifacts during deployment.
+pub struct MaelstromDeployment {
+    /// Number of nodes in the cluster.
+    pub node_count: usize,
+    /// Path to the maelstrom binary.
+    pub maelstrom_path: PathBuf,
+    /// Workload to run (e.g., "echo", "broadcast", "g-counter").
+    pub workload: String,
+    /// Time limit in seconds.
+    pub time_limit: Option<u64>,
+    /// Rate of requests per second.
+    pub rate: Option<u64>,
+    /// The availability of nodes.
+    pub availability: Option<String>,
+    /// Nemesis to run during tests.
+    pub nemesis: Option<String>,
+    /// Additional maelstrom arguments.
+    pub extra_args: Vec<String>,
+
+    // Populated during deployment
+    pub(crate) bin_name: Option<String>,
+    pub(crate) project_dir: Option<PathBuf>,
+    pub(crate) target_dir: Option<PathBuf>,
+    pub(crate) features: Option<Vec<String>>,
+}
+
+impl MaelstromDeployment {
+    /// Create a new Maelstrom deployment with the given node count.
+    pub fn new(workload: impl Into<String>) -> Self {
+        Self {
+            node_count: 1,
+            maelstrom_path: PathBuf::from("maelstrom"),
+            workload: workload.into(),
+            time_limit: None,
+            rate: None,
+            availability: None,
+            nemesis: None,
+            extra_args: vec![],
+            bin_name: None,
+            project_dir: None,
+            target_dir: None,
+            features: None,
+        }
+    }
+
+    /// Set the node count.
+    pub fn node_count(mut self, count: usize) -> Self {
+        self.node_count = count;
+        self
+    }
+
+    /// Set the path to the maelstrom binary.
+    pub fn maelstrom_path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.maelstrom_path = path.into();
+        self
+    }
+
+    /// Set the time limit in seconds.
+    pub fn time_limit(mut self, seconds: u64) -> Self {
+        self.time_limit = Some(seconds);
+        self
+    }
+
+    /// Set the request rate per second.
+    pub fn rate(mut self, rate: u64) -> Self {
+        self.rate = Some(rate);
+        self
+    }
+
+    /// Set the availability for the test.
+    pub fn availability(mut self, availability: impl Into<String>) -> Self {
+        self.availability = Some(availability.into());
+        self
+    }
+
+    /// Set the nemesis for the test.
+    pub fn nemesis(mut self, nemesis: impl Into<String>) -> Self {
+        self.nemesis = Some(nemesis.into());
+        self
+    }
+
+    /// Add extra arguments to pass to maelstrom.
+    pub fn extra_args(mut self, args: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.extra_args.extend(args.into_iter().map(Into::into));
+        self
+    }
+
+    /// Build the compiled binary in dev mode.
+    /// Returns the path to the compiled binary.
+    pub fn build(&self) -> Result<PathBuf, Error> {
+        let bin_name = self
+            .bin_name
+            .as_ref()
+            .expect("No binary name set - did you call deploy?");
+        let project_dir = self.project_dir.as_ref().expect("No project dir set");
+        let target_dir = self.target_dir.as_ref().expect("No target dir set");
+
+        let mut cmd = std::process::Command::new("cargo");
+        cmd.arg("build")
+            .arg("--example")
+            .arg(bin_name)
+            .arg("--no-default-features")
+            .current_dir(project_dir)
+            .env("CARGO_TARGET_DIR", target_dir)
+            .env("STAGELEFT_TRYBUILD_BUILD_STAGED", "1");
+
+        // Always include maelstrom_runtime feature for runtime support
+        let mut all_features = vec!["hydro___feature_maelstrom_runtime".to_owned()];
+        if let Some(features) = &self.features {
+            all_features.extend(features.iter().cloned());
+        }
+        if !all_features.is_empty() {
+            cmd.arg("--features").arg(all_features.join(","));
+        }
+
+        let status = cmd.status()?;
+        if !status.success() {
+            return Err(Error::other(format!(
+                "cargo build failed with status: {}",
+                status
+            )));
+        }
+
+        Ok(target_dir.join("debug").join("examples").join(bin_name))
+    }
+
+    /// Run Maelstrom with the compiled binary, return Ok(()) if all checks pass.
+    ///
+    /// This will block until Maelstrom completes.
+    pub fn run(self) -> Result<(), Error> {
+        let binary_path = self.build()?;
+
+        let mut cmd = std::process::Command::new(&self.maelstrom_path);
+        cmd.arg("test")
+            .arg("-w")
+            .arg(&self.workload)
+            .arg("--bin")
+            .arg(&binary_path)
+            .arg("--node-count")
+            .arg(self.node_count.to_string())
+            .stdout(Stdio::piped());
+
+        if let Some(time_limit) = self.time_limit {
+            cmd.arg("--time-limit").arg(time_limit.to_string());
+        }
+
+        if let Some(rate) = self.rate {
+            cmd.arg("--rate").arg(rate.to_string());
+        }
+
+        if let Some(availability) = self.availability {
+            cmd.arg("--availability").arg(availability);
+        }
+
+        if let Some(nemesis) = self.nemesis {
+            cmd.arg("--nemesis").arg(nemesis);
+        }
+
+        for arg in &self.extra_args {
+            cmd.arg(arg);
+        }
+
+        let spawned = cmd.spawn()?;
+
+        for line in BufReader::new(spawned.stdout.unwrap()).lines() {
+            let line = line?;
+            eprintln!("{}", &line);
+
+            if line.starts_with("Analysis invalid!") {
+                return Err(Error::other("Analysis was invalid"));
+            } else if line.starts_with("Errors occurred during analysis, but no anomalies found.")
+                || line.starts_with("Everything looks good!")
+            {
+                return Ok(());
+            }
+        }
+
+        Err(Error::other("Maelstrom produced an unexpected result"))
+    }
+
+    /// Get the path to the compiled binary (after building).
+    pub fn binary_path(&self) -> Option<PathBuf> {
+        let bin_name = self.bin_name.as_ref()?;
+        let target_dir = self.target_dir.as_ref()?;
+        Some(target_dir.join("debug").join("examples").join(bin_name))
+    }
+}

--- a/hydro_lang/src/deploy/maelstrom/deploy_runtime_maelstrom.rs
+++ b/hydro_lang/src/deploy/maelstrom/deploy_runtime_maelstrom.rs
@@ -1,0 +1,287 @@
+//! Runtime support for Maelstrom deployment backend.
+//!
+//! This module provides the runtime code that runs inside Maelstrom nodes,
+//! handling stdin/stdout JSON message passing according to the Maelstrom protocol.
+
+#![allow(
+    unused,
+    reason = "unused in trybuild but the __staged version is needed"
+)]
+#![allow(missing_docs, reason = "used internally")]
+
+use std::io::{BufRead, Write};
+
+use futures::{Stream, StreamExt};
+use serde::{Deserialize, Serialize};
+use stageleft::{QuotedWithContext, RuntimeData, q};
+
+use crate::forward_handle::ForwardHandle;
+use crate::live_collections::boundedness::Unbounded;
+use crate::live_collections::keyed_stream::KeyedStream;
+use crate::live_collections::stream::{ExactlyOnce, NoOrder, TotalOrder};
+use crate::location::dynamic::LocationId;
+use crate::location::member_id::TaglessMemberId;
+use crate::location::{Cluster, LocationKey, MembershipEvent, NoTick};
+use crate::nondet::nondet;
+
+/// Maelstrom message envelope structure.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MaelstromMessage<T> {
+    pub src: String,
+    pub dest: String,
+    pub body: T,
+}
+
+/// Maelstrom init message body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InitBody {
+    #[serde(rename = "type")]
+    pub msg_type: String,
+    pub msg_id: u64,
+    pub node_id: String,
+    pub node_ids: Vec<String>,
+}
+
+/// Maelstrom init_ok response body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InitOkBody {
+    #[serde(rename = "type")]
+    pub msg_type: String,
+    pub in_reply_to: u64,
+}
+
+/// Metadata for a Maelstrom node, populated from the init message.
+/// Also manages a shared stdin reader that broadcasts lines to multiple subscribers.
+pub struct MaelstromMeta {
+    pub node_id: String,
+    pub node_ids: Vec<String>,
+    stdin_tx: tokio::sync::broadcast::Sender<String>,
+}
+
+impl MaelstromMeta {
+    /// Subscribe to stdin lines. Each subscriber receives all lines read from stdin.
+    /// Multiple subscribers can be created and each will receive a copy of every line.
+    pub fn subscribe_stdin(&self) -> tokio_stream::wrappers::BroadcastStream<String> {
+        tokio_stream::wrappers::BroadcastStream::new(self.stdin_tx.subscribe())
+    }
+
+    /// Start receiving incoming messages from clients and other nodes, after launching the DFIR.
+    pub fn start_receiving(&self) {
+        let tx_clone = self.stdin_tx.clone();
+
+        // Spawn thread to read stdin and broadcast lines
+        std::thread::spawn(move || {
+            let stdin = std::io::stdin();
+            for line in stdin.lock().lines() {
+                match line {
+                    Ok(l) => {
+                        // Ignore send errors (no receivers)
+                        let _ = tx_clone.send(l);
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+    }
+}
+
+/// Initialize a Maelstrom node by reading the init message from stdin.
+/// Returns the node metadata and sends init_ok response.
+/// Also spawns a background thread to read stdin and broadcast lines to subscribers.
+pub fn maelstrom_init() -> MaelstromMeta {
+    let stdin = std::io::stdin();
+    let mut stdout = std::io::stdout();
+
+    // Read the init message
+    let mut line = String::new();
+    stdin
+        .lock()
+        .read_line(&mut line)
+        .expect("Failed to read init message");
+
+    let msg: MaelstromMessage<InitBody> =
+        serde_json::from_str(&line).expect("Failed to parse init message");
+
+    assert_eq!(msg.body.msg_type, "init", "First message must be init");
+
+    // Set up broadcast channel for stdin lines
+    let (stdin_tx, _) = tokio::sync::broadcast::channel::<String>(1024);
+
+    let meta = MaelstromMeta {
+        node_id: msg.body.node_id.clone(),
+        node_ids: msg.body.node_ids.clone(),
+        stdin_tx,
+    };
+
+    // Send init_ok response
+    let response = MaelstromMessage {
+        src: msg.body.node_id,
+        dest: msg.src,
+        body: InitOkBody {
+            msg_type: "init_ok".to_owned(),
+            in_reply_to: msg.body.msg_id,
+        },
+    };
+
+    let response_json = serde_json::to_string(&response).expect("Failed to serialize init_ok");
+    writeln!(stdout, "{}", response_json).expect("Failed to write init_ok");
+    stdout.flush().expect("Failed to flush stdout");
+
+    meta
+}
+
+/// Get the cluster member IDs from the Maelstrom metadata.
+/// The `meta` parameter is a RuntimeData reference to the MaelstromMeta that will be
+/// available at runtime as `__hydro_lang_maelstrom_meta`.
+pub(super) fn cluster_members<'a>(
+    meta: RuntimeData<&'a MaelstromMeta>,
+    _of_cluster: LocationKey,
+) -> impl QuotedWithContext<'a, &'a [TaglessMemberId], ()> + Clone + 'a {
+    q!({
+        let members: &'static [TaglessMemberId] = Box::leak(
+            meta.node_ids
+                .iter()
+                .map(|id| TaglessMemberId::from_maelstrom_node_id(id.clone()))
+                .collect::<Vec<TaglessMemberId>>()
+                .into_boxed_slice(),
+        );
+        members
+    })
+}
+
+/// Get the self ID for this cluster member.
+pub(super) fn cluster_self_id<'a>(
+    meta: RuntimeData<&'a MaelstromMeta>,
+) -> impl QuotedWithContext<'a, TaglessMemberId, ()> + Clone + 'a {
+    q!(TaglessMemberId::from_maelstrom_node_id(
+        meta.node_id.clone()
+    ))
+}
+
+/// Get the cluster membership stream (static for Maelstrom - all members join at start).
+/// This references `__hydro_lang_maelstrom_meta` which will be in scope at runtime.
+pub(super) fn cluster_membership_stream<'a>(
+    _location_id: &LocationId,
+) -> impl QuotedWithContext<'a, Box<dyn Stream<Item = (TaglessMemberId, MembershipEvent)> + Unpin>, ()>
+{
+    let meta: RuntimeData<&MaelstromMeta> = RuntimeData::new("__hydro_lang_maelstrom_meta");
+    q!(Box::new(futures::stream::iter(
+        meta.node_ids
+            .iter()
+            .map(|id| (
+                TaglessMemberId::from_maelstrom_node_id(id.clone()),
+                MembershipEvent::Joined
+            ))
+            .collect::<Vec<_>>()
+    ))
+        as Box<
+            dyn futures::Stream<Item = (TaglessMemberId, MembershipEvent)> + Unpin,
+        >)
+}
+
+/// Create sink and source for m2m (cluster member to cluster member) communication.
+/// Messages are routed through Maelstrom's network via stdin/stdout.
+pub(super) fn deploy_maelstrom_m2m(meta: RuntimeData<&MaelstromMeta>) -> (syn::Expr, syn::Expr) {
+    // Sink: serialize and write to stdout with Maelstrom message envelope
+    let sink_expr = q!({
+        let node_id = meta.node_id.clone();
+        sinktools::map(
+            move |(dest_id, payload): (TaglessMemberId, bytes::Bytes)| {
+                let msg = serde_json::json!({
+                    "src": node_id,
+                    "dest": dest_id.get_maelstrom_node_id(),
+                    "body": {
+                        "type": "hydro_data",
+                        "data": payload.to_vec()
+                    }
+                });
+                serde_json::to_string(&msg).unwrap() + "\n"
+            },
+            futures::sink::unfold((), |(), line: String| {
+                Box::pin(async move {
+                    print!("{}", line);
+                    std::io::stdout().flush().ok();
+                    Ok::<_, std::io::Error>(())
+                })
+            }),
+        )
+    })
+    .splice_untyped_ctx(&());
+
+    // Source: subscribe to the shared stdin broadcast stream
+    let source_expr = q!({
+        let node_ids: std::collections::HashSet<String> = meta.node_ids.iter().cloned().collect();
+        let lines = meta.subscribe_stdin();
+        futures::StreamExt::filter_map(lines, move |line_result| {
+            let node_ids = node_ids.clone();
+            Box::pin(async move {
+                let line = line_result.ok()?;
+                let mut msg =
+                    serde_json::from_str::<MaelstromMessage<serde_json::Value>>(&line).ok()?;
+                // Only process messages from other nodes (not clients)
+                if msg
+                    .body
+                    .get("type")
+                    .is_some_and(|t| t.as_str() == Some("hydro_data"))
+                {
+                    let deser: Vec<u8> =
+                        serde_json::from_value(msg.body.get_mut("data").unwrap().take()).unwrap();
+                    Some(Ok::<_, std::io::Error>((
+                        TaglessMemberId::from_maelstrom_node_id(msg.src),
+                        bytes::BytesMut::from(&deser[..]),
+                    )))
+                } else {
+                    None
+                }
+            })
+        })
+    })
+    .splice_untyped_ctx(&());
+
+    (sink_expr, source_expr)
+}
+
+/// Creates a stream of client messages from Maelstrom stdin.
+/// Returns tuples of (client_id, message_body) where client_id is the source client
+/// and message_body is the JSON value of the message body.
+///
+/// This function is meant to be used with `source_stream` on a Cluster location.
+pub fn maelstrom_client_source(
+    meta: &MaelstromMeta,
+) -> impl Stream<Item = (String, serde_json::Value)> + Unpin {
+    use std::collections::HashSet;
+
+    let node_ids: HashSet<String> = meta.node_ids.iter().cloned().collect();
+    let lines = meta.subscribe_stdin();
+
+    Box::pin(lines.filter_map(move |line_result| {
+        let node_ids = node_ids.clone();
+        async move {
+            let line = line_result.ok()?;
+            let msg: MaelstromMessage<serde_json::Value> = serde_json::from_str(&line).ok()?;
+            // Only process messages from clients (not other nodes)
+            if !node_ids.contains(&msg.src) {
+                Some((msg.src, msg.body))
+            } else {
+                None
+            }
+        }
+    }))
+}
+
+/// Sends a response to a Maelstrom client via stdout.
+///
+/// This function is meant to be used with `for_each` on a stream of responses.
+pub fn maelstrom_send_response(node_id: &str, client_id: &str, body: serde_json::Value) {
+    use std::io::Write;
+
+    let msg = MaelstromMessage {
+        src: node_id.to_owned(),
+        dest: client_id.to_owned(),
+        body,
+    };
+
+    let json = serde_json::to_string(&msg).expect("Failed to serialize response");
+    println!("{}", json);
+    std::io::stdout().flush().ok();
+}

--- a/hydro_lang/src/deploy/maelstrom/mod.rs
+++ b/hydro_lang/src/deploy/maelstrom/mod.rs
@@ -1,0 +1,75 @@
+//! Deployment backend for running correctness tests against Jepsen Maelstrom (<https://github.com/jepsen-io/maelstrom>)
+
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+use crate::forward_handle::ForwardHandle;
+use crate::live_collections::KeyedStream;
+use crate::location::{Cluster, NoTick};
+use crate::nondet::nondet;
+
+#[cfg(stageleft_runtime)]
+#[cfg(feature = "maelstrom")]
+#[cfg_attr(docsrs, doc(cfg(feature = "maelstrom")))]
+pub mod deploy_maelstrom;
+
+pub mod deploy_runtime_maelstrom;
+
+/// Sets up bidirectional communication with Maelstrom clients on a cluster.
+///
+/// This function provides a similar API to `bidi_external_many_bytes` but for Maelstrom
+/// client communication. It returns a keyed input stream of client messages and accepts
+/// a keyed output stream of responses.
+///
+/// The key type is `String` (the client ID like "c1", "c2").
+/// The value type is `serde_json::Value` (the message body).
+///
+/// # Example
+/// ```ignore
+/// let (input, output_handle) = maelstrom_bidi_clients(&cluster);
+/// output_handle.complete(input.map(q!(|(client_id, body)| {
+///     // Process and return response
+///     (client_id, response_body)
+/// })));
+/// ```
+#[expect(clippy::type_complexity, reason = "stream markers")]
+pub fn maelstrom_bidi_clients<'a, C, In: DeserializeOwned, Out: Serialize>(
+    cluster: &Cluster<'a, C>,
+) -> (
+    KeyedStream<String, In, Cluster<'a, C>>,
+    ForwardHandle<'a, KeyedStream<String, Out, Cluster<'a, C>>>,
+)
+where
+    Cluster<'a, C>: NoTick,
+{
+    use stageleft::q;
+
+    use crate::location::Location;
+
+    let meta: stageleft::RuntimeData<&deploy_runtime_maelstrom::MaelstromMeta> =
+        stageleft::RuntimeData::new("__hydro_lang_maelstrom_meta");
+
+    // Create the input stream from Maelstrom clients
+    let input: KeyedStream<String, In, Cluster<'a, C>> = cluster
+        .source_stream(q!(deploy_runtime_maelstrom::maelstrom_client_source(meta)))
+        .into_keyed()
+        .map(q!(|b| serde_json::from_value(b).unwrap()));
+
+    // Create a forward reference for the output stream
+    let (fwd_handle, output_stream) =
+        cluster.forward_ref::<KeyedStream<String, Out, Cluster<'a, C>>>();
+
+    // Set up the output sink to send responses back to clients
+    output_stream
+        .entries()
+        .assume_ordering(nondet!(/** maelstrom responses can be sent in any order */))
+        .for_each(q!(|(client_id, body)| {
+            deploy_runtime_maelstrom::maelstrom_send_response(
+                &meta.node_id,
+                &client_id,
+                serde_json::to_value(body).unwrap(),
+            );
+        }));
+
+    (input, fwd_handle)
+}

--- a/hydro_lang/src/deploy/mod.rs
+++ b/hydro_lang/src/deploy/mod.rs
@@ -9,6 +9,9 @@ pub mod deploy_runtime_containerized;
 #[cfg(feature = "ecs_runtime")]
 pub mod deploy_runtime_containerized_ecs;
 
+#[cfg(any(feature = "maelstrom", feature = "maelstrom_runtime"))]
+pub mod maelstrom;
+
 #[cfg(stageleft_runtime)]
 #[cfg(feature = "deploy")]
 #[cfg_attr(docsrs, doc(cfg(feature = "deploy")))]

--- a/hydro_lang/src/location/member_id.rs
+++ b/hydro_lang/src/location/member_id.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 pub enum TaglessMemberId {
     Legacy { raw_id: u32 },
     Docker { container_name: String },
+    Maelstrom { node_id: String },
 }
 
 impl TaglessMemberId {
@@ -18,6 +19,12 @@ impl TaglessMemberId {
     pub fn from_container_name(container_name: impl ToString) -> Self {
         Self::Docker {
             container_name: container_name.to_string(),
+        }
+    }
+
+    pub fn from_maelstrom_node_id(node_id: impl ToString) -> Self {
+        Self::Maelstrom {
+            node_id: node_id.to_string(),
         }
     }
 
@@ -34,6 +41,13 @@ impl TaglessMemberId {
             _ => panic!(),
         }
     }
+
+    pub fn get_maelstrom_node_id(&self) -> String {
+        match &self {
+            TaglessMemberId::Maelstrom { node_id } => node_id.clone(),
+            _ => panic!(),
+        }
+    }
 }
 
 impl Hash for TaglessMemberId {
@@ -41,6 +55,7 @@ impl Hash for TaglessMemberId {
         match self {
             TaglessMemberId::Legacy { raw_id } => raw_id.hash(state),
             TaglessMemberId::Docker { container_name } => container_name.hash(state),
+            TaglessMemberId::Maelstrom { node_id } => node_id.hash(state),
         }
     }
 }
@@ -60,6 +75,12 @@ impl PartialEq for TaglessMemberId {
                     container_name: other_container_name,
                 },
             ) => container_name == other_container_name,
+            (
+                TaglessMemberId::Maelstrom { node_id },
+                TaglessMemberId::Maelstrom {
+                    node_id: other_node_id,
+                },
+            ) => node_id == other_node_id,
             _ => unreachable!(),
         }
     }
@@ -89,6 +110,12 @@ impl Ord for TaglessMemberId {
                     container_name: other_container_name,
                 },
             ) => container_name.cmp(other_container_name),
+            (
+                TaglessMemberId::Maelstrom { node_id },
+                TaglessMemberId::Maelstrom {
+                    node_id: other_node_id,
+                },
+            ) => node_id.cmp(other_node_id),
             _ => unreachable!(),
         }
     }
@@ -147,6 +174,14 @@ impl<Tag> Display for MemberId<Tag> {
                     "MemberId::<{}>(\"{}\")",
                     std::any::type_name::<Tag>(),
                     container_name
+                )
+            }
+            TaglessMemberId::Maelstrom { node_id, .. } => {
+                write!(
+                    f,
+                    "MemberId::<{}>(\"{}\")",
+                    std::any::type_name::<Tag>(),
+                    node_id
                 )
             }
         }

--- a/hydro_lang/src/telemetry/mod.rs
+++ b/hydro_lang/src/telemetry/mod.rs
@@ -135,6 +135,7 @@ pub fn initialize_tracing_with_filter(filter: EnvFilter) {
     set_global_default(
         registry().with(
             fmt::layer()
+                .with_writer(std::io::stderr)
                 .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
                 .event_format(Formatter)
                 .with_filter(filter.clone()),

--- a/hydro_test/Cargo.toml
+++ b/hydro_test/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 [features]
 docker = ["hydro_lang/docker_deploy"]
 ecs = ["hydro_lang/ecs_deploy"]
+maelstrom = ["hydro_lang/maelstrom"]
 
 [dependencies]
 hydro_lang = { path = "../hydro_lang", version = "^0.15.0" }
@@ -45,6 +46,7 @@ futures = "0.3.0"
 hydro_deploy = { path = "../hydro_deploy/core", version = "^0.15.0" }
 hydro_lang = { path = "../hydro_lang", version = "^0.15.0", features = [
     "deploy",
+    "maelstrom",
     "sim",
     "viz",
 ] }

--- a/hydro_test/build.rs
+++ b/hydro_test/build.rs
@@ -2,4 +2,10 @@ fn main() {
     hydro_build_utils::emit_nightly_configuration!();
 
     stageleft_tool::gen_final!();
+
+    println!("cargo:rerun-if-env-changed=MAELSTROM_PATH");
+    println!("cargo::rustc-check-cfg=cfg(maelstrom_available)");
+    if std::env::var("MAELSTROM_PATH").is_ok() {
+        println!("cargo:rustc-cfg=maelstrom_available");
+    }
 }

--- a/hydro_test/src/lib.rs
+++ b/hydro_test/src/lib.rs
@@ -5,6 +5,7 @@ pub mod cluster;
 pub mod distributed;
 pub mod external_client;
 pub mod local;
+pub mod maelstrom;
 pub mod tutorials;
 
 #[doc(hidden)]

--- a/hydro_test/src/maelstrom/broadcast.rs
+++ b/hydro_test/src/maelstrom/broadcast.rs
@@ -1,0 +1,170 @@
+//! This implements the Maelstrom broadcast workload.
+//!
+//! See <https://fly.io/dist-sys/3a/> and <https://fly.io/dist-sys/3b/>
+
+use hydro_lang::live_collections::stream::NoOrder;
+use hydro_lang::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Broadcast {
+    pub msg_id: usize,
+    pub message: u32,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Read {
+    pub msg_id: usize,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Topology {
+    pub msg_id: usize,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(tag = "type")]
+pub enum Request {
+    #[serde(alias = "broadcast")]
+    Broadcast(Broadcast),
+    #[serde(alias = "read")]
+    Read(Read),
+    #[serde(alias = "topology")]
+    Topology(Topology),
+}
+
+fn broadcast_core<'a, C: 'a>(
+    cluster: &Cluster<'a, C>,
+    writes: Stream<u32, Cluster<'a, C>, Unbounded, NoOrder>,
+) -> Stream<u32, Cluster<'a, C>, Unbounded, NoOrder> {
+    writes
+        .broadcast(cluster, TCP.bincode(), nondet!(/** TODO */))
+        .values()
+}
+
+pub fn broadcast_server<'a, C: 'a>(
+    cluster: &Cluster<'a, C>,
+    input: KeyedStream<String, Request, Cluster<'a, C>>,
+) -> KeyedStream<String, serde_json::Value, Cluster<'a, C>, Unbounded, NoOrder> {
+    let broadcast_requests = input.clone().filter_map(q!(|body| {
+        if let Request::Broadcast(b) = body {
+            Some(b)
+        } else {
+            None
+        }
+    }));
+
+    let broadcast_response = broadcast_requests.clone().map(q!(|req| {
+        serde_json::json!({
+            "type": "broadcast_ok",
+            "in_reply_to": req.msg_id
+        })
+    }));
+
+    let written_data = broadcast_requests.values().map(q!(|t| t.message));
+    let current_state = broadcast_core(cluster, written_data);
+
+    let read_requests = input.clone().filter_map(q!(|body| {
+        if let Request::Read(r) = body {
+            Some(r)
+        } else {
+            None
+        }
+    }));
+
+    let read_response = sliced! {
+        let req = use(read_requests, nondet!(/** batching of requests does not matter */));
+        let data = use(
+            current_state
+                .assume_ordering(nondet!(/** client ignores order */))
+                .fold(q!(|| vec![]), q!(|v, d| v.push(d))),
+            nondet!(/** we only guarantee eventual consistency */)
+        );
+
+        req.cross_singleton(data).map(q!(|(req, data)| {
+            serde_json::json!({
+                "type": "read_ok",
+                "messages": data,
+                "in_reply_to": req.msg_id
+            })
+        }))
+    };
+
+    let topology_requests = input.filter_map(q!(|body| {
+        if let Request::Topology(t) = body {
+            Some(t)
+        } else {
+            None
+        }
+    }));
+
+    let topology_response = topology_requests.map(q!(|req| {
+        serde_json::json!({
+            "type": "topology_ok",
+            "in_reply_to": req.msg_id
+        })
+    }));
+
+    broadcast_response
+        .interleave(read_response)
+        .interleave(topology_response)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::str::FromStr;
+
+    use hydro_lang::deploy::maelstrom::deploy_maelstrom::{
+        MaelstromClusterSpec, MaelstromDeployment,
+    };
+    use hydro_lang::deploy::maelstrom::maelstrom_bidi_clients;
+
+    use super::*;
+
+    #[tokio::test]
+    #[cfg_attr(not(maelstrom_available), ignore)]
+    async fn broadcast_3a_maelstrom() {
+        let mut flow = FlowBuilder::new();
+        let cluster = flow.cluster::<()>();
+
+        let (input, output_handle) = maelstrom_bidi_clients(&cluster);
+        output_handle
+            .complete(broadcast_server(&cluster, input).assume_ordering(nondet!(/** test */)));
+
+        let mut deployment = MaelstromDeployment::new("broadcast")
+            .maelstrom_path(PathBuf::from_str(&std::env::var("MAELSTROM_PATH").unwrap()).unwrap())
+            .node_count(1)
+            .time_limit(20)
+            .rate(10);
+
+        let _ = flow
+            .with_cluster(&cluster, MaelstromClusterSpec)
+            .deploy(&mut deployment);
+
+        deployment.run().unwrap();
+    }
+
+    #[tokio::test]
+    #[cfg_attr(not(maelstrom_available), ignore)]
+    async fn broadcast_3b_maelstrom() {
+        let mut flow = FlowBuilder::new();
+        let cluster = flow.cluster::<()>();
+
+        let (input, output_handle) = maelstrom_bidi_clients(&cluster);
+        output_handle
+            .complete(broadcast_server(&cluster, input).assume_ordering(nondet!(/** test */)));
+
+        let mut deployment = MaelstromDeployment::new("broadcast")
+            .maelstrom_path(PathBuf::from_str(&std::env::var("MAELSTROM_PATH").unwrap()).unwrap())
+            .node_count(5)
+            .time_limit(20)
+            .rate(10);
+
+        let _ = flow
+            .with_cluster(&cluster, MaelstromClusterSpec)
+            .deploy(&mut deployment);
+
+        deployment.run().unwrap();
+    }
+}

--- a/hydro_test/src/maelstrom/echo.rs
+++ b/hydro_test/src/maelstrom/echo.rs
@@ -1,0 +1,58 @@
+//! This implements the Maelstrom echo workload.
+//!
+//! See <https://fly.io/dist-sys/1/>
+
+use hydro_lang::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct EchoMessage {
+    pub msg_id: usize,
+    pub echo: String,
+}
+
+pub fn echo_server<'a, C>(
+    input: KeyedStream<String, EchoMessage, Cluster<'a, C>>,
+) -> KeyedStream<String, serde_json::Value, Cluster<'a, C>> {
+    input.map(q!(|msg| {
+        serde_json::json!({
+            "type": "echo_ok",
+            "echo": msg.echo,
+            "in_reply_to": msg.msg_id
+        })
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::str::FromStr;
+
+    use hydro_lang::deploy::maelstrom::deploy_maelstrom::{
+        MaelstromClusterSpec, MaelstromDeployment,
+    };
+    use hydro_lang::deploy::maelstrom::maelstrom_bidi_clients;
+
+    use super::*;
+
+    #[tokio::test]
+    #[cfg_attr(not(maelstrom_available), ignore)]
+    async fn test_with_maelstrom() {
+        let mut flow = FlowBuilder::new();
+        let cluster = flow.cluster::<()>();
+
+        let (input, output_handle) = maelstrom_bidi_clients(&cluster);
+        output_handle.complete(echo_server(input));
+
+        let mut deployment = MaelstromDeployment::new("echo")
+            .maelstrom_path(PathBuf::from_str(&std::env::var("MAELSTROM_PATH").unwrap()).unwrap())
+            .node_count(1)
+            .time_limit(10);
+
+        let _ = flow
+            .with_cluster(&cluster, MaelstromClusterSpec)
+            .deploy(&mut deployment);
+
+        deployment.run().unwrap();
+    }
+}

--- a/hydro_test/src/maelstrom/mod.rs
+++ b/hydro_test/src/maelstrom/mod.rs
@@ -1,0 +1,5 @@
+//! Maelstrom examples for testing the Maelstrom deployment backend.
+
+pub mod broadcast;
+pub mod echo;
+pub mod unique_ids;

--- a/hydro_test/src/maelstrom/unique_ids.rs
+++ b/hydro_test/src/maelstrom/unique_ids.rs
@@ -1,0 +1,74 @@
+//! This implements the Maelstrom unique-ids workload.
+//!
+//! See <https://fly.io/dist-sys/2/>
+
+use hydro_lang::location::cluster::CLUSTER_SELF_ID;
+use hydro_lang::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct GenerateMessage {
+    pub msg_id: usize,
+}
+
+pub fn unique_id_server<'a, C: 'a>(
+    input: KeyedStream<String, GenerateMessage, Cluster<'a, C>>,
+    nondet_ids: NonDet,
+) -> KeyedStream<String, serde_json::Value, Cluster<'a, C>> {
+    input
+        .entries()
+        .assume_ordering(nondet_ids)
+        .enumerate()
+        .map(q!(move |(idx, (sender, msg))| {
+            let self_id = &CLUSTER_SELF_ID;
+            (
+                sender,
+                serde_json::json!({
+                    "type": "generate_ok",
+                    "id": format!("{}-{}", self_id, idx),
+                    "in_reply_to": msg.msg_id
+                }),
+            )
+        }))
+        .into_keyed()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::str::FromStr;
+
+    use hydro_lang::deploy::maelstrom::deploy_maelstrom::{
+        MaelstromClusterSpec, MaelstromDeployment,
+    };
+    use hydro_lang::deploy::maelstrom::maelstrom_bidi_clients;
+
+    use super::*;
+
+    #[tokio::test]
+    #[cfg_attr(not(maelstrom_available), ignore)]
+    async fn test_with_maelstrom() {
+        let mut flow = FlowBuilder::new();
+        let cluster = flow.cluster::<()>();
+
+        let (input, output_handle) = maelstrom_bidi_clients(&cluster);
+        output_handle.complete(unique_id_server(
+            input,
+            nondet!(/** ids can be nondeterministic */),
+        ));
+
+        let mut deployment = MaelstromDeployment::new("unique-ids")
+            .maelstrom_path(PathBuf::from_str(&std::env::var("MAELSTROM_PATH").unwrap()).unwrap())
+            .node_count(3)
+            .time_limit(30)
+            .rate(1000)
+            .availability("total")
+            .nemesis("partition");
+
+        let _ = flow
+            .with_cluster(&cluster, MaelstromClusterSpec)
+            .deploy(&mut deployment);
+
+        deployment.run().unwrap();
+    }
+}


### PR DESCRIPTION

This adds Jepsen's Maelstrom system as another deployment target for Hydro. This enables running Hydro programs with the Maelstrom harness, which tests distributed systems for consistency violations using the same techniques as Jepsen's database evaluations.

The Hydro simulator remains the primary method for testing programs. It is order of magnitudes faster and tests *all* concurrent executions instead of randomizing. But Maelstrom provides a handy set of exercises that we can use to evaluate Hydro, provides carefully-specced verifiers for transaction semantics, and makes it possible to compare Hydro to other distributed systems.
