### PR TITLE
refactor(dfir_lang,hydro_lang)!: have `_counter` take in a single (now-combined) prefix arg

### DIFF
--- a/dfir_lang/src/graph/ops/_counter.rs
+++ b/dfir_lang/src/graph/ops/_counter.rs
@@ -1,5 +1,4 @@
 use quote::quote_spanned;
-use syn::parse_quote_spanned;
 
 use super::{
     OperatorCategory, OperatorConstraints, OperatorWriteOutput, RANGE_0, RANGE_1, WriteContextArgs,
@@ -12,7 +11,7 @@ use super::{
 ///
 /// ```dfir
 /// source_stream(dfir_rs::util::iter_batches_stream(0..=100_000, 1))
-///     -> _counter("nums", std::time::Duration::from_millis(100));
+///     -> _counter("_counter(nums)", std::time::Duration::from_millis(100));
 /// ```
 /// stdout:
 /// ```text
@@ -68,7 +67,6 @@ pub const _COUNTER: OperatorConstraints = OperatorConstraints {
         let tag_ident = wc.make_ident("tag");
         let duration_expr = &arguments[1];
         let duration_ident = wc.make_ident("duration");
-        let prefix = arguments.get(2).cloned().unwrap_or(parse_quote_spanned!(op_span=> "_counter"));
 
         let write_prologue = quote_spanned! {op_span=>
             let #write_ident = ::std::rc::Rc::new(::std::cell::Cell::new(0_u64));
@@ -78,7 +76,7 @@ pub const _COUNTER: OperatorConstraints = OperatorConstraints {
             let #tag_ident = #tag_expr;
             #df_ident.request_task(async move {
                 loop {
-                    println!("{}({}): {}", #prefix, #tag_ident, #read_ident.get());
+                    println!("{}: {}", #tag_ident, #read_ident.get());
                     #root::tokio::time::sleep(#duration_ident).await;
                 }
             });

--- a/dfir_rs/tests/surface_counter.rs
+++ b/dfir_rs/tests/surface_counter.rs
@@ -20,7 +20,7 @@ pub async fn test_fib() {
     let mut df: Dfir = dfir_syntax! {
         source_stream(iter_batches_stream(0..=40, 1))
             -> map(fib)
-            -> _counter("nums", Duration::from_millis(50));
+            -> _counter("_counter(nums)", Duration::from_millis(50));
     };
 
     df.run_available().await;
@@ -36,7 +36,7 @@ pub async fn test_fib() {
 pub async fn test_stream() {
     let mut df: Dfir = dfir_syntax! {
         source_stream(iter_batches_stream(0..=100_000, 1))
-            -> _counter("nums", Duration::from_millis(100));
+            -> _counter("_counter(nums)", Duration::from_millis(100));
     };
 
     df.run_available().await;
@@ -65,7 +65,7 @@ pub async fn test_pull() {
 
     let mut df: Dfir = dfir_syntax! {
         source_iter(0..10)
-            -> _counter("pull_test", Duration::from_millis(50))
+            -> _counter("_counter(pull_test)", Duration::from_millis(50))
             -> for_each(|x| output_ref.borrow_mut().push(x));
     };
 

--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -3412,10 +3412,11 @@ impl HydroNode {
 
                         match builders_or_callback {
                             BuildersOrCallback::Builders(graph_builders) => {
+                                let arg = format!("{}({})", prefix, tag);
                                 let builder = graph_builders.get_dfir_mut(&out_location);
                                 builder.add_dfir(
                                     parse_quote! {
-                                        #counter_ident = #input_ident -> _counter(#tag, #duration, #prefix);
+                                        #counter_ident = #input_ident -> _counter(#arg, #duration);
                                     },
                                     None,
                                     Some(&next_stmt_id.to_string()),


### PR DESCRIPTION
Previously `hydro_lang` allowed `_counter` to be called with 3 args (despite `num_args: 2`) since it previously ignored `dfir_lang` errors. However now since #2541 those errors are checked, which means `_counter` compilation fails. This simplifies the counter API to always take 2 arguments.

BREAKING CHANGE: The format that `_counter` emits is different. `_counter("foo", ...)` previously emitted `_counter(foo): ...`, will now emit `foo: ...`. Change to `_counter("_counter(foo)", ...)` to maintain old behavior.