### PR TITLE
fix: Preserve boundedness in resolve_futures and resolve_futures_ordered

### DIFF
--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -2197,14 +2197,14 @@ where
     /// #   },
     /// # ));
     /// # }
-    pub fn resolve_futures(self) -> Stream<T, L, Unbounded, NoOrder, R> {
+    pub fn resolve_futures(self) -> Stream<T, L, B, NoOrder, R> {
         Stream::new(
             self.location.clone(),
             HydroNode::ResolveFutures {
                 input: Box::new(self.ir_node.into_inner()),
                 metadata: self
                     .location
-                    .new_node_metadata(Stream::<T, L, Unbounded, NoOrder, R>::collection_kind()),
+                    .new_node_metadata(Stream::<T, L, B, NoOrder, R>::collection_kind()),
             },
         )
     }
@@ -2239,14 +2239,14 @@ where
     /// #   },
     /// # ));
     /// # }
-    pub fn resolve_futures_ordered(self) -> Stream<T, L, Unbounded, O, R> {
+    pub fn resolve_futures_ordered(self) -> Stream<T, L, B, O, R> {
         Stream::new(
             self.location.clone(),
             HydroNode::ResolveFuturesOrdered {
                 input: Box::new(self.ir_node.into_inner()),
                 metadata: self
                     .location
-                    .new_node_metadata(Stream::<T, L, Unbounded, O, R>::collection_kind()),
+                    .new_node_metadata(Stream::<T, L, B, O, R>::collection_kind()),
             },
         )
     }

--- a/hydro_test/src/local/futures.rs
+++ b/hydro_test/src/local/futures.rs
@@ -4,7 +4,7 @@ use hydro_lang::live_collections::stream::NoOrder;
 use hydro_lang::prelude::*;
 use stageleft::q;
 
-pub fn unordered<'a>(process: &Process<'a>) -> Stream<u32, Process<'a>, Unbounded, NoOrder> {
+pub fn unordered<'a>(process: &Process<'a>) -> Stream<u32, Process<'a>, Bounded, NoOrder> {
     process
         .source_iter(q!([2, 3, 1, 9, 6, 5, 4, 7, 8]))
         .map(q!(|x| async move {
@@ -14,7 +14,7 @@ pub fn unordered<'a>(process: &Process<'a>) -> Stream<u32, Process<'a>, Unbounde
         .resolve_futures()
 }
 
-pub fn ordered<'a>(process: &Process<'a>) -> Stream<u32, Process<'a>, Unbounded> {
+pub fn ordered<'a>(process: &Process<'a>) -> Stream<u32, Process<'a>, Bounded> {
     process
         .source_iter(q!([2, 3, 1, 9, 6, 5, 4, 7, 8]))
         .map(q!(|x| async move {


### PR DESCRIPTION
Both methods were hardcoding Unbounded in their return types regardless of the input stream's boundedness. Resolving a finite number of futures produces a finite number of results, so the boundedness should be preserved from the input, consistent with how map behaves.