### PR TITLE
feat(hydro_lang)!: add `.partition()` operator for splitting streams without cloning

### DIFF
--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -713,7 +713,7 @@ impl HydroRoot {
     pub fn compile_network<'a, D>(
         &mut self,
         extra_stmts: &mut SparseSecondaryMap<LocationKey, Vec<syn::Stmt>>,
-        seen_tees: &mut SeenTees,
+        seen_tees: &mut SeenSharedNodes,
         seen_cluster_members: &mut HashSet<(LocationId, LocationId)>,
         processes: &SparseSecondaryMap<LocationKey, D::Process>,
         clusters: &SparseSecondaryMap<LocationKey, D::Cluster>,
@@ -986,7 +986,7 @@ impl HydroRoot {
         );
     }
 
-    pub fn connect_network(&mut self, seen_tees: &mut SeenTees) {
+    pub fn connect_network(&mut self, seen_tees: &mut SeenSharedNodes) {
         self.transform_bottom_up(
             &mut |l| {
                 if let HydroRoot::SendExternal { instantiate_fn, .. } = l {
@@ -1021,7 +1021,7 @@ impl HydroRoot {
         &mut self,
         transform_root: &mut impl FnMut(&mut HydroRoot),
         transform_node: &mut impl FnMut(&mut HydroNode),
-        seen_tees: &mut SeenTees,
+        seen_tees: &mut SeenSharedNodes,
         check_well_formed: bool,
     ) {
         self.transform_children(
@@ -1034,8 +1034,8 @@ impl HydroRoot {
 
     pub fn transform_children(
         &mut self,
-        mut transform: impl FnMut(&mut HydroNode, &mut SeenTees),
-        seen_tees: &mut SeenTees,
+        mut transform: impl FnMut(&mut HydroNode, &mut SeenSharedNodes),
+        seen_tees: &mut SeenSharedNodes,
     ) {
         match self {
             HydroRoot::ForEach { input, .. }
@@ -1048,7 +1048,7 @@ impl HydroRoot {
         }
     }
 
-    pub fn deep_clone(&self, seen_tees: &mut SeenTees) -> HydroRoot {
+    pub fn deep_clone(&self, seen_tees: &mut SeenSharedNodes) -> HydroRoot {
         match self {
             HydroRoot::ForEach {
                 f,
@@ -1112,8 +1112,8 @@ impl HydroRoot {
     pub fn emit(
         &mut self,
         graph_builders: &mut dyn DfirBuilder,
-        seen_tees: &mut SeenTees,
-        built_tees: &mut HashMap<*const RefCell<HydroNode>, syn::Ident>,
+        seen_tees: &mut SeenSharedNodes,
+        built_tees: &mut HashMap<*const RefCell<HydroNode>, Vec<syn::Ident>>,
         next_stmt_id: &mut usize,
     ) {
         self.emit_core(
@@ -1134,8 +1134,8 @@ impl HydroRoot {
             impl FnMut(&mut HydroRoot, &mut usize),
             impl FnMut(&mut HydroNode, &mut usize),
         >,
-        seen_tees: &mut SeenTees,
-        built_tees: &mut HashMap<*const RefCell<HydroNode>, syn::Ident>,
+        seen_tees: &mut SeenSharedNodes,
+        built_tees: &mut HashMap<*const RefCell<HydroNode>, Vec<syn::Ident>>,
         next_stmt_id: &mut usize,
     ) {
         match self {
@@ -1434,15 +1434,15 @@ pub fn dbg_dedup_tee<T>(f: impl FnOnce() -> T) -> T {
     })
 }
 
-pub struct TeeNode(pub Rc<RefCell<HydroNode>>);
+pub struct SharedNode(pub Rc<RefCell<HydroNode>>);
 
-impl TeeNode {
+impl SharedNode {
     pub fn as_ptr(&self) -> *const RefCell<HydroNode> {
         Rc::as_ptr(&self.0)
     }
 }
 
-impl Debug for TeeNode {
+impl Debug for SharedNode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         PRINTED_TEES.with(|printed_tees| {
             let mut printed_tees_mut_borrow = printed_tees.borrow_mut();
@@ -1453,7 +1453,7 @@ impl Debug for TeeNode {
                     .1
                     .get(&(self.0.as_ref() as *const RefCell<HydroNode>))
                 {
-                    write!(f, "<tee {}>", existing)
+                    write!(f, "<shared {}>", existing)
                 } else {
                     let next_id = printed_tees_mut.0;
                     printed_tees_mut.0 += 1;
@@ -1461,19 +1461,19 @@ impl Debug for TeeNode {
                         .1
                         .insert(self.0.as_ref() as *const RefCell<HydroNode>, next_id);
                     drop(printed_tees_mut_borrow);
-                    write!(f, "<tee {}>: ", next_id)?;
+                    write!(f, "<shared {}>: ", next_id)?;
                     Debug::fmt(&self.0.borrow(), f)
                 }
             } else {
                 drop(printed_tees_mut_borrow);
-                write!(f, "<tee>: ")?;
+                write!(f, "<shared>: ")?;
                 Debug::fmt(&self.0.borrow(), f)
             }
         })
     }
 }
 
-impl Hash for TeeNode {
+impl Hash for SharedNode {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.0.borrow_mut().hash(state);
     }
@@ -1674,7 +1674,14 @@ pub enum HydroNode {
     },
 
     Tee {
-        inner: TeeNode,
+        inner: SharedNode,
+        metadata: HydroIrMetadata,
+    },
+
+    Partition {
+        inner: SharedNode,
+        f: DebugExpr,
+        is_true: bool,
         metadata: HydroIrMetadata,
     },
 
@@ -1860,14 +1867,14 @@ pub enum HydroNode {
     },
 }
 
-pub type SeenTees = HashMap<*const RefCell<HydroNode>, Rc<RefCell<HydroNode>>>;
-pub type SeenTeeLocations = HashMap<*const RefCell<HydroNode>, LocationId>;
+pub type SeenSharedNodes = HashMap<*const RefCell<HydroNode>, Rc<RefCell<HydroNode>>>;
+pub type SeenSharedNodeLocations = HashMap<*const RefCell<HydroNode>, LocationId>;
 
 impl HydroNode {
     pub fn transform_bottom_up(
         &mut self,
         transform: &mut impl FnMut(&mut HydroNode),
-        seen_tees: &mut SeenTees,
+        seen_tees: &mut SeenSharedNodes,
         check_well_formed: bool,
     ) {
         self.transform_children(
@@ -1902,8 +1909,8 @@ impl HydroNode {
     #[inline(always)]
     pub fn transform_children(
         &mut self,
-        mut transform: impl FnMut(&mut HydroNode, &mut SeenTees),
-        seen_tees: &mut SeenTees,
+        mut transform: impl FnMut(&mut HydroNode, &mut SeenSharedNodes),
+        seen_tees: &mut SeenSharedNodes,
     ) {
         match self {
             HydroNode::Placeholder => {
@@ -1917,14 +1924,27 @@ impl HydroNode {
 
             HydroNode::Tee { inner, .. } => {
                 if let Some(transformed) = seen_tees.get(&inner.as_ptr()) {
-                    *inner = TeeNode(transformed.clone());
+                    *inner = SharedNode(transformed.clone());
                 } else {
                     let transformed_cell = Rc::new(RefCell::new(HydroNode::Placeholder));
                     seen_tees.insert(inner.as_ptr(), transformed_cell.clone());
                     let mut orig = inner.0.replace(HydroNode::Placeholder);
                     transform(&mut orig, seen_tees);
                     *transformed_cell.borrow_mut() = orig;
-                    *inner = TeeNode(transformed_cell);
+                    *inner = SharedNode(transformed_cell);
+                }
+            }
+
+            HydroNode::Partition { inner, .. } => {
+                if let Some(transformed) = seen_tees.get(&inner.as_ptr()) {
+                    *inner = SharedNode(transformed.clone());
+                } else {
+                    let transformed_cell = Rc::new(RefCell::new(HydroNode::Placeholder));
+                    seen_tees.insert(inner.as_ptr(), transformed_cell.clone());
+                    let mut orig = inner.0.replace(HydroNode::Placeholder);
+                    transform(&mut orig, seen_tees);
+                    *transformed_cell.borrow_mut() = orig;
+                    *inner = SharedNode(transformed_cell);
                 }
             }
 
@@ -1989,7 +2009,7 @@ impl HydroNode {
         }
     }
 
-    pub fn deep_clone(&self, seen_tees: &mut SeenTees) -> HydroNode {
+    pub fn deep_clone(&self, seen_tees: &mut SeenSharedNodes) -> HydroNode {
         match self {
             HydroNode::Placeholder => HydroNode::Placeholder,
             HydroNode::Cast { inner, metadata } => HydroNode::Cast {
@@ -2025,7 +2045,7 @@ impl HydroNode {
             HydroNode::Tee { inner, metadata } => {
                 if let Some(transformed) = seen_tees.get(&inner.as_ptr()) {
                     HydroNode::Tee {
-                        inner: TeeNode(transformed.clone()),
+                        inner: SharedNode(transformed.clone()),
                         metadata: metadata.clone(),
                     }
                 } else {
@@ -2034,7 +2054,33 @@ impl HydroNode {
                     let cloned = inner.0.borrow().deep_clone(seen_tees);
                     *new_rc.borrow_mut() = cloned;
                     HydroNode::Tee {
-                        inner: TeeNode(new_rc),
+                        inner: SharedNode(new_rc),
+                        metadata: metadata.clone(),
+                    }
+                }
+            }
+            HydroNode::Partition {
+                inner,
+                f,
+                is_true,
+                metadata,
+            } => {
+                if let Some(transformed) = seen_tees.get(&inner.as_ptr()) {
+                    HydroNode::Partition {
+                        inner: SharedNode(transformed.clone()),
+                        f: f.clone(),
+                        is_true: *is_true,
+                        metadata: metadata.clone(),
+                    }
+                } else {
+                    let new_rc = Rc::new(RefCell::new(HydroNode::Placeholder));
+                    seen_tees.insert(inner.as_ptr(), new_rc.clone());
+                    let cloned = inner.0.borrow().deep_clone(seen_tees);
+                    *new_rc.borrow_mut() = cloned;
+                    HydroNode::Partition {
+                        inner: SharedNode(new_rc),
+                        f: f.clone(),
+                        is_true: *is_true,
                         metadata: metadata.clone(),
                     }
                 }
@@ -2274,8 +2320,8 @@ impl HydroNode {
             impl FnMut(&mut HydroRoot, &mut usize),
             impl FnMut(&mut HydroNode, &mut usize),
         >,
-        seen_tees: &mut SeenTees,
-        built_tees: &mut HashMap<*const RefCell<HydroNode>, syn::Ident>,
+        seen_tees: &mut SeenSharedNodes,
+        built_tees: &mut HashMap<*const RefCell<HydroNode>, Vec<syn::Ident>>,
         next_stmt_id: &mut usize,
     ) -> syn::Ident {
         let mut ident_stack: Vec<syn::Ident> = Vec::new();
@@ -2597,7 +2643,7 @@ impl HydroNode {
                     }
 
                     HydroNode::Tee { inner, .. } => {
-                        let ret_ident = if let Some(teed_from) =
+                        let ret_ident = if let Some(built_idents) =
                             built_tees.get(&(inner.0.as_ref() as *const RefCell<HydroNode>))
                         {
                             match builders_or_callback {
@@ -2607,7 +2653,7 @@ impl HydroNode {
                                 }
                             }
 
-                            teed_from.clone()
+                            built_idents[0].clone()
                         } else {
                             // The inner node was already processed by transform_bottom_up,
                             // so its ident is on the stack
@@ -2618,7 +2664,7 @@ impl HydroNode {
 
                             built_tees.insert(
                                 inner.0.as_ref() as *const RefCell<HydroNode>,
-                                tee_ident.clone(),
+                                vec![tee_ident.clone()],
                             );
 
                             match builders_or_callback {
@@ -2642,6 +2688,69 @@ impl HydroNode {
 
                         // we consume a stmt id regardless of if we emit the tee() operator,
                         // so that during rewrites we touch all recipients of the tee()
+
+                        *next_stmt_id += 1;
+                        ident_stack.push(ret_ident);
+                    }
+
+                    HydroNode::Partition {
+                        inner, f, is_true, ..
+                    } => {
+                        let is_true = *is_true; // need to copy early to avoid borrow checking issues with node
+                        let ptr = inner.0.as_ref() as *const RefCell<HydroNode>;
+                        let ret_ident = if let Some(built_idents) = built_tees.get(&ptr) {
+                            match builders_or_callback {
+                                BuildersOrCallback::Builders(_) => {}
+                                BuildersOrCallback::Callback(_, node_callback) => {
+                                    node_callback(node, next_stmt_id);
+                                }
+                            }
+
+                            let idx = if is_true { 0 } else { 1 };
+                            built_idents[idx].clone()
+                        } else {
+                            // The inner node was already processed by transform_bottom_up,
+                            // so its ident is on the stack
+                            let inner_ident = ident_stack.pop().unwrap();
+
+                            let partition_ident = syn::Ident::new(
+                                &format!("stream_{}_partition", *next_stmt_id),
+                                Span::call_site(),
+                            );
+                            let true_ident = syn::Ident::new(
+                                &format!("stream_{}_true", *next_stmt_id),
+                                Span::call_site(),
+                            );
+                            let false_ident = syn::Ident::new(
+                                &format!("stream_{}_false", *next_stmt_id),
+                                Span::call_site(),
+                            );
+
+                            built_tees.insert(
+                                ptr,
+                                vec![true_ident.clone(), false_ident.clone()],
+                            );
+
+                            match builders_or_callback {
+                                BuildersOrCallback::Builders(graph_builders) => {
+                                    let builder = graph_builders.get_dfir_mut(&out_location);
+                                    builder.add_dfir(
+                                        parse_quote! {
+                                            #partition_ident = #inner_ident -> partition(|__item, __num_outputs| if (#f)(__item) { 0_usize } else { 1_usize });
+                                            #true_ident = #partition_ident[0];
+                                            #false_ident = #partition_ident[1];
+                                        },
+                                        None,
+                                        Some(&next_stmt_id.to_string()),
+                                    );
+                                }
+                                BuildersOrCallback::Callback(_, node_callback) => {
+                                    node_callback(node, next_stmt_id);
+                                }
+                            }
+
+                            if is_true { true_ident } else { false_ident }
+                        };
 
                         *next_stmt_id += 1;
                         ident_stack.push(ret_ident);
@@ -3657,6 +3766,7 @@ impl HydroNode {
             | HydroNode::Filter { f, .. }
             | HydroNode::FilterMap { f, .. }
             | HydroNode::Inspect { f, .. }
+            | HydroNode::Partition { f, .. }
             | HydroNode::Reduce { f, .. }
             | HydroNode::ReduceKeyed { f, .. }
             | HydroNode::ReduceKeyedWatermark { f, .. } => {
@@ -3706,6 +3816,7 @@ impl HydroNode {
             HydroNode::SingletonSource { metadata, .. } => metadata,
             HydroNode::CycleSource { metadata, .. } => metadata,
             HydroNode::Tee { metadata, .. } => metadata,
+            HydroNode::Partition { metadata, .. } => metadata,
             HydroNode::YieldConcat { metadata, .. } => metadata,
             HydroNode::BeginAtomic { metadata, .. } => metadata,
             HydroNode::EndAtomic { metadata, .. } => metadata,
@@ -3755,6 +3866,7 @@ impl HydroNode {
             HydroNode::SingletonSource { metadata, .. } => metadata,
             HydroNode::CycleSource { metadata, .. } => metadata,
             HydroNode::Tee { metadata, .. } => metadata,
+            HydroNode::Partition { metadata, .. } => metadata,
             HydroNode::YieldConcat { metadata, .. } => metadata,
             HydroNode::BeginAtomic { metadata, .. } => metadata,
             HydroNode::EndAtomic { metadata, .. } => metadata,
@@ -3798,8 +3910,9 @@ impl HydroNode {
             | HydroNode::SingletonSource { .. }
             | HydroNode::ExternalInput { .. }
             | HydroNode::CycleSource { .. }
-            | HydroNode::Tee { .. } => {
-                // Tee should find its input in separate special ways
+            | HydroNode::Tee { .. }
+            | HydroNode::Partition { .. } => {
+                // Tee/Partition should find their input in separate special ways
                 vec![]
             }
             HydroNode::Cast { inner, .. }
@@ -3877,6 +3990,9 @@ impl HydroNode {
             ),
             HydroNode::CycleSource { cycle_id, .. } => format!("CycleSource({})", cycle_id),
             HydroNode::Tee { inner, .. } => format!("Tee({})", inner.0.borrow().print_root()),
+            HydroNode::Partition { f, is_true, .. } => {
+                format!("Partition({:?}, is_true={})", f, is_true)
+            }
             HydroNode::YieldConcat { .. } => "YieldConcat()".to_owned(),
             HydroNode::BeginAtomic { .. } => "BeginAtomic()".to_owned(),
             HydroNode::EndAtomic { .. } => "EndAtomic()".to_owned(),

--- a/hydro_lang/src/live_collections/keyed_singleton.rs
+++ b/hydro_lang/src/live_collections/keyed_singleton.rs
@@ -16,7 +16,7 @@ use super::singleton::Singleton;
 use super::stream::{ExactlyOnce, NoOrder, Stream, TotalOrder};
 use crate::compile::builder::CycleId;
 use crate::compile::ir::{
-    CollectionKind, HydroIrOpMetadata, HydroNode, HydroRoot, KeyedSingletonBoundKind, TeeNode,
+    CollectionKind, HydroIrOpMetadata, HydroNode, HydroRoot, KeyedSingletonBoundKind, SharedNode,
 };
 #[cfg(stageleft_runtime)]
 use crate::forward_handle::{CycleCollection, ReceiverComplete};
@@ -135,7 +135,7 @@ impl<'a, K: Clone, V: Clone, Loc: Location<'a>, Bound: KeyedSingletonBound> Clon
         if !matches!(self.ir_node.borrow().deref(), HydroNode::Tee { .. }) {
             let orig_ir_node = self.ir_node.replace(HydroNode::Placeholder);
             *self.ir_node.borrow_mut() = HydroNode::Tee {
-                inner: TeeNode(Rc::new(RefCell::new(orig_ir_node))),
+                inner: SharedNode(Rc::new(RefCell::new(orig_ir_node))),
                 metadata: self.location.new_node_metadata(Self::collection_kind()),
             };
         }
@@ -144,7 +144,7 @@ impl<'a, K: Clone, V: Clone, Loc: Location<'a>, Bound: KeyedSingletonBound> Clon
             KeyedSingleton {
                 location: self.location.clone(),
                 ir_node: HydroNode::Tee {
-                    inner: TeeNode(inner.0.clone()),
+                    inner: SharedNode(inner.0.clone()),
                     metadata: metadata.clone(),
                 }
                 .into(),

--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -18,7 +18,7 @@ use super::stream::{
 };
 use crate::compile::builder::CycleId;
 use crate::compile::ir::{
-    CollectionKind, HydroIrOpMetadata, HydroNode, HydroRoot, StreamOrder, StreamRetry, TeeNode,
+    CollectionKind, HydroIrOpMetadata, HydroNode, HydroRoot, SharedNode, StreamOrder, StreamRetry,
 };
 #[cfg(stageleft_runtime)]
 use crate::forward_handle::{CycleCollection, ReceiverComplete};
@@ -202,7 +202,7 @@ impl<'a, K: Clone, V: Clone, Loc: Location<'a>, Bound: Boundedness, Order: Order
         if !matches!(self.ir_node.borrow().deref(), HydroNode::Tee { .. }) {
             let orig_ir_node = self.ir_node.replace(HydroNode::Placeholder);
             *self.ir_node.borrow_mut() = HydroNode::Tee {
-                inner: TeeNode(Rc::new(RefCell::new(orig_ir_node))),
+                inner: SharedNode(Rc::new(RefCell::new(orig_ir_node))),
                 metadata: self.location.new_node_metadata(Self::collection_kind()),
             };
         }
@@ -211,7 +211,7 @@ impl<'a, K: Clone, V: Clone, Loc: Location<'a>, Bound: Boundedness, Order: Order
             KeyedStream {
                 location: self.location.clone(),
                 ir_node: HydroNode::Tee {
-                    inner: TeeNode(inner.0.clone()),
+                    inner: SharedNode(inner.0.clone()),
                     metadata: metadata.clone(),
                 }
                 .into(),

--- a/hydro_lang/src/live_collections/optional.rs
+++ b/hydro_lang/src/live_collections/optional.rs
@@ -12,7 +12,7 @@ use super::boundedness::{Bounded, Boundedness, IsBounded, Unbounded};
 use super::singleton::Singleton;
 use super::stream::{AtLeastOnce, ExactlyOnce, NoOrder, Stream, TotalOrder};
 use crate::compile::builder::CycleId;
-use crate::compile::ir::{CollectionKind, HydroIrOpMetadata, HydroNode, HydroRoot, TeeNode};
+use crate::compile::ir::{CollectionKind, HydroIrOpMetadata, HydroNode, HydroRoot, SharedNode};
 #[cfg(stageleft_runtime)]
 use crate::forward_handle::{CycleCollection, CycleCollectionWithInitial, ReceiverComplete};
 use crate::forward_handle::{ForwardRef, TickCycle};
@@ -263,7 +263,7 @@ where
         if !matches!(self.ir_node.borrow().deref(), HydroNode::Tee { .. }) {
             let orig_ir_node = self.ir_node.replace(HydroNode::Placeholder);
             *self.ir_node.borrow_mut() = HydroNode::Tee {
-                inner: TeeNode(Rc::new(RefCell::new(orig_ir_node))),
+                inner: SharedNode(Rc::new(RefCell::new(orig_ir_node))),
                 metadata: self.location.new_node_metadata(Self::collection_kind()),
             };
         }
@@ -272,7 +272,7 @@ where
             Optional {
                 location: self.location.clone(),
                 ir_node: HydroNode::Tee {
-                    inner: TeeNode(inner.0.clone()),
+                    inner: SharedNode(inner.0.clone()),
                     metadata: metadata.clone(),
                 }
                 .into(),

--- a/hydro_lang/src/live_collections/singleton.rs
+++ b/hydro_lang/src/live_collections/singleton.rs
@@ -12,7 +12,7 @@ use super::optional::Optional;
 use super::sliced::sliced;
 use super::stream::{AtLeastOnce, ExactlyOnce, NoOrder, Stream, TotalOrder};
 use crate::compile::builder::CycleId;
-use crate::compile::ir::{CollectionKind, HydroIrOpMetadata, HydroNode, HydroRoot, TeeNode};
+use crate::compile::ir::{CollectionKind, HydroIrOpMetadata, HydroNode, HydroRoot, SharedNode};
 #[cfg(stageleft_runtime)]
 use crate::forward_handle::{CycleCollection, CycleCollectionWithInitial, ReceiverComplete};
 use crate::forward_handle::{ForwardRef, TickCycle};
@@ -183,7 +183,7 @@ where
         if !matches!(self.ir_node.borrow().deref(), HydroNode::Tee { .. }) {
             let orig_ir_node = self.ir_node.replace(HydroNode::Placeholder);
             *self.ir_node.borrow_mut() = HydroNode::Tee {
-                inner: TeeNode(Rc::new(RefCell::new(orig_ir_node))),
+                inner: SharedNode(Rc::new(RefCell::new(orig_ir_node))),
                 metadata: self.location.new_node_metadata(Self::collection_kind()),
             };
         }
@@ -192,7 +192,7 @@ where
             Singleton {
                 location: self.location.clone(),
                 ir_node: HydroNode::Tee {
-                    inner: TeeNode(inner.0.clone()),
+                    inner: SharedNode(inner.0.clone()),
                     metadata: metadata.clone(),
                 }
                 .into(),

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -17,7 +17,7 @@ use super::optional::Optional;
 use super::singleton::Singleton;
 use crate::compile::builder::CycleId;
 use crate::compile::ir::{
-    CollectionKind, HydroIrOpMetadata, HydroNode, HydroRoot, StreamOrder, StreamRetry, TeeNode,
+    CollectionKind, HydroIrOpMetadata, HydroNode, HydroRoot, SharedNode, StreamOrder, StreamRetry,
 };
 #[cfg(stageleft_runtime)]
 use crate::forward_handle::{CycleCollection, CycleCollectionWithInitial, ReceiverComplete};
@@ -363,7 +363,7 @@ where
         if !matches!(self.ir_node.borrow().deref(), HydroNode::Tee { .. }) {
             let orig_ir_node = self.ir_node.replace(HydroNode::Placeholder);
             *self.ir_node.borrow_mut() = HydroNode::Tee {
-                inner: TeeNode(Rc::new(RefCell::new(orig_ir_node))),
+                inner: SharedNode(Rc::new(RefCell::new(orig_ir_node))),
                 metadata: self.location.new_node_metadata(Self::collection_kind()),
             };
         }
@@ -372,7 +372,7 @@ where
             Stream {
                 location: self.location.clone(),
                 ir_node: HydroNode::Tee {
-                    inner: TeeNode(inner.0.clone()),
+                    inner: SharedNode(inner.0.clone()),
                     metadata: metadata.clone(),
                 }
                 .into(),
@@ -637,6 +637,77 @@ where
                 metadata: self.location.new_node_metadata(Self::collection_kind()),
             },
         )
+    }
+
+    /// Splits the stream into two streams based on a predicate, without cloning elements.
+    ///
+    /// Elements for which `f` returns `true` are sent to the first output stream,
+    /// and elements for which `f` returns `false` are sent to the second output stream.
+    ///
+    /// Unlike using `filter` twice, this only evaluates the predicate once per element
+    /// and does not require `T: Clone`.
+    ///
+    /// The closure `f` receives a reference `&T` rather than an owned value `T` because
+    /// the predicate is only used for routing; the element itself is moved to the
+    /// appropriate output stream.
+    ///
+    /// # Example
+    /// ```rust
+    /// # #[cfg(feature = "deploy")] {
+    /// # use hydro_lang::prelude::*;
+    /// # use hydro_lang::live_collections::stream::{NoOrder, ExactlyOnce};
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test::<_, _, _, NoOrder, ExactlyOnce>(|process| {
+    /// let numbers: Stream<_, _, Unbounded> = process.source_iter(q!(vec![1, 2, 3, 4, 5, 6])).into();
+    /// let (evens, odds) = numbers.partition(q!(|&x| x % 2 == 0));
+    /// // evens: 2, 4, 6 tagged with true; odds: 1, 3, 5 tagged with false
+    /// evens.map(q!(|x| (x, true)))
+    ///     .interleave(odds.map(q!(|x| (x, false))))
+    /// # }, |mut stream| async move {
+    /// # let mut results = Vec::new();
+    /// # for _ in 0..6 {
+    /// #     results.push(stream.next().await.unwrap());
+    /// # }
+    /// # results.sort();
+    /// # assert_eq!(results, vec![(1, false), (2, true), (3, false), (4, true), (5, false), (6, true)]);
+    /// # }));
+    /// # }
+    /// ```
+    #[expect(
+        clippy::type_complexity,
+        reason = "return type mirrors the input stream type"
+    )]
+    pub fn partition<F>(
+        self,
+        f: impl IntoQuotedMut<'a, F, L>,
+    ) -> (Stream<T, L, B, O, R>, Stream<T, L, B, O, R>)
+    where
+        F: Fn(&T) -> bool + 'a,
+    {
+        let f: crate::compile::ir::DebugExpr = f.splice_fn1_borrow_ctx(&self.location).into();
+        let shared = SharedNode(Rc::new(RefCell::new(self.ir_node.into_inner())));
+
+        let true_stream = Stream::new(
+            self.location.clone(),
+            HydroNode::Partition {
+                inner: SharedNode(shared.0.clone()),
+                f: f.clone(),
+                is_true: true,
+                metadata: self.location.new_node_metadata(Self::collection_kind()),
+            },
+        );
+
+        let false_stream = Stream::new(
+            self.location.clone(),
+            HydroNode::Partition {
+                inner: SharedNode(shared.0),
+                f,
+                is_true: false,
+                metadata: self.location.new_node_metadata(Self::collection_kind()),
+            },
+        );
+
+        (true_stream, false_stream)
     }
 
     /// An operator that both filters and maps. It yields only the items for which the supplied closure `f` returns `Some(value)`.
@@ -3253,5 +3324,46 @@ mod tests {
         });
 
         assert_eq!(instance_count, 22)
+    }
+
+    #[cfg(feature = "deploy")]
+    #[tokio::test]
+    async fn partition_evens_odds() {
+        let mut deployment = Deployment::new();
+
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<()>();
+        let external = flow.external::<()>();
+
+        let numbers = node.source_iter(q!(vec![1i32, 2, 3, 4, 5, 6]));
+        let (evens, odds) = numbers.partition(q!(|x: &i32| x % 2 == 0));
+        let evens_port = evens.send_bincode_external(&external);
+        let odds_port = odds.send_bincode_external(&external);
+
+        let nodes = flow
+            .with_process(&node, deployment.Localhost())
+            .with_external(&external, deployment.Localhost())
+            .deploy(&mut deployment);
+
+        deployment.deploy().await.unwrap();
+
+        let mut evens_out = nodes.connect(evens_port).await;
+        let mut odds_out = nodes.connect(odds_port).await;
+
+        deployment.start().await.unwrap();
+
+        let mut even_results = Vec::new();
+        for _ in 0..3 {
+            even_results.push(evens_out.next().await.unwrap());
+        }
+        even_results.sort();
+        assert_eq!(even_results, vec![2, 4, 6]);
+
+        let mut odd_results = Vec::new();
+        for _ in 0..3 {
+            odd_results.push(odds_out.next().await.unwrap());
+        }
+        odd_results.sort();
+        assert_eq!(odd_results, vec![1, 3, 5]);
     }
 }

--- a/hydro_lang/src/viz/render.rs
+++ b/hydro_lang/src/viz/render.rs
@@ -1121,6 +1121,42 @@ impl HydroNode {
                 tee_id
             }
 
+            HydroNode::Partition {
+                inner, metadata, ..
+            } => {
+                let ptr = inner.as_ptr();
+                if let Some(&existing_id) = seen_tees.get(&ptr) {
+                    return existing_id;
+                }
+
+                let input_id = inner
+                    .0
+                    .borrow()
+                    .build_graph_structure(structure, seen_tees, config);
+                let partition_id = structure.add_node_with_metadata(
+                    NodeLabel::Static(extract_op_name(self.print_root())),
+                    HydroNodeType::Tee,
+                    metadata,
+                );
+
+                seen_tees.insert(ptr, partition_id);
+
+                // Extract semantic tags from input
+                let inner_borrow = inner.0.borrow();
+                let input_metadata = inner_borrow.metadata();
+                add_edge_with_metadata(
+                    structure,
+                    input_id,
+                    partition_id,
+                    Some(input_metadata),
+                    Some(metadata),
+                    None,
+                );
+                drop(inner_borrow);
+
+                partition_id
+            }
+
             // Non-deterministic operation
             HydroNode::ObserveNonDet {
                 inner, metadata, ..

--- a/hydro_test/src/cluster/snapshots/paxos_ir.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir.snap
@@ -11,7 +11,7 @@ expression: built.ir()
             f: stageleft :: runtime_support :: fn1_type_hint :: < ((u32 , core :: option :: Option < i32 >) , usize) , core :: option :: Option < (u32 , core :: option :: Option < i32 >) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; move | ((virtual_id , _) , num_clients_per_node) | { if virtual_id < num_clients_per_node as u32 { Some ((virtual_id + 1 , None)) } else { None } } }),
             input: CrossSingleton {
                 left: Tee {
-                    inner: <tee 0>: ChainFirst {
+                    inner: <shared 0>: ChainFirst {
                         first: DeferTick {
                             input: CycleSource {
                                 cycle_id: CycleId(
@@ -197,12 +197,12 @@ expression: built.ir()
             8,
         ),
         input: Tee {
-            inner: <tee 1>: Map {
+            inner: <shared 1>: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , u32) , u32 > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless ((__hydro_lang_cluster_self_id_loc1v1) . clone ()) ; move | (received_max_ballot , ballot_num) | { if received_max_ballot > (Ballot { num : ballot_num , proposer_id : CLUSTER_SELF_ID__free . clone () , }) { received_max_ballot . num + 1 } else { ballot_num } } }),
                 input: Cast {
                     inner: CrossSingleton {
                         left: Tee {
-                            inner: <tee 2>: Batch {
+                            inner: <shared 2>: Batch {
                                 inner: YieldConcat {
                                     inner: Batch {
                                         inner: Cast {
@@ -516,7 +516,7 @@ expression: built.ir()
             6,
         ),
         input: Tee {
-            inner: <tee 3>: Map {
+            inner: <shared 3>: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
                 input: Cast {
                     inner: Cast {
@@ -678,13 +678,13 @@ expression: built.ir()
                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , ()) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _signal) | d }),
                                                                             input: CrossSingleton {
                                                                                 left: Tee {
-                                                                                    inner: <tee 4>: Batch {
+                                                                                    inner: <shared 4>: Batch {
                                                                                         inner: YieldConcat {
                                                                                             inner: Tee {
-                                                                                                inner: <tee 5>: Map {
+                                                                                                inner: <shared 5>: Map {
                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < u32 , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless ((__hydro_lang_cluster_self_id_loc1v1) . clone ()) ; move | num | Ballot { num , proposer_id : CLUSTER_SELF_ID__free . clone () } }),
                                                                                                     input: Tee {
-                                                                                                        inner: <tee 1>,
+                                                                                                        inner: <shared 1>,
                                                                                                         metadata: HydroIrMetadata {
                                                                                                             location_id: Tick(1, Cluster(loc1v1)),
                                                                                                             collection_kind: Singleton {
@@ -736,7 +736,7 @@ expression: built.ir()
                                                                                 right: Map {
                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _u | () }),
                                                                                     input: Tee {
-                                                                                        inner: <tee 6>: CycleSource {
+                                                                                        inner: <shared 6>: CycleSource {
                                                                                             cycle_id: CycleId(
                                                                                                 7,
                                                                                             ),
@@ -988,7 +988,7 @@ expression: built.ir()
         ),
         input: AntiJoin {
             pos: Tee {
-                inner: <tee 7>: Chain {
+                inner: <shared 7>: Chain {
                     first: DeferTick {
                         input: CycleSource {
                             cycle_id: CycleId(
@@ -1016,7 +1016,7 @@ expression: built.ir()
                     },
                     second: Batch {
                         inner: Tee {
-                            inner: <tee 8>: Inspect {
+                            inner: <shared 8>: Inspect {
                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | p1b | println ! ("Proposer received P1b: {:?}" , p1b) }),
                                 input: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
@@ -1041,7 +1041,7 @@ expression: built.ir()
                                                             input: CrossSingleton {
                                                                 left: CrossSingleton {
                                                                     left: Tee {
-                                                                        inner: <tee 9>: Batch {
+                                                                        inner: <shared 9>: Batch {
                                                                             inner: Map {
                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
                                                                                 input: Cast {
@@ -1189,7 +1189,7 @@ expression: built.ir()
                                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , ()) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _signal) | d }),
                                                                                                                             input: CrossSingleton {
                                                                                                                                 left: Tee {
-                                                                                                                                    inner: <tee 4>,
+                                                                                                                                    inner: <shared 4>,
                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                         location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                         collection_kind: Singleton {
@@ -1217,7 +1217,7 @@ expression: built.ir()
                                                                                                                                                                         input: ObserveNonDet {
                                                                                                                                                                             inner: ObserveNonDet {
                                                                                                                                                                                 inner: Tee {
-                                                                                                                                                                                    inner: <tee 3>,
+                                                                                                                                                                                    inner: <shared 3>,
                                                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                                                         location_id: Cluster(loc1v1),
                                                                                                                                                                                         collection_kind: Stream {
@@ -1301,7 +1301,7 @@ expression: built.ir()
                                                                                                                                                                         input: Map {
                                                                                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                                                                                                                                             input: Tee {
-                                                                                                                                                                                inner: <tee 6>,
+                                                                                                                                                                                inner: <shared 6>,
                                                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                                                     location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                                                     collection_kind: Optional {
@@ -1614,7 +1614,7 @@ expression: built.ir()
                                                                     },
                                                                     right: Cast {
                                                                         inner: Tee {
-                                                                            inner: <tee 10>: Cast {
+                                                                            inner: <shared 10>: Cast {
                                                                                 inner: ChainFirst {
                                                                                     first: Batch {
                                                                                         inner: Reduce {
@@ -1624,7 +1624,7 @@ expression: built.ir()
                                                                                                     inner: Inspect {
                                                                                                         f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | p1a | println ! ("Acceptor received P1a: {:?}" , p1a) }),
                                                                                                         input: Tee {
-                                                                                                            inner: <tee 9>,
+                                                                                                            inner: <shared 9>,
                                                                                                             metadata: HydroIrMetadata {
                                                                                                                 location_id: Tick(2, Cluster(loc2v1)),
                                                                                                                 collection_kind: Stream {
@@ -1898,20 +1898,20 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <tee 11>: Map {
+                inner: <shared 11>: Map {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
                     input: Cast {
                         inner: Cast {
                             inner: Filter {
                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < (usize , usize) , bool > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; let max__free = 3usize ; move | (success , error) | (success + error) >= max__free }) ; { let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) } }),
                                 input: Tee {
-                                    inner: <tee 12>: FoldKeyed {
+                                    inner: <shared 12>: FoldKeyed {
                                         init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | | (0 , 0) }),
                                         acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } } }),
                                         input: ObserveNonDet {
                                             inner: Cast {
                                                 inner: Tee {
-                                                    inner: <tee 7>,
+                                                    inner: <shared 7>,
                                                     metadata: HydroIrMetadata {
                                                         location_id: Tick(9, Cluster(loc1v1)),
                                                         collection_kind: Stream {
@@ -2037,7 +2037,7 @@ expression: built.ir()
                         inner: Filter {
                             f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < (usize , usize) , bool > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; let min__free = 2usize ; move | (success , _error) | success >= & min__free }) ; { let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) } }),
                             input: Tee {
-                                inner: <tee 12>,
+                                inner: <shared 12>,
                                 metadata: HydroIrMetadata {
                                     location_id: Tick(9, Cluster(loc1v1)),
                                     collection_kind: KeyedSingleton {
@@ -2088,7 +2088,7 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <tee 11>,
+                inner: <shared 11>,
                 metadata: HydroIrMetadata {
                     location_id: Tick(9, Cluster(loc1v1)),
                     collection_kind: Stream {
@@ -2116,13 +2116,13 @@ expression: built.ir()
             7,
         ),
         input: Tee {
-            inner: <tee 13>: Map {
+            inner: <shared 13>: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (() , ()) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | (d , _signal) | d }),
                 input: CrossSingleton {
                     left: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | _ | () }),
                         input: Tee {
-                            inner: <tee 14>: FilterMap {
+                            inner: <shared 14>: FilterMap {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < ((hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; move | ((quorum_ballot , quorum_accepted) , my_ballot) | if quorum_ballot == my_ballot { Some (quorum_accepted) } else { None } }),
                                 input: CrossSingleton {
                                     left: Batch {
@@ -2145,7 +2145,7 @@ expression: built.ir()
                                                                                     input: AntiJoin {
                                                                                         pos: AntiJoin {
                                                                                             pos: Tee {
-                                                                                                inner: <tee 7>,
+                                                                                                inner: <shared 7>,
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_id: Tick(9, Cluster(loc1v1)),
                                                                                                     collection_kind: Stream {
@@ -2163,7 +2163,7 @@ expression: built.ir()
                                                                                                         inner: Filter {
                                                                                                             f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < (usize , usize) , bool > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; let min__free = 2usize ; move | (success , _error) | success < & min__free }) ; { let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) } }),
                                                                                                             input: Tee {
-                                                                                                                inner: <tee 12>,
+                                                                                                                inner: <shared 12>,
                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                     location_id: Tick(9, Cluster(loc1v1)),
                                                                                                                     collection_kind: KeyedSingleton {
@@ -2381,7 +2381,7 @@ expression: built.ir()
                                     },
                                     right: Cast {
                                         inner: Tee {
-                                            inner: <tee 4>,
+                                            inner: <shared 4>,
                                             metadata: HydroIrMetadata {
                                                 location_id: Tick(1, Cluster(loc1v1)),
                                                 collection_kind: Singleton {
@@ -2433,7 +2433,7 @@ expression: built.ir()
                     right: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _u | () }),
                         input: Tee {
-                            inner: <tee 15>: Batch {
+                            inner: <shared 15>: Batch {
                                 inner: YieldConcat {
                                     inner: Map {
                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | _ | () }),
@@ -2442,7 +2442,7 @@ expression: built.ir()
                                             input: Cast {
                                                 inner: CrossSingleton {
                                                     left: Tee {
-                                                        inner: <tee 2>,
+                                                        inner: <shared 2>,
                                                         metadata: HydroIrMetadata {
                                                             location_id: Tick(1, Cluster(loc1v1)),
                                                             collection_kind: Singleton {
@@ -2452,7 +2452,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     right: Tee {
-                                                        inner: <tee 5>,
+                                                        inner: <shared 5>,
                                                         metadata: HydroIrMetadata {
                                                             location_id: Tick(1, Cluster(loc1v1)),
                                                             collection_kind: Singleton {
@@ -2560,7 +2560,7 @@ expression: built.ir()
             input: FilterMap {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | (key , res) | match res { Ok (_) => None , Err (e) => Some ((key , e)) , } }),
                 input: Tee {
-                    inner: <tee 8>,
+                    inner: <shared 8>,
                     metadata: HydroIrMetadata {
                         location_id: Cluster(loc1v1),
                         collection_kind: Stream {
@@ -2601,7 +2601,7 @@ expression: built.ir()
             f: stageleft :: runtime_support :: fn1_type_hint :: < ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , ()) , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | (d , _signal) | d }),
             input: CrossSingleton {
                 left: Tee {
-                    inner: <tee 16>: Chain {
+                    inner: <shared 16>: Chain {
                         first: DeferTick {
                             input: CycleSource {
                                 cycle_id: CycleId(
@@ -2633,14 +2633,14 @@ expression: built.ir()
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , i32) , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos_bench :: Client > :: from_tagless ((__hydro_lang_cluster_self_id_loc3v1) . clone ()) ; move | (virtual_id , payload) | { (virtual_id , (CLUSTER_SELF_ID__free . clone () , payload)) } }),
                                     input: Cast {
                                         inner: Tee {
-                                            inner: <tee 17>: Map {
+                                            inner: <shared 17>: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , core :: option :: Option < i32 >) , (u32 , i32) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < i32 > , i32 > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; move | payload | { if let Some (counter) = payload { counter + 1 } else { 0 } } }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
                                                 input: Chain {
                                                     first: YieldConcat {
                                                         inner: Cast {
                                                             inner: Cast {
                                                                 inner: Tee {
-                                                                    inner: <tee 0>,
+                                                                    inner: <shared 0>,
                                                                     metadata: HydroIrMetadata {
                                                                         location_id: Tick(0, Cluster(loc3v1)),
                                                                         collection_kind: Optional {
@@ -2814,7 +2814,7 @@ expression: built.ir()
                                     input: Map {
                                         f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ | () }),
                                         input: Tee {
-                                            inner: <tee 18>: Batch {
+                                            inner: <shared 18>: Batch {
                                                 inner: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | ballot | ballot . proposer_id }),
                                                     input: Reduce {
@@ -2967,7 +2967,7 @@ expression: built.ir()
                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , ()) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _signal) | d }),
                                                                                                             input: CrossSingleton {
                                                                                                                 left: Tee {
-                                                                                                                    inner: <tee 4>,
+                                                                                                                    inner: <shared 4>,
                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                         location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                         collection_kind: Singleton {
@@ -2979,11 +2979,11 @@ expression: built.ir()
                                                                                                                 right: Map {
                                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _u | () }),
                                                                                                                     input: Tee {
-                                                                                                                        inner: <tee 19>: Map {
+                                                                                                                        inner: <shared 19>: Map {
                                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (() , ()) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | (d , _signal) | d }),
                                                                                                                             input: CrossSingleton {
                                                                                                                                 left: Tee {
-                                                                                                                                    inner: <tee 13>,
+                                                                                                                                    inner: <shared 13>,
                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                         location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                         collection_kind: Optional {
@@ -3004,7 +3004,7 @@ expression: built.ir()
                                                                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                                                                                                                         input: DeferTick {
                                                                                                                                                             input: Tee {
-                                                                                                                                                                inner: <tee 13>,
+                                                                                                                                                                inner: <shared 13>,
                                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                                     location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                                     collection_kind: Optional {
@@ -3395,7 +3395,7 @@ expression: built.ir()
                         init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | | 0usize }),
                         acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | count , _ | * count += 1 }),
                         input: Tee {
-                            inner: <tee 20>: Map {
+                            inner: <shared 20>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , usize) , (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | ((index , payload) , base_slot) | (base_slot + index , payload) }),
                                 input: CrossSingleton {
                                     left: Enumerate {
@@ -3428,7 +3428,7 @@ expression: built.ir()
                                                                                         input: YieldConcat {
                                                                                             inner: CrossSingleton {
                                                                                                 left: Tee {
-                                                                                                    inner: <tee 16>,
+                                                                                                    inner: <shared 16>,
                                                                                                     metadata: HydroIrMetadata {
                                                                                                         location_id: Tick(11, Cluster(loc3v1)),
                                                                                                         collection_kind: Stream {
@@ -3440,7 +3440,7 @@ expression: built.ir()
                                                                                                     },
                                                                                                 },
                                                                                                 right: Tee {
-                                                                                                    inner: <tee 18>,
+                                                                                                    inner: <shared 18>,
                                                                                                     metadata: HydroIrMetadata {
                                                                                                         location_id: Tick(11, Cluster(loc3v1)),
                                                                                                         collection_kind: Optional {
@@ -3555,7 +3555,7 @@ expression: built.ir()
                                                         right: Map {
                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _u | () }),
                                                             input: Tee {
-                                                                inner: <tee 13>,
+                                                                inner: <shared 13>,
                                                                 metadata: HydroIrMetadata {
                                                                     location_id: Tick(1, Cluster(loc1v1)),
                                                                     collection_kind: Optional {
@@ -3624,14 +3624,14 @@ expression: built.ir()
                                     },
                                     right: Cast {
                                         inner: Tee {
-                                            inner: <tee 21>: Cast {
+                                            inner: <shared 21>: Cast {
                                                 inner: ChainFirst {
                                                     first: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < usize , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | s | s + 1 }),
                                                         input: Batch {
                                                             inner: YieldConcat {
                                                                 inner: Tee {
-                                                                    inner: <tee 22>: Reduce {
+                                                                    inner: <shared 22>: Reduce {
                                                                         f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | curr , new | { if new > * curr { * curr = new ; } } }),
                                                                         input: ObserveNonDet {
                                                                             inner: Map {
@@ -3639,7 +3639,7 @@ expression: built.ir()
                                                                                 input: Cast {
                                                                                     inner: Cast {
                                                                                         inner: Tee {
-                                                                                            inner: <tee 23>: Map {
+                                                                                            inner: <shared 23>: Map {
                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)) , (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (count , entry) | (count , entry . unwrap ()) }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
                                                                                                 input: FoldKeyed {
                                                                                                     init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | | (0 , None) }),
@@ -3651,10 +3651,10 @@ expression: built.ir()
                                                                                                                 input: Map {
                                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (_checkpoint , log) | log }),
                                                                                                                     input: Tee {
-                                                                                                                        inner: <tee 24>: FlatMap {
+                                                                                                                        inner: <shared 24>: FlatMap {
                                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | v }),
                                                                                                                             input: Tee {
-                                                                                                                                inner: <tee 14>,
+                                                                                                                                inner: <shared 14>,
                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                     location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                     collection_kind: Optional {
@@ -3974,7 +3974,7 @@ expression: built.ir()
                         },
                     },
                     right: Tee {
-                        inner: <tee 21>,
+                        inner: <shared 21>,
                         metadata: HydroIrMetadata {
                             location_id: Tick(1, Cluster(loc1v1)),
                             collection_kind: Singleton {
@@ -4015,7 +4015,7 @@ expression: built.ir()
         ),
         input: AntiJoin {
             pos: Tee {
-                inner: <tee 25>: Chain {
+                inner: <shared 25>: Chain {
                     first: DeferTick {
                         input: CycleSource {
                             cycle_id: CycleId(
@@ -4043,7 +4043,7 @@ expression: built.ir()
                     },
                     second: Batch {
                         inner: Tee {
-                            inner: <tee 26>: Map {
+                            inner: <shared 26>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
                                 input: Cast {
                                     inner: Cast {
@@ -4065,7 +4065,7 @@ expression: built.ir()
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (p2a , max_ballot) | (p2a . sender , ((p2a . slot , p2a . ballot . clone ()) , if p2a . ballot == max_ballot { Ok (()) } else { Err (max_ballot) })) }),
                                                         input: CrossSingleton {
                                                             left: Tee {
-                                                                inner: <tee 27>: Batch {
+                                                                inner: <shared 27>: Batch {
                                                                     inner: Map {
                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >) , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
                                                                         input: Cast {
@@ -4209,7 +4209,7 @@ expression: built.ir()
                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless ((__hydro_lang_cluster_self_id_loc1v1) . clone ()) ; move | ((slot , ballot) , value) | P2a { sender : CLUSTER_SELF_ID__free . clone () , ballot , slot , value } }),
                                                                                                         input: EndAtomic {
                                                                                                             inner: Tee {
-                                                                                                                inner: <tee 28>: YieldConcat {
+                                                                                                                inner: <shared 28>: YieldConcat {
                                                                                                                     inner: Map {
                                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , ()) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | (d , _signal) | d }),
                                                                                                                         input: CrossSingleton {
@@ -4220,7 +4220,7 @@ expression: built.ir()
                                                                                                                                         left: Batch {
                                                                                                                                             inner: YieldConcat {
                                                                                                                                                 inner: Tee {
-                                                                                                                                                    inner: <tee 20>,
+                                                                                                                                                    inner: <shared 20>,
                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                         location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                         collection_kind: Stream {
@@ -4253,7 +4253,7 @@ expression: built.ir()
                                                                                                                                         },
                                                                                                                                         right: Cast {
                                                                                                                                             inner: Tee {
-                                                                                                                                                inner: <tee 4>,
+                                                                                                                                                inner: <shared 4>,
                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                     location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                     collection_kind: Singleton {
@@ -4298,7 +4298,7 @@ expression: built.ir()
                                                                                                                                                 left: Cast {
                                                                                                                                                     inner: Cast {
                                                                                                                                                         inner: Tee {
-                                                                                                                                                            inner: <tee 23>,
+                                                                                                                                                            inner: <shared 23>,
                                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                                 location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                                 collection_kind: KeyedSingleton {
@@ -4331,7 +4331,7 @@ expression: built.ir()
                                                                                                                                                 },
                                                                                                                                                 right: Cast {
                                                                                                                                                     inner: Tee {
-                                                                                                                                                        inner: <tee 4>,
+                                                                                                                                                        inner: <shared 4>,
                                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                                             location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                             collection_kind: Singleton {
@@ -4360,7 +4360,7 @@ expression: built.ir()
                                                                                                                                             },
                                                                                                                                             right: Cast {
                                                                                                                                                 inner: Tee {
-                                                                                                                                                    inner: <tee 29>: Cast {
+                                                                                                                                                    inner: <shared 29>: Cast {
                                                                                                                                                         inner: ChainFirst {
                                                                                                                                                             first: Map {
                                                                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < usize , core :: option :: Option < usize > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
@@ -4370,7 +4370,7 @@ expression: built.ir()
                                                                                                                                                                         inner: FilterMap {
                                                                                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (checkpoint , _log) | checkpoint }),
                                                                                                                                                                             input: Tee {
-                                                                                                                                                                                inner: <tee 24>,
+                                                                                                                                                                                inner: <shared 24>,
                                                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                                                     location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                                                     collection_kind: Stream {
@@ -4498,7 +4498,7 @@ expression: built.ir()
                                                                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , core :: option :: Option < usize >) , std :: ops :: Range < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (max_slot , checkpoint) | { if let Some (checkpoint) = checkpoint { (checkpoint + 1) .. max_slot } else { 0 .. max_slot } } }),
                                                                                                                                                     input: CrossSingleton {
                                                                                                                                                         left: Tee {
-                                                                                                                                                            inner: <tee 22>,
+                                                                                                                                                            inner: <shared 22>,
                                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                                 location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                                 collection_kind: Optional {
@@ -4509,7 +4509,7 @@ expression: built.ir()
                                                                                                                                                         },
                                                                                                                                                         right: Cast {
                                                                                                                                                             inner: Tee {
-                                                                                                                                                                inner: <tee 29>,
+                                                                                                                                                                inner: <shared 29>,
                                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                                     location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                                     collection_kind: Singleton {
@@ -4549,7 +4549,7 @@ expression: built.ir()
                                                                                                                                                     input: Cast {
                                                                                                                                                         inner: Cast {
                                                                                                                                                             inner: Tee {
-                                                                                                                                                                inner: <tee 23>,
+                                                                                                                                                                inner: <shared 23>,
                                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                                     location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                                     collection_kind: KeyedSingleton {
@@ -4602,7 +4602,7 @@ expression: built.ir()
                                                                                                                                             },
                                                                                                                                             right: Cast {
                                                                                                                                                 inner: Tee {
-                                                                                                                                                    inner: <tee 4>,
+                                                                                                                                                    inner: <shared 4>,
                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                         location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                                         collection_kind: Singleton {
@@ -4662,7 +4662,7 @@ expression: built.ir()
                                                                                                                             right: Map {
                                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _u | () }),
                                                                                                                                 input: Tee {
-                                                                                                                                    inner: <tee 13>,
+                                                                                                                                    inner: <shared 13>,
                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                         location_id: Tick(1, Cluster(loc1v1)),
                                                                                                                                         collection_kind: Optional {
@@ -4844,7 +4844,7 @@ expression: built.ir()
                                                             },
                                                             right: Cast {
                                                                 inner: Tee {
-                                                                    inner: <tee 10>,
+                                                                    inner: <shared 10>,
                                                                     metadata: HydroIrMetadata {
                                                                         location_id: Tick(2, Cluster(loc2v1)),
                                                                         collection_kind: Singleton {
@@ -4984,20 +4984,20 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <tee 30>: Map {
+                inner: <shared 30>: Map {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (usize , usize)) , (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
                     input: Cast {
                         inner: Cast {
                             inner: Filter {
                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (usize , usize)) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < (usize , usize) , bool > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; let max__free = 3usize ; move | (success , error) | (success + error) >= max__free }) ; { let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) } }),
                                 input: Tee {
-                                    inner: <tee 31>: FoldKeyed {
+                                    inner: <shared 31>: FoldKeyed {
                                         init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | | (0 , 0) }),
                                         acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } } }),
                                         input: ObserveNonDet {
                                             inner: Cast {
                                                 inner: Tee {
-                                                    inner: <tee 25>,
+                                                    inner: <shared 25>,
                                                     metadata: HydroIrMetadata {
                                                         location_id: Tick(13, Cluster(loc1v1)),
                                                         collection_kind: Stream {
@@ -5117,12 +5117,12 @@ expression: built.ir()
         ),
         input: Difference {
             pos: Tee {
-                inner: <tee 32>: FilterMap {
+                inner: <shared 32>: FilterMap {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (usize , usize)) , core :: option :: Option < (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; let min__free = 2usize ; move | (key , (success , _error)) | if success >= min__free { Some (key) } else { None } }),
                     input: Cast {
                         inner: Cast {
                             inner: Tee {
-                                inner: <tee 31>,
+                                inner: <shared 31>,
                                 metadata: HydroIrMetadata {
                                     location_id: Tick(13, Cluster(loc1v1)),
                                     collection_kind: KeyedSingleton {
@@ -5174,7 +5174,7 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <tee 30>,
+                inner: <shared 30>,
                 metadata: HydroIrMetadata {
                     location_id: Tick(13, Cluster(loc1v1)),
                     collection_kind: Stream {
@@ -5203,7 +5203,7 @@ expression: built.ir()
         ),
         input: AntiJoin {
             pos: Tee {
-                inner: <tee 33>: Chain {
+                inner: <shared 33>: Chain {
                     first: DeferTick {
                         input: CycleSource {
                             cycle_id: CycleId(
@@ -5233,7 +5233,7 @@ expression: built.ir()
                         inner: YieldConcat {
                             inner: Batch {
                                 inner: Tee {
-                                    inner: <tee 28>,
+                                    inner: <shared 28>,
                                     metadata: HydroIrMetadata {
                                         location_id: Atomic(Tick(1, Cluster(loc1v1))),
                                         collection_kind: Stream {
@@ -5297,13 +5297,13 @@ expression: built.ir()
             neg: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ()) , (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: request_response :: * ; | (key , _) | key }),
                 input: Tee {
-                    inner: <tee 34>: Batch {
+                    inner: <shared 34>: Batch {
                         inner: Map {
                             f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ()) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | k | (k , ()) }),
                             input: YieldConcat {
                                 inner: Difference {
                                     pos: Tee {
-                                        inner: <tee 32>,
+                                        inner: <shared 32>,
                                         metadata: HydroIrMetadata {
                                             location_id: Tick(13, Cluster(loc1v1)),
                                             collection_kind: Stream {
@@ -5424,7 +5424,7 @@ expression: built.ir()
                                 first: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < usize , core :: option :: Option < usize > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                     input: Tee {
-                                        inner: <tee 35>: Batch {
+                                        inner: <shared 35>: Batch {
                                             inner: CycleSource {
                                                 cycle_id: CycleId(
                                                     2,
@@ -5513,7 +5513,7 @@ expression: built.ir()
                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (p2a , max_ballot) | if p2a . ballot >= max_ballot { Some ((p2a . slot , LogValue { ballot : p2a . ballot , value : p2a . value , })) } else { None } }),
                                                                 input: CrossSingleton {
                                                                     left: Tee {
-                                                                        inner: <tee 27>,
+                                                                        inner: <shared 27>,
                                                                         metadata: HydroIrMetadata {
                                                                             location_id: Tick(2, Cluster(loc2v1)),
                                                                             collection_kind: Stream {
@@ -5526,7 +5526,7 @@ expression: built.ir()
                                                                     },
                                                                     right: Cast {
                                                                         inner: Tee {
-                                                                            inner: <tee 10>,
+                                                                            inner: <shared 10>,
                                                                             metadata: HydroIrMetadata {
                                                                                 location_id: Tick(2, Cluster(loc2v1)),
                                                                                 collection_kind: Singleton {
@@ -5597,7 +5597,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 watermark: Tee {
-                                                    inner: <tee 35>,
+                                                    inner: <shared 35>,
                                                     metadata: HydroIrMetadata {
                                                         location_id: Tick(2, Cluster(loc2v1)),
                                                         collection_kind: Optional {
@@ -5707,7 +5707,7 @@ expression: built.ir()
             input: FilterMap {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , core :: option :: Option < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | (key , res) | match res { Ok (_) => None , Err (e) => Some ((key , e)) , } }),
                 input: Tee {
-                    inner: <tee 26>,
+                    inner: <shared 26>,
                     metadata: HydroIrMetadata {
                         location_id: Cluster(loc1v1),
                         collection_kind: Stream {
@@ -5750,7 +5750,7 @@ expression: built.ir()
                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; | (sorted_payload , highest_seq) | sorted_payload . seq > * highest_seq }),
                 input: CrossSingleton {
                     left: Tee {
-                        inner: <tee 36>: Sort {
+                        inner: <shared 36>: Sort {
                             input: Chain {
                                 first: Batch {
                                     inner: Map {
@@ -5903,7 +5903,7 @@ expression: built.ir()
                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , ())) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , ())) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: request_response :: * ; | (key , (meta , resp)) | (key , (meta , resp)) }),
                                                                                         input: Join {
                                                                                             left: Tee {
-                                                                                                inner: <tee 33>,
+                                                                                                inner: <shared 33>,
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_id: Tick(1, Cluster(loc1v1)),
                                                                                                     collection_kind: Stream {
@@ -5915,7 +5915,7 @@ expression: built.ir()
                                                                                                 },
                                                                                             },
                                                                                             right: Tee {
-                                                                                                inner: <tee 34>,
+                                                                                                inner: <shared 34>,
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_id: Tick(1, Cluster(loc1v1)),
                                                                                                     collection_kind: Stream {
@@ -6136,12 +6136,12 @@ expression: built.ir()
                     },
                     right: Cast {
                         inner: Tee {
-                            inner: <tee 37>: Fold {
+                            inner: <shared 37>: Fold {
                                 init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; | | 0 }),
                                 acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; | new_next_slot , (sorted_payload , next_slot) | { if sorted_payload . seq == std :: cmp :: max (* new_next_slot , next_slot) { * new_next_slot = sorted_payload . seq + 1 ; } } }),
                                 input: CrossSingleton {
                                     left: Tee {
-                                        inner: <tee 36>,
+                                        inner: <shared 36>,
                                         metadata: HydroIrMetadata {
                                             location_id: Tick(15, Cluster(loc5v1)),
                                             collection_kind: Stream {
@@ -6291,7 +6291,7 @@ expression: built.ir()
             17,
         ),
         input: Tee {
-            inner: <tee 38>: Map {
+            inner: <shared 38>: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: collections :: hash_map :: HashMap < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; | (_kv_store , next_slot) | next_slot }),
                 input: Batch {
                     inner: Fold {
@@ -6299,13 +6299,13 @@ expression: built.ir()
                         acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (std :: collections :: hash_map :: HashMap < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; | (kv_store , next_slot) , payload | { if let Some (kv) = payload . kv { kv_store . insert (kv . key , kv . value) ; } * next_slot = payload . seq + 1 ; } }),
                         input: YieldConcat {
                             inner: Tee {
-                                inner: <tee 39>: Map {
+                                inner: <shared 39>: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; | (sorted_payload , _) | { sorted_payload } }),
                                     input: Filter {
                                         f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; | (sorted_payload , highest_seq) | sorted_payload . seq < * highest_seq }),
                                         input: CrossSingleton {
                                             left: Tee {
-                                                inner: <tee 36>,
+                                                inner: <shared 36>,
                                                 metadata: HydroIrMetadata {
                                                     location_id: Tick(15, Cluster(loc5v1)),
                                                     collection_kind: Stream {
@@ -6318,7 +6318,7 @@ expression: built.ir()
                                             },
                                             right: Cast {
                                                 inner: Tee {
-                                                    inner: <tee 37>,
+                                                    inner: <shared 37>,
                                                     metadata: HydroIrMetadata {
                                                         location_id: Tick(15, Cluster(loc5v1)),
                                                         collection_kind: Singleton {
@@ -6424,7 +6424,7 @@ expression: built.ir()
             18,
         ),
         input: Tee {
-            inner: <tee 40>: FilterMap {
+            inner: <shared 40>: FilterMap {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (core :: option :: Option < usize > , usize) , core :: option :: Option < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; let checkpoint_frequency__free = 1000usize ; move | (max_checkpointed_seq , next_slot) | if max_checkpointed_seq . map (| m | next_slot - m >= checkpoint_frequency__free) . unwrap_or (true) { Some (next_slot) } else { None } }),
                 input: Cast {
                     inner: CrossSingleton {
@@ -6543,7 +6543,7 @@ expression: built.ir()
                                 first: DeferTick {
                                     input: Cast {
                                         inner: Tee {
-                                            inner: <tee 38>,
+                                            inner: <shared 38>,
                                             metadata: HydroIrMetadata {
                                                 location_id: Tick(15, Cluster(loc5v1)),
                                                 collection_kind: Singleton {
@@ -6654,7 +6654,7 @@ expression: built.ir()
                                 left: Cast {
                                     inner: Cast {
                                         inner: Tee {
-                                            inner: <tee 41>: Batch {
+                                            inner: <shared 41>: Batch {
                                                 inner: ReduceKeyed {
                                                     f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; | curr_seq , seq | { if seq > * curr_seq { * curr_seq = seq ; } } }),
                                                     input: Cast {
@@ -6796,7 +6796,7 @@ expression: built.ir()
                                                                             inner: YieldConcat {
                                                                                 inner: Cast {
                                                                                     inner: Tee {
-                                                                                        inner: <tee 40>,
+                                                                                        inner: <shared 40>,
                                                                                         metadata: HydroIrMetadata {
                                                                                             location_id: Tick(15, Cluster(loc5v1)),
                                                                                             collection_kind: Optional {
@@ -6947,7 +6947,7 @@ expression: built.ir()
                                                 inner: Cast {
                                                     inner: Cast {
                                                         inner: Tee {
-                                                            inner: <tee 41>,
+                                                            inner: <shared 41>,
                                                             metadata: HydroIrMetadata {
                                                                 location_id: Tick(17, Cluster(loc2v1)),
                                                                 collection_kind: KeyedSingleton {
@@ -7078,7 +7078,7 @@ expression: built.ir()
         ),
         input: AntiJoin {
             pos: Tee {
-                inner: <tee 42>: Chain {
+                inner: <shared 42>: Chain {
                     first: DeferTick {
                         input: CycleSource {
                             cycle_id: CycleId(
@@ -7106,7 +7106,7 @@ expression: built.ir()
                     },
                     second: Batch {
                         inner: Tee {
-                            inner: <tee 43>: Map {
+                            inner: <shared 43>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica > , ((u32 , i32) , core :: result :: Result < () , () >)) , ((u32 , i32) , core :: result :: Result < () , () >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
                                 input: Cast {
                                     inner: Cast {
@@ -7129,7 +7129,7 @@ expression: built.ir()
                                                         inner: FilterMap {
                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; | payload | payload . kv }),
                                                             input: Tee {
-                                                                inner: <tee 39>,
+                                                                inner: <shared 39>,
                                                                 metadata: HydroIrMetadata {
                                                                     location_id: Tick(15, Cluster(loc5v1)),
                                                                     collection_kind: Stream {
@@ -7263,18 +7263,18 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <tee 44>: FilterMap {
+                inner: <shared 44>: FilterMap {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < ((u32 , i32) , (usize , usize)) , core :: option :: Option < (u32 , i32) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; let min__free = 2usize ; move | (key , (success , _error)) | if success >= min__free { Some (key) } else { None } }),
                     input: Cast {
                         inner: Cast {
                             inner: Tee {
-                                inner: <tee 45>: FoldKeyed {
+                                inner: <shared 45>: FoldKeyed {
                                     init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | | (0 , 0) }),
                                     acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < () , () > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } } }),
                                     input: ObserveNonDet {
                                         inner: Cast {
                                             inner: Tee {
-                                                inner: <tee 42>,
+                                                inner: <shared 42>,
                                                 metadata: HydroIrMetadata {
                                                     location_id: Tick(18, Cluster(loc3v1)),
                                                     collection_kind: Stream {
@@ -7415,10 +7415,10 @@ expression: built.ir()
             1,
         ),
         input: Tee {
-            inner: <tee 46>: Cast {
+            inner: <shared 46>: Cast {
                 inner: YieldConcat {
                     inner: Tee {
-                        inner: <tee 44>,
+                        inner: <shared 44>,
                         metadata: HydroIrMetadata {
                             location_id: Tick(18, Cluster(loc3v1)),
                             collection_kind: Stream {
@@ -7473,12 +7473,12 @@ expression: built.ir()
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (new , old) | { old . borrow_mut () . add (new) . expect ("Error adding value to histogram") ; old } }),
                     input: CrossSingleton {
                         left: Tee {
-                            inner: <tee 47>: Fold {
+                            inner: <shared 47>: Fold {
                                 init: stageleft :: runtime_support :: fn0_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; move | | Histogram :: < u64 > :: new (3) . unwrap () }),
                                 acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , core :: time :: Duration , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; move | latencies , latency | { latencies . record (latency . as_nanos () as u64) . unwrap () ; } }),
                                 input: ObserveNonDet {
                                     inner: Tee {
-                                        inner: <tee 48>: Batch {
+                                        inner: <shared 48>: Batch {
                                             inner: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , (i32 , core :: time :: Duration)) , core :: time :: Duration > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; | (_virtual_client_id , (_output , latency)) | latency }),
                                                 input: Cast {
@@ -7500,7 +7500,7 @@ expression: built.ir()
                                                                                                         f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < i32 , i32 , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | curr , new | { * curr = new ; } }),
                                                                                                         input: ObserveNonDet {
                                                                                                             inner: Tee {
-                                                                                                                inner: <tee 17>,
+                                                                                                                inner: <shared 17>,
                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                     location_id: Cluster(loc3v1),
                                                                                                                     collection_kind: KeyedStream {
@@ -7590,7 +7590,7 @@ expression: built.ir()
                                                                                                 input: ObserveNonDet {
                                                                                                     inner: Batch {
                                                                                                         inner: Tee {
-                                                                                                            inner: <tee 46>,
+                                                                                                            inner: <shared 46>,
                                                                                                             metadata: HydroIrMetadata {
                                                                                                                 location_id: Cluster(loc3v1),
                                                                                                                 collection_kind: KeyedStream {
@@ -7804,11 +7804,11 @@ expression: built.ir()
                             },
                         },
                         right: Tee {
-                            inner: <tee 49>: Map {
+                            inner: <shared 49>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , ()) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _signal) | d }),
                                 input: CrossSingleton {
                                     left: Tee {
-                                        inner: <tee 50>: Cast {
+                                        inner: <shared 50>: Cast {
                                             inner: ChainFirst {
                                                 first: DeferTick {
                                                     input: CycleSource {
@@ -7886,7 +7886,7 @@ expression: built.ir()
                                                         input: Map {
                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _ | () }),
                                                             input: Tee {
-                                                                inner: <tee 51>: Reduce {
+                                                                inner: <shared 51>: Reduce {
                                                                     f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
                                                                     input: Batch {
                                                                         inner: Source {
@@ -8041,7 +8041,7 @@ expression: built.ir()
                     inner: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | histogram | Rc :: new (RefCell :: new (histogram)) }),
                         input: Tee {
-                            inner: <tee 47>,
+                            inner: <shared 47>,
                             metadata: HydroIrMetadata {
                                 location_id: Tick(20, Cluster(loc3v1)),
                                 collection_kind: Singleton {
@@ -8094,12 +8094,12 @@ expression: built.ir()
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , usize) , usize > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (new , old) | new + old }),
                     input: CrossSingleton {
                         left: Tee {
-                            inner: <tee 52>: Fold {
+                            inner: <shared 52>: Fold {
                                 init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | | 0usize }),
                                 acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , core :: time :: Duration , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | count , _ | * count += 1 }),
                                 input: ObserveNonDet {
                                     inner: Tee {
-                                        inner: <tee 48>,
+                                        inner: <shared 48>,
                                         metadata: HydroIrMetadata {
                                             location_id: Tick(20, Cluster(loc3v1)),
                                             collection_kind: Stream {
@@ -8138,11 +8138,11 @@ expression: built.ir()
                             },
                         },
                         right: Tee {
-                            inner: <tee 53>: Map {
+                            inner: <shared 53>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , ()) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _signal) | d }),
                                 input: CrossSingleton {
                                     left: Tee {
-                                        inner: <tee 54>: Cast {
+                                        inner: <shared 54>: Cast {
                                             inner: ChainFirst {
                                                 first: DeferTick {
                                                     input: CycleSource {
@@ -8220,7 +8220,7 @@ expression: built.ir()
                                                         input: Map {
                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _ | () }),
                                                             input: Tee {
-                                                                inner: <tee 51>,
+                                                                inner: <shared 51>,
                                                                 metadata: HydroIrMetadata {
                                                                     location_id: Tick(20, Cluster(loc3v1)),
                                                                     collection_kind: Optional {
@@ -8339,7 +8339,7 @@ expression: built.ir()
                 },
                 second: Cast {
                     inner: Tee {
-                        inner: <tee 52>,
+                        inner: <shared 52>,
                         metadata: HydroIrMetadata {
                             location_id: Tick(20, Cluster(loc3v1)),
                             collection_kind: Singleton {
@@ -8385,7 +8385,7 @@ expression: built.ir()
                     left: Cast {
                         inner: CrossSingleton {
                             left: Tee {
-                                inner: <tee 55>: Cast {
+                                inner: <shared 55>: Cast {
                                     inner: ChainFirst {
                                         first: DeferTick {
                                             input: CycleSource {
@@ -8486,7 +8486,7 @@ expression: built.ir()
                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , ()) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _signal) | d }),
                                                                                         input: CrossSingleton {
                                                                                             left: Tee {
-                                                                                                inner: <tee 50>,
+                                                                                                inner: <shared 50>,
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_id: Tick(20, Cluster(loc3v1)),
                                                                                                     collection_kind: Singleton {
@@ -8498,7 +8498,7 @@ expression: built.ir()
                                                                                             right: Map {
                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _u | () }),
                                                                                                 input: Tee {
-                                                                                                    inner: <tee 51>,
+                                                                                                    inner: <shared 51>,
                                                                                                     metadata: HydroIrMetadata {
                                                                                                         location_id: Tick(20, Cluster(loc3v1)),
                                                                                                         collection_kind: Optional {
@@ -8706,7 +8706,7 @@ expression: built.ir()
                             first: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                 input: Tee {
-                                    inner: <tee 56>: Reduce {
+                                    inner: <shared 56>: Reduce {
                                         f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
                                         input: Batch {
                                             inner: Source {
@@ -8851,7 +8851,7 @@ expression: built.ir()
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , ()) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _signal) | d }),
                                                     input: CrossSingleton {
                                                         left: Tee {
-                                                            inner: <tee 54>,
+                                                            inner: <shared 54>,
                                                             metadata: HydroIrMetadata {
                                                                 location_id: Tick(20, Cluster(loc3v1)),
                                                                 collection_kind: Singleton {
@@ -8863,7 +8863,7 @@ expression: built.ir()
                                                         right: Map {
                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _u | () }),
                                                             input: Tee {
-                                                                inner: <tee 51>,
+                                                                inner: <shared 51>,
                                                                 metadata: HydroIrMetadata {
                                                                     location_id: Tick(20, Cluster(loc3v1)),
                                                                     collection_kind: Optional {
@@ -8972,7 +8972,7 @@ expression: built.ir()
                             f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , ()) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _signal) | d }),
                             input: CrossSingleton {
                                 left: Tee {
-                                    inner: <tee 57>: Cast {
+                                    inner: <shared 57>: Cast {
                                         inner: ChainFirst {
                                             first: DeferTick {
                                                 input: CycleSource {
@@ -9050,7 +9050,7 @@ expression: built.ir()
                                                     input: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _ | () }),
                                                         input: Tee {
-                                                            inner: <tee 56>,
+                                                            inner: <shared 56>,
                                                             metadata: HydroIrMetadata {
                                                                 location_id: Tick(21, Process(loc4v1)),
                                                                 collection_kind: Optional {
@@ -9192,7 +9192,7 @@ expression: built.ir()
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , ()) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _signal) | d }),
                     input: CrossSingleton {
                         left: Tee {
-                            inner: <tee 57>,
+                            inner: <shared 57>,
                             metadata: HydroIrMetadata {
                                 location_id: Tick(21, Process(loc4v1)),
                                 collection_kind: Singleton {
@@ -9204,7 +9204,7 @@ expression: built.ir()
                         right: Map {
                             f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _u | () }),
                             input: Tee {
-                                inner: <tee 56>,
+                                inner: <shared 56>,
                                 metadata: HydroIrMetadata {
                                     location_id: Tick(21, Process(loc4v1)),
                                     collection_kind: Optional {
@@ -9269,7 +9269,7 @@ expression: built.ir()
                         f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , ()) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _signal) | d }),
                         input: CrossSingleton {
                             left: Tee {
-                                inner: <tee 55>,
+                                inner: <shared 55>,
                                 metadata: HydroIrMetadata {
                                     location_id: Tick(21, Process(loc4v1)),
                                     collection_kind: Singleton {
@@ -9281,7 +9281,7 @@ expression: built.ir()
                             right: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _u | () }),
                                 input: Tee {
-                                    inner: <tee 56>,
+                                    inner: <shared 56>,
                                     metadata: HydroIrMetadata {
                                         location_id: Tick(21, Process(loc4v1)),
                                         collection_kind: Optional {

--- a/hydro_test/src/cluster/snapshots/two_pc_ir.snap
+++ b/hydro_test/src/cluster/snapshots/two_pc_ir.snap
@@ -11,7 +11,7 @@ expression: built.ir()
             f: stageleft :: runtime_support :: fn1_type_hint :: < ((u32 , core :: option :: Option < i32 >) , usize) , core :: option :: Option < (u32 , core :: option :: Option < i32 >) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; move | ((virtual_id , _) , num_clients_per_node) | { if virtual_id < num_clients_per_node as u32 { Some ((virtual_id + 1 , None)) } else { None } } }),
             input: CrossSingleton {
                 left: Tee {
-                    inner: <tee 0>: ChainFirst {
+                    inner: <shared 0>: ChainFirst {
                         first: DeferTick {
                             input: CycleSource {
                                 cycle_id: CycleId(
@@ -162,7 +162,7 @@ expression: built.ir()
         ),
         input: AntiJoin {
             pos: Tee {
-                inner: <tee 1>: Chain {
+                inner: <shared 1>: Chain {
                     first: DeferTick {
                         input: CycleSource {
                             cycle_id: CycleId(
@@ -190,7 +190,7 @@ expression: built.ir()
                     },
                     second: Batch {
                         inner: Tee {
-                            inner: <tee 2>: Map {
+                            inner: <shared 2>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) , ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) , core :: result :: Result < () , () >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: two_pc :: * ; | kv | (kv , Ok :: < () , () > (())) }),
                                 input: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32))) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
@@ -359,14 +359,14 @@ expression: built.ir()
                                                                                 ),
                                                                                 input: Cast {
                                                                                     inner: Tee {
-                                                                                        inner: <tee 3>: Map {
+                                                                                        inner: <shared 3>: Map {
                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , core :: option :: Option < i32 >) , (u32 , i32) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < i32 > , i32 > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; move | payload | { if let Some (counter) = payload { counter + 1 } else { 0 } } }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
                                                                                             input: Chain {
                                                                                                 first: YieldConcat {
                                                                                                     inner: Cast {
                                                                                                         inner: Cast {
                                                                                                             inner: Tee {
-                                                                                                                inner: <tee 0>,
+                                                                                                                inner: <shared 0>,
                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                     location_id: Tick(0, Cluster(loc3v1)),
                                                                                                                     collection_kind: Optional {
@@ -653,18 +653,18 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <tee 4>: FilterMap {
+                inner: <shared 4>: FilterMap {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) , (usize , usize)) , core :: option :: Option < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; let min__free = 3usize ; move | (key , (success , _error)) | if success >= min__free { Some (key) } else { None } }),
                     input: Cast {
                         inner: Cast {
                             inner: Tee {
-                                inner: <tee 5>: FoldKeyed {
+                                inner: <shared 5>: FoldKeyed {
                                     init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | | (0 , 0) }),
                                     acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < () , () > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } } }),
                                     input: ObserveNonDet {
                                         inner: Cast {
                                             inner: Tee {
-                                                inner: <tee 1>,
+                                                inner: <shared 1>,
                                                 metadata: HydroIrMetadata {
                                                     location_id: Tick(2, Process(loc1v1)),
                                                     collection_kind: Stream {
@@ -806,7 +806,7 @@ expression: built.ir()
         ),
         input: AntiJoin {
             pos: Tee {
-                inner: <tee 6>: Chain {
+                inner: <shared 6>: Chain {
                     first: DeferTick {
                         input: CycleSource {
                             cycle_id: CycleId(
@@ -834,7 +834,7 @@ expression: built.ir()
                     },
                     second: Batch {
                         inner: Tee {
-                            inner: <tee 7>: Map {
+                            inner: <shared 7>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) , ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) , core :: result :: Result < () , () >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: two_pc :: * ; | kv | (kv , Ok :: < () , () > (())) }),
                                 input: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32))) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
@@ -989,7 +989,7 @@ expression: built.ir()
                                                                 right: Batch {
                                                                     inner: YieldConcat {
                                                                         inner: Tee {
-                                                                            inner: <tee 4>,
+                                                                            inner: <shared 4>,
                                                                             metadata: HydroIrMetadata {
                                                                                 location_id: Tick(2, Process(loc1v1)),
                                                                                 collection_kind: Stream {
@@ -1154,18 +1154,18 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <tee 8>: FilterMap {
+                inner: <shared 8>: FilterMap {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) , (usize , usize)) , core :: option :: Option < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; let min__free = 3usize ; move | (key , (success , _error)) | if success >= min__free { Some (key) } else { None } }),
                     input: Cast {
                         inner: Cast {
                             inner: Tee {
-                                inner: <tee 9>: FoldKeyed {
+                                inner: <shared 9>: FoldKeyed {
                                     init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | | (0 , 0) }),
                                     acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < () , () > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } } }),
                                     input: ObserveNonDet {
                                         inner: Cast {
                                             inner: Tee {
-                                                inner: <tee 6>,
+                                                inner: <shared 6>,
                                                 metadata: HydroIrMetadata {
                                                     location_id: Tick(4, Process(loc1v1)),
                                                     collection_kind: Stream {
@@ -1306,7 +1306,7 @@ expression: built.ir()
             1,
         ),
         input: Tee {
-            inner: <tee 10>: Cast {
+            inner: <shared 10>: Cast {
                 inner: Network {
                     name: None,
                     networking_info: Tcp {
@@ -1322,7 +1322,7 @@ expression: built.ir()
                     input: Cast {
                         inner: YieldConcat {
                             inner: Tee {
-                                inner: <tee 8>,
+                                inner: <shared 8>,
                                 metadata: HydroIrMetadata {
                                     location_id: Tick(4, Process(loc1v1)),
                                     collection_kind: Stream {
@@ -1398,12 +1398,12 @@ expression: built.ir()
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (new , old) | { old . borrow_mut () . add (new) . expect ("Error adding value to histogram") ; old } }),
                     input: CrossSingleton {
                         left: Tee {
-                            inner: <tee 11>: Fold {
+                            inner: <shared 11>: Fold {
                                 init: stageleft :: runtime_support :: fn0_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; move | | Histogram :: < u64 > :: new (3) . unwrap () }),
                                 acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , core :: time :: Duration , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; move | latencies , latency | { latencies . record (latency . as_nanos () as u64) . unwrap () ; } }),
                                 input: ObserveNonDet {
                                     inner: Tee {
-                                        inner: <tee 12>: Batch {
+                                        inner: <shared 12>: Batch {
                                             inner: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , (i32 , core :: time :: Duration)) , core :: time :: Duration > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: two_pc_bench :: * ; | (_virtual_client_id , (_output , latency)) | latency }),
                                                 input: Cast {
@@ -1425,7 +1425,7 @@ expression: built.ir()
                                                                                                         f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < i32 , i32 , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | curr , new | { * curr = new ; } }),
                                                                                                         input: ObserveNonDet {
                                                                                                             inner: Tee {
-                                                                                                                inner: <tee 3>,
+                                                                                                                inner: <shared 3>,
                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                     location_id: Cluster(loc3v1),
                                                                                                                     collection_kind: KeyedStream {
@@ -1515,7 +1515,7 @@ expression: built.ir()
                                                                                                 input: ObserveNonDet {
                                                                                                     inner: Batch {
                                                                                                         inner: Tee {
-                                                                                                            inner: <tee 10>,
+                                                                                                            inner: <shared 10>,
                                                                                                             metadata: HydroIrMetadata {
                                                                                                                 location_id: Cluster(loc3v1),
                                                                                                                 collection_kind: KeyedStream {
@@ -1729,11 +1729,11 @@ expression: built.ir()
                             },
                         },
                         right: Tee {
-                            inner: <tee 13>: Map {
+                            inner: <shared 13>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , ()) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _signal) | d }),
                                 input: CrossSingleton {
                                     left: Tee {
-                                        inner: <tee 14>: Cast {
+                                        inner: <shared 14>: Cast {
                                             inner: ChainFirst {
                                                 first: DeferTick {
                                                     input: CycleSource {
@@ -1811,7 +1811,7 @@ expression: built.ir()
                                                         input: Map {
                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _ | () }),
                                                             input: Tee {
-                                                                inner: <tee 15>: Reduce {
+                                                                inner: <shared 15>: Reduce {
                                                                     f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
                                                                     input: Batch {
                                                                         inner: Source {
@@ -1966,7 +1966,7 @@ expression: built.ir()
                     inner: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | histogram | Rc :: new (RefCell :: new (histogram)) }),
                         input: Tee {
-                            inner: <tee 11>,
+                            inner: <shared 11>,
                             metadata: HydroIrMetadata {
                                 location_id: Tick(6, Cluster(loc3v1)),
                                 collection_kind: Singleton {
@@ -2019,12 +2019,12 @@ expression: built.ir()
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , usize) , usize > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (new , old) | new + old }),
                     input: CrossSingleton {
                         left: Tee {
-                            inner: <tee 16>: Fold {
+                            inner: <shared 16>: Fold {
                                 init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | | 0usize }),
                                 acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , core :: time :: Duration , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | count , _ | * count += 1 }),
                                 input: ObserveNonDet {
                                     inner: Tee {
-                                        inner: <tee 12>,
+                                        inner: <shared 12>,
                                         metadata: HydroIrMetadata {
                                             location_id: Tick(6, Cluster(loc3v1)),
                                             collection_kind: Stream {
@@ -2063,11 +2063,11 @@ expression: built.ir()
                             },
                         },
                         right: Tee {
-                            inner: <tee 17>: Map {
+                            inner: <shared 17>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , ()) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _signal) | d }),
                                 input: CrossSingleton {
                                     left: Tee {
-                                        inner: <tee 18>: Cast {
+                                        inner: <shared 18>: Cast {
                                             inner: ChainFirst {
                                                 first: DeferTick {
                                                     input: CycleSource {
@@ -2145,7 +2145,7 @@ expression: built.ir()
                                                         input: Map {
                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _ | () }),
                                                             input: Tee {
-                                                                inner: <tee 15>,
+                                                                inner: <shared 15>,
                                                                 metadata: HydroIrMetadata {
                                                                     location_id: Tick(6, Cluster(loc3v1)),
                                                                     collection_kind: Optional {
@@ -2264,7 +2264,7 @@ expression: built.ir()
                 },
                 second: Cast {
                     inner: Tee {
-                        inner: <tee 16>,
+                        inner: <shared 16>,
                         metadata: HydroIrMetadata {
                             location_id: Tick(6, Cluster(loc3v1)),
                             collection_kind: Singleton {
@@ -2310,7 +2310,7 @@ expression: built.ir()
                     left: Cast {
                         inner: CrossSingleton {
                             left: Tee {
-                                inner: <tee 19>: Cast {
+                                inner: <shared 19>: Cast {
                                     inner: ChainFirst {
                                         first: DeferTick {
                                             input: CycleSource {
@@ -2411,7 +2411,7 @@ expression: built.ir()
                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , ()) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _signal) | d }),
                                                                                         input: CrossSingleton {
                                                                                             left: Tee {
-                                                                                                inner: <tee 14>,
+                                                                                                inner: <shared 14>,
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_id: Tick(6, Cluster(loc3v1)),
                                                                                                     collection_kind: Singleton {
@@ -2423,7 +2423,7 @@ expression: built.ir()
                                                                                             right: Map {
                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _u | () }),
                                                                                                 input: Tee {
-                                                                                                    inner: <tee 15>,
+                                                                                                    inner: <shared 15>,
                                                                                                     metadata: HydroIrMetadata {
                                                                                                         location_id: Tick(6, Cluster(loc3v1)),
                                                                                                         collection_kind: Optional {
@@ -2631,7 +2631,7 @@ expression: built.ir()
                             first: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                 input: Tee {
-                                    inner: <tee 20>: Reduce {
+                                    inner: <shared 20>: Reduce {
                                         f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
                                         input: Batch {
                                             inner: Source {
@@ -2776,7 +2776,7 @@ expression: built.ir()
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , ()) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _signal) | d }),
                                                     input: CrossSingleton {
                                                         left: Tee {
-                                                            inner: <tee 18>,
+                                                            inner: <shared 18>,
                                                             metadata: HydroIrMetadata {
                                                                 location_id: Tick(6, Cluster(loc3v1)),
                                                                 collection_kind: Singleton {
@@ -2788,7 +2788,7 @@ expression: built.ir()
                                                         right: Map {
                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _u | () }),
                                                             input: Tee {
-                                                                inner: <tee 15>,
+                                                                inner: <shared 15>,
                                                                 metadata: HydroIrMetadata {
                                                                     location_id: Tick(6, Cluster(loc3v1)),
                                                                     collection_kind: Optional {
@@ -2897,7 +2897,7 @@ expression: built.ir()
                             f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , ()) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _signal) | d }),
                             input: CrossSingleton {
                                 left: Tee {
-                                    inner: <tee 21>: Cast {
+                                    inner: <shared 21>: Cast {
                                         inner: ChainFirst {
                                             first: DeferTick {
                                                 input: CycleSource {
@@ -2975,7 +2975,7 @@ expression: built.ir()
                                                     input: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _ | () }),
                                                         input: Tee {
-                                                            inner: <tee 20>,
+                                                            inner: <shared 20>,
                                                             metadata: HydroIrMetadata {
                                                                 location_id: Tick(7, Process(loc4v1)),
                                                                 collection_kind: Optional {
@@ -3117,7 +3117,7 @@ expression: built.ir()
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , ()) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _signal) | d }),
                     input: CrossSingleton {
                         left: Tee {
-                            inner: <tee 21>,
+                            inner: <shared 21>,
                             metadata: HydroIrMetadata {
                                 location_id: Tick(7, Process(loc4v1)),
                                 collection_kind: Singleton {
@@ -3129,7 +3129,7 @@ expression: built.ir()
                         right: Map {
                             f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _u | () }),
                             input: Tee {
-                                inner: <tee 20>,
+                                inner: <shared 20>,
                                 metadata: HydroIrMetadata {
                                     location_id: Tick(7, Process(loc4v1)),
                                     collection_kind: Optional {
@@ -3194,7 +3194,7 @@ expression: built.ir()
                         f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , ()) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _signal) | d }),
                         input: CrossSingleton {
                             left: Tee {
-                                inner: <tee 19>,
+                                inner: <shared 19>,
                                 metadata: HydroIrMetadata {
                                     location_id: Tick(7, Process(loc4v1)),
                                     collection_kind: Singleton {
@@ -3206,7 +3206,7 @@ expression: built.ir()
                             right: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _u | () }),
                                 input: Tee {
-                                    inner: <tee 20>,
+                                    inner: <shared 20>,
                                     metadata: HydroIrMetadata {
                                         location_id: Tick(7, Process(loc4v1)),
                                         collection_kind: Optional {


### PR DESCRIPTION
Add a new `Stream::partition()` method that takes a `Fn(&T) -> bool` closure and returns two output streams — one for elements where the predicate is true, one for false — without ever cloning elements.

Breaking Change: TeeNode / SeenTees / SeenTeeLocations have been renamed to SharedNode / SeenSharedNodes / SeenSharedNodeLocations

Under the hood this is backed by a new `HydroNode::Partition` IR node that compiles to DFIR's `partition` operator. Both output streams share a single subtree via `SharedNode` (renamed from `TeeNode`), reusing the same deduplication pattern that `Tee` already uses for `seen_tees`/`built_tees`.

The `Partition` IR node carries an `is_true: bool` field indicating which side of the partition it represents. Whichever side is encountered first during `emit_core` adds the DFIR `partition` operator to the graph and creates two `identity()` bridge nodes (one per output port). The second side simply looks up its ident from `built_tees`.

To support multiple output idents per shared node, `built_tees` is changed from `HashMap<ptr, syn::Ident>` to `HashMap<ptr, Vec<syn::Ident>>` — Tee stores `[ident]` (both sides index 0), Partition stores `[true_ident, false_ident]`.

Key changes:
- Rename `TeeNode` to `SharedNode` (with backwards-compat type alias)
- Add `HydroNode::Partition { inner, f, is_true, metadata }` variant
- Add `Stream::partition()` returning `(Stream, Stream)` — no `T: Clone` bound
- Update `transform_children`, `deep_clone`, `emit_core`, `metadata`, `metadata_mut`, `input`, `visit_debug_expr`, `print_root`, and viz rendering
- Update all live collection files for the `SharedNode` rename
- Add deploy integration test and doctest verifying correct element routing

Towards #2138