### PR TITLE
feat(hydro_lang): preliminary support for embedding Hydro programs in other Rust code

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -40,3 +40,7 @@ test-group = 'hydro-trybuild-group'
 [[profile.default.overrides]]
 filter = 'package(hydro_test_template)'
 test-group = 'hydro-trybuild-group'
+
+[[profile.default.overrides]]
+filter = 'package(hydro_test_embedded) & kind(example)'
+test-group = 'hydro-trybuild-group'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,6 @@
     "rust-analyzer.rustfmt.extraArgs": [
         "+nightly"
     ],
-    "rust-analyzer.cargo.features": "all",
     "editor.semanticTokenColorCustomizations": {
         "enabled": true,
         "rules": {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2782,6 +2782,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hydro_test_embedded"
+version = "0.0.0"
+dependencies = [
+ "dfir_rs",
+ "hydro_lang",
+ "hydro_test",
+ "prettyplease",
+ "stageleft",
+ "tokio",
+]
+
+[[package]]
 name = "hydro_test_template"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "hydro_lang",
     "hydro_std",
     "hydro_test",
+    "hydro_test_embedded",
     "hydro_test_template",
     "include_mdtests",
     "lattices_macro",

--- a/hydro_lang/src/compile/deploy.rs
+++ b/hydro_lang/src/compile/deploy.rs
@@ -269,7 +269,7 @@ impl<'a, D: Deploy<'a>> DeployFlow<'a, D> {
     /// Same as [`Self::compile`] but does not invalidate `self`, for internal use.
     ///
     /// Empties `self.sidecars` and modifies `self.ir`, leaving `self` in a partial state.
-    fn compile_internal(&mut self) -> CompiledFlow<'a> {
+    pub(super) fn compile_internal(&mut self) -> CompiledFlow<'a> {
         let mut seen_tees: HashMap<_, _> = HashMap::new();
         let mut extra_stmts = SparseSecondaryMap::new();
         for leaf in self.ir.iter_mut() {

--- a/hydro_lang/src/compile/embedded.rs
+++ b/hydro_lang/src/compile/embedded.rs
@@ -1,0 +1,387 @@
+//! "Embedded" deployment backend for Hydro.
+//!
+//! Instead of compiling each location into a standalone binary, this backend generates
+//! a Rust source file containing one function per location. Each function returns a
+//! `dfir_rs::scheduled::graph::Dfir` that can be manually driven by the caller.
+//!
+//! This is useful when you want full control over where and how the projected DFIR
+//! code runs (e.g. embedding it into an existing application).
+//!
+//! # Limitations
+//!
+//! Networking is **not** supported. All `Deploy` networking trait methods will panic
+//! if called. Only pure local computations (with data embedded in the Hydro program)
+//! are supported.
+
+use std::future::Future;
+use std::io::Error;
+use std::pin::Pin;
+
+use bytes::{Bytes, BytesMut};
+use dfir_lang::diagnostic::Diagnostics;
+use dfir_lang::graph::DfirGraph;
+use futures::{Sink, Stream};
+use proc_macro2::Span;
+use quote::quote;
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use stageleft::{QuotedWithContext, q};
+
+use super::deploy_provider::{ClusterSpec, Deploy, ExternalSpec, Node, ProcessSpec, RegisterPort};
+use crate::compile::builder::ExternalPortId;
+use crate::location::dynamic::LocationId;
+use crate::location::member_id::TaglessMemberId;
+use crate::location::{LocationKey, MembershipEvent, NetworkHint};
+
+/// Marker type for the embedded deployment backend.
+///
+/// All networking methods panic — this backend only supports pure local computation.
+pub enum EmbeddedDeploy {}
+
+/// A trivial node type for embedded deployment. Stores a user-provided function name.
+#[derive(Clone)]
+pub struct EmbeddedNode {
+    /// The function name to use in the generated code for this location.
+    pub fn_name: String,
+}
+
+impl Node for EmbeddedNode {
+    type Port = ();
+    type Meta = ();
+    type InstantiateEnv = ();
+
+    fn next_port(&self) -> Self::Port {}
+
+    fn update_meta(&self, _meta: &Self::Meta) {}
+
+    fn instantiate(
+        &self,
+        _env: &mut Self::InstantiateEnv,
+        _meta: &mut Self::Meta,
+        _graph: DfirGraph,
+        _extra_stmts: &[syn::Stmt],
+        _sidecars: &[syn::Expr],
+    ) {
+        // No-op: embedded mode doesn't instantiate nodes at deploy time.
+    }
+}
+
+impl<'a> RegisterPort<'a, EmbeddedDeploy> for EmbeddedNode {
+    fn register(&self, _external_port_id: ExternalPortId, _port: Self::Port) {
+        panic!("EmbeddedDeploy does not support external ports");
+    }
+
+    #[expect(clippy::manual_async_fn, reason = "false positive, involves lifetimes")]
+    fn as_bytes_bidi(
+        &self,
+        _external_port_id: ExternalPortId,
+    ) -> impl Future<
+        Output = super::deploy_provider::DynSourceSink<Result<BytesMut, Error>, Bytes, Error>,
+    > + 'a {
+        async { panic!("EmbeddedDeploy does not support external ports") }
+    }
+
+    #[expect(clippy::manual_async_fn, reason = "false positive, involves lifetimes")]
+    fn as_bincode_bidi<InT, OutT>(
+        &self,
+        _external_port_id: ExternalPortId,
+    ) -> impl Future<Output = super::deploy_provider::DynSourceSink<OutT, InT, Error>> + 'a
+    where
+        InT: Serialize + 'static,
+        OutT: DeserializeOwned + 'static,
+    {
+        async { panic!("EmbeddedDeploy does not support external ports") }
+    }
+
+    #[expect(clippy::manual_async_fn, reason = "false positive, involves lifetimes")]
+    fn as_bincode_sink<T>(
+        &self,
+        _external_port_id: ExternalPortId,
+    ) -> impl Future<Output = Pin<Box<dyn Sink<T, Error = Error>>>> + 'a
+    where
+        T: Serialize + 'static,
+    {
+        async { panic!("EmbeddedDeploy does not support external ports") }
+    }
+
+    #[expect(clippy::manual_async_fn, reason = "false positive, involves lifetimes")]
+    fn as_bincode_source<T>(
+        &self,
+        _external_port_id: ExternalPortId,
+    ) -> impl Future<Output = Pin<Box<dyn Stream<Item = T>>>> + 'a
+    where
+        T: DeserializeOwned + 'static,
+    {
+        async { panic!("EmbeddedDeploy does not support external ports") }
+    }
+}
+
+impl<S: Into<String>> ProcessSpec<'_, EmbeddedDeploy> for S {
+    fn build(self, _location_key: LocationKey, _name_hint: &str) -> EmbeddedNode {
+        EmbeddedNode {
+            fn_name: self.into(),
+        }
+    }
+}
+
+impl<S: Into<String>> ClusterSpec<'_, EmbeddedDeploy> for S {
+    fn build(self, _location_key: LocationKey, _name_hint: &str) -> EmbeddedNode {
+        EmbeddedNode {
+            fn_name: self.into(),
+        }
+    }
+}
+
+impl<S: Into<String>> ExternalSpec<'_, EmbeddedDeploy> for S {
+    fn build(self, _location_key: LocationKey, _name_hint: &str) -> EmbeddedNode {
+        EmbeddedNode {
+            fn_name: self.into(),
+        }
+    }
+}
+
+impl<'a> Deploy<'a> for EmbeddedDeploy {
+    type Meta = ();
+    type InstantiateEnv = ();
+
+    type Process = EmbeddedNode;
+    type Cluster = EmbeddedNode;
+    type External = EmbeddedNode;
+
+    fn o2o_sink_source(
+        _p1: &Self::Process,
+        _p1_port: &(),
+        _p2: &Self::Process,
+        _p2_port: &(),
+    ) -> (syn::Expr, syn::Expr) {
+        panic!("EmbeddedDeploy does not support networking (o2o)")
+    }
+
+    fn o2o_connect(
+        _p1: &Self::Process,
+        _p1_port: &(),
+        _p2: &Self::Process,
+        _p2_port: &(),
+    ) -> Box<dyn FnOnce()> {
+        panic!("EmbeddedDeploy does not support networking (o2o)")
+    }
+
+    fn o2m_sink_source(
+        _p1: &Self::Process,
+        _p1_port: &(),
+        _c2: &Self::Cluster,
+        _c2_port: &(),
+    ) -> (syn::Expr, syn::Expr) {
+        panic!("EmbeddedDeploy does not support networking (o2m)")
+    }
+
+    fn o2m_connect(
+        _p1: &Self::Process,
+        _p1_port: &(),
+        _c2: &Self::Cluster,
+        _c2_port: &(),
+    ) -> Box<dyn FnOnce()> {
+        panic!("EmbeddedDeploy does not support networking (o2m)")
+    }
+
+    fn m2o_sink_source(
+        _c1: &Self::Cluster,
+        _c1_port: &(),
+        _p2: &Self::Process,
+        _p2_port: &(),
+    ) -> (syn::Expr, syn::Expr) {
+        panic!("EmbeddedDeploy does not support networking (m2o)")
+    }
+
+    fn m2o_connect(
+        _c1: &Self::Cluster,
+        _c1_port: &(),
+        _p2: &Self::Process,
+        _p2_port: &(),
+    ) -> Box<dyn FnOnce()> {
+        panic!("EmbeddedDeploy does not support networking (m2o)")
+    }
+
+    fn m2m_sink_source(
+        _c1: &Self::Cluster,
+        _c1_port: &(),
+        _c2: &Self::Cluster,
+        _c2_port: &(),
+    ) -> (syn::Expr, syn::Expr) {
+        panic!("EmbeddedDeploy does not support networking (m2m)")
+    }
+
+    fn m2m_connect(
+        _c1: &Self::Cluster,
+        _c1_port: &(),
+        _c2: &Self::Cluster,
+        _c2_port: &(),
+    ) -> Box<dyn FnOnce()> {
+        panic!("EmbeddedDeploy does not support networking (m2m)")
+    }
+
+    fn e2o_many_source(
+        _extra_stmts: &mut Vec<syn::Stmt>,
+        _p2: &Self::Process,
+        _p2_port: &(),
+        _codec_type: &syn::Type,
+        _shared_handle: String,
+    ) -> syn::Expr {
+        panic!("EmbeddedDeploy does not support networking (e2o)")
+    }
+
+    fn e2o_many_sink(_shared_handle: String) -> syn::Expr {
+        panic!("EmbeddedDeploy does not support networking (e2o)")
+    }
+
+    fn e2o_source(
+        _extra_stmts: &mut Vec<syn::Stmt>,
+        _p1: &Self::External,
+        _p1_port: &(),
+        _p2: &Self::Process,
+        _p2_port: &(),
+        _codec_type: &syn::Type,
+        _shared_handle: String,
+    ) -> syn::Expr {
+        panic!("EmbeddedDeploy does not support networking (e2o)")
+    }
+
+    fn e2o_connect(
+        _p1: &Self::External,
+        _p1_port: &(),
+        _p2: &Self::Process,
+        _p2_port: &(),
+        _many: bool,
+        _server_hint: NetworkHint,
+    ) -> Box<dyn FnOnce()> {
+        panic!("EmbeddedDeploy does not support networking (e2o)")
+    }
+
+    fn o2e_sink(
+        _p1: &Self::Process,
+        _p1_port: &(),
+        _p2: &Self::External,
+        _p2_port: &(),
+        _shared_handle: String,
+    ) -> syn::Expr {
+        panic!("EmbeddedDeploy does not support networking (o2e)")
+    }
+
+    #[expect(
+        unreachable_code,
+        reason = "panic before q! which is only for return type"
+    )]
+    fn cluster_ids(
+        _of_cluster: LocationKey,
+    ) -> impl QuotedWithContext<'a, &'a [TaglessMemberId], ()> + Clone + 'a {
+        panic!("EmbeddedDeploy does not support cluster IDs");
+        q!(unreachable!("EmbeddedDeploy does not support cluster IDs"))
+    }
+
+    #[expect(
+        unreachable_code,
+        reason = "panic before q! which is only for return type"
+    )]
+    fn cluster_self_id() -> impl QuotedWithContext<'a, TaglessMemberId, ()> + Clone + 'a {
+        panic!("EmbeddedDeploy does not support cluster self ID");
+        q!(unreachable!(
+            "EmbeddedDeploy does not support cluster self ID"
+        ))
+    }
+
+    #[expect(
+        unreachable_code,
+        reason = "panic before q! which is only for return type"
+    )]
+    fn cluster_membership_stream(
+        _location_id: &LocationId,
+    ) -> impl QuotedWithContext<'a, Box<dyn Stream<Item = (TaglessMemberId, MembershipEvent)> + Unpin>, ()>
+    {
+        panic!("EmbeddedDeploy does not support cluster membership streams");
+        q!(unreachable!(
+            "EmbeddedDeploy does not support cluster membership streams"
+        ))
+    }
+}
+
+impl super::deploy::DeployFlow<'_, EmbeddedDeploy> {
+    /// Generates a `syn::File` containing one function per location in the flow.
+    ///
+    /// Each generated function has the signature:
+    /// ```ignore
+    /// pub fn <fn_name>() -> dfir_rs::scheduled::graph::Dfir<'static>
+    /// ```
+    /// where `fn_name` is the `String` passed to `with_process` / `with_cluster`.
+    ///
+    /// The returned `Dfir` can be manually executed by the caller.
+    ///
+    /// # Arguments
+    ///
+    /// * `crate_name` — the name of the crate containing the Hydro program (used for stageleft
+    ///   re-exports). Hyphens will be replaced with underscores.
+    ///
+    /// # Usage
+    ///
+    /// Typically called from a `build.rs` in a wrapper crate:
+    /// ```ignore
+    /// // build.rs
+    /// let deploy = flow.with_process(&process, "my_fn".to_string());
+    /// let code = deploy.generate_embedded("my_hydro_crate");
+    /// let out_dir = std::env::var("OUT_DIR").unwrap();
+    /// std::fs::write(format!("{out_dir}/embedded.rs"), prettyplease::unparse(&code)).unwrap();
+    /// ```
+    ///
+    /// Then in `lib.rs`:
+    /// ```ignore
+    /// include!(concat!(env!("OUT_DIR"), "/embedded.rs"));
+    /// ```
+    pub fn generate_embedded(mut self, crate_name: &str) -> syn::File {
+        let compiled = self.compile_internal();
+
+        let root = crate::staging_util::get_this_crate();
+        let orig_crate_name = quote::format_ident!("{}", crate_name.replace('-', "_"));
+
+        let mut functions: Vec<syn::Item> = Vec::new();
+
+        // Sort location keys for deterministic output.
+        let mut location_keys: Vec<_> = compiled.all_dfir().keys().collect();
+        location_keys.sort();
+
+        for location_key in location_keys {
+            let graph = &compiled.all_dfir()[location_key];
+
+            // Get the user-provided function name from the node.
+            let fn_name = self
+                .processes
+                .get(location_key)
+                .map(|n| &n.fn_name)
+                .or_else(|| self.clusters.get(location_key).map(|n| &n.fn_name))
+                .or_else(|| self.externals.get(location_key).map(|n| &n.fn_name))
+                .expect("location key not found in any node map");
+
+            let fn_ident = syn::Ident::new(fn_name, Span::call_site());
+
+            let mut diagnostics = Diagnostics::new();
+            let dfir_tokens = graph
+                .as_code(&quote! { __root_dfir_rs }, true, quote!(), &mut diagnostics)
+                .expect("DFIR code generation failed with diagnostics.");
+
+            let func: syn::Item = syn::parse_quote! {
+                #[allow(unused, non_snake_case, clippy::suspicious_else_formatting)]
+                pub fn #fn_ident<'a>() -> #root::runtime_support::dfir_rs::scheduled::graph::Dfir<'a> {
+                    #dfir_tokens
+                }
+            };
+            functions.push(func);
+        }
+
+        syn::parse_quote! {
+            use #orig_crate_name::__staged::__deps::*;
+            use #root::prelude::*;
+            use #root::runtime_support::dfir_rs as __root_dfir_rs;
+            pub use #orig_crate_name::__staged;
+
+            #( #functions )*
+        }
+    }
+}

--- a/hydro_lang/src/compile/mod.rs
+++ b/hydro_lang/src/compile/mod.rs
@@ -20,6 +20,10 @@ pub mod deploy;
 
 #[cfg(feature = "build")]
 #[cfg_attr(docsrs, doc(cfg(feature = "build")))]
+pub mod embedded;
+
+#[cfg(feature = "build")]
+#[cfg_attr(docsrs, doc(cfg(feature = "build")))]
 #[expect(missing_docs, reason = "TODO")]
 pub mod deploy_provider;
 
@@ -45,6 +49,6 @@ pub mod trybuild;
 pub use trybuild::generate::init_test;
 
 /// Ident used for the DFIR runtime instance variable name.
-#[cfg(feature = "trybuild")]
-#[cfg_attr(docsrs, doc(cfg(feature = "trybuild")))]
+#[cfg(feature = "build")]
+#[cfg_attr(docsrs, doc(cfg(feature = "build")))]
 pub(crate) const DFIR_IDENT: &str = "flow";

--- a/hydro_test/Cargo.toml
+++ b/hydro_test/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 docker = ["hydro_lang/docker_deploy"]
 ecs = ["hydro_lang/ecs_deploy"]
 maelstrom = ["hydro_lang/maelstrom"]
+stageleft_macro_entrypoint = []
 
 [dependencies]
 hydro_lang = { path = "../hydro_lang", version = "^0.15.0" }

--- a/hydro_test/src/local/first_ten.rs
+++ b/hydro_test/src/local/first_ten.rs
@@ -1,0 +1,7 @@
+use hydro_lang::prelude::*;
+
+pub fn first_ten<'a>(process: &Process<'a, ()>) {
+    process
+        .source_iter(q!(0..10))
+        .for_each(q!(|n| println!("{}", n)));
+}

--- a/hydro_test/src/local/mod.rs
+++ b/hydro_test/src/local/mod.rs
@@ -1,4 +1,5 @@
 pub mod chat_app;
 pub mod count_elems;
+pub mod first_ten;
 pub mod futures;
 pub mod graph_reachability;

--- a/hydro_test_embedded/Cargo.toml
+++ b/hydro_test_embedded/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "hydro_test_embedded"
+publish = false
+version = "0.0.0"
+edition = "2024"
+
+[lints]
+workspace = true
+
+[features]
+default = []
+test_embedded = [
+    "dep:hydro_lang",
+    "dep:hydro_test",
+    "dep:stageleft",
+    "dep:prettyplease",
+]
+
+[dependencies]
+hydro_lang = { path = "../hydro_lang", version = "^0.15.0", features = ["runtime_support"], optional = true }
+hydro_test = { path = "../hydro_test", version = "0.0.0", features = ["stageleft_macro_entrypoint"], optional = true }
+stageleft = { workspace = true, optional = true }
+
+[dev-dependencies]
+dfir_rs = { path = "../dfir_rs", version = "^0.15.0", default-features = false }
+tokio = { version = "1.29.0", features = ["full"] }
+
+[build-dependencies]
+hydro_lang = { path = "../hydro_lang", version = "^0.15.0", features = ["build"], optional = true }
+hydro_test = { path = "../hydro_test", version = "0.0.0", optional = true }
+prettyplease = { version = "0.2.0", features = ["verbatim"], optional = true }

