### PR TITLE
feat(hydro_lang,hydro_test): add `TCP.lossy()` fault tolerance and fault-tolerant broadcast challenge

### DIFF
--- a/hydro_lang/src/compile/deploy_provider.rs
+++ b/hydro_lang/src/compile/deploy_provider.rs
@@ -34,6 +34,7 @@ pub trait Deploy<'a> {
         p2: &Self::Process,
         p2_port: &<Self::Process as Node>::Port,
         name: Option<&str>,
+        networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr);
 
     /// Performs any runtime wiring needed after code generation for a
@@ -61,6 +62,7 @@ pub trait Deploy<'a> {
         c2: &Self::Cluster,
         c2_port: &<Self::Cluster as Node>::Port,
         name: Option<&str>,
+        networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr);
 
     /// Performs any runtime wiring needed after code generation for a
@@ -88,6 +90,7 @@ pub trait Deploy<'a> {
         p2: &Self::Process,
         p2_port: &<Self::Process as Node>::Port,
         name: Option<&str>,
+        networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr);
 
     /// Performs any runtime wiring needed after code generation for a
@@ -115,6 +118,7 @@ pub trait Deploy<'a> {
         c2: &Self::Cluster,
         c2_port: &<Self::Cluster as Node>::Port,
         name: Option<&str>,
+        networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr);
 
     /// Performs any runtime wiring needed after code generation for a

