### PR TITLE
feat(hydro_deploy): Pin cores

### DIFF
--- a/hydro_deploy/core/src/lib.rs
+++ b/hydro_deploy/core/src/lib.rs
@@ -147,6 +147,7 @@ pub trait LaunchedHost: Send + Sync {
         args: &[String],
         perf: Option<TracingOptions>,
         env: &HashMap<String, String>,
+        pin_to_core: Option<usize>,
     ) -> Result<Box<dyn LaunchedBinary>>;
 
     async fn forward_port(&self, addr: &SocketAddr) -> Result<SocketAddr>;

--- a/hydro_deploy/core/src/localhost/mod.rs
+++ b/hydro_deploy/core/src/localhost/mod.rs
@@ -147,7 +147,14 @@ impl LaunchedHost for LaunchedLocalhost {
         args: &[String],
         tracing: Option<TracingOptions>,
         env: &HashMap<String, String>,
+        pin_to_core: Option<usize>,
     ) -> Result<Box<dyn LaunchedBinary>> {
+        if pin_to_core.is_some() {
+            ProgressTracker::println(format!(
+                "[{id}] pin_to_core is not supported on localhost, ignoring"
+            ));
+        }
+
         let (maybe_perf_outfile, mut command) = if let Some(tracing) = tracing.as_ref() {
             if cfg!(any(target_os = "macos", target_family = "windows")) {
                 // samply

--- a/hydro_deploy/core/src/rust_crate/mod.rs
+++ b/hydro_deploy/core/src/rust_crate/mod.rs
@@ -49,6 +49,7 @@ pub struct RustCrate {
     args: Vec<String>,
     display_name: Option<String>,
     env: HashMap<String, String>,
+    pin_to_core: Option<usize>,
 }
 
 impl RustCrate {
@@ -74,6 +75,7 @@ impl RustCrate {
             args: vec![],
             display_name: None,
             env: HashMap::new(),
+            pin_to_core: None,
         }
     }
 
@@ -192,6 +194,11 @@ impl RustCrate {
         self
     }
 
+    pub fn pin_to_core(mut self, core: usize) -> Self {
+        self.pin_to_core = Some(core);
+        self
+    }
+
     pub fn get_build_params(&self, target: HostTargetType) -> BuildParams {
         let (bin, example) = match &self.target {
             CrateTarget::Default => (None, None),
@@ -231,6 +238,7 @@ impl ServiceBuilder for RustCrate {
             self.display_name,
             vec![],
             self.env,
+            self.pin_to_core,
         )
     }
 }

--- a/hydro_deploy/core/src/rust_crate/service.rs
+++ b/hydro_deploy/core/src/rust_crate/service.rs
@@ -30,6 +30,7 @@ pub struct RustCrateService {
     display_id: Option<String>,
     external_ports: Vec<u16>,
     env: HashMap<String, String>,
+    pin_to_core: Option<usize>,
 
     meta: OnceLock<String>,
 
@@ -60,6 +61,7 @@ impl RustCrateService {
         display_id: Option<String>,
         external_ports: Vec<u16>,
         env: HashMap<String, String>,
+        pin_to_core: Option<usize>,
     ) -> Self {
         Self {
             id,
@@ -70,6 +72,7 @@ impl RustCrateService {
             display_id,
             external_ports,
             env,
+            pin_to_core,
             meta: OnceLock::new(),
             port_to_server: MemoMap::new(),
             port_to_bind: MemoMap::new(),
@@ -215,6 +218,7 @@ impl Service for RustCrateService {
                                 &args,
                                 self.tracing.clone(),
                                 &self.env,
+                                self.pin_to_core,
                             )
                             .await?;
 

--- a/hydro_deploy/core/src/ssh.rs
+++ b/hydro_deploy/core/src/ssh.rs
@@ -379,6 +379,7 @@ impl<T: LaunchedSshHost> LaunchedHost for T {
         args: &[String],
         tracing: Option<TracingOptions>,
         env: &HashMap<String, String>,
+        pin_to_core: Option<usize>,
     ) -> Result<Box<dyn LaunchedBinary>> {
         let session = self.open_ssh_session().await?;
 
@@ -391,8 +392,9 @@ impl<T: LaunchedSshHost> LaunchedHost for T {
             command.push_str(&format!("{}={} ", k, shell_escape::unix::escape(v.into())));
         }
 
-        // Pin the binary to core 0 so it doesn't hop around
-        command.push_str("taskset -c 0 ");
+        if let Some(core) = pin_to_core {
+            command.push_str(&format!("taskset -c {core} "));
+        }
         command.push_str(binary_path.to_str().unwrap());
         for arg in args {
             command.push(' ');

--- a/hydro_lang/src/deploy/deploy_graph.rs
+++ b/hydro_lang/src/deploy/deploy_graph.rs
@@ -482,6 +482,7 @@ pub struct TrybuildHost {
     tracing: Option<TracingOptions>,
     build_envs: Vec<(String, String)>,
     env: HashMap<String, String>,
+    pin_to_core: Option<usize>,
     name_hint: Option<String>,
     cluster_idx: Option<usize>,
 }
@@ -498,6 +499,7 @@ impl From<Arc<dyn Host>> for TrybuildHost {
             tracing: None,
             build_envs: vec![],
             env: HashMap::new(),
+            pin_to_core: None,
             name_hint: None,
             cluster_idx: None,
         }
@@ -516,6 +518,7 @@ impl<H: Host + 'static> From<Arc<H>> for TrybuildHost {
             tracing: None,
             build_envs: vec![],
             env: HashMap::new(),
+            pin_to_core: None,
             name_hint: None,
             cluster_idx: None,
         }
@@ -535,6 +538,7 @@ impl TrybuildHost {
             tracing: None,
             build_envs: vec![],
             env: HashMap::new(),
+            pin_to_core: None,
             name_hint: None,
             cluster_idx: None,
         }
@@ -614,6 +618,13 @@ impl TrybuildHost {
         env.insert(key.into(), value.into());
         Self { env, ..self }
     }
+
+    pub fn pin_to_core(self, core: usize) -> Self {
+        Self {
+            pin_to_core: Some(core),
+            ..self
+        }
+    }
 }
 
 impl IntoProcessSpec<'_, HydroDeploy> for Arc<dyn Host> {
@@ -629,6 +640,7 @@ impl IntoProcessSpec<'_, HydroDeploy> for Arc<dyn Host> {
             tracing: None,
             build_envs: vec![],
             env: HashMap::new(),
+            pin_to_core: None,
             name_hint: None,
             cluster_idx: None,
         }
@@ -648,6 +660,7 @@ impl<H: Host + 'static> IntoProcessSpec<'_, HydroDeploy> for Arc<H> {
             tracing: None,
             build_envs: vec![],
             env: HashMap::new(),
+            pin_to_core: None,
             name_hint: None,
             cluster_idx: None,
         }
@@ -1167,6 +1180,10 @@ fn create_trybuild_service(
 
     if let Some(tracing) = trybuild.tracing {
         ret = ret.tracing(tracing);
+    }
+
+    if let Some(core) = trybuild.pin_to_core {
+        ret = ret.pin_to_core(core);
     }
 
     ret = ret.features(

--- a/hydro_test/examples/paxos.rs
+++ b/hydro_test/examples/paxos.rs
@@ -147,9 +147,13 @@ async fn main() {
         ""
     };
     let create_trybuild_host = |host: Arc<dyn Host + 'static>, name: &str, i: usize| {
-        let tbh = TrybuildHost::new(host).rustflags(rustflags);
+        let mut tbh = TrybuildHost::new(host).rustflags(rustflags);
+        // Pin to core 0 on remote machines
+        if args.gcp.is_some() || args.aws {
+            tbh = tbh.pin_to_core(0);
+        }
         if args.tracing {
-            tbh.tracing(
+            tbh = tbh.tracing(
                 TracingOptions::builder()
                     .perf_raw_outfile(format!("{name}{i}.perf.data"))
                     .samply_outfile(format!("{name}{i}.profile"))
@@ -158,10 +162,9 @@ async fn main() {
                     .frequency(frequency)
                     .setup_command(setup_command)
                     .build(),
-            )
-        } else {
-            tbh
+            );
         }
+        tbh
     };
 
     let _nodes = optimized


### PR DESCRIPTION
Can yield up to 15% higher throughput. Only one core was effectively being used before pinning anyway.

See y-axis label of graphs for throughput/latency. Each row is an increasing number of physical clients (from 1-10) and each column is a different cluster of Paxos. Runs are 90 seconds; throughput and latency are averages between 30 and 60 seconds.

Before pinning
<img width="7980" height="5890" alt="cpu" src="https://github.com/user-attachments/assets/196155d4-9926-48fc-ad45-6eb452c78ec3" />

and after pinning
<img width="7980" height="5890" alt="pinned_cpu" src="https://github.com/user-attachments/assets/87e011c8-8648-4c9e-a14c-7b9d2b6efd45" />