--- a/hydro_test_embedded/build.rs
+++ b/hydro_test_embedded/build.rs
@@ -1,0 +1,21 @@
+fn main() {
+    #[cfg(feature = "test_embedded")]
+    generate_embedded();
+}
+
+#[cfg(feature = "test_embedded")]
+fn generate_embedded() {
+    println!("cargo::rerun-if-changed=build.rs");
+
+    let mut flow = hydro_lang::compile::builder::FlowBuilder::new();
+    let process = flow.process::<()>();
+    hydro_test::local::first_ten::first_ten(&process);
+
+    let code = flow
+        .with_process(&process, "first_ten")
+        .generate_embedded("hydro_test");
+
+    let out_dir = std::env::var("OUT_DIR").unwrap();
+    let out_path = format!("{out_dir}/embedded.rs");
+    std::fs::write(&out_path, prettyplease::unparse(&code)).unwrap();
+}

--- a/hydro_test_embedded/examples/embedded_first_ten.rs
+++ b/hydro_test_embedded/examples/embedded_first_ten.rs
@@ -1,0 +1,54 @@
+#[cfg(feature = "test_embedded")]
+#[tokio::main]
+async fn main() {
+    let mut flow = hydro_test_embedded::embedded::first_ten();
+    tokio::task::LocalSet::new()
+        .run_until(flow.run_available())
+        .await;
+}
+
+#[cfg(not(feature = "test_embedded"))]
+fn main() {
+    eprintln!("This example requires the `test_embedded` feature.");
+    std::process::exit(1);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::{Command, Stdio};
+
+    #[test]
+    fn test_embedded_first_ten() {
+        let output = Command::new("cargo")
+            .args([
+                "run",
+                "--frozen",
+                "-p",
+                "hydro_test_embedded",
+                "--example",
+                "embedded_first_ten",
+                "--features",
+                "test_embedded",
+            ])
+            .stdout(Stdio::piped())
+            .output()
+            .expect("failed to spawn cargo run");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        assert!(
+            output.status.success(),
+            "example failed with status {}.\nstdout:\n{}",
+            output.status,
+            stdout,
+        );
+
+        let lines: Vec<&str> = stdout.lines().collect();
+        let expected: Vec<String> = (0..10).map(|i| i.to_string()).collect();
+        assert_eq!(
+            lines, expected,
+            "expected first 10 numbers, got:\n{}",
+            stdout
+        );
+    }
+}

--- a/hydro_test_embedded/src/lib.rs
+++ b/hydro_test_embedded/src/lib.rs
@@ -1,0 +1,10 @@
+#[cfg(feature = "test_embedded")]
+#[expect(
+    clippy::allow_attributes,
+    clippy::allow_attributes_without_reason,
+    reason = "generated code"
+)]
+#[allow(unused_imports, unused_qualifications, missing_docs, non_snake_case)]
+pub mod embedded {
+    include!(concat!(env!("OUT_DIR"), "/embedded.rs"));
+}


### PR DESCRIPTION

When we got rid of the original macro-entrypoint approach to building Hydro programs (in favor of trybuild + Hydro Deploy), we also lost option to incrementally adopt Hydro in existing Rust codebases by manually instantiating the DFIR projections for each location.

This is the first step towards restoring this incremental adoption path by using build scripts as a mechanism to pull generated DFIR projections into a regular Rust crate. For now, we do not support any external inputs or outputs or inter-location networking. In followup PRs, we will start with external in/out support and later support networking operators (which require more design work).
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydro-project/hydro/pull/2557).
* #2559
* __->__ #2557