### PR TITLE
feat(hydro_lang): use marker trait to improve error messages for wrong ordering / retries

### DIFF
--- a/hydro_lang/src/properties/mod.rs
+++ b/hydro_lang/src/properties/mod.rs
@@ -98,7 +98,8 @@ impl<C, I> Property for AggFuncAlgebra<C, I> {
 /// Marker trait identifying that the commutativity property is valid for the given stream ordering.
 #[diagnostic::on_unimplemented(
     message = "Because the input stream has ordering `{O}`, the closure must demonstrate commutativity with a `commutative = ...` annotation.",
-    label = "required for this call"
+    label = "required for this call",
+    note = "To intentionally process the stream with a non-deterministic (shuffled) order of elements, use `.assume_ordering`. This bypasses the safety guarantees so avoid unless necessary."
 )]
 #[sealed::sealed]
 pub trait ValidCommutativityFor<O: Ordering> {}
@@ -110,7 +111,8 @@ impl<O: Ordering> ValidCommutativityFor<O> for Proved {}
 /// Marker trait identifying that the idempotence property is valid for the given stream ordering.
 #[diagnostic::on_unimplemented(
     message = "Because the input stream has retries `{R}`, the closure must demonstrate idempotence with an `idempotent = ...` annotation.",
-    label = "required for this call"
+    label = "required for this call",
+    note = "To intentionally process the stream with non-deterministic (randomly duplicated) retries, use `.assume_retries`. This bypasses the safety guarantees so avoid unless necessary."
 )]
 #[sealed::sealed]
 pub trait ValidIdempotenceFor<R: Retries> {}

--- a/hydro_lang/tests/compile-fail-stable/non_commutative.stderr
+++ b/hydro_lang/tests/compile-fail-stable/non_commutative.stderr
@@ -4,6 +4,7 @@ error[E0277]: Because the input stream has ordering `hydro_lang::live_collection
 9 |         .fold(q!(|| 0), q!(|acc, x| *acc += x));
   |          ^^^^ required for this call
   |
+  = note: To intentionally process the stream with a non-deterministic (shuffled) order of elements, use `.assume_ordering`. This bypasses the safety guarantees so avoid unless necessary.
   = help: the trait `ValidCommutativityFor<hydro_lang::live_collections::stream::NoOrder>` is not implemented for `NotProved`
           but trait `ValidCommutativityFor<hydro_lang::live_collections::stream::TotalOrder>` is implemented for it
   = help: for that trait implementation, expected `hydro_lang::live_collections::stream::TotalOrder`, found `hydro_lang::live_collections::stream::NoOrder`

--- a/hydro_lang/tests/compile-fail-stable/non_commutative_operator.rs
+++ b/hydro_lang/tests/compile-fail-stable/non_commutative_operator.rs
@@ -1,0 +1,1 @@
+../compile-fail/non_commutative_operator.rs

--- a/hydro_lang/tests/compile-fail-stable/non_commutative_operator.stderr
+++ b/hydro_lang/tests/compile-fail-stable/non_commutative_operator.stderr
@@ -1,0 +1,16 @@
+error[E0277]: The input stream must be totally-ordered (`TotalOrder`), but has order `hydro_lang::live_collections::stream::NoOrder`. Strengthen the order upstream or consider a different API.
+ --> tests/compile-fail-stable/non_commutative_operator.rs:7:68
+  |
+7 |     let _ = p1.source_iter(q!(0..10)).weaken_ordering::<NoOrder>().enumerate();
+  |                                                                    ^^^^^^^^^ required for this call
+  |
+  = help: the trait `IsOrdered` is not implemented for `hydro_lang::live_collections::stream::NoOrder`
+  = note: To intentionally process the stream with a non-deterministic (shuffled) order of elements, use `.assume_ordering`. This bypasses the safety guarantees so avoid unless necessary.
+note: required by a bound in `hydro_lang::prelude::Stream::<T, L, B, O, R>::enumerate`
+ --> src/live_collections/stream/mod.rs
+  |
+  |     pub fn enumerate(self) -> Stream<(usize, T), L, B, O, R>
+  |            --------- required by a bound in this associated function
+  |     where
+  |         O: IsOrdered,
+  |            ^^^^^^^^^ required by this bound in `Stream::<T, L, B, O, R>::enumerate`

--- a/hydro_lang/tests/compile-fail/non_commutative_operator.rs
+++ b/hydro_lang/tests/compile-fail/non_commutative_operator.rs
@@ -1,0 +1,10 @@
+use hydro_lang::live_collections::stream::NoOrder;
+use hydro_lang::prelude::*;
+
+struct P1 {}
+
+fn test<'a>(p1: &Process<'a, P1>) {
+    let _ = p1.source_iter(q!(0..10)).weaken_ordering::<NoOrder>().enumerate();
+}
+
+fn main() {}


### PR DESCRIPTION

Old Error Message:
```
error[E0599]: the method `enumerate` exists for struct `hydro_lang::prelude::Stream<{integer}, hydro_lang::prelude::Process<'a, P1>, hydro_lang::prelude::Bounded, hydro_lang::live_collections::stream::NoOrder>`, but its trait bounds were not satisfied
 --> tests/compile-fail-stable/non_commutative.rs
  |
  |       let _ = p1.source_iter(q!(0..10)).weaken_ordering::<NoOrder>().enumerate();
  |                                                                      ^^^^^^^^^ method cannot be called due to unsatisfied trait bounds
  |
 ::: src/live_collections/stream/mod.rs
  |
  | / pub struct Stream<
  | |     Type,
  | |     Loc,
  | |     Bound: Boundedness = Unbounded,
  | |     Order: Ordering = TotalOrder,
  | |     Retry: Retries = ExactlyOnce,
  | | > {
  | |_- doesn't satisfy `_: Iterator`
  |
  = note: the following trait bounds were not satisfied:
          `hydro_lang::prelude::Stream<{integer}, hydro_lang::prelude::Process<'a, P1>, hydro_lang::prelude::Bounded, hydro_lang::live_collections::stream::NoOrder>: Iterator`
          which is required by `&mut hydro_lang::prelude::Stream<{integer}, hydro_lang::prelude::Process<'a, P1>, hydro_lang::prelude::Bounded, hydro_lang::live_collections::stream::NoOrder>: Iterator`
```

New Error Message:
```
error[E0277]: The input stream must be totally-ordered (`TotalOrder`), but has order `hydro_lang::live_collections::stream::NoOrder`. Strengthen the order upstream or consider a different API.
 --> tests/compile-fail-stable/non_commutative_operator.rs:7:68
  |
7 |     let _ = p1.source_iter(q!(0..10)).weaken_ordering::<NoOrder>().enumerate();
  |                                                                    ^^^^^^^^^ required for this call
  |
  = help: the trait `IsOrdered` is not implemented for `hydro_lang::live_collections::stream::NoOrder`
  = note: To intentionally process the stream with a non-deterministic (shuffled) order of elements, use `.assume_ordering`.
note: required by a bound in `hydro_lang::prelude::Stream::<T, L, B, O, R>::enumerate`
 --> src/live_collections/stream/mod.rs
  |
  |     pub fn enumerate(self) -> Stream<(usize, T), L, B, O, R>
  |            --------- required by a bound in this associated function
  |     where O: IsOrdered, R: IsExactlyOnce {
  |              ^^^^^^^^^ required by this bound in `Stream::<T, L, B, O, R>::enumerate`
```

Only implemented for `enumerate` for now because this is not a breaking change. Will follow-up to expand its usage to all other stream operators.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydro-project/hydro/pull/2595).
* #2599
* __->__ #2595