### PR TITLE
feat(hydro_lang): add `manual_proof!` macro that accepts doc comments

### DIFF
--- a/docs/docs/hydro/reference/live-collections/keyed-streams.mdx
+++ b/docs/docs/hydro/reference/live-collections/keyed-streams.mdx
@@ -167,8 +167,8 @@ health_checks.fold(
     q!(|| false), 
     q!(
         |acc, check| *acc |= check,
-        commutative = ManualProof(/* bool or is commutative */),
-        idempotent = ManualProof(/* bool or is idempotent */)
+        commutative = manual_proof!(/** bool or is commutative */),
+        idempotent = manual_proof!(/** bool or is idempotent */)
     )
 )
 # ;

--- a/docs/docs/hydro/reference/live-collections/streams.md
+++ b/docs/docs/hydro/reference/live-collections/streams.md
@@ -112,7 +112,7 @@ To perform an aggregation with an unordered stream, you must add a **property an
 #     .send(&process, TCP.fail_stop().bincode())
 #     .values();
 let words_count = all_words
-    .fold(q!(|| 0), q!(|acc, _| *acc += 1, commutative = ManualProof(/* increment is commutative */)));
+    .fold(q!(|| 0), q!(|acc, _| *acc += 1, commutative = manual_proof!(/** increment is commutative */)));
 ```
 
 :::danger

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -182,7 +182,7 @@ export default function Home() {
     .send(leader, TCP.fail_stop().bincode())
     // Stream<(MemberId<Worker>, usize), Process<Leader>, ..., NoOrder>
     .map(q!(|v| v.1)) // drop the ID
-    .fold(q!(0), q!(|acc, v| *acc += v, commutative = ManualProof(...)))
+    .fold(q!(0), q!(|acc, v| *acc += v, commutative = manual_proof!(...)))
 }`}
             </CodeBlock>
           </div>

--- a/hydro_lang/src/lib.rs
+++ b/hydro_lang/src/lib.rs
@@ -58,7 +58,7 @@ pub mod prelude {
     pub use crate::location::{Cluster, External, Location as _, Process, Tick};
     pub use crate::networking::TCP;
     pub use crate::nondet::{NonDet, nondet};
-    pub use crate::properties::ManualProof;
+    pub use crate::properties::{ManualProof, manual_proof};
 
     /// A macro to set up a Hydro crate.
     #[macro_export]

--- a/hydro_lang/src/live_collections/keyed_singleton.rs
+++ b/hydro_lang/src/live_collections/keyed_singleton.rs
@@ -28,7 +28,7 @@ use crate::location::tick::DeferTick;
 use crate::location::{Atomic, Location, NoTick, Tick, check_matching_location};
 use crate::manual_expr::ManualExpr;
 use crate::nondet::{NonDet, nondet};
-use crate::properties::ManualProof;
+use crate::properties::manual_proof;
 
 /// A marker trait indicating which components of a [`KeyedSingleton`] may change.
 ///
@@ -1122,7 +1122,7 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound<ValueBound = Bounded>>
                         *curr = new;
                     }
                 },
-                idempotent = ManualProof(/* repeated elements are ignored */)
+                idempotent = manual_proof!(/** repeated elements are ignored */)
             ))
     }
 

--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -2653,7 +2653,7 @@ mod tests {
     #[cfg(any(feature = "deploy", feature = "sim"))]
     use crate::nondet::nondet;
     #[cfg(feature = "deploy")]
-    use crate::properties::ManualProof;
+    use crate::properties::manual_proof;
 
     #[cfg(feature = "deploy")]
     #[tokio::test]
@@ -2781,7 +2781,7 @@ mod tests {
                     |acc, v| {
                         *acc += v;
                     },
-                    commutative = ManualProof(/* integer addition is commutative */)
+                    commutative = manual_proof!(/** integer addition is commutative */)
                 ),
             )
             .snapshot(&node_tick, nondet!(/** test */))

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -28,7 +28,7 @@ use crate::location::dynamic::{DynLocation, LocationId};
 use crate::location::tick::{Atomic, DeferTick, NoAtomic};
 use crate::location::{Location, NoTick, Tick, check_matching_location};
 use crate::nondet::{NonDet, nondet};
-use crate::prelude::ManualProof;
+use crate::prelude::manual_proof;
 use crate::properties::{AggFuncAlgebra, ValidCommutativityFor, ValidIdempotenceFor};
 
 pub mod networking;
@@ -1423,7 +1423,7 @@ where
                 |latest, _| {
                     *latest = Some(Instant::now());
                 },
-                commutative = ManualProof(/* TODO */)
+                commutative = manual_proof!(/** TODO */)
             ),
         );
 
@@ -2215,8 +2215,8 @@ where
                 q!(|| ()),
                 q!(
                     |_, _| {},
-                    commutative = ManualProof(/* values are ignored */),
-                    idempotent = ManualProof(/* values are ignored */)
+                    commutative = manual_proof!(/** values are ignored */),
+                    idempotent = manual_proof!(/** values are ignored */)
                 ),
             )
             .keys()

--- a/hydro_lang/src/properties/mod.rs
+++ b/hydro_lang/src/properties/mod.rs
@@ -25,6 +25,9 @@ pub trait IdempotentProof {
 }
 
 /// A hand-written human proof of the correctness property.
+///
+/// To create a manual proof, use the [`manual_proof!`] macro, which takes in a doc comment
+/// explaining why the property holds.
 pub struct ManualProof();
 #[sealed::sealed]
 impl CommutativeProof for ManualProof {
@@ -33,6 +36,33 @@ impl CommutativeProof for ManualProof {
 #[sealed::sealed]
 impl IdempotentProof for ManualProof {
     fn register_proof(&self, _expr: &syn::Expr) {}
+}
+
+#[doc(inline)]
+pub use crate::__manual_proof__ as manual_proof;
+
+#[macro_export]
+/// Fulfills a proof parameter by declaring a human-written justification for why
+/// the algebraic property (e.g. commutativity, idempotence) holds.
+///
+/// The argument must be a doc comment explaining why the property is satisfied.
+///
+/// # Examples
+/// ```rust,ignore
+/// use hydro_lang::prelude::*;
+///
+/// stream.fold(
+///     q!(|| 0),
+///     q!(
+///         |acc, x| *acc += x,
+///         commutative = manual_proof!(/** integer addition is commutative */)
+///     )
+/// )
+/// ```
+macro_rules! __manual_proof__ {
+    ($(#[doc = $doc:expr])+) => {
+        $crate::properties::ManualProof()
+    };
 }
 
 /// Marks that the property is not proved.

--- a/hydro_std/src/bench_client/mod.rs
+++ b/hydro_std/src/bench_client/mod.rs
@@ -99,7 +99,7 @@ where
             |curr, new| {
                 *curr = new;
             },
-            commutative = ManualProof(/* The value will be thrown away */)
+            commutative = manual_proof!(/** The value will be thrown away */)
         ))
         .map(q!(|_input| SystemTime::now()));
 
@@ -157,9 +157,7 @@ pub fn compute_throughput_latency<'a, Client: 'a>(
                         .record(latency.as_nanos() as u64)
                         .unwrap();
                 },
-                commutative = ManualProof(
-                    /* adding elements to histogram is commutative */
-                )
+                commutative = manual_proof!(/** adding elements to histogram is commutative */)
             ),
         );
 
@@ -250,7 +248,7 @@ pub fn aggregate_bench_results<'a, Client: 'a, Aggregator>(
             .fold(q!(|| 0usize), q!(|curr, new| {
                     *curr += new;
                 },
-                commutative = ManualProof(/* Addition is commutative */)
+                commutative = manual_proof!(/** Addition is commutative */)
             ));
 
         // Merge new values
@@ -259,7 +257,7 @@ pub fn aggregate_bench_results<'a, Client: 'a, Aggregator>(
                 q!(|curr, new| {
                     curr.borrow_mut().add(&*new.borrow_mut()).expect("Error adding value to histogram");
                 },
-                commutative = ManualProof(/* Merge is commutative */)
+                commutative = manual_proof!(/** Merge is commutative */)
             ));
         // Clear every punctuation
         latency_histogram = latency_histogram

--- a/hydro_std/src/quorum.rs
+++ b/hydro_std/src/quorum.rs
@@ -39,7 +39,7 @@ pub fn collect_quorum_with_response<
                 } else {
                     accum.1 += 1;
                 }
-            }, commutative = ManualProof(/* increment counters is commutative */)),
+            }, commutative = manual_proof!(/** increment counters is commutative */)),
         );
 
          let not_reached_min_count = count_per_key
@@ -121,7 +121,7 @@ pub fn collect_quorum<
                 } else {
                     accum.1 += 1;
                 }
-            }, commutative = ManualProof(/* increment counters is commutative */)),
+            }, commutative = manual_proof!(/** increment counters is commutative */)),
         );
 
         let reached_min_count = count_per_key

--- a/hydro_test/src/cluster/compute_pi.rs
+++ b/hydro_test/src/cluster/compute_pi.rs
@@ -38,7 +38,7 @@ pub fn compute_pi<'a>(
                 *inside += inside_batch;
                 *total += total_batch;
             },
-            commutative = ManualProof(/* int addition is commutative */)
+            commutative = manual_proof!(/** int addition is commutative */)
         ));
 
     estimate

--- a/hydro_test/src/cluster/map_reduce.rs
+++ b/hydro_test/src/cluster/map_reduce.rs
@@ -34,7 +34,7 @@ pub fn map_reduce<'a>(flow: &mut FlowBuilder<'a>) -> (Process<'a, Leader>, Clust
 
     let reduced = batches.into_keyed().reduce(q!(
         |total, count| *total += count,
-        commutative = ManualProof(/* integer add is commutative */)
+        commutative = manual_proof!(/** integer add is commutative */)
     ));
 
     reduced

--- a/hydro_test/src/cluster/paxos.rs
+++ b/hydro_test/src/cluster/paxos.rs
@@ -613,7 +613,7 @@ pub fn recommit_after_leader_election<'a, P: PaxosPayload>(
             } else {
                 *curr_entry = (1, Some(new_entry));
             }
-        }, commutative = ManualProof(/* TODO */)))
+        }, commutative = manual_proof!(/** TODO */)))
         .map(q!(|(count, entry)| (count, entry.unwrap())));
     let p_log_to_try_commit = p_p1b_highest_entries_and_count
         .clone()
@@ -840,7 +840,7 @@ pub fn acceptor_p2<'a, P: PaxosPayload, S: Clone>(
                         value: entry.value,
                     };
                 }
-            }, commutative = ManualProof(/* max by ballot (TODO: not if two entries with same ballot, need assume) */)),
+            }, commutative = manual_proof!(/** max by ballot (TODO: not if two entries with same ballot, need assume) */)),
         )
     });
     let a_log_snapshot = a_log.entries().fold(
@@ -849,9 +849,7 @@ pub fn acceptor_p2<'a, P: PaxosPayload, S: Clone>(
             |map, (slot, entry)| {
                 map.insert(slot, entry);
             },
-            commutative = ManualProof(
-                /* inserting elements into map is commutative because no keys will overlap */
-            )
+            commutative = manual_proof!(/** inserting elements into map is commutative because no keys will overlap */)
         ),
     );
 

--- a/hydro_test/src/cluster/paxos_bench.rs
+++ b/hydro_test/src/cluster/paxos_bench.rs
@@ -75,7 +75,7 @@ pub fn paxos_bench<'a>(
                                 *curr_seq = seq;
                             }
                         },
-                        commutative = ManualProof(/* max is commutative */)
+                        commutative = manual_proof!(/** max is commutative */)
                     ));
 
                 sliced! {

--- a/hydro_test/src/maelstrom/broadcast.rs
+++ b/hydro_test/src/maelstrom/broadcast.rs
@@ -53,7 +53,7 @@ fn broadcast_core<'a, C: 'a>(
             .unique();
         local_state.clone().fold(q!(|| HashSet::new()), q!(|set, v| {
             set.insert(v);
-        }, commutative = ManualProof(/* TODO */)))
+        }, commutative = manual_proof!(/** TODO */)))
     };
 
     broadcasted_forward.complete(


### PR DESCRIPTION

Fixes #2502, a common trip-up area for coding agents.
