### PR TITLE
fix(hydro_lang)!: fix compilation bug in `Singleton::zip`, require boundedness

### DIFF
--- a/hydro_lang/src/live_collections/optional.rs
+++ b/hydro_lang/src/live_collections/optional.rs
@@ -217,7 +217,7 @@ where
 }
 
 #[cfg(stageleft_runtime)]
-fn zip_inside_tick<'a, T, O, L: Location<'a>, B: Boundedness>(
+pub(super) fn zip_inside_tick<'a, T, O, L: Location<'a>, B: Boundedness>(
     me: Optional<T, L, B>,
     other: Optional<O, L, B>,
 ) -> Optional<(T, O), L, B> {
@@ -625,7 +625,7 @@ where
     /// ```
     pub fn zip<O>(self, other: impl Into<Optional<O, L, B>>) -> Optional<(T, O), L, B>
     where
-        O: Clone,
+        B: IsBounded,
     {
         let other: Optional<O, L, B> = other.into();
         check_matching_location(&self.location, &other.location);


### PR DESCRIPTION

Breaking Change: `Singleton::zip` and `Optional::zip` now both require their inputs to be bounded, to avoid requiring a `Clone` bound on their value types. To handle unbounded inputs, you should manually use a `sliced!` region.

Produced invalid Hydro IR which caused panics whenever the API is used. Fixes the compiler bug and adds simulator tests for their behavior.