--- a/hydro_lang/src/compile/embedded.rs
+++ b/hydro_lang/src/compile/embedded.rs
@@ -193,6 +193,7 @@ impl<'a> Deploy<'a> for EmbeddedDeploy {
         p2: &Self::Process,
         _p2_port: &(),
         name: Option<&str>,
+        _networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr) {
         let name = name.expect(
             "EmbeddedDeploy o2o networking requires a channel name. Use `TCP.name(\"my_channel\")` to provide one.",
@@ -234,6 +235,7 @@ impl<'a> Deploy<'a> for EmbeddedDeploy {
         c2: &Self::Cluster,
         _c2_port: &(),
         name: Option<&str>,
+        _networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr) {
         let name = name.expect("EmbeddedDeploy o2m networking requires a channel name.");
         let sink_ident = syn::Ident::new(&format!("__network_out_{name}"), Span::call_site());
@@ -270,6 +272,7 @@ impl<'a> Deploy<'a> for EmbeddedDeploy {
         p2: &Self::Process,
         _p2_port: &(),
         name: Option<&str>,
+        _networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr) {
         let name = name.expect("EmbeddedDeploy m2o networking requires a channel name.");
         let sink_ident = syn::Ident::new(&format!("__network_out_{name}"), Span::call_site());
@@ -306,6 +309,7 @@ impl<'a> Deploy<'a> for EmbeddedDeploy {
         c2: &Self::Cluster,
         _c2_port: &(),
         name: Option<&str>,
+        _networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr) {
         let name = name.expect("EmbeddedDeploy m2m networking requires a channel name.");
         let sink_ident = syn::Ident::new(&format!("__network_out_{name}"), Span::call_site());

--- a/hydro_lang/src/deploy/deploy_graph.rs
+++ b/hydro_lang/src/deploy/deploy_graph.rs
@@ -60,7 +60,14 @@ impl<'a> Deploy<'a> for HydroDeploy {
         _p2: &Self::Process,
         p2_port: &<Self::Process as Node>::Port,
         _name: Option<&str>,
+        networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr) {
+        match networking_info {
+            crate::networking::NetworkingInfo::Tcp {
+                fault: crate::networking::TcpFault::FailStop,
+            } => {}
+            _ => panic!("Unsupported networking info: {:?}", networking_info),
+        }
         let p1_port = p1_port.as_str();
         let p2_port = p2_port.as_str();
         deploy_o2o(
@@ -101,7 +108,14 @@ impl<'a> Deploy<'a> for HydroDeploy {
         _c2: &Self::Cluster,
         c2_port: &<Self::Cluster as Node>::Port,
         _name: Option<&str>,
+        networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr) {
+        match networking_info {
+            crate::networking::NetworkingInfo::Tcp {
+                fault: crate::networking::TcpFault::FailStop,
+            } => {}
+            _ => panic!("Unsupported networking info: {:?}", networking_info),
+        }
         let p1_port = p1_port.as_str();
         let c2_port = c2_port.as_str();
         deploy_o2m(
@@ -154,7 +168,14 @@ impl<'a> Deploy<'a> for HydroDeploy {
         _p2: &Self::Process,
         p2_port: &<Self::Process as Node>::Port,
         _name: Option<&str>,
+        networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr) {
+        match networking_info {
+            crate::networking::NetworkingInfo::Tcp {
+                fault: crate::networking::TcpFault::FailStop,
+            } => {}
+            _ => panic!("Unsupported networking info: {:?}", networking_info),
+        }
         let c1_port = c1_port.as_str();
         let p2_port = p2_port.as_str();
         deploy_m2o(
@@ -199,7 +220,14 @@ impl<'a> Deploy<'a> for HydroDeploy {
         _c2: &Self::Cluster,
         c2_port: &<Self::Cluster as Node>::Port,
         _name: Option<&str>,
+        networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr) {
+        match networking_info {
+            crate::networking::NetworkingInfo::Tcp {
+                fault: crate::networking::TcpFault::FailStop,
+            } => {}
+            _ => panic!("Unsupported networking info: {:?}", networking_info),
+        }
         let c1_port = c1_port.as_str();
         let c2_port = c2_port.as_str();
         deploy_m2m(

--- a/hydro_lang/src/deploy/deploy_graph_containerized.rs
+++ b/hydro_lang/src/deploy/deploy_graph_containerized.rs
@@ -913,7 +913,14 @@ impl<'a> Deploy<'a> for DockerDeploy {
         p2: &Self::Process,
         p2_port: &<Self::Process as Node>::Port,
         _name: Option<&str>,
+        networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr) {
+        match networking_info {
+            crate::networking::NetworkingInfo::Tcp {
+                fault: crate::networking::TcpFault::FailStop,
+            } => {}
+            _ => panic!("Unsupported networking info: {:?}", networking_info),
+        }
         let bind_addr = format!("0.0.0.0:{}", p2_port);
         let target = format!("{}:{p2_port}", p2.name);
 
@@ -942,7 +949,14 @@ impl<'a> Deploy<'a> for DockerDeploy {
         c2: &Self::Cluster,
         c2_port: &<Self::Cluster as Node>::Port,
         _name: Option<&str>,
+        networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr) {
+        match networking_info {
+            crate::networking::NetworkingInfo::Tcp {
+                fault: crate::networking::TcpFault::FailStop,
+            } => {}
+            _ => panic!("Unsupported networking info: {:?}", networking_info),
+        }
         deploy_containerized_o2m(*c2_port)
     }
 
@@ -968,7 +982,14 @@ impl<'a> Deploy<'a> for DockerDeploy {
         p2: &Self::Process,
         p2_port: &<Self::Process as Node>::Port,
         _name: Option<&str>,
+        networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr) {
+        match networking_info {
+            crate::networking::NetworkingInfo::Tcp {
+                fault: crate::networking::TcpFault::FailStop,
+            } => {}
+            _ => panic!("Unsupported networking info: {:?}", networking_info),
+        }
         deploy_containerized_m2o(*p2_port, &p2.name)
     }
 
@@ -994,7 +1015,14 @@ impl<'a> Deploy<'a> for DockerDeploy {
         c2: &Self::Cluster,
         c2_port: &<Self::Cluster as Node>::Port,
         _name: Option<&str>,
+        networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr) {
+        match networking_info {
+            crate::networking::NetworkingInfo::Tcp {
+                fault: crate::networking::TcpFault::FailStop,
+            } => {}
+            _ => panic!("Unsupported networking info: {:?}", networking_info),
+        }
         deploy_containerized_m2m(*c2_port)
     }
 

--- a/hydro_lang/src/deploy/deploy_graph_containerized_ecs.rs
+++ b/hydro_lang/src/deploy/deploy_graph_containerized_ecs.rs
@@ -439,7 +439,14 @@ impl<'a> Deploy<'a> for EcsDeploy {
         p2: &Self::Process,
         p2_port: &<Self::Process as Node>::Port,
         _name: Option<&str>,
+        networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr) {
+        match networking_info {
+            crate::networking::NetworkingInfo::Tcp {
+                fault: crate::networking::TcpFault::FailStop,
+            } => {}
+            _ => panic!("Unsupported networking info: {:?}", networking_info),
+        }
         deploy_containerized_o2o(&p2.name, *p2_port)
     }
 
@@ -468,7 +475,14 @@ impl<'a> Deploy<'a> for EcsDeploy {
         c2: &Self::Cluster,
         c2_port: &<Self::Cluster as Node>::Port,
         _name: Option<&str>,
+        networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr) {
+        match networking_info {
+            crate::networking::NetworkingInfo::Tcp {
+                fault: crate::networking::TcpFault::FailStop,
+            } => {}
+            _ => panic!("Unsupported networking info: {:?}", networking_info),
+        }
         deploy_containerized_o2m(*c2_port)
     }
 
@@ -497,7 +511,14 @@ impl<'a> Deploy<'a> for EcsDeploy {
         p2: &Self::Process,
         p2_port: &<Self::Process as Node>::Port,
         _name: Option<&str>,
+        networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr) {
+        match networking_info {
+            crate::networking::NetworkingInfo::Tcp {
+                fault: crate::networking::TcpFault::FailStop,
+            } => {}
+            _ => panic!("Unsupported networking info: {:?}", networking_info),
+        }
         deploy_containerized_m2o(*p2_port, &p2.name)
     }
 
@@ -526,7 +547,14 @@ impl<'a> Deploy<'a> for EcsDeploy {
         c2: &Self::Cluster,
         c2_port: &<Self::Cluster as Node>::Port,
         _name: Option<&str>,
+        networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr) {
+        match networking_info {
+            crate::networking::NetworkingInfo::Tcp {
+                fault: crate::networking::TcpFault::FailStop,
+            } => {}
+            _ => panic!("Unsupported networking info: {:?}", networking_info),
+        }
         deploy_containerized_m2m(*c2_port)
     }
 

--- a/hydro_lang/src/live_collections/keyed_stream/networking.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/networking.rs
@@ -125,6 +125,7 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
             to.clone(),
             HydroNode::Network {
                 name: name.map(ToOwned::to_owned),
+                networking_info: N::networking_info(),
                 serialize_fn: serialize_pipeline.map(|e| e.into()),
                 instantiate_fn: DebugInstantiate::Building,
                 deserialize_fn: deserialize_pipeline.map(|e| e.into()),
@@ -242,6 +243,7 @@ impl<'a, K, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
             to.clone(),
             HydroNode::Network {
                 name: name.map(ToOwned::to_owned),
+                networking_info: N::networking_info(),
                 serialize_fn: serialize_pipeline.map(|e| e.into()),
                 instantiate_fn: DebugInstantiate::Building,
                 deserialize_fn: deserialize_pipeline.map(|e| e.into()),
@@ -390,6 +392,7 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
             to.clone(),
             HydroNode::Network {
                 name: name.map(ToOwned::to_owned),
+                networking_info: N::networking_info(),
                 serialize_fn: serialize_pipeline.map(|e| e.into()),
                 instantiate_fn: DebugInstantiate::Building,
                 deserialize_fn: deserialize_pipeline.map(|e| e.into()),
@@ -558,6 +561,7 @@ impl<'a, K, V, L, B: Boundedness, O: Ordering, R: Retries>
                 to.clone(),
                 HydroNode::Network {
                     name: name.map(ToOwned::to_owned),
+                    networking_info: N::networking_info(),
                     serialize_fn: serialize_pipeline.map(|e| e.into()),
                     instantiate_fn: DebugInstantiate::Building,
                     deserialize_fn: deserialize_pipeline.map(|e| e.into()),

--- a/hydro_lang/src/live_collections/stream/networking.rs
+++ b/hydro_lang/src/live_collections/stream/networking.rs
@@ -179,6 +179,7 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Process<'a, L>
             to.clone(),
             HydroNode::Network {
                 name: name.map(ToOwned::to_owned),
+                networking_info: N::networking_info(),
                 serialize_fn: serialize_pipeline.map(|e| e.into()),
                 instantiate_fn: DebugInstantiate::Building,
                 deserialize_fn: deserialize_pipeline.map(|e| e.into()),
@@ -917,6 +918,7 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Cluster<'a, L>
             to.clone(),
             HydroNode::Network {
                 name: name.map(ToOwned::to_owned),
+                networking_info: N::networking_info(),
                 serialize_fn: serialize_pipeline.map(|e| e.into()),
                 instantiate_fn: DebugInstantiate::Building,
                 deserialize_fn: deserialize_pipeline.map(|e| e.into()),

--- a/hydro_lang/src/sim/builder.rs
+++ b/hydro_lang/src/sim/builder.rs
@@ -838,7 +838,16 @@ impl DfirBuilder for SimBuilder {
         source: syn::Expr,
         deserialize: Option<&DebugExpr>,
         tag_id: usize,
+        networking_info: &crate::networking::NetworkingInfo,
     ) {
+        use crate::networking::{NetworkingInfo, TcpFault};
+        match networking_info {
+            NetworkingInfo::Tcp { fault } => match fault {
+                TcpFault::FailStop => {}
+                _ => todo!("SimBuilder only supports fail-stop TCP networking"),
+            },
+        }
+
         let root = get_this_crate();
 
         match (from, to) {

--- a/hydro_lang/src/sim/graph.rs
+++ b/hydro_lang/src/sim/graph.rs
@@ -182,6 +182,7 @@ impl<'a> Deploy<'a> for SimDeploy {
         _p2: &Self::Process,
         p2_port: &<Self::Process as Node>::Port,
         _name: Option<&str>,
+        _networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr) {
         let ident_sink =
             syn::Ident::new(&format!("__hydro_o2o_sink_{}", p1_port), Span::call_site());
@@ -211,6 +212,7 @@ impl<'a> Deploy<'a> for SimDeploy {
         _c2: &Self::Cluster,
         c2_port: &<Self::Cluster as Node>::Port,
         _name: Option<&str>,
+        _networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr) {
         let ident_sink =
             syn::Ident::new(&format!("__hydro_o2m_sink_{}", p1_port), Span::call_site());
@@ -240,6 +242,7 @@ impl<'a> Deploy<'a> for SimDeploy {
         _p2: &Self::Process,
         p2_port: &<Self::Process as Node>::Port,
         _name: Option<&str>,
+        _networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr) {
         let ident_sink =
             syn::Ident::new(&format!("__hydro_m2o_sink_{}", c1_port), Span::call_site());
@@ -270,6 +273,7 @@ impl<'a> Deploy<'a> for SimDeploy {
         _c2: &Self::Cluster,
         c2_port: &<Self::Cluster as Node>::Port,
         _name: Option<&str>,
+        _networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr) {
         let ident_sink =
             syn::Ident::new(&format!("__hydro_m2m_sink_{}", c1_port), Span::call_site());

--- a/hydro_test/src/cluster/snapshots/compute_pi_ir.snap
+++ b/hydro_test/src/cluster/snapshots/compute_pi_ir.snap
@@ -22,6 +22,9 @@ expression: built.ir()
                                                     inner: Cast {
                                                         inner: Network {
                                                             name: None,
+                                                            networking_info: Tcp {
+                                                                fault: FailStop,
+                                                            },
                                                             serialize_fn: Some(
                                                                 hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (u64 , u64) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                                                             ),

--- a/hydro_test/src/cluster/snapshots/many_to_many_ir.snap
+++ b/hydro_test/src/cluster/snapshots/many_to_many_ir.snap
@@ -12,6 +12,9 @@ expression: built.ir()
                         name: Some(
                             "m2m_broadcast",
                         ),
+                        networking_info: Tcp {
+                            fault: FailStop,
+                        },
                         serialize_fn: Some(
                             hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , i32) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                         ),

--- a/hydro_test/src/cluster/snapshots/map_reduce_ir.snap
+++ b/hydro_test/src/cluster/snapshots/map_reduce_ir.snap
@@ -20,6 +20,9 @@ expression: built.ir()
                                                 inner: Cast {
                                                     inner: Network {
                                                         name: None,
+                                                        networking_info: Tcp {
+                                                            fault: FailStop,
+                                                        },
                                                         serialize_fn: Some(
                                                             hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (std :: string :: String , i32) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                                                         ),
@@ -41,6 +44,9 @@ expression: built.ir()
                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < std :: string :: String , (std :: string :: String , ()) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: map_reduce :: * ; | string | (string , ()) }),
                                                                                         input: Network {
                                                                                             name: None,
+                                                                                            networking_info: Tcp {
+                                                                                                fault: FailStop,
+                                                                                            },
                                                                                             serialize_fn: Some(
                                                                                                 hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , std :: string :: String) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                             ),

--- a/hydro_test/src/cluster/snapshots/paxos_ir.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir.snap
@@ -491,6 +491,9 @@ expression: built.ir()
                     inner: Cast {
                         inner: Network {
                             name: None,
+                            networking_info: Tcp {
+                                fault: FailStop,
+                            },
                             serialize_fn: Some(
                                 hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                             ),
@@ -990,6 +993,9 @@ expression: built.ir()
                                         inner: Cast {
                                             inner: Network {
                                                 name: None,
+                                                networking_info: Tcp {
+                                                    fault: FailStop,
+                                                },
                                                 serialize_fn: Some(
                                                     hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                 ),
@@ -1011,6 +1017,9 @@ expression: built.ir()
                                                                                     inner: Cast {
                                                                                         inner: Network {
                                                                                             name: None,
+                                                                                            networking_info: Tcp {
+                                                                                                fault: FailStop,
+                                                                                            },
                                                                                             serialize_fn: Some(
                                                                                                 hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                             ),
@@ -2786,6 +2795,9 @@ expression: built.ir()
                                                                         inner: Cast {
                                                                             inner: Network {
                                                                                 name: None,
+                                                                                networking_info: Tcp {
+                                                                                    fault: FailStop,
+                                                                                },
                                                                                 serialize_fn: Some(
                                                                                     hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                 ),
@@ -3365,6 +3377,9 @@ expression: built.ir()
                                                                         inner: Cast {
                                                                             inner: Network {
                                                                                 name: None,
+                                                                                networking_info: Tcp {
+                                                                                    fault: FailStop,
+                                                                                },
                                                                                 serialize_fn: Some(
                                                                                     hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                 ),
@@ -3998,6 +4013,9 @@ expression: built.ir()
                                     inner: Cast {
                                         inner: Network {
                                             name: None,
+                                            networking_info: Tcp {
+                                                fault: FailStop,
+                                            },
                                             serialize_fn: Some(
                                                 hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                             ),
@@ -4018,6 +4036,9 @@ expression: built.ir()
                                                                             inner: Cast {
                                                                                 inner: Network {
                                                                                     name: None,
+                                                                                    networking_info: Tcp {
+                                                                                        fault: FailStop,
+                                                                                    },
                                                                                     serialize_fn: Some(
                                                                                         hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                                                     ),
@@ -5704,6 +5725,9 @@ expression: built.ir()
                                                     inner: Cast {
                                                         inner: Network {
                                                             name: None,
+                                                            networking_info: Tcp {
+                                                                fault: FailStop,
+                                                            },
                                                             serialize_fn: Some(
                                                                 hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , (usize , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                             ),
@@ -6595,6 +6619,9 @@ expression: built.ir()
                                                     input: Cast {
                                                         inner: Network {
                                                             name: None,
+                                                            networking_info: Tcp {
+                                                                fault: FailStop,
+                                                            },
                                                             serialize_fn: Some(
                                                                 hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , usize) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                             ),
@@ -7044,6 +7071,9 @@ expression: built.ir()
                                     inner: Cast {
                                         inner: Network {
                                             name: None,
+                                            networking_info: Tcp {
+                                                fault: FailStop,
+                                            },
                                             serialize_fn: Some(
                                                 hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , ((u32 , i32) , core :: result :: Result < () , () >)) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                             ),
@@ -8392,6 +8422,9 @@ expression: built.ir()
                                                                 inner: Cast {
                                                                     inner: Network {
                                                                         name: None,
+                                                                        networking_info: Tcp {
+                                                                            fault: FailStop,
+                                                                        },
                                                                         serialize_fn: Some(
                                                                             hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                                                                         ),
@@ -8754,6 +8787,9 @@ expression: built.ir()
                                 inner: Cast {
                                     inner: Network {
                                         name: None,
+                                        networking_info: Tcp {
+                                            fault: FailStop,
+                                        },
                                         serialize_fn: Some(
                                             hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < usize , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                                         ),

--- a/hydro_test/src/cluster/snapshots/simple_cluster_ir.snap
+++ b/hydro_test/src/cluster/snapshots/simple_cluster_ir.snap
@@ -10,6 +10,9 @@ expression: built.ir()
                 inner: Cast {
                     inner: Network {
                         name: None,
+                        networking_info: Tcp {
+                            fault: FailStop,
+                        },
                         serialize_fn: Some(
                             hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                         ),
@@ -21,6 +24,9 @@ expression: built.ir()
                             f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: simple_cluster :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: __staged :: location :: MemberId :: < () > :: from_tagless ((__hydro_lang_cluster_self_id_loc2v1) . clone ()) ; move | n | println ! ("cluster received: {:?} (self cluster id: {})" , n , CLUSTER_SELF_ID__free) }),
                             input: Network {
                                 name: None,
+                                networking_info: Tcp {
+                                    fault: FailStop,
+                                },
                                 serialize_fn: Some(
                                     hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32)) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                 ),

--- a/hydro_test/src/cluster/snapshots/two_pc_ir.snap
+++ b/hydro_test/src/cluster/snapshots/two_pc_ir.snap
@@ -169,6 +169,9 @@ expression: built.ir()
                                         inner: Cast {
                                             inner: Network {
                                                 name: None,
+                                                networking_info: Tcp {
+                                                    fault: FailStop,
+                                                },
                                                 serialize_fn: Some(
                                                     hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                                                 ),
@@ -178,6 +181,9 @@ expression: built.ir()
                                                 ),
                                                 input: Network {
                                                     name: None,
+                                                    networking_info: Tcp {
+                                                        fault: FailStop,
+                                                    },
                                                     serialize_fn: Some(
                                                         hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32))) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                     ),
@@ -312,6 +318,9 @@ expression: built.ir()
                                                                         inner: Cast {
                                                                             inner: Network {
                                                                                 name: None,
+                                                                                networking_info: Tcp {
+                                                                                    fault: FailStop,
+                                                                                },
                                                                                 serialize_fn: Some(
                                                                                     hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , i32) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                                                                                 ),
@@ -804,6 +813,9 @@ expression: built.ir()
                                         inner: Cast {
                                             inner: Network {
                                                 name: None,
+                                                networking_info: Tcp {
+                                                    fault: FailStop,
+                                                },
                                                 serialize_fn: Some(
                                                     hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                                                 ),
@@ -813,6 +825,9 @@ expression: built.ir()
                                                 ),
                                                 input: Network {
                                                     name: None,
+                                                    networking_info: Tcp {
+                                                        fault: FailStop,
+                                                    },
                                                     serialize_fn: Some(
                                                         hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32))) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                     ),
@@ -1265,6 +1280,9 @@ expression: built.ir()
             inner: <tee 10>: Cast {
                 inner: Network {
                     name: None,
+                    networking_info: Tcp {
+                        fault: FailStop,
+                    },
                     serialize_fn: Some(
                         hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , (u32 , i32)) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                     ),
@@ -2341,6 +2359,9 @@ expression: built.ir()
                                                                 inner: Cast {
                                                                     inner: Network {
                                                                         name: None,
+                                                                        networking_info: Tcp {
+                                                                            fault: FailStop,
+                                                                        },
                                                                         serialize_fn: Some(
                                                                             hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                                                                         ),
@@ -2703,6 +2724,9 @@ expression: built.ir()
                                 inner: Cast {
                                     inner: Network {
                                         name: None,
+                                        networking_info: Tcp {
+                                            fault: FailStop,
+                                        },
                                         serialize_fn: Some(
                                             hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < usize , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                                         ),

--- a/hydro_test/src/distributed/snapshots/first_ten_distributed_ir.snap
+++ b/hydro_test/src/distributed/snapshots/first_ten_distributed_ir.snap
@@ -95,6 +95,9 @@ expression: builder.finalize().ir()
         f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: distributed :: first_ten :: SendOverNetwork , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: distributed :: first_ten :: * ; | n | println ! ("{}" , n . n) }),
         input: Network {
             name: None,
+            networking_info: Tcp {
+                fault: FailStop,
+            },
             serialize_fn: Some(
                 hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: distributed :: first_ten :: SendOverNetwork , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
             ),

--- a/hydro_test/src/maelstrom/broadcast.rs
+++ b/hydro_test/src/maelstrom/broadcast.rs
@@ -2,7 +2,10 @@
 //!
 //! See <https://fly.io/dist-sys/3a/> and <https://fly.io/dist-sys/3b/>
 
-use hydro_lang::live_collections::stream::NoOrder;
+use std::collections::HashSet;
+use std::time::Duration;
+
+use hydro_lang::live_collections::stream::{AtLeastOnce, NoOrder};
 use hydro_lang::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -36,10 +39,36 @@ pub enum Request {
 fn broadcast_core<'a, C: 'a>(
     cluster: &Cluster<'a, C>,
     writes: Stream<u32, Cluster<'a, C>, Unbounded, NoOrder>,
-) -> Stream<u32, Cluster<'a, C>, Unbounded, NoOrder> {
-    writes
-        .broadcast(cluster, TCP.fail_stop().bincode(), nondet!(/** TODO */))
-        .values()
+) -> Singleton<HashSet<u32>, Cluster<'a, C>, Unbounded> {
+    let (broadcasted_forward, broadcasted) =
+        cluster.forward_ref::<Stream<_, _, Unbounded, NoOrder, AtLeastOnce>>();
+
+    let cur_state = sliced! {
+        let new_writes = use(writes, nondet!(/** TODO */));
+        let recv_broadcast = use(broadcasted, nondet!(/** TODO */));
+        let mut local_state = use::state_null::<Stream<_, _, _, NoOrder>>();
+
+        local_state = local_state.chain(new_writes).weaken_retries::<AtLeastOnce>()
+            .chain(recv_broadcast.flatten_unordered())
+            .unique();
+        local_state.clone().fold(q!(|| HashSet::new()), q!(|set, v| {
+            set.insert(v);
+        }, commutative = ManualProof(/* TODO */)))
+    };
+
+    broadcasted_forward.complete(
+        cur_state
+            .clone()
+            .sample_every(q!(Duration::from_millis(50)), nondet!(/** TODO */))
+            .broadcast(
+                cluster,
+                TCP.lossy(nondet!(/** TODO */)).bincode(),
+                nondet!(/** TODO */),
+            )
+            .values(),
+    );
+
+    cur_state
 }
 
 pub fn broadcast_server<'a, C: 'a>(
@@ -75,16 +104,14 @@ pub fn broadcast_server<'a, C: 'a>(
     let read_response = sliced! {
         let req = use(read_requests, nondet!(/** batching of requests does not matter */));
         let data = use(
-            current_state
-                .assume_ordering(nondet!(/** client ignores order */))
-                .fold(q!(|| vec![]), q!(|v, d| v.push(d))),
+            current_state,
             nondet!(/** we only guarantee eventual consistency */)
         );
 
         req.cross_singleton(data).map(q!(|(req, data)| {
             serde_json::json!({
                 "type": "read_ok",
-                "messages": data,
+                "messages": data.into_iter().collect::<Vec<_>>(),
                 "in_reply_to": req.msg_id
             })
         }))
@@ -160,6 +187,30 @@ mod tests {
             .node_count(5)
             .time_limit(20)
             .rate(10);
+
+        let _ = flow
+            .with_cluster(&cluster, MaelstromClusterSpec)
+            .deploy(&mut deployment);
+
+        deployment.run().unwrap();
+    }
+
+    #[tokio::test]
+    #[cfg_attr(not(maelstrom_available), ignore)]
+    async fn broadcast_3c_maelstrom() {
+        let mut flow = FlowBuilder::new();
+        let cluster = flow.cluster::<()>();
+
+        let (input, output_handle) = maelstrom_bidi_clients(&cluster);
+        output_handle
+            .complete(broadcast_server(&cluster, input).assume_ordering(nondet!(/** test */)));
+
+        let mut deployment = MaelstromDeployment::new("broadcast")
+            .maelstrom_path(PathBuf::from_str(&std::env::var("MAELSTROM_PATH").unwrap()).unwrap())
+            .node_count(5)
+            .time_limit(20)
+            .rate(10)
+            .nemesis("partition");
 
         let _ = flow
             .with_cluster(&cluster, MaelstromClusterSpec)


### PR DESCRIPTION

Previously, the only available fault-tolerance option for TCP channels was fault-stop, which isn't very practical for long running distributed systems that can tolerate network failures.

This adds a new mode `TCP.lossy(nondet!(/** ... */))` which non-deterministically drops packets. We thread this through into the compilation layer, where (currently) lossy mode is only supported on the Maelstrom backend (we will eventually wire up support in the production deployment backends with runtime TCP re-connect logic).

For Maelstrom, we are able to use the fault-tolerance choice to validate that the Hydro code is correctly designed to handle the faults configured in Maelstrom. For example, if network partitions are enabled, the backend will require that all channels are lossy.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydro-project/hydro/pull/2549).
* #2609
* __->__ #2549