### PR TITLE
feat(hydro_lang)!: require explicit failure policy for TCP channels

### DIFF
--- a/docs/docs/hydro/learn/quickstart/partitioned-counter.mdx
+++ b/docs/docs/hydro/learn/quickstart/partitioned-counter.mdx
@@ -83,7 +83,7 @@ let sharded_increment_requests = increment_requests
         key.hash(&mut hasher);
         MemberId::from_raw_id(hasher.finish() as u32 % 5)
     }))
-    .demux(shard_servers, TCP.bincode());
+    .demux(shard_servers, TCP.fail_stop().bincode());
 `)}</CodeBlock>
 
 The `prefix_key` method adds a new key to the front of the keyed stream. Here, you compute a `MemberId` by hashing the key name and taking modulo 5 (assuming 5 shards). The result is a stream keyed by `(MemberId, client_id, key_name)`.
@@ -109,7 +109,7 @@ let sharded_increment_requests = increment_requests
         key.hash(&mut hasher);
         MemberId::from_raw_id(hasher.finish() as u32 % 5)
     }))
-    .demux(shard_servers, TCP.bincode());
+    .demux(shard_servers, TCP.fail_stop().bincode());
 
 let sharded_get_requests = get_requests
     .prefix_key(q!(|(_client, key)| {
@@ -117,7 +117,7 @@ let sharded_get_requests = get_requests
         key.hash(&mut hasher);
         MemberId::from_raw_id(hasher.finish() as u32 % 5)
     }))
-    .demux(shard_servers, TCP.bincode());
+    .demux(shard_servers, TCP.fail_stop().bincode());
 `), [7, 15])}</CodeBlock>
 
 After `demux`, the stream is now located at the cluster. The stream returned by a demux operator preserves the remaining keys after the `MemberId` is consumed for routing. In this case, we are left with a `KeyedStream<u32, String, Cluster<'a, CounterShard>>` - a stream keyed by client ID and key name, located on the cluster.
@@ -143,7 +143,7 @@ Finally, you need to send the responses back to the leader process:
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/partitioned_counter.rs">src/partitioned_counter.rs</Link>
 } showLineNumbers={41}>{getLines(partitionedCounterSrc, 41, 44, `
 let increment_ack = sharded_increment_ack
-    .send(leader, TCP.bincode())
+    .send(leader, TCP.fail_stop().bincode())
     .drop_key_prefix();
 `)}</CodeBlock>
 

--- a/docs/docs/hydro/reference/locations/processes.md
+++ b/docs/docs/hydro/reference/locations/processes.md
@@ -39,5 +39,5 @@ Because a process represents a single machine, it is straightforward to send dat
 # let leader: Process<Leader> = flow.process::<Leader>();
 let numbers = leader.source_iter(q!(vec![1, 2, 3, 4]));
 let process2: Process<()> = flow.process::<()>();
-let on_p2: Stream<_, Process<()>, _> = numbers.send(&process2, TCP.bincode());
+let on_p2: Stream<_, Process<()>, _> = numbers.send(&process2, TCP.fail_stop().bincode());
 ```

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -1,6 +1,6 @@
 import Link from "@docusaurus/Link";
 import Layout from "@theme/Layout";
-import CodeBlock from '@theme/CodeBlock';
+import CodeBlock from "@theme/CodeBlock";
 
 import styles from "./index.module.css";
 import Head from "@docusaurus/Head";
@@ -9,8 +9,14 @@ export default function Home() {
   return (
     <Layout>
       <Head>
-        <title>Hydro - a Rust framework for correct and performant distributed systems</title>
-        <meta property="og:title" content="Hydro - a Rust framework for correct and performant distributed systems" />
+        <title>
+          Hydro - a Rust framework for correct and performant distributed
+          systems
+        </title>
+        <meta
+          property="og:title"
+          content="Hydro - a Rust framework for correct and performant distributed systems"
+        />
       </Head>
       <main>
         <div className={styles["jumbo"]}>
@@ -66,22 +72,46 @@ export default function Home() {
           </div>
         </div>
         <div className={styles["panel"]}>
-          <div style={{
-            flexGrow: 1,
-            maxWidth: "650px"
-          }}>
+          <div
+            style={{
+              flexGrow: 1,
+              maxWidth: "650px",
+            }}
+          >
             <h1>Distributed Safety Built-In</h1>
             <p>
-              Hydro helps you avoid distributed systems bugs at each stage of development. Just like Rust ensures memory safety through the borrow checker, Hydro ensures <i>distributed safety</i> through <b>stream types</b>. These types have <b>zero runtime overhead</b>; you retain full control over the network protocol, compute placement, and serialization format.
+              Hydro helps you avoid distributed systems bugs at each stage of
+              development. Just like Rust ensures memory safety through the
+              borrow checker, Hydro ensures <i>distributed safety</i> through{" "}
+              <b>stream types</b>. These types have <b>zero runtime overhead</b>
+              ; you retain full control over the network protocol, compute
+              placement, and serialization format.
             </p>
-            <p>Hydro automatically flags situations where messages may be out-of-order, or duplicated, and guides you to appropriately handle them. These are surfaced through the Rust type system, visible to your editor, language server, and agents.</p>
+            <p>
+              Hydro automatically flags situations where messages may be
+              out-of-order, or duplicated, and guides you to appropriately
+              handle them. These are surfaced through the Rust type system,
+              visible to your editor, language server, and agents.
+            </p>
             <div className={styles["inDevPanel"]}>
-              <b>In Preview (<a href={"https://github.com/hydro-project/hydro/pull/2158"}>#2158</a>)</b>
-              <p style={{
-                fontSize: "0.95em",
-                marginTop: "5px",
-                marginBottom: 0,
-              }}>Hydro offers built-in <b>deterministic simulation testing</b>, which lets you simulate distributed programs on your laptop and use cutting-edge fuzzers to quickly find complex edge-cases.</p>
+              <b>
+                In Preview (
+                <a href={"https://github.com/hydro-project/hydro/pull/2158"}>
+                  #2158
+                </a>
+                )
+              </b>
+              <p
+                style={{
+                  fontSize: "0.95em",
+                  marginTop: "5px",
+                  marginBottom: 0,
+                }}
+              >
+                Hydro offers built-in <b>deterministic simulation testing</b>,
+                which lets you simulate distributed programs on your laptop and
+                use cutting-edge fuzzers to quickly find complex edge-cases.
+              </p>
             </div>
           </div>
 
@@ -93,7 +123,7 @@ export default function Home() {
                 marginRight: "auto",
                 width: "100%",
                 aspectRatio: "16 / 9",
-                borderRadius: "15px"
+                borderRadius: "15px",
               }}
               src="https://www.youtube.com/embed/LdZ94m7anTw?si=5duyR1MjSRRdPJId"
               title="YouTube video player"
@@ -106,28 +136,50 @@ export default function Home() {
         </div>
 
         <div className={styles["panel"]}>
-          <div style={{
-            flexGrow: 1,
-            maxWidth: "650px"
-          }}>
+          <div
+            style={{
+              flexGrow: 1,
+              maxWidth: "650px",
+            }}
+          >
             <h1>A New Kind of Modularity</h1>
             <p>
-              Hydro is the first production framework with <b>location-oriented programming</b>, where a single function can encapsulate logic spanning several machines. Instead of splitting your app on network boundaries with opaque RPC calls, Hydro encourages you to split your app into <b>logical modules</b> that can be independently tested.
+              Hydro is the first production framework with{" "}
+              <b>location-oriented programming</b>, where a single function can
+              encapsulate logic spanning several machines. Instead of splitting
+              your app on network boundaries with opaque RPC calls, Hydro
+              encourages you to split your app into <b>logical modules</b> that
+              can be independently tested.
             </p>
-            <p style={{
-              marginBottom: 0
-            }}>Quorum counting? Two-Phase Commit? Each a single function in Hydro's standard library. Want just the leader-election piece of Paxos? It's already a separate module. Hydro unlocks new opportunities to share distributed code across your organization with confidence.</p>
+            <p
+              style={{
+                marginBottom: 0,
+              }}
+            >
+              Quorum counting? Two-Phase Commit? Each a single function in
+              Hydro's standard library. Want just the leader-election piece of
+              Paxos? It's already a separate module. Hydro unlocks new
+              opportunities to share distributed code across your organization
+              with confidence.
+            </p>
           </div>
 
-          <div className={styles["panelImage"]} style={{ fontSize: "16px", flexShrink: 1, flexBasis: "10%", marginBottom: "calc(-1 * var(--ifm-leading))" }}>
-            <CodeBlock
-          language="rust">
-            {`fn reduce_from_cluster(
+          <div
+            className={styles["panelImage"]}
+            style={{
+              fontSize: "16px",
+              flexShrink: 1,
+              flexBasis: "10%",
+              marginBottom: "calc(-1 * var(--ifm-leading))",
+            }}
+          >
+            <CodeBlock language="rust">
+              {`fn reduce_from_cluster(
   data: Stream<usize, Cluster<Worker>>,
   leader: &Process<Leader>
 ) -> Singleton<usize, Process<Leader>> {
   data
-    .send(leader, TCP.bincode())
+    .send(leader, TCP.fail_stop().bincode())
     // Stream<(MemberId<Worker>, usize), Process<Leader>, ..., NoOrder>
     .map(q!(|v| v.1)) // drop the ID
     .fold(q!(0), q!(|acc, v| *acc += v, commutative = ManualProof(...)))
@@ -137,58 +189,104 @@ export default function Home() {
         </div>
 
         <div className={styles["panel"]}>
-          <div style={{
-            flexGrow: 1,
-            maxWidth: "650px"
-          }}>
+          <div
+            style={{
+              flexGrow: 1,
+              maxWidth: "650px",
+            }}
+          >
             <h1>Bare-Metal Performance</h1>
             <p>
-              Hydro is powered by the <b>Dataflow Intermediate Representation (DFIR)</b>, a compiler and low-level runtime for stream processing. DFIR uses a microbatch processing architecture, which enables automatic vectorization and efficient scheduling without restricting your application logic.
+              Hydro is powered by the{" "}
+              <b>Dataflow Intermediate Representation (DFIR)</b>, a compiler and
+              low-level runtime for stream processing. DFIR uses a microbatch
+              processing architecture, which enables automatic vectorization and
+              efficient scheduling without restricting your application logic.
             </p>
-            <p>DFIR emits rich profiling information for observability and performance tuning, and can automatically generate Mermaid diagrams to visualize your streaming logic. It already powers production database engines like <a style={{ fontWeight: "bold" }} href="https://github.com/GreptimeTeam/greptimedb">GreptimeDB</a>.</p>
+            <p>
+              DFIR emits rich profiling information for observability and
+              performance tuning, and can automatically generate Mermaid
+              diagrams to visualize your streaming logic. It already powers
+              production database engines like{" "}
+              <a
+                style={{ fontWeight: "bold" }}
+                href="https://github.com/GreptimeTeam/greptimedb"
+              >
+                GreptimeDB
+              </a>
+              .
+            </p>
             <div className={styles["comingSoonPanel"]}>
-              <b>Coming Soon (<a href={"https://github.com/hydro-project/hydro/issues/1890"}>#1890</a>)</b>
-              <p style={{
-                fontSize: "0.9em",
-                marginTop: "5px",
-                marginBottom: 0,
-              }}>We are developing an io-uring backend for DFIR that enables even higher network performance and zero-copy I/O, all without any changes to your high-level Hydro logic.</p>
+              <b>
+                Coming Soon (
+                <a href={"https://github.com/hydro-project/hydro/issues/1890"}>
+                  #1890
+                </a>
+                )
+              </b>
+              <p
+                style={{
+                  fontSize: "0.9em",
+                  marginTop: "5px",
+                  marginBottom: 0,
+                }}
+              >
+                We are developing an io-uring backend for DFIR that enables even
+                higher network performance and zero-copy I/O, all without any
+                changes to your high-level Hydro logic.
+              </p>
             </div>
           </div>
 
-          <div style={{ minWidth: "260px", width: 0 }} className={styles["panelImage"]}>
+          <div
+            style={{ minWidth: "260px", width: 0 }}
+            className={styles["panelImage"]}
+          >
             <img
               src="/img/dfir-profile.png"
               style={{
                 display: "block",
                 minWidth: "0px",
                 width: "100%",
-                borderRadius: "15px"
+                borderRadius: "15px",
               }}
             ></img>
           </div>
         </div>
 
         <div className={styles["panel"]}>
-          <div style={{
-            flexGrow: 1,
-            maxWidth: "650px"
-          }}>
+          <div
+            style={{
+              flexGrow: 1,
+              maxWidth: "650px",
+            }}
+          >
             <h1>Research Backed. Production Ready.</h1>
             <p>
-              Hydro has its roots in foundational distributed systems research at UC Berkeley, such as the CALM theorem. It is now co-led by a team at Berkeley and AWS, with contributions from the open-source community.
+              Hydro has its roots in foundational distributed systems research
+              at UC Berkeley, such as the CALM theorem. It is now co-led by a
+              team at Berkeley and AWS, with contributions from the open-source
+              community.
             </p>
-            <p>Hydro continues to lead the way with cutting-edge capabilities, such as automatically optimizing distributed protocols, while supporting production use with cloud integrations and observability tooling.</p>
+            <p>
+              Hydro continues to lead the way with cutting-edge capabilities,
+              such as automatically optimizing distributed protocols, while
+              supporting production use with cloud integrations and
+              observability tooling.
+            </p>
           </div>
 
-          <div style={{ minWidth: "260px", width: 0, marginBottom: 0 }} className={styles["panelImage"]}>
+          <div
+            style={{ minWidth: "260px", width: 0, marginBottom: 0 }}
+            className={styles["panelImage"]}
+          >
             <img
               src="/img/hydro-papers.png"
               style={{
                 display: "block",
                 minWidth: "0px",
                 width: "100%",
-                borderRadius: "15px"
+                borderRadius: "15px",
               }}
             ></img>
           </div>

--- a/hydro_lang/src/live_collections/keyed_stream/networking.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/networking.rs
@@ -16,7 +16,7 @@ use crate::networking::{NetworkFor, TCP};
 impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
     KeyedStream<MemberId<L2>, T, Process<'a, L>, B, O, R>
 {
-    #[deprecated = "use KeyedStream::demux(..., TCP.bincode()) instead"]
+    #[deprecated = "use KeyedStream::demux(..., TCP.fail_stop().bincode()) instead"]
     /// Sends each group of this stream to a specific member of a cluster, with the [`MemberId`] key
     /// identifying the recipient for each group and using [`bincode`] to serialize/deserialize messages.
     ///
@@ -61,7 +61,7 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
     where
         T: Serialize + DeserializeOwned,
     {
-        self.demux(other, TCP.bincode())
+        self.demux(other, TCP.fail_stop().bincode())
     }
 
     /// Sends each group of this stream to a specific member of a cluster, with the [`MemberId`] key
@@ -85,8 +85,8 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
     /// let on_worker: Stream<_, Cluster<_>, _> = numbers
     ///     .map(q!(|x| (hydro_lang::location::MemberId::from_raw_id(x), x)))
     ///     .into_keyed()
-    ///     .demux(&workers, TCP.bincode());
-    /// # on_worker.send(&p2, TCP.bincode()).entries()
+    ///     .demux(&workers, TCP.fail_stop().bincode());
+    /// # on_worker.send(&p2, TCP.fail_stop().bincode()).entries()
     /// // if there are 4 members in the cluster, each receives one element
     /// // - MemberId::<()>(0): [0]
     /// // - MemberId::<()>(1): [1]
@@ -140,7 +140,7 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
 impl<'a, K, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
     KeyedStream<(MemberId<L2>, K), T, Process<'a, L>, B, O, R>
 {
-    #[deprecated = "use KeyedStream::demux(..., TCP.bincode()) instead"]
+    #[deprecated = "use KeyedStream::demux(..., TCP.fail_stop().bincode()) instead"]
     /// Sends each group of this stream to a specific member of a cluster. The input stream has a
     /// compound key where the first element is the recipient's [`MemberId`] and the second element
     /// is a key that will be sent along with the value, using [`bincode`] to serialize/deserialize
@@ -182,7 +182,7 @@ impl<'a, K, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
         K: Serialize + DeserializeOwned,
         T: Serialize + DeserializeOwned,
     {
-        self.demux(other, TCP.bincode())
+        self.demux(other, TCP.fail_stop().bincode())
     }
 
     /// Sends each group of this stream to a specific member of a cluster. The input stream has a
@@ -202,8 +202,8 @@ impl<'a, K, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
     ///     .source_iter(q!(vec![0, 1, 2, 3]))
     ///     .map(q!(|x| ((hydro_lang::location::MemberId::from_raw_id(x), x), x + 123)))
     ///     .into_keyed();
-    /// let on_worker: KeyedStream<_, _, Cluster<_>, _> = to_send.demux(&workers, TCP.bincode());
-    /// # on_worker.entries().send(&p2, TCP.bincode()).entries()
+    /// let on_worker: KeyedStream<_, _, Cluster<_>, _> = to_send.demux(&workers, TCP.fail_stop().bincode());
+    /// # on_worker.entries().send(&p2, TCP.fail_stop().bincode()).entries()
     /// // if there are 4 members in the cluster, each receives one element
     /// // - MemberId::<()>(0): { 0: [123] }
     /// // - MemberId::<()>(1): { 1: [124] }
@@ -262,7 +262,7 @@ impl<'a, K, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
 impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
     KeyedStream<MemberId<L2>, T, Cluster<'a, L>, B, O, R>
 {
-    #[deprecated = "use KeyedStream::demux(..., TCP.bincode()) instead"]
+    #[deprecated = "use KeyedStream::demux(..., TCP.fail_stop().bincode()) instead"]
     /// Sends each group of this stream at each source member to a specific member of a destination
     /// cluster, with the [`MemberId`] key identifying the recipient for each group and using
     /// [`bincode`] to serialize/deserialize messages.
@@ -317,7 +317,7 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
     where
         T: Serialize + DeserializeOwned,
     {
-        self.demux(other, TCP.bincode())
+        self.demux(other, TCP.fail_stop().bincode())
     }
 
     /// Sends each group of this stream at each source member to a specific member of a destination
@@ -346,8 +346,8 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
     ///     .map(q!(|x| (hydro_lang::location::MemberId::from_raw_id(x), x)))
     ///     .into_keyed();
     /// let destination: Cluster<Destination> = flow.cluster::<Destination>();
-    /// let all_received = to_send.demux(&destination, TCP.bincode()); // KeyedStream<MemberId<Source>, i32, ...>
-    /// # all_received.entries().send(&p2, TCP.bincode()).entries()
+    /// let all_received = to_send.demux(&destination, TCP.fail_stop().bincode()); // KeyedStream<MemberId<Source>, i32, ...>
+    /// # all_received.entries().send(&p2, TCP.fail_stop().bincode()).entries()
     /// # }, |mut stream| async move {
     /// // if there are 4 members in the destination cluster, each receives one message from each source member
     /// // - Destination(0): { Source(0): [0], Source(1): [0], ... }
@@ -412,7 +412,7 @@ impl<'a, K, V, L, B: Boundedness, O: Ordering, R: Retries>
     KeyedStream<K, V, Cluster<'a, L>, B, O, R>
 {
     #[expect(clippy::type_complexity, reason = "compound key types with ordering")]
-    #[deprecated = "use KeyedStream::send(..., TCP.bincode()) instead"]
+    #[deprecated = "use KeyedStream::send(..., TCP.fail_stop().bincode()) instead"]
     /// "Moves" elements of this keyed stream from a cluster to a process by sending them over the
     /// network, using [`bincode`] to serialize/deserialize messages. The resulting [`KeyedStream`]
     /// has a compound key where the first element is the sender's [`MemberId`] and the second
@@ -475,7 +475,7 @@ impl<'a, K, V, L, B: Boundedness, O: Ordering, R: Retries>
         K: Serialize + DeserializeOwned,
         V: Serialize + DeserializeOwned,
     {
-        self.send(other, TCP.bincode())
+        self.send(other, TCP.fail_stop().bincode())
     }
 
     #[expect(clippy::type_complexity, reason = "compound key types with ordering")]
@@ -498,8 +498,8 @@ impl<'a, K, V, L, B: Boundedness, O: Ordering, R: Retries>
     ///     .map(q!(|x| (x, x + 123)))
     ///     .into_keyed();
     /// let destination_process = flow.process::<Destination>();
-    /// let all_received = to_send.send(&destination_process, TCP.bincode()); // KeyedStream<(MemberId<Source>, i32), i32, ...>
-    /// # all_received.entries().send(&p2, TCP.bincode())
+    /// let all_received = to_send.send(&destination_process, TCP.fail_stop().bincode()); // KeyedStream<(MemberId<Source>, i32), i32, ...>
+    /// # all_received.entries().send(&p2, TCP.fail_stop().bincode())
     /// # }, |mut stream| async move {
     /// // if there are 4 members in the source cluster, the destination process receives four messages from each source member
     /// // {

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -2480,7 +2480,7 @@ mod tests {
         let numbers = first_node.source_iter(q!(0..10));
         let out_port = numbers
             .map(q!(|n| SendOverNetwork { n }))
-            .send(&second_node, TCP.bincode())
+            .send(&second_node, TCP.fail_stop().bincode())
             .send_bincode_external(&external);
 
         let nodes = flow

--- a/hydro_lang/src/live_collections/stream/networking.rs
+++ b/hydro_lang/src/live_collections/stream/networking.rs
@@ -90,7 +90,7 @@ pub(crate) fn deserialize_bincode<T: DeserializeOwned>(tagged: Option<&syn::Type
 }
 
 impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Process<'a, L>, B, O, R> {
-    #[deprecated = "use Stream::send(..., TCP.bincode()) instead"]
+    #[deprecated = "use Stream::send(..., TCP.fail_stop().bincode()) instead"]
     /// "Moves" elements of this stream to a new distributed location by sending them over the network,
     /// using [`bincode`] to serialize/deserialize messages.
     ///
@@ -126,7 +126,7 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Process<'a, L>
     where
         T: Serialize + DeserializeOwned,
     {
-        self.send(other, TCP.bincode())
+        self.send(other, TCP.fail_stop().bincode())
     }
 
     /// "Moves" elements of this stream to a new distributed location by sending them over the network,
@@ -147,9 +147,9 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Process<'a, L>
     /// let p1 = flow.process::<()>();
     /// let numbers: Stream<_, Process<_>, Bounded> = p1.source_iter(q!(vec![1, 2, 3]));
     /// let p2 = flow.process::<()>();
-    /// let on_p2: Stream<_, Process<_>, Unbounded> = numbers.send(&p2, TCP.bincode());
+    /// let on_p2: Stream<_, Process<_>, Unbounded> = numbers.send(&p2, TCP.fail_stop().bincode());
     /// // 1, 2, 3
-    /// # on_p2.send(&p_out, TCP.bincode())
+    /// # on_p2.send(&p_out, TCP.fail_stop().bincode())
     /// # }, |mut stream| async move {
     /// # for w in 1..=3 {
     /// #     assert_eq!(stream.next().await, Some(w));
@@ -190,7 +190,7 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Process<'a, L>
         )
     }
 
-    #[deprecated = "use Stream::broadcast(..., TCP.bincode()) instead"]
+    #[deprecated = "use Stream::broadcast(..., TCP.fail_stop().bincode()) instead"]
     /// Broadcasts elements of this stream to all members of a cluster by sending them over the network,
     /// using [`bincode`] to serialize/deserialize messages.
     ///
@@ -239,7 +239,7 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Process<'a, L>
     where
         T: Clone + Serialize + DeserializeOwned,
     {
-        self.broadcast(other, TCP.bincode(), nondet_membership)
+        self.broadcast(other, TCP.fail_stop().bincode(), nondet_membership)
     }
 
     /// Broadcasts elements of this stream to all members of a cluster by sending them over the network,
@@ -265,8 +265,8 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Process<'a, L>
     /// let p1 = flow.process::<()>();
     /// let workers: Cluster<()> = flow.cluster::<()>();
     /// let numbers: Stream<_, Process<_>, _> = p1.source_iter(q!(vec![123]));
-    /// let on_worker: Stream<_, Cluster<_>, _> = numbers.broadcast(&workers, TCP.bincode(), nondet!(/** assuming stable membership */));
-    /// # on_worker.send(&p2, TCP.bincode()).entries()
+    /// let on_worker: Stream<_, Cluster<_>, _> = numbers.broadcast(&workers, TCP.fail_stop().bincode(), nondet!(/** assuming stable membership */));
+    /// # on_worker.send(&p2, TCP.fail_stop().bincode()).entries()
     /// // if there are 4 members in the cluster, each receives one element
     /// // - MemberId::<()>(0): [123]
     /// // - MemberId::<()>(1): [123]
@@ -385,7 +385,7 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Process<'a, L>
 impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
     Stream<(MemberId<L2>, T), Process<'a, L>, B, O, R>
 {
-    #[deprecated = "use Stream::demux(..., TCP.bincode()) instead"]
+    #[deprecated = "use Stream::demux(..., TCP.fail_stop().bincode()) instead"]
     /// Sends elements of this stream to specific members of a cluster, identified by a [`MemberId`],
     /// using [`bincode`] to serialize/deserialize messages.
     ///
@@ -429,7 +429,7 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
     where
         T: Serialize + DeserializeOwned,
     {
-        self.demux(other, TCP.bincode())
+        self.demux(other, TCP.fail_stop().bincode())
     }
 
     /// Sends elements of this stream to specific members of a cluster, identified by a [`MemberId`],
@@ -451,8 +451,8 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
     /// let numbers: Stream<_, Process<_>, _> = p1.source_iter(q!(vec![0, 1, 2, 3]));
     /// let on_worker: Stream<_, Cluster<_>, _> = numbers
     ///     .map(q!(|x| (hydro_lang::location::MemberId::from_raw_id(x), x)))
-    ///     .demux(&workers, TCP.bincode());
-    /// # on_worker.send(&p2, TCP.bincode()).entries()
+    ///     .demux(&workers, TCP.fail_stop().bincode());
+    /// # on_worker.send(&p2, TCP.fail_stop().bincode()).entries()
     /// // if there are 4 members in the cluster, each receives one element
     /// // - MemberId::<()>(0): [0]
     /// // - MemberId::<()>(1): [1]
@@ -481,7 +481,7 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
 }
 
 impl<'a, T, L, B: Boundedness> Stream<T, Process<'a, L>, B, TotalOrder, ExactlyOnce> {
-    #[deprecated = "use Stream::round_robin(..., TCP.bincode()) instead"]
+    #[deprecated = "use Stream::round_robin(..., TCP.fail_stop().bincode()) instead"]
     /// Distributes elements of this stream to cluster members in a round-robin fashion, using
     /// [`bincode`] to serialize/deserialize messages.
     ///
@@ -535,7 +535,7 @@ impl<'a, T, L, B: Boundedness> Stream<T, Process<'a, L>, B, TotalOrder, ExactlyO
     where
         T: Serialize + DeserializeOwned,
     {
-        self.round_robin(other, TCP.bincode(), nondet_membership)
+        self.round_robin(other, TCP.fail_stop().bincode(), nondet_membership)
     }
 
     /// Distributes elements of this stream to cluster members in a round-robin fashion, using
@@ -565,8 +565,8 @@ impl<'a, T, L, B: Boundedness> Stream<T, Process<'a, L>, B, TotalOrder, ExactlyO
     /// let p1 = flow.process::<()>();
     /// let workers: Cluster<()> = flow.cluster::<()>();
     /// let numbers: Stream<_, Process<_>, _, TotalOrder, ExactlyOnce> = p1.source_iter(q!(vec![1, 2, 3, 4]));
-    /// let on_worker: Stream<_, Cluster<_>, _> = numbers.round_robin(&workers, TCP.bincode(), nondet!(/** assuming stable membership */));
-    /// on_worker.send(&p2, TCP.bincode())
+    /// let on_worker: Stream<_, Cluster<_>, _> = numbers.round_robin(&workers, TCP.fail_stop().bincode(), nondet!(/** assuming stable membership */));
+    /// on_worker.send(&p2, TCP.fail_stop().bincode())
     /// # .first().values() // we use first to assert that each member gets one element
     /// // with 4 cluster members, elements are distributed (with a non-deterministic round-robin order):
     /// // - MemberId::<()>(?): [1]
@@ -615,7 +615,7 @@ impl<'a, T, L, B: Boundedness> Stream<T, Process<'a, L>, B, TotalOrder, ExactlyO
 }
 
 impl<'a, T, L, B: Boundedness> Stream<T, Cluster<'a, L>, B, TotalOrder, ExactlyOnce> {
-    #[deprecated = "use Stream::round_robin(..., TCP.bincode()) instead"]
+    #[deprecated = "use Stream::round_robin(..., TCP.fail_stop().bincode()) instead"]
     /// Distributes elements of this stream to cluster members in a round-robin fashion, using
     /// [`bincode`] to serialize/deserialize messages.
     ///
@@ -672,7 +672,7 @@ impl<'a, T, L, B: Boundedness> Stream<T, Cluster<'a, L>, B, TotalOrder, ExactlyO
     where
         T: Serialize + DeserializeOwned,
     {
-        self.round_robin(other, TCP.bincode(), nondet_membership)
+        self.round_robin(other, TCP.fail_stop().bincode(), nondet_membership)
     }
 
     /// Distributes elements of this stream to cluster members in a round-robin fashion, using
@@ -704,9 +704,9 @@ impl<'a, T, L, B: Boundedness> Stream<T, Cluster<'a, L>, B, TotalOrder, ExactlyO
     /// let workers1: Cluster<()> = flow.cluster::<()>();
     /// let workers2: Cluster<()> = flow.cluster::<()>();
     /// let numbers: Stream<_, Process<_>, _, TotalOrder, ExactlyOnce> = p1.source_iter(q!(0..=16));
-    /// let on_worker1: Stream<_, Cluster<_>, _> = numbers.round_robin(&workers1, TCP.bincode(), nondet!(/** assuming stable membership */));
-    /// let on_worker2: Stream<_, Cluster<_>, _> = on_worker1.round_robin(&workers2, TCP.bincode(), nondet!(/** assuming stable membership */)).entries().assume_ordering(nondet!(/** assuming stable membership */));
-    /// on_worker2.send(&p2, TCP.bincode())
+    /// let on_worker1: Stream<_, Cluster<_>, _> = numbers.round_robin(&workers1, TCP.fail_stop().bincode(), nondet!(/** assuming stable membership */));
+    /// let on_worker2: Stream<_, Cluster<_>, _> = on_worker1.round_robin(&workers2, TCP.fail_stop().bincode(), nondet!(/** assuming stable membership */)).entries().assume_ordering(nondet!(/** assuming stable membership */));
+    /// on_worker2.send(&p2, TCP.fail_stop().bincode())
     /// # .entries()
     /// # .map(q!(|(w2, (w1, v))| ((w2, w1), v)))
     /// # }, |mut stream| async move {
@@ -755,7 +755,7 @@ impl<'a, T, L, B: Boundedness> Stream<T, Cluster<'a, L>, B, TotalOrder, ExactlyO
 }
 
 impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Cluster<'a, L>, B, O, R> {
-    #[deprecated = "use Stream::send(..., TCP.bincode()) instead"]
+    #[deprecated = "use Stream::send(..., TCP.fail_stop().bincode()) instead"]
     /// "Moves" elements of this stream from a cluster to a process by sending them over the network,
     /// using [`bincode`] to serialize/deserialize messages.
     ///
@@ -816,7 +816,7 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Cluster<'a, L>
     where
         T: Serialize + DeserializeOwned,
     {
-        self.send(other, TCP.bincode())
+        self.send(other, TCP.fail_stop().bincode())
     }
 
     /// "Moves" elements of this stream from a cluster to a process by sending them over the network,
@@ -833,7 +833,7 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Cluster<'a, L>
     /// # tokio_test::block_on(hydro_lang::test_util::multi_location_test(|flow, process| {
     /// let workers: Cluster<()> = flow.cluster::<()>();
     /// let numbers: Stream<_, Cluster<_>, _> = workers.source_iter(q!(vec![1]));
-    /// let all_received = numbers.send(&process, TCP.bincode()); // KeyedStream<MemberId<()>, i32, ...>
+    /// let all_received = numbers.send(&process, TCP.fail_stop().bincode()); // KeyedStream<MemberId<()>, i32, ...>
     /// # all_received.entries()
     /// # }, |mut stream| async move {
     /// // if there are 4 members in the cluster, we should receive 4 elements
@@ -858,7 +858,8 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Cluster<'a, L>
     /// # tokio_test::block_on(hydro_lang::test_util::multi_location_test(|flow, process| {
     /// # let workers: Cluster<()> = flow.cluster::<()>();
     /// # let numbers: Stream<_, Cluster<_>, _> = workers.source_iter(q!(vec![1]));
-    /// let values: Stream<i32, _, _, NoOrder> = numbers.send(&process, TCP.bincode()).values();
+    /// let values: Stream<i32, _, _, NoOrder> =
+    ///     numbers.send(&process, TCP.fail_stop().bincode()).values();
     /// # values
     /// # }, |mut stream| async move {
     /// # let mut results = Vec::new();
@@ -912,7 +913,7 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Cluster<'a, L>
         raw_stream.into_keyed()
     }
 
-    #[deprecated = "use Stream::broadcast(..., TCP.bincode()) instead"]
+    #[deprecated = "use Stream::broadcast(..., TCP.fail_stop().bincode()) instead"]
     /// Broadcasts elements of this stream at each source member to all members of a destination
     /// cluster, using [`bincode`] to serialize/deserialize messages.
     ///
@@ -968,7 +969,7 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Cluster<'a, L>
     where
         T: Clone + Serialize + DeserializeOwned,
     {
-        self.broadcast(other, TCP.bincode(), nondet_membership)
+        self.broadcast(other, TCP.fail_stop().bincode(), nondet_membership)
     }
 
     /// Broadcasts elements of this stream at each source member to all members of a destination
@@ -997,8 +998,8 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Cluster<'a, L>
     /// let source: Cluster<Source> = flow.cluster::<Source>();
     /// let numbers: Stream<_, Cluster<Source>, _> = source.source_iter(q!(vec![123]));
     /// let destination: Cluster<Destination> = flow.cluster::<Destination>();
-    /// let on_destination: KeyedStream<MemberId<Source>, _, Cluster<Destination>, _> = numbers.broadcast(&destination, TCP.bincode(), nondet!(/** assuming stable membership */));
-    /// # on_destination.entries().send(&p2, TCP.bincode()).entries()
+    /// let on_destination: KeyedStream<MemberId<Source>, _, Cluster<Destination>, _> = numbers.broadcast(&destination, TCP.fail_stop().bincode(), nondet!(/** assuming stable membership */));
+    /// # on_destination.entries().send(&p2, TCP.fail_stop().bincode()).entries()
     /// // if there are 4 members in the desination, each receives one element from each source member
     /// // - Destination(0): { Source(0): [123], Source(1): [123], ... }
     /// // - Destination(1): { Source(0): [123], Source(1): [123], ... }
@@ -1042,7 +1043,7 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Cluster<'a, L>
 impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
     Stream<(MemberId<L2>, T), Cluster<'a, L>, B, O, R>
 {
-    #[deprecated = "use Stream::demux(..., TCP.bincode()) instead"]
+    #[deprecated = "use Stream::demux(..., TCP.fail_stop().bincode()) instead"]
     /// Sends elements of this stream at each source member to specific members of a destination
     /// cluster, identified by a [`MemberId`], using [`bincode`] to serialize/deserialize messages.
     ///
@@ -1095,7 +1096,7 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
     where
         T: Serialize + DeserializeOwned,
     {
-        self.demux(other, TCP.bincode())
+        self.demux(other, TCP.fail_stop().bincode())
     }
 
     /// Sends elements of this stream at each source member to specific members of a destination
@@ -1123,8 +1124,8 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
     ///     .source_iter(q!(vec![0, 1, 2, 3]))
     ///     .map(q!(|x| (hydro_lang::location::MemberId::from_raw_id(x), x)));
     /// let destination: Cluster<Destination> = flow.cluster::<Destination>();
-    /// let all_received = to_send.demux(&destination, TCP.bincode()); // KeyedStream<MemberId<Source>, i32, ...>
-    /// # all_received.entries().send(&p2, TCP.bincode()).entries()
+    /// let all_received = to_send.demux(&destination, TCP.fail_stop().bincode()); // KeyedStream<MemberId<Source>, i32, ...>
+    /// # all_received.entries().send(&p2, TCP.fail_stop().bincode()).entries()
     /// # }, |mut stream| async move {
     /// // if there are 4 members in the destination cluster, each receives one message from each source member
     /// // - Destination(0): { Source(0): [0], Source(1): [0], ... }
@@ -1182,7 +1183,7 @@ mod tests {
         let (in_send, input) = node.sim_input();
 
         let out_recv = input
-            .send(&node2, TCP.bincode())
+            .send(&node2, TCP.fail_stop().bincode())
             .batch(&node2.tick(), nondet!(/** test */))
             .count()
             .all_ticks()
@@ -1210,7 +1211,7 @@ mod tests {
         let input = cluster.source_iter(q!(vec![1]));
 
         let out_recv = input
-            .send(&node, TCP.bincode())
+            .send(&node, TCP.fail_stop().bincode())
             .entries()
             .batch(&node.tick(), nondet!(/** test */))
             .all_ticks()
@@ -1243,13 +1244,13 @@ mod tests {
 
         let out_recv_1 = cluster1
             .source_iter(q!(vec![1]))
-            .send(&node, TCP.bincode())
+            .send(&node, TCP.fail_stop().bincode())
             .entries()
             .sim_output();
 
         let out_recv_2 = cluster2
             .source_iter(q!(vec![2]))
-            .send(&node, TCP.bincode())
+            .send(&node, TCP.fail_stop().bincode())
             .entries()
             .sim_output();
 
@@ -1292,9 +1293,9 @@ mod tests {
         ]));
 
         let out_recv = input
-            .demux(&cluster, TCP.bincode())
+            .demux(&cluster, TCP.fail_stop().bincode())
             .map(q!(|x| x + 1))
-            .send(&node, TCP.bincode())
+            .send(&node, TCP.fail_stop().bincode())
             .entries()
             .sim_output();
 
@@ -1320,9 +1321,9 @@ mod tests {
         let input = node.source_iter(q!(vec![123, 456]));
 
         let out_recv = input
-            .broadcast(&cluster, TCP.bincode(), nondet!(/** test */))
+            .broadcast(&cluster, TCP.fail_stop().bincode(), nondet!(/** test */))
             .map(q!(|x| x + 1))
-            .send(&node, TCP.bincode())
+            .send(&node, TCP.fail_stop().bincode())
             .entries()
             .sim_output();
 
@@ -1362,15 +1363,15 @@ mod tests {
         ]));
 
         let out_recv = input
-            .demux(&cluster, TCP.bincode())
+            .demux(&cluster, TCP.fail_stop().bincode())
             .map(q!(|x| x + 1))
             .flat_map_ordered(q!(|x| vec![
                 (MemberId::from_raw_id(0), x),
                 (MemberId::from_raw_id(1), x),
             ]))
-            .demux(&cluster, TCP.bincode())
+            .demux(&cluster, TCP.fail_stop().bincode())
             .entries()
-            .send(&node, TCP.bincode())
+            .send(&node, TCP.fail_stop().bincode())
             .entries()
             .sim_output();
 

--- a/hydro_lang/src/location/cluster.rs
+++ b/hydro_lang/src/location/cluster.rs
@@ -195,12 +195,12 @@ mod tests {
 
         let out_recv = cluster1
             .source_iter(q!(vec![CLUSTER_SELF_ID]))
-            .send(&node, TCP.bincode())
+            .send(&node, TCP.fail_stop().bincode())
             .values()
             .interleave(
                 cluster2
                     .source_iter(q!(vec![CLUSTER_SELF_ID]))
-                    .send(&node, TCP.bincode())
+                    .send(&node, TCP.fail_stop().bincode())
                     .values(),
             )
             .sim_output();
@@ -229,7 +229,7 @@ mod tests {
             .batch(&cluster.tick(), nondet!(/** test */))
             .count()
             .all_ticks()
-            .send(&node, TCP.bincode())
+            .send(&node, TCP.fail_stop().bincode())
             .entries()
             .map(q!(|(id, v)| (id, v)))
             .sim_output();

--- a/hydro_lang/src/location/mod.rs
+++ b/hydro_lang/src/location/mod.rs
@@ -403,7 +403,7 @@ pub trait Location<'a>: dynamic::DynLocation {
     /// # // do nothing on each worker
     /// # workers.source_iter(q!(vec![])).for_each(q!(|_: ()| {}));
     /// let cluster_members = p1.source_cluster_members(&workers);
-    /// # cluster_members.entries().send(&p2, TCP.bincode())
+    /// # cluster_members.entries().send(&p2, TCP.fail_stop().bincode())
     /// // if there are 4 members in the cluster, we would see a join event for each
     /// // { MemberId::<Worker>(0): [MembershipEvent::Join], MemberId::<Worker>(2): [MembershipEvent::Join], ... }
     /// # }, |mut stream| async move {

--- a/hydro_lang/tests/compile-fail-stable/send_lifetime.stderr
+++ b/hydro_lang/tests/compile-fail-stable/send_lifetime.stderr
@@ -5,7 +5,7 @@ error: lifetime may not live long enough
   |         --  -- lifetime `'b` defined here
   |         |
   |         lifetime `'a` defined here
-7 |     p1.source_iter(q!(0..10)).send(p2, TCP.bincode()).for_each(q!(|n| println!("{}", n)));
+7 |     p1.source_iter(q!(0..10))
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
   |
   = help: consider adding the following bound: `'b: 'a`
@@ -16,12 +16,13 @@ error: lifetime may not live long enough
 error: lifetime may not live long enough
  --> tests/compile-fail-stable/send_lifetime.rs:7:5
   |
-6 | fn test<'a, 'b>(p1: &Process<'a, P1>, p2: &Process<'b, P2>) {
-  |         --  -- lifetime `'b` defined here
-  |         |
-  |         lifetime `'a` defined here
-7 |     p1.source_iter(q!(0..10)).send(p2, TCP.bincode()).for_each(q!(|n| println!("{}", n)));
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'a` must outlive `'b`
+6 |   fn test<'a, 'b>(p1: &Process<'a, P1>, p2: &Process<'b, P2>) {
+  |           --  -- lifetime `'b` defined here
+  |           |
+  |           lifetime `'a` defined here
+7 | /     p1.source_iter(q!(0..10))
+8 | |         .send(p2, TCP.fail_stop().bincode())
+  | |____________________________________________^ argument requires that `'a` must outlive `'b`
   |
   = help: consider adding the following bound: `'a: 'b`
   = note: requirement occurs because of the type `hydro_lang::prelude::Process<'_, P2>`, which makes the generic argument `'_` invariant

--- a/hydro_lang/tests/compile-fail/send_lifetime.rs
+++ b/hydro_lang/tests/compile-fail/send_lifetime.rs
@@ -4,7 +4,9 @@ struct P1 {}
 struct P2 {}
 
 fn test<'a, 'b>(p1: &Process<'a, P1>, p2: &Process<'b, P2>) {
-    p1.source_iter(q!(0..10)).send(p2, TCP.bincode()).for_each(q!(|n| println!("{}", n)));
+    p1.source_iter(q!(0..10))
+        .send(p2, TCP.fail_stop().bincode())
+        .for_each(q!(|n| println!("{}", n)));
 }
 
 fn main() {}

--- a/hydro_lang/tests/compile-fail/send_lifetime.stderr
+++ b/hydro_lang/tests/compile-fail/send_lifetime.stderr
@@ -5,7 +5,7 @@ error: lifetime may not live long enough
   |         --  -- lifetime `'b` defined here
   |         |
   |         lifetime `'a` defined here
-7 |     p1.source_iter(q!(0..10)).send(p2, TCP.bincode()).for_each(q!(|n| println!("{}", n)));
+7 |     p1.source_iter(q!(0..10)).send(p2, TCP.fail_stop().bincode()).for_each(q!(|n| println!("{}", n)));
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
   |
   = help: consider adding the following bound: `'b: 'a`
@@ -20,7 +20,7 @@ error: lifetime may not live long enough
   |         --  -- lifetime `'b` defined here
   |         |
   |         lifetime `'a` defined here
-7 |     p1.source_iter(q!(0..10)).send(p2, TCP.bincode()).for_each(q!(|n| println!("{}", n)));
+7 |     p1.source_iter(q!(0..10)).send(p2, TCP.fail_stop().bincode()).for_each(q!(|n| println!("{}", n)));
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'a` must outlive `'b`
   |
   = help: consider adding the following bound: `'a: 'b`

--- a/hydro_std/src/bench_client/mod.rs
+++ b/hydro_std/src/bench_client/mod.rs
@@ -212,7 +212,10 @@ pub fn aggregate_bench_results<'a, Client: 'a, Aggregator>(
         nondet_sampling,
     );
 
-    let a_throughputs = results.throughput.send(aggregator, TCP.bincode()).values();
+    let a_throughputs = results
+        .throughput
+        .send(aggregator, TCP.fail_stop().bincode())
+        .values();
 
     let a_latencies = results
         .latency_histogram
@@ -221,7 +224,7 @@ pub fn aggregate_bench_results<'a, Client: 'a, Aggregator>(
                 histogram: latencies,
             }
         }))
-        .send(aggregator, TCP.bincode())
+        .send(aggregator, TCP.fail_stop().bincode())
         .values()
         .map(q!(|wrapper| wrapper.histogram));
 

--- a/hydro_std/src/compartmentalize.rs
+++ b/hydro_std/src/compartmentalize.rs
@@ -28,7 +28,9 @@ impl<'a, T, C1, C2, Order: Ordering> PartitionStream<'a, T, C1, C2, Order>
     where
         T: Clone + Serialize + DeserializeOwned,
     {
-        self.map(dist_policy).demux(other, TCP.bincode()).values()
+        self.map(dist_policy)
+            .demux(other, TCP.fail_stop().bincode())
+            .values()
     }
 }
 
@@ -60,7 +62,7 @@ where
                 MemberId::from_tagless(CLUSTER_SELF_ID.clone().into_tagless()), // this is a seemingly round about way to convert from one member id tag to another.
                 b
             )))
-            .demux(other, TCP.bincode())
+            .demux(other, TCP.fail_stop().bincode())
             .values();
 
         sent.assume_ordering(
@@ -88,6 +90,6 @@ impl<'a, T, L, B: Boundedness, Order: Ordering>
     where
         T: Clone + Serialize + DeserializeOwned,
     {
-        self.send(other, TCP.bincode())
+        self.send(other, TCP.fail_stop().bincode())
     }
 }

--- a/hydro_test/src/cluster/compartmentalized_paxos.rs
+++ b/hydro_test/src/cluster/compartmentalized_paxos.rs
@@ -277,7 +277,7 @@ fn sequence_payload<'a, P: PaxosPayload>(
             ((slot, ballot), payload)
         ))))
         .all_ticks()
-        .demux(proxy_leaders, TCP.bincode())
+        .demux(proxy_leaders, TCP.fail_stop().bincode())
         .values()
         .atomic(proxy_leader_tick);
 
@@ -305,7 +305,7 @@ fn sequence_payload<'a, P: PaxosPayload>(
             p2as
         }))
         .end_atomic()
-        .demux(acceptors, TCP.bincode())
+        .demux(acceptors, TCP.fail_stop().bincode())
         .values();
 
     let (a_log, a_to_proxy_leaders_p2b) = acceptor_p2(
@@ -336,7 +336,7 @@ fn sequence_payload<'a, P: PaxosPayload>(
     let pl_failed_p2b_to_proposer = fails
         .map(q!(|(_, ballot)| (ballot.proposer_id.clone(), ballot)))
         .inspect(q!(|(_, ballot)| println!("Failed P2b: {:?}", ballot)))
-        .demux(proposers, TCP.bincode())
+        .demux(proposers, TCP.fail_stop().bincode())
         .values();
 
     (

--- a/hydro_test/src/cluster/compute_pi.rs
+++ b/hydro_test/src/cluster/compute_pi.rs
@@ -29,13 +29,16 @@ pub fn compute_pi<'a>(
         )
         .all_ticks();
 
-    let estimate = trials.send(&process, TCP.bincode()).values().reduce(q!(
-        |(inside, total), (inside_batch, total_batch)| {
-            *inside += inside_batch;
-            *total += total_batch;
-        },
-        commutative = ManualProof(/* int addition is commutative */)
-    ));
+    let estimate = trials
+        .send(&process, TCP.fail_stop().bincode())
+        .values()
+        .reduce(q!(
+            |(inside, total), (inside_batch, total_batch)| {
+                *inside += inside_batch;
+                *total += total_batch;
+            },
+            commutative = ManualProof(/* int addition is commutative */)
+        ));
 
     estimate
         .sample_every(

--- a/hydro_test/src/cluster/many_to_many.rs
+++ b/hydro_test/src/cluster/many_to_many.rs
@@ -6,7 +6,7 @@ pub fn many_to_many<'a>(flow: &mut FlowBuilder<'a>) -> Cluster<'a, ()> {
         .source_iter(q!(0..2))
         .broadcast(
             &cluster,
-            TCP.bincode().name("m2m_broadcast"),
+            TCP.fail_stop().bincode().name("m2m_broadcast"),
             nondet!(/** test */),
         )
         .entries()

--- a/hydro_test/src/cluster/map_reduce.rs
+++ b/hydro_test/src/cluster/map_reduce.rs
@@ -12,7 +12,7 @@ pub fn map_reduce<'a>(flow: &mut FlowBuilder<'a>) -> (Process<'a, Leader>, Clust
         .map(q!(|s| s.to_owned()));
 
     let partitioned_words = words
-        .round_robin(&cluster, TCP.bincode(), nondet!(/** test */))
+        .round_robin(&cluster, TCP.fail_stop().bincode(), nondet!(/** test */))
         .map(q!(|string| (string, ())))
         .into_keyed();
 
@@ -28,7 +28,7 @@ pub fn map_reduce<'a>(flow: &mut FlowBuilder<'a>) -> (Process<'a, Leader>, Clust
             string, count
         )))
         .all_ticks()
-        .send(&process, TCP.bincode())
+        .send(&process, TCP.fail_stop().bincode())
         .values();
 
     let reduced = batches.into_keyed().reduce(q!(

--- a/hydro_test/src/cluster/paxos.rs
+++ b/hydro_test/src/cluster/paxos.rs
@@ -308,7 +308,7 @@ pub fn leader_election<'a, L: Clone + Debug + Serialize + DeserializeOwned>(
         .if_some_then(p_ballot.clone())
         .all_ticks()
         .inspect(q!(|_| println!("Proposer leader expired, sending P1a")))
-        .broadcast(acceptors, TCP.bincode(), nondet!(/** TODO */))
+        .broadcast(acceptors, TCP.fail_stop().bincode(), nondet!(/** TODO */))
         .values();
 
     let (a_max_ballot, a_to_proposers_p1b) = acceptor_p1(
@@ -420,7 +420,7 @@ fn p_leader_heartbeat<'a>(
                 nondet_reelection
             ),
         )
-        .broadcast(proposers, TCP.bincode(), nondet!(/** TODO */))
+        .broadcast(proposers, TCP.fail_stop().bincode(), nondet!(/** TODO */))
         .values();
 
     let p_leader_expired = p_to_proposers_i_am_leader
@@ -496,7 +496,7 @@ fn acceptor_p1<'a, L: Serialize + DeserializeOwned + Clone>(
                 )
             )))
             .all_ticks()
-            .demux(proposers, TCP.bincode())
+            .demux(proposers, TCP.fail_stop().bincode())
             .values(),
     )
 }
@@ -727,7 +727,7 @@ fn sequence_payload<'a, P: PaxosPayload>(
                 slot,
                 value
             }))
-            .broadcast(acceptors, TCP.bincode(), nondet!(/** TODO */))
+            .broadcast(acceptors, TCP.fail_stop().bincode(), nondet!(/** TODO */))
             .values(),
         a_checkpoint,
         proposers,
@@ -869,7 +869,7 @@ pub fn acceptor_p2<'a, P: PaxosPayload, S: Clone>(
             )
         )))
         .all_ticks()
-        .demux(proposers, TCP.bincode())
+        .demux(proposers, TCP.fail_stop().bincode())
         .values();
 
     (

--- a/hydro_test/src/cluster/paxos_bench.rs
+++ b/hydro_test/src/cluster/paxos_bench.rs
@@ -54,7 +54,7 @@ pub fn paxos_bench<'a>(
             );
 
             let sequenced_to_replicas = sequenced_payloads
-                .broadcast(replicas, TCP.bincode(), nondet!(/** TODO */))
+                .broadcast(replicas, TCP.fail_stop().bincode(), nondet!(/** TODO */))
                 .values()
                 .map(q!(|(index, payload)| (
                     index,
@@ -68,7 +68,7 @@ pub fn paxos_bench<'a>(
             // Get the latest checkpoint sequence per replica
             let a_checkpoint = {
                 let a_checkpoint_largest_seqs = replica_checkpoint
-                    .broadcast(&acceptors, TCP.bincode(), nondet!(/** TODO */))
+                    .broadcast(&acceptors, TCP.fail_stop().bincode(), nondet!(/** TODO */))
                     .reduce(q!(
                         |curr_seq, seq| {
                             if seq > *curr_seq {
@@ -109,7 +109,7 @@ pub fn paxos_bench<'a>(
                     payload.value.0,
                     ((payload.key, payload.value.1), Ok(()))
                 )))
-                .demux(clients, TCP.bincode())
+                .demux(clients, TCP.fail_stop().bincode())
                 .values();
 
             // we only mark a transaction as committed when all replicas have applied it

--- a/hydro_test/src/cluster/paxos_with_client.rs
+++ b/hydro_test/src/cluster/paxos_with_client.rs
@@ -59,7 +59,7 @@ pub trait PaxosLike<'a>: Sized {
             move |new_leader_elected| {
                 let cur_leader_id = Self::get_recipient_from_ballot(
                     new_leader_elected
-                        .broadcast(clients, TCP.bincode(), nondet!(/** TODO */))
+                        .broadcast(clients, TCP.fail_stop().bincode(), nondet!(/** TODO */))
                         .values()
                         .inspect(q!(|ballot| println!(
                             "Client notified that leader was elected: {:?}",
@@ -88,7 +88,7 @@ pub trait PaxosLike<'a>: Sized {
                     all_payloads.cross_singleton(latest_leader)
                 }
                 .map(q!(move |(payload, leader_id)| (leader_id, payload)))
-                .demux(&leaders, TCP.bincode())
+                .demux(&leaders, TCP.fail_stop().bincode())
                 .values();
 
                 let payloads_at_proposer = {

--- a/hydro_test/src/cluster/simple_cluster.rs
+++ b/hydro_test/src/cluster/simple_cluster.rs
@@ -61,12 +61,12 @@ pub fn simple_cluster<'a>(flow: &mut FlowBuilder<'a>) -> (Process<'a, ()>, Clust
 
     ids.cross_product(numbers.into())
         .map(q!(|(id, n)| (id.clone(), (id, n))))
-        .demux(&cluster, TCP.bincode())
+        .demux(&cluster, TCP.fail_stop().bincode())
         .inspect(q!(move |n| println!(
             "cluster received: {:?} (self cluster id: {})",
             n, CLUSTER_SELF_ID
         )))
-        .send(&process, TCP.bincode())
+        .send(&process, TCP.fail_stop().bincode())
         .entries()
         .assume_ordering(nondet!(/** testing, order does not matter */))
         .for_each(q!(|(id, d)| println!("node received: ({}, {:?})", id, d)));

--- a/hydro_test/src/cluster/two_pc.rs
+++ b/hydro_test/src/cluster/two_pc.rs
@@ -24,7 +24,7 @@ where
     // broadcast prepare message to participants
     let p_prepare = payloads.ir_node_named("c_prepare").broadcast(
         participants,
-        TCP.bincode(),
+        TCP.fail_stop().bincode(),
         nondet!(/** TODO */),
     );
 
@@ -32,7 +32,7 @@ where
     // TODO: Participants log
     let c_votes = p_prepare
         .ir_node_named("p_prepare")
-        .send(coordinator, TCP.bincode())
+        .send(coordinator, TCP.fail_stop().bincode())
         .ir_node_named("c_votes")
         .values();
 
@@ -46,12 +46,16 @@ where
     // TODO: Coordinator log
 
     // broadcast commit transactions to participants.
-    let p_commit = c_all_vote_yes.broadcast(participants, TCP.bincode(), nondet!(/** TODO */));
+    let p_commit = c_all_vote_yes.broadcast(
+        participants,
+        TCP.fail_stop().bincode(),
+        nondet!(/** TODO */),
+    );
     // TODO: Participants log
 
     let c_commits = p_commit
         .ir_node_named("p_commits")
-        .send(coordinator, TCP.bincode())
+        .send(coordinator, TCP.fail_stop().bincode())
         .ir_node_named("c_commits")
         .values();
     let (c_all_commit, _) = collect_quorum(

--- a/hydro_test/src/cluster/two_pc_bench.rs
+++ b/hydro_test/src/cluster/two_pc_bench.rs
@@ -31,9 +31,12 @@ pub fn two_pc_bench<'a>(
                 coordinator,
                 participants,
                 num_participants,
-                input.entries().send(coordinator, TCP.bincode()).entries(),
+                input
+                    .entries()
+                    .send(coordinator, TCP.fail_stop().bincode())
+                    .entries(),
             )
-            .demux(clients, TCP.bincode())
+            .demux(clients, TCP.fail_stop().bincode())
             .into_keyed()
         },
     )

--- a/hydro_test/src/distributed/distributed_echo.rs
+++ b/hydro_test/src/distributed/distributed_echo.rs
@@ -42,24 +42,24 @@ pub fn distributed_echo<'a>(
         .entries()
         .map(q!(|(client_id, n)| (client_id, n + 1)))
         .assume_ordering::<TotalOrder>(nondet!(/** external input order */))
-        .round_robin(c2, TCP.bincode(), nondet!(/** test */))
+        .round_robin(c2, TCP.fail_stop().bincode(), nondet!(/** test */))
         .inspect(q!(|(client_id, n)| println!(
             "[C2] received from client {client_id}: {n}"
         )))
         .map(q!(|(client_id, n)| (client_id, n + 1)))
-        .round_robin(c3, TCP.bincode(), nondet!(/** test */))
+        .round_robin(c3, TCP.fail_stop().bincode(), nondet!(/** test */))
         .inspect(q!(|(client_id, n)| println!(
             "[C3] received from client {client_id}: {n}"
         )))
         .map(q!(|(client_id, n)| (client_id, n + 1)))
         .values()
-        .send(p4, TCP.bincode())
+        .send(p4, TCP.fail_stop().bincode())
         .inspect(q!(|(client_id, n)| println!(
             "[P4] received from client {client_id}: {n}"
         )))
         .map(q!(|(client_id, n)| (client_id, n + 1)))
         .values()
-        .send(p1, TCP.bincode());
+        .send(p1, TCP.fail_stop().bincode());
 
     let tick = p1.tick();
 

--- a/hydro_test/src/distributed/first_ten.rs
+++ b/hydro_test/src/distributed/first_ten.rs
@@ -21,7 +21,7 @@ pub fn first_ten_distributed<'a>(
     let numbers = process.source_iter(q!(0..10));
     numbers
         .map(q!(|n| SendOverNetwork { n }))
-        .send(second_process, TCP.bincode())
+        .send(second_process, TCP.fail_stop().bincode())
         .for_each(q!(|n| println!("{}", n.n)));
 
     numbers_external_port

--- a/hydro_test/src/maelstrom/broadcast.rs
+++ b/hydro_test/src/maelstrom/broadcast.rs
@@ -38,7 +38,7 @@ fn broadcast_core<'a, C: 'a>(
     writes: Stream<u32, Cluster<'a, C>, Unbounded, NoOrder>,
 ) -> Stream<u32, Cluster<'a, C>, Unbounded, NoOrder> {
     writes
-        .broadcast(cluster, TCP.bincode(), nondet!(/** TODO */))
+        .broadcast(cluster, TCP.fail_stop().bincode(), nondet!(/** TODO */))
         .values()
 }
 


### PR DESCRIPTION

Currently, we only offer `fail_stop` as a policy, which was the implicit default TCP guarantees thus far.
