### PR TITLE
feat(hydro_lang)!: implement o2o networking in embedded mode

### DIFF
--- a/docs/docs/hydro/reference/deploy/embedded.mdx
+++ b/docs/docs/hydro/reference/deploy/embedded.mdx
@@ -13,7 +13,9 @@ Instead of producing self-contained binaries, embedded mode generates a Rust sou
 - **Custom I/O**: You need to connect Hydro to a transport or runtime that Hydro Deploy doesn't support (DPDK, shared memory, a game loop, etc.).
 - **Library use**: You want to ship a crate that uses Hydro internally but exposes a normal Rust API to consumers.
 
-Embedded mode only supports **local, single-process computation**. Networking between locations is not available — all `Deploy` networking trait methods will panic if called. If you need multi-node communication, use [Hydro Deploy](./index.mdx) instead.
+Embedded mode only supports **local, single-process computation** and **process-to-process (o2o) networking**. Cluster networking, external ports, and other multi-node patterns are not yet available.
+
+When your Hydro program sends data between processes, the generated functions gain additional `network_out` and `network_in` parameters. You wire these up yourself — for example with in-memory channels, Unix sockets, or any transport you like. See [Networking](#networking) below for details.
 
 ## How It Works
 Embedded mode uses a `build.rs` script to compile your Hydro program at build time. The generated code is then `include!`-ed into your crate. The workflow has three parts:
@@ -140,3 +142,46 @@ async fn run() {
 ```
 
 The generated function accepts your input streams as `impl Stream<Item = T> + Unpin` parameters and a mutable reference to the `EmbeddedOutputs` struct. It returns a `Dfir` graph that you run with `run_available()` (or tick manually).
+
+
+## Networking
+
+Embedded mode supports process-to-process (o2o) networking. When your Hydro program uses `.send()` between two processes, the generated functions get extra parameters so you can wire up the transport yourself.
+
+Network channels in embedded mode **must be named**. Use `.name()` on the networking config:
+
+```rust,ignore
+input.send(receiver, TCP.fail_stop().bincode().name("messages"))
+```
+
+The name becomes a field name in the generated structs, so it must be a valid Rust identifier. Consider a two-process program where `Sender` sends to `Receiver` over a channel named `"messages"`. `Sender` gets an `EmbeddedNetworkOut` struct parameter with an `FnMut(Bytes)` field per outgoing channel:
+
+```rust,ignore
+pub mod echo_sender {
+    pub struct EmbeddedNetworkOut<F: FnMut(Bytes)> {
+        pub messages: F,
+    }
+}
+
+pub fn echo_sender<'a, F: FnMut(Bytes) + 'a>(
+    input: impl Stream<Item = String> + Unpin + 'a,
+    __network_out: &'a mut echo_sender::EmbeddedNetworkOut<F>,
+) -> Dfir<'a> { ... }
+```
+
+On the other side, `Receiver` gets an `EmbeddedNetworkIn` struct parameter with a `Stream<Item = Result<BytesMut, io::Error>>` field per incoming channel:
+
+```rust,ignore
+pub mod echo_receiver {
+    pub struct EmbeddedNetworkIn<S: Stream<Item = Result<BytesMut, io::Error>> + Unpin> {
+        pub messages: S,
+    }
+}
+
+pub fn echo_receiver<'a, S: Stream<Item = Result<BytesMut, io::Error>> + Unpin + 'a>(
+    __outputs: &'a mut echo_receiver::EmbeddedOutputs<...>,
+    __network_in: echo_receiver::EmbeddedNetworkIn<S>,
+) -> Dfir<'a> { ... }
+```
+
+Hydro automatically handles serialization — just shuttle the raw bytes between sender and receiver. You must ensure that you are preserving any guarantees of the network protocol specified in the Hydro program. For example, if the channel uses `TCP`, you must ensure that your networking mechanism preserves ordering and exactly-once delivery.

--- a/docs/src/pages/research.mdx
+++ b/docs/src/pages/research.mdx
@@ -1,5 +1,6 @@
 ---
 title: Research Publications
+wrapperClassName: research-page
 ---
 
 import "./research.module.css";

--- a/docs/src/pages/research.module.css
+++ b/docs/src/pages/research.module.css
@@ -1,44 +1,46 @@
-h1 {
-    font-size: 50px;
-}
-
-@media screen and (max-width: 1000px) {
+:global(.research-page) {
     h1 {
-        font-size: 45px;
+        font-size: 50px;
     }
-}
 
-h2 {
-    font-size: 35px;
-}
+    @media screen and (max-width: 1000px) {
+        h1 {
+            font-size: 45px;
+        }
+    }
 
-h3 {
-    border-top: 1px solid #0a0a0a;
-    padding-top: 15px;
-    font-size: 22px;
-    margin-bottom: 5px;
-}
+    h2 {
+        font-size: 35px;
+    }
 
-[data-theme="dark"] h3 {
-    border-top: 1px solid #f0f0f0;
-}
+    h3 {
+        border-top: 1px solid #0a0a0a;
+        padding-top: 15px;
+        font-size: 22px;
+        margin-bottom: 5px;
+    }
 
-h3 + p {
-    font-size: 20px;
-    line-height: 1.4;
-    margin-bottom: 10px;
-}
+    [data-theme="dark"] h3 {
+        border-top: 1px solid #f0f0f0;
+    }
 
-:global(.col--8) {
-    --ifm-col-width: calc(9 / 12 * 100%) !important;
-}
+    h3 + p {
+        font-size: 20px;
+        line-height: 1.4;
+        margin-bottom: 10px;
+    }
 
-@media (max-width: 996px) {
     :global(.col--8) {
-        --ifm-col-width: 100% !important;
+        --ifm-col-width: calc(9 / 12 * 100%) !important;
     }
-}
 
-:global(.col--2) {
-    --ifm-col-width: calc(3 / 12 * 100%) !important;
+    @media (max-width: 996px) {
+        :global(.col--8) {
+            --ifm-col-width: 100% !important;
+        }
+    }
+
+    :global(.col--2) {
+        --ifm-col-width: calc(3 / 12 * 100%) !important;
+    }
 }

--- a/hydro_lang/src/compile/deploy_provider.rs
+++ b/hydro_lang/src/compile/deploy_provider.rs
@@ -23,10 +23,12 @@ pub trait Deploy<'a> {
         + RegisterPort<'a, Self>;
 
     fn o2o_sink_source(
+        env: &mut Self::InstantiateEnv,
         p1: &Self::Process,
         p1_port: &<Self::Process as Node>::Port,
         p2: &Self::Process,
         p2_port: &<Self::Process as Node>::Port,
+        name: Option<&str>,
     ) -> (syn::Expr, syn::Expr);
     fn o2o_connect(
         p1: &Self::Process,

--- a/hydro_lang/src/deploy/deploy_graph.rs
+++ b/hydro_lang/src/deploy/deploy_graph.rs
@@ -54,10 +54,12 @@ impl<'a> Deploy<'a> for HydroDeploy {
     type External = DeployExternal;
 
     fn o2o_sink_source(
+        _env: &mut Self::InstantiateEnv,
         _p1: &Self::Process,
         p1_port: &<Self::Process as Node>::Port,
         _p2: &Self::Process,
         p2_port: &<Self::Process as Node>::Port,
+        _name: Option<&str>,
     ) -> (syn::Expr, syn::Expr) {
         let p1_port = p1_port.as_str();
         let p2_port = p2_port.as_str();

--- a/hydro_lang/src/deploy/deploy_graph_containerized.rs
+++ b/hydro_lang/src/deploy/deploy_graph_containerized.rs
@@ -907,10 +907,12 @@ impl<'a> Deploy<'a> for DockerDeploy {
 
     #[instrument(level = "trace", skip_all, fields(p1 = p1.name, %p1_port, p2 = p2.name, p2_port))]
     fn o2o_sink_source(
+        _env: &mut Self::InstantiateEnv,
         p1: &Self::Process,
         p1_port: &<Self::Process as Node>::Port,
         p2: &Self::Process,
         p2_port: &<Self::Process as Node>::Port,
+        _name: Option<&str>,
     ) -> (syn::Expr, syn::Expr) {
         let bind_addr = format!("0.0.0.0:{}", p2_port);
         let target = format!("{}:{p2_port}", p2.name);

--- a/hydro_lang/src/deploy/deploy_graph_containerized_ecs.rs
+++ b/hydro_lang/src/deploy/deploy_graph_containerized_ecs.rs
@@ -433,10 +433,12 @@ impl<'a> Deploy<'a> for EcsDeploy {
 
     #[instrument(level = "trace", skip_all, fields(p1 = p1.name, %p1_port, p2 = p2.name, p2_port))]
     fn o2o_sink_source(
+        _env: &mut Self::InstantiateEnv,
         p1: &Self::Process,
         p1_port: &<Self::Process as Node>::Port,
         p2: &Self::Process,
         p2_port: &<Self::Process as Node>::Port,
+        _name: Option<&str>,
     ) -> (syn::Expr, syn::Expr) {
         deploy_containerized_o2o(&p2.name, *p2_port)
     }

--- a/hydro_lang/src/deploy/maelstrom/deploy_maelstrom.rs
+++ b/hydro_lang/src/deploy/maelstrom/deploy_maelstrom.rs
@@ -44,10 +44,12 @@ impl<'a> Deploy<'a> for MaelstromDeploy {
     type External = MaelstromExternal;
 
     fn o2o_sink_source(
+        _env: &mut Self::InstantiateEnv,
         _p1: &Self::Process,
         _p1_port: &<Self::Process as Node>::Port,
         _p2: &Self::Process,
         _p2_port: &<Self::Process as Node>::Port,
+        _name: Option<&str>,
     ) -> (syn::Expr, syn::Expr) {
         panic!("Maelstrom deployment does not support processes, only clusters")
     }

--- a/hydro_lang/src/sim/graph.rs
+++ b/hydro_lang/src/sim/graph.rs
@@ -176,10 +176,12 @@ impl<'a> Deploy<'a> for SimDeploy {
     type External = SimExternal;
 
     fn o2o_sink_source(
+        _env: &mut Self::InstantiateEnv,
         _p1: &Self::Process,
         p1_port: &<Self::Process as Node>::Port,
         _p2: &Self::Process,
         p2_port: &<Self::Process as Node>::Port,
+        _name: Option<&str>,
     ) -> (syn::Expr, syn::Expr) {
         let ident_sink =
             syn::Ident::new(&format!("__hydro_o2o_sink_{}", p1_port), Span::call_site());

--- a/hydro_test/src/embedded/echo_network.rs
+++ b/hydro_test/src/embedded/echo_network.rs
@@ -1,0 +1,13 @@
+use hydro_lang::prelude::*;
+
+pub struct Sender {}
+pub struct Receiver {}
+
+pub fn echo_network<'a>(
+    receiver: &Process<'a, Receiver>,
+    input: Stream<String, Process<'a, Sender>>,
+) -> Stream<String, Process<'a, Receiver>> {
+    input
+        .send(receiver, TCP.fail_stop().bincode().name("messages"))
+        .map(q!(|s| s.to_uppercase()))
+}

--- a/hydro_test/src/embedded/mod.rs
+++ b/hydro_test/src/embedded/mod.rs
@@ -1,0 +1,1 @@
+pub mod echo_network;

--- a/hydro_test/src/lib.rs
+++ b/hydro_test/src/lib.rs
@@ -3,6 +3,7 @@ hydro_lang::setup!();
 
 pub mod cluster;
 pub mod distributed;
+pub mod embedded;
 pub mod external_client;
 pub mod local;
 pub mod maelstrom;

--- a/hydro_test_embedded/build.rs
+++ b/hydro_test_embedded/build.rs
@@ -9,15 +9,42 @@ fn generate_embedded() {
 
     println!("cargo::rerun-if-changed=build.rs");
 
-    let mut flow = hydro_lang::compile::builder::FlowBuilder::new();
-    let process = flow.process::<()>();
-    hydro_test::local::capitalize::capitalize(process.embedded_input("input"));
-
-    let code = flow
-        .with_process(&process, "capitalize")
-        .generate_embedded("hydro_test");
-
     let out_dir = std::env::var("OUT_DIR").unwrap();
-    let out_path = format!("{out_dir}/embedded.rs");
-    std::fs::write(&out_path, prettyplease::unparse(&code)).unwrap();
+
+    // --- capitalize (local, no networking) ---
+    {
+        let mut flow = hydro_lang::compile::builder::FlowBuilder::new();
+        let process = flow.process::<()>();
+        hydro_test::local::capitalize::capitalize(process.embedded_input("input"));
+
+        let code = flow
+            .with_process(&process, "capitalize")
+            .generate_embedded("hydro_test");
+
+        std::fs::write(
+            format!("{out_dir}/embedded.rs"),
+            prettyplease::unparse(&code),
+        )
+        .unwrap();
+    }
+
+    // --- echo_network (o2o networking) ---
+    {
+        let mut flow = hydro_lang::compile::builder::FlowBuilder::new();
+        let sender = flow.process::<hydro_test::embedded::echo_network::Sender>();
+        let receiver = flow.process::<hydro_test::embedded::echo_network::Receiver>();
+        hydro_test::embedded::echo_network::echo_network(&receiver, sender.embedded_input("input"))
+            .embedded_output("output");
+
+        let code = flow
+            .with_process(&sender, "echo_sender")
+            .with_process(&receiver, "echo_receiver")
+            .generate_embedded("hydro_test");
+
+        std::fs::write(
+            format!("{out_dir}/echo_network.rs"),
+            prettyplease::unparse(&code),
+        )
+        .unwrap();
+    }
 }

--- a/hydro_test_embedded/src/lib.rs
+++ b/hydro_test_embedded/src/lib.rs
@@ -9,6 +9,17 @@ pub mod embedded {
     include!(concat!(env!("OUT_DIR"), "/embedded.rs"));
 }
 
+#[cfg(feature = "test_embedded")]
+#[expect(
+    clippy::allow_attributes,
+    clippy::allow_attributes_without_reason,
+    reason = "generated code"
+)]
+#[allow(unused_imports, unused_qualifications, missing_docs, non_snake_case)]
+pub mod echo_network {
+    include!(concat!(env!("OUT_DIR"), "/echo_network.rs"));
+}
+
 #[cfg(all(test, feature = "test_embedded"))]
 mod tests {
     #[tokio::test]
@@ -33,5 +44,57 @@ mod tests {
         drop(flow);
 
         assert_eq!(collected, vec!["HELLO", "WORLD", "HYDRO"],);
+    }
+
+    #[tokio::test]
+    async fn test_echo_network() {
+        use dfir_rs::bytes::{Bytes, BytesMut};
+        use dfir_rs::futures::stream;
+
+        // Wire sender -> receiver via an in-memory channel.
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Bytes>();
+
+        // --- Run sender ---
+        let input = stream::iter(vec!["hello".to_owned(), "world".to_owned()]);
+
+        let mut sender_net_out = crate::echo_network::echo_sender::EmbeddedNetworkOut {
+            messages: move |bytes: Bytes| {
+                tx.send(bytes).unwrap();
+            },
+        };
+
+        let mut sender_flow = crate::echo_network::echo_sender(input, &mut sender_net_out);
+        tokio::task::LocalSet::new()
+            .run_until(sender_flow.run_available())
+            .await;
+        drop(sender_flow);
+
+        // Collect serialized bytes.
+        let mut bytes_vec = vec![];
+        while let Ok(b) = rx.try_recv() {
+            bytes_vec.push(Ok(BytesMut::from(b.as_ref())));
+        }
+        assert_eq!(bytes_vec.len(), 2, "sender should have produced 2 messages");
+
+        // --- Run receiver ---
+        let receiver_net_in = crate::echo_network::echo_receiver::EmbeddedNetworkIn {
+            messages: stream::iter(bytes_vec),
+        };
+
+        let mut received = vec![];
+        let mut receiver_outputs = crate::echo_network::echo_receiver::EmbeddedOutputs {
+            output: |s: String| {
+                received.push(s);
+            },
+        };
+
+        let mut receiver_flow =
+            crate::echo_network::echo_receiver(&mut receiver_outputs, receiver_net_in);
+        tokio::task::LocalSet::new()
+            .run_until(receiver_flow.run_available())
+            .await;
+        drop(receiver_flow);
+
+        assert_eq!(received, vec!["HELLO", "WORLD"]);
     }
 }


### PR DESCRIPTION

Breaking Change: add additional parameters to `Deploy::o2o_sink_source` to include instantiate env and network channel name (the latter will be needed for the multiversioned runtime anyways).

Also fixes an issue with CSS for the research page being applied globally.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydro-project/hydro/pull/2577).
* #2578
* __->__ #2577