### PR TITLE
feat(hydro_lang): add `lossy_delayed_forever()` fault-tolerance mode

### DIFF
--- a/docs/docs/hydro/reference/locations/network-configuration.md
+++ b/docs/docs/hydro/reference/locations/network-configuration.md
@@ -38,7 +38,7 @@ The `.bincode()` API configures the channel to use the [`bincode`](https://docs.
 
 ## TCP
 
-TCP is currently the only transport backend. When using `TCP`, you **must** choose a fault tolerance policy before configuring serialization. Calling `TCP.bincode()` directly will result in a compile error—you need to first call either `.fail_stop()` or `.lossy()`.
+TCP is currently the only transport backend. When using `TCP`, you **must** choose a fault tolerance policy before configuring serialization. Calling `TCP.bincode()` directly will result in a compile error—you need to first call `.fail_stop()`, `.lossy_delayed_forever()`, or `.lossy()`.
 
 ### Fail-Stop
 
@@ -57,6 +57,41 @@ This is the most common choice and is appropriate when your application can tole
 The Hydro simulator will not simulate connection failures that block **liveness** (i.e., it won't cause a test to hang). However, it will still catch **safety** issues caused by connection failures, such as race conditions between a dropped connection and other messages.
 :::
 
+### Lossy Delayed Forever
+
+```rust,no_run
+# use hydro_lang::prelude::*;
+let config = TCP.lossy_delayed_forever().bincode();
+```
+
+With `lossy_delayed_forever`, messages may be **dropped**, but dropped messages are modeled as being **indefinitely delayed** rather than lost. This mode does **not** require a `nondet!` annotation because the output stream is unordered, so even if messages are lost the output will have a subset of the intended elements.
+
+The tradeoff is that the output stream has a [`NoOrder`](pathname:///rustdoc/hydro_lang/live_collections/stream/enum.NoOrder) guarantee, imposing stricter conditions on downstream consumers. For example, you cannot use order-dependent operators like `fold` without proving commutativity.
+
+This is the **preferred** mode for protocols that tolerate message loss, because:
+- It does not require `nondet!`, making it easier to reason about correctness.
+- It can be easily simulated in exhaustive mode without running into fairness issues, so you can write simulator tests for your protocol.
+
+:::note
+
+When using `lossy_delayed_forever` in the Hydro simulator, you must call `.test_safety_only()` on the simulation:
+
+```rust,ignore
+flow.sim().test_safety_only().exhaustive(async || { /* ... */ });
+```
+
+This is required because the simulator models dropped messages as delayed to after the undropped messages, which only tests **safety** (race-condition) properties (not **liveness**). A message that is "delayed forever" may never arrive, so the simulator cannot guarantee that your program will eventually make progress—only that it won't produce incorrect results.
+
+:::
+
+:::caution
+
+The `lossy_delayed_forever` fault model is currently only available for the Hydro simulator and Maelstrom testing. Support in Hydro Deploy will be available once TCP reconnect is implemented.
+
+:::
+
+This is appropriate for gossip protocols, retransmission-based protocols, or any system running under network partition testing (e.g. [Maelstrom](https://github.com/jepsen-io/maelstrom)).
+
 ### Lossy
 
 ```rust,no_run
@@ -65,6 +100,12 @@ let config = TCP.lossy(nondet!(/** messages may be dropped, explanation... */)).
 ```
 
 With `lossy`, messages may be **arbitrarily dropped**. Unlike `fail_stop`, there is no guarantee that a prefix of messages is delivered—any individual message may be lost. But the network connection can still be used to send future messages, even after a message loss.
+
+:::tip
+
+In most cases, prefer [`lossy_delayed_forever`](#lossy-delayed-forever) over `lossy`. The `lossy_delayed_forever` mode does not require `nondet!` and can be simulated in exhaustive mode, making it much easier to test. Use `lossy` only if you specifically need to preserve the ordering guarantee of the input stream (since `lossy` preserves `TotalOrder` while `lossy_delayed_forever` weakens to `NoOrder`).
+
+:::
 
 :::caution
 

--- a/hydro_lang/src/compile/built.rs
+++ b/hydro_lang/src/compile/built.rs
@@ -250,6 +250,7 @@ impl<'a> BuiltFlow<'a> {
             externals,
             cluster_max_sizes: SparseSecondaryMap::new(),
             externals_port_registry: Default::default(),
+            test_safety_only: false,
             _phantom: PhantomData,
         }
     }

--- a/hydro_lang/src/deploy/maelstrom/deploy_maelstrom.rs
+++ b/hydro_lang/src/deploy/maelstrom/deploy_maelstrom.rs
@@ -118,12 +118,12 @@ impl<'a> Deploy<'a> for MaelstromDeploy {
         use crate::networking::{NetworkingInfo, TcpFault};
         match networking_info {
             NetworkingInfo::Tcp { fault } => match (fault, env.nemesis.as_deref()) {
-                (TcpFault::Lossy, _) => {} // lossy is always allowed
-                (_, None) => {}            // no nemesis means any fault model is fine
+                (TcpFault::Lossy | TcpFault::LossyDelayedForever, _) => {} /* lossy/delayed are always allowed */
+                (_, None) => {} // no nemesis means any fault model is fine
                 (TcpFault::FailStop, Some("partition")) => {
                     panic!(
                         "Maelstrom partition nemesis requires lossy networking, but fail_stop was used. \
-                         Use `TCP.lossy().bincode()` instead of `TCP.fail_stop().bincode()`."
+                         Use `TCP.lossy().bincode()` or `TCP.lossy_delayed_forever().bincode()` instead of `TCP.fail_stop().bincode()`."
                     );
                 }
                 (TcpFault::FailStop, Some(_)) => {} // other nemeses are fine with fail_stop

--- a/hydro_lang/src/live_collections/keyed_stream/networking.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/networking.rs
@@ -7,7 +7,7 @@ use stageleft::{q, quote_type};
 use super::KeyedStream;
 use crate::compile::ir::{DebugInstantiate, HydroNode};
 use crate::live_collections::boundedness::{Boundedness, Unbounded};
-use crate::live_collections::stream::{Ordering, Retries, Stream};
+use crate::live_collections::stream::{MinOrder, Ordering, Retries, Stream};
 #[cfg(stageleft_runtime)]
 use crate::location::dynamic::DynLocation;
 use crate::location::{Cluster, MemberId, Process};
@@ -106,9 +106,10 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
         self,
         to: &Cluster<'a, L2>,
         via: N,
-    ) -> Stream<T, Cluster<'a, L2>, Unbounded, O, R>
+    ) -> Stream<T, Cluster<'a, L2>, Unbounded, <O as MinOrder<N::OrderingGuarantee>>::Min, R>
     where
         T: Serialize + DeserializeOwned,
+        O: MinOrder<N::OrderingGuarantee>,
     {
         let serialize_pipeline = Some(N::serialize_thunk(true));
 
@@ -130,9 +131,13 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
                 instantiate_fn: DebugInstantiate::Building,
                 deserialize_fn: deserialize_pipeline.map(|e| e.into()),
                 input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
-                metadata: to.new_node_metadata(
-                    Stream::<T, Cluster<'a, L2>, Unbounded, O, R>::collection_kind(),
-                ),
+                metadata: to.new_node_metadata(Stream::<
+                    T,
+                    Cluster<'a, L2>,
+                    Unbounded,
+                    <O as MinOrder<N::OrderingGuarantee>>::Min,
+                    R,
+                >::collection_kind()),
             },
         )
     }
@@ -219,14 +224,16 @@ impl<'a, K, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
     /// # }));
     /// # }
     /// ```
+    #[expect(clippy::type_complexity, reason = "MinOrder projection in return type")]
     pub fn demux<N: NetworkFor<(K, T)>>(
         self,
         to: &Cluster<'a, L2>,
         via: N,
-    ) -> KeyedStream<K, T, Cluster<'a, L2>, Unbounded, O, R>
+    ) -> KeyedStream<K, T, Cluster<'a, L2>, Unbounded, <O as MinOrder<N::OrderingGuarantee>>::Min, R>
     where
         K: Serialize + DeserializeOwned,
         T: Serialize + DeserializeOwned,
+        O: MinOrder<N::OrderingGuarantee>,
     {
         let serialize_pipeline = Some(N::serialize_thunk(true));
 
@@ -253,9 +260,14 @@ impl<'a, K, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
                         .ir_node
                         .replace(HydroNode::Placeholder),
                 ),
-                metadata: to.new_node_metadata(
-                    KeyedStream::<K, T, Cluster<'a, L2>, Unbounded, O, R>::collection_kind(),
-                ),
+                metadata: to.new_node_metadata(KeyedStream::<
+                    K,
+                    T,
+                    Cluster<'a, L2>,
+                    Unbounded,
+                    <O as MinOrder<N::OrderingGuarantee>>::Min,
+                    R,
+                >::collection_kind()),
             },
         )
     }
@@ -369,13 +381,22 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
     /// # }));
     /// # }
     /// ```
+    #[expect(clippy::type_complexity, reason = "MinOrder projection in return type")]
     pub fn demux<N: NetworkFor<T>>(
         self,
         to: &Cluster<'a, L2>,
         via: N,
-    ) -> KeyedStream<MemberId<L>, T, Cluster<'a, L2>, Unbounded, O, R>
+    ) -> KeyedStream<
+        MemberId<L>,
+        T,
+        Cluster<'a, L2>,
+        Unbounded,
+        <O as MinOrder<N::OrderingGuarantee>>::Min,
+        R,
+    >
     where
         T: Serialize + DeserializeOwned,
+        O: MinOrder<N::OrderingGuarantee>,
     {
         let serialize_pipeline = Some(N::serialize_thunk(true));
 
@@ -388,7 +409,13 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
             );
         }
 
-        let raw_stream: Stream<(MemberId<L>, T), Cluster<'a, L2>, Unbounded, O, R> = Stream::new(
+        let raw_stream: Stream<
+            (MemberId<L>, T),
+            Cluster<'a, L2>,
+            Unbounded,
+            <O as MinOrder<N::OrderingGuarantee>>::Min,
+            R,
+        > = Stream::new(
             to.clone(),
             HydroNode::Network {
                 name: name.map(ToOwned::to_owned),
@@ -401,7 +428,7 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
                     (MemberId<L>, T),
                     Cluster<'a, L2>,
                     Unbounded,
-                    O,
+                    <O as MinOrder<N::OrderingGuarantee>>::Min,
                     R,
                 >::collection_kind()),
             },
@@ -540,10 +567,18 @@ impl<'a, K, V, L, B: Boundedness, O: Ordering, R: Retries>
         self,
         to: &Process<'a, L2>,
         via: N,
-    ) -> KeyedStream<(MemberId<L>, K), V, Process<'a, L2>, Unbounded, O, R>
+    ) -> KeyedStream<
+        (MemberId<L>, K),
+        V,
+        Process<'a, L2>,
+        Unbounded,
+        <O as MinOrder<N::OrderingGuarantee>>::Min,
+        R,
+    >
     where
         K: Serialize + DeserializeOwned,
         V: Serialize + DeserializeOwned,
+        O: MinOrder<N::OrderingGuarantee>,
     {
         let serialize_pipeline = Some(N::serialize_thunk(false));
 
@@ -556,25 +591,30 @@ impl<'a, K, V, L, B: Boundedness, O: Ordering, R: Retries>
             );
         }
 
-        let raw_stream: Stream<(MemberId<L>, (K, V)), Process<'a, L2>, Unbounded, O, R> =
-            Stream::new(
-                to.clone(),
-                HydroNode::Network {
-                    name: name.map(ToOwned::to_owned),
-                    networking_info: N::networking_info(),
-                    serialize_fn: serialize_pipeline.map(|e| e.into()),
-                    instantiate_fn: DebugInstantiate::Building,
-                    deserialize_fn: deserialize_pipeline.map(|e| e.into()),
-                    input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
-                    metadata: to.new_node_metadata(Stream::<
-                        (MemberId<L>, (K, V)),
-                        Cluster<'a, L2>,
-                        Unbounded,
-                        O,
-                        R,
-                    >::collection_kind()),
-                },
-            );
+        let raw_stream: Stream<
+            (MemberId<L>, (K, V)),
+            Process<'a, L2>,
+            Unbounded,
+            <O as MinOrder<N::OrderingGuarantee>>::Min,
+            R,
+        > = Stream::new(
+            to.clone(),
+            HydroNode::Network {
+                name: name.map(ToOwned::to_owned),
+                networking_info: N::networking_info(),
+                serialize_fn: serialize_pipeline.map(|e| e.into()),
+                instantiate_fn: DebugInstantiate::Building,
+                deserialize_fn: deserialize_pipeline.map(|e| e.into()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                metadata: to.new_node_metadata(Stream::<
+                    (MemberId<L>, (K, V)),
+                    Cluster<'a, L2>,
+                    Unbounded,
+                    <O as MinOrder<N::OrderingGuarantee>>::Min,
+                    R,
+                >::collection_kind()),
+            },
+        );
 
         raw_stream
             .map(q!(|(sender, (k, v))| ((sender, k), v)))

--- a/hydro_lang/src/live_collections/stream/networking.rs
+++ b/hydro_lang/src/live_collections/stream/networking.rs
@@ -7,7 +7,7 @@ use serde::de::DeserializeOwned;
 use stageleft::{q, quote_type};
 use syn::parse_quote;
 
-use super::{ExactlyOnce, Ordering, Stream, TotalOrder};
+use super::{ExactlyOnce, MinOrder, Ordering, Stream, TotalOrder};
 use crate::compile::ir::{DebugInstantiate, HydroIrOpMetadata, HydroNode, HydroRoot};
 use crate::live_collections::boundedness::{Boundedness, Unbounded};
 use crate::live_collections::keyed_singleton::KeyedSingleton;
@@ -161,9 +161,10 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Process<'a, L>
         self,
         to: &Process<'a, L2>,
         via: N,
-    ) -> Stream<T, Process<'a, L2>, Unbounded, O, R>
+    ) -> Stream<T, Process<'a, L2>, Unbounded, <O as MinOrder<N::OrderingGuarantee>>::Min, R>
     where
         T: Serialize + DeserializeOwned,
+        O: MinOrder<N::OrderingGuarantee>,
     {
         let serialize_pipeline = Some(N::serialize_thunk(false));
         let deserialize_pipeline = Some(N::deserialize_thunk(None));
@@ -184,9 +185,13 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Process<'a, L>
                 instantiate_fn: DebugInstantiate::Building,
                 deserialize_fn: deserialize_pipeline.map(|e| e.into()),
                 input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
-                metadata: to.new_node_metadata(
-                    Stream::<T, Process<'a, L2>, Unbounded, O, R>::collection_kind(),
-                ),
+                metadata: to.new_node_metadata(Stream::<
+                    T,
+                    Process<'a, L2>,
+                    Unbounded,
+                    <O as MinOrder<N::OrderingGuarantee>>::Min,
+                    R,
+                >::collection_kind()),
             },
         )
     }
@@ -288,9 +293,10 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Process<'a, L>
         to: &Cluster<'a, L2>,
         via: N,
         nondet_membership: NonDet,
-    ) -> Stream<T, Cluster<'a, L2>, Unbounded, O, R>
+    ) -> Stream<T, Cluster<'a, L2>, Unbounded, <O as MinOrder<N::OrderingGuarantee>>::Min, R>
     where
         T: Clone + Serialize + DeserializeOwned,
+        O: MinOrder<N::OrderingGuarantee>,
     {
         let ids = track_membership(self.location.source_cluster_members(to));
         sliced! {
@@ -494,9 +500,10 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
         self,
         to: &Cluster<'a, L2>,
         via: N,
-    ) -> Stream<T, Cluster<'a, L2>, Unbounded, O, R>
+    ) -> Stream<T, Cluster<'a, L2>, Unbounded, <O as MinOrder<N::OrderingGuarantee>>::Min, R>
     where
         T: Serialize + DeserializeOwned,
+        O: MinOrder<N::OrderingGuarantee>,
     {
         self.into_keyed().demux(to, via)
     }
@@ -610,7 +617,7 @@ impl<'a, T, L, B: Boundedness> Stream<T, Process<'a, L>, B, TotalOrder, ExactlyO
         to: &Cluster<'a, L2>,
         via: N,
         nondet_membership: NonDet,
-    ) -> Stream<T, Cluster<'a, L2>, Unbounded, TotalOrder, ExactlyOnce>
+    ) -> Stream<T, Cluster<'a, L2>, Unbounded, N::OrderingGuarantee, ExactlyOnce>
     where
         T: Serialize + DeserializeOwned,
     {
@@ -750,7 +757,7 @@ impl<'a, T, L, B: Boundedness> Stream<T, Cluster<'a, L>, B, TotalOrder, ExactlyO
         to: &Cluster<'a, L2>,
         via: N,
         nondet_membership: NonDet,
-    ) -> KeyedStream<MemberId<L>, T, Cluster<'a, L2>, Unbounded, TotalOrder, ExactlyOnce>
+    ) -> KeyedStream<MemberId<L>, T, Cluster<'a, L2>, Unbounded, N::OrderingGuarantee, ExactlyOnce>
     where
         T: Serialize + DeserializeOwned,
     {
@@ -895,13 +902,22 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Cluster<'a, L>
     /// # }));
     /// # }
     /// ```
+    #[expect(clippy::type_complexity, reason = "MinOrder projection in return type")]
     pub fn send<L2, N: NetworkFor<T>>(
         self,
         to: &Process<'a, L2>,
         via: N,
-    ) -> KeyedStream<MemberId<L>, T, Process<'a, L2>, Unbounded, O, R>
+    ) -> KeyedStream<
+        MemberId<L>,
+        T,
+        Process<'a, L2>,
+        Unbounded,
+        <O as MinOrder<N::OrderingGuarantee>>::Min,
+        R,
+    >
     where
         T: Serialize + DeserializeOwned,
+        O: MinOrder<N::OrderingGuarantee>,
     {
         let serialize_pipeline = Some(N::serialize_thunk(false));
 
@@ -914,7 +930,13 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Cluster<'a, L>
             );
         }
 
-        let raw_stream: Stream<(MemberId<L>, T), Process<'a, L2>, Unbounded, O, R> = Stream::new(
+        let raw_stream: Stream<
+            (MemberId<L>, T),
+            Process<'a, L2>,
+            Unbounded,
+            <O as MinOrder<N::OrderingGuarantee>>::Min,
+            R,
+        > = Stream::new(
             to.clone(),
             HydroNode::Network {
                 name: name.map(ToOwned::to_owned),
@@ -927,7 +949,7 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Cluster<'a, L>
                     (MemberId<L>, T),
                     Process<'a, L2>,
                     Unbounded,
-                    O,
+                    <O as MinOrder<N::OrderingGuarantee>>::Min,
                     R,
                 >::collection_kind()),
             },
@@ -1042,14 +1064,23 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Cluster<'a, L>
     /// # }));
     /// # }
     /// ```
+    #[expect(clippy::type_complexity, reason = "MinOrder projection in return type")]
     pub fn broadcast<L2: 'a, N: NetworkFor<T>>(
         self,
         to: &Cluster<'a, L2>,
         via: N,
         nondet_membership: NonDet,
-    ) -> KeyedStream<MemberId<L>, T, Cluster<'a, L2>, Unbounded, O, R>
+    ) -> KeyedStream<
+        MemberId<L>,
+        T,
+        Cluster<'a, L2>,
+        Unbounded,
+        <O as MinOrder<N::OrderingGuarantee>>::Min,
+        R,
+    >
     where
         T: Clone + Serialize + DeserializeOwned,
+        O: MinOrder<N::OrderingGuarantee>,
     {
         let ids = track_membership(self.location.source_cluster_members(to));
         sliced! {
@@ -1168,13 +1199,22 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
     /// # }));
     /// # }
     /// ```
+    #[expect(clippy::type_complexity, reason = "MinOrder projection in return type")]
     pub fn demux<N: NetworkFor<T>>(
         self,
         to: &Cluster<'a, L2>,
         via: N,
-    ) -> KeyedStream<MemberId<L>, T, Cluster<'a, L2>, Unbounded, O, R>
+    ) -> KeyedStream<
+        MemberId<L>,
+        T,
+        Cluster<'a, L2>,
+        Unbounded,
+        <O as MinOrder<N::OrderingGuarantee>>::Min,
+        R,
+    >
     where
         T: Serialize + DeserializeOwned,
+        O: MinOrder<N::OrderingGuarantee>,
     {
         self.into_keyed().demux(to, via)
     }
@@ -1185,6 +1225,8 @@ mod tests {
     #[cfg(feature = "sim")]
     use stageleft::q;
 
+    #[cfg(feature = "sim")]
+    use crate::live_collections::sliced::sliced;
     #[cfg(feature = "sim")]
     use crate::location::{Location, MemberId};
     #[cfg(feature = "sim")]
@@ -1410,5 +1452,59 @@ mod tests {
                     ])
                     .await
             });
+    }
+
+    #[cfg(feature = "sim")]
+    #[test]
+    fn sim_lossy_delayed_forever_o2o() {
+        use std::collections::HashSet;
+
+        use crate::properties::manual_proof;
+
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<()>();
+        let node2 = flow.process::<()>();
+
+        let received = node
+            .source_iter(q!(0..3_u32))
+            .send(&node2, TCP.lossy_delayed_forever().bincode())
+            .fold(
+                q!(|| std::collections::HashSet::<u32>::new()),
+                q!(
+                    |set, v| {
+                        set.insert(v);
+                    },
+                    commutative = manual_proof!(/** set insert is commutative */)
+                ),
+            );
+
+        let out_recv = sliced! {
+            let snapshot = use(received, nondet!(/** test */));
+            snapshot.into_stream()
+        }
+        .sim_output();
+
+        let mut saw_non_contiguous = false;
+
+        flow.sim().test_safety_only().exhaustive(async || {
+            let snapshots = out_recv.collect::<Vec<HashSet<u32>>>().await;
+
+            // Check each individual snapshot for a non-contiguous subset.
+            for set in &snapshots {
+                #[expect(clippy::disallowed_methods, reason = "min / max are deterministic")]
+                if set.len() >= 2 && set.len() < 3 {
+                    let min = *set.iter().min().unwrap();
+                    let max = *set.iter().max().unwrap();
+                    if set.len() < (max - min + 1) as usize {
+                        saw_non_contiguous = true;
+                    }
+                }
+            }
+        });
+
+        assert!(
+            saw_non_contiguous,
+            "Expected at least one execution with a non-contiguous subset of inputs"
+        );
     }
 }

--- a/hydro_lang/src/networking/mod.rs
+++ b/hydro_lang/src/networking/mod.rs
@@ -6,6 +6,7 @@ use serde::Serialize;
 use serde::de::DeserializeOwned;
 
 use crate::live_collections::stream::networking::{deserialize_bincode, serialize_bincode};
+use crate::live_collections::stream::{NoOrder, TotalOrder};
 use crate::nondet::NonDet;
 
 #[sealed::sealed]
@@ -32,8 +33,12 @@ impl<T: Serialize + DeserializeOwned> SerKind<T> for Bincode {
 /// An unconfigured serialization backend.
 pub enum NoSer {}
 
+/// A transport backend for network channels.
 #[sealed::sealed]
-trait TransportKind {
+pub trait TransportKind {
+    /// The ordering guarantee provided by this transport.
+    type OrderingGuarantee: crate::live_collections::stream::Ordering;
+
     /// Returns the [`NetworkingInfo`] describing this transport's configuration.
     fn networking_info() -> NetworkingInfo;
 }
@@ -42,7 +47,12 @@ trait TransportKind {
 #[diagnostic::on_unimplemented(
     message = "TCP transport requires a failure policy. For example, `TCP.fail_stop()` stops sending messages after a failed connection."
 )]
-trait TcpFailPolicy {
+/// A failure policy for TCP connections, determining how the transport handles
+/// connection failures and what ordering guarantees the output stream provides.
+pub trait TcpFailPolicy {
+    /// The ordering guarantee provided by this failure policy.
+    type OrderingGuarantee: crate::live_collections::stream::Ordering;
+
     /// Returns the [`TcpFault`] variant for this failure policy.
     fn tcp_fault() -> TcpFault;
 }
@@ -51,6 +61,8 @@ trait TcpFailPolicy {
 pub enum FailStop {}
 #[sealed::sealed]
 impl TcpFailPolicy for FailStop {
+    type OrderingGuarantee = TotalOrder;
+
     fn tcp_fault() -> TcpFault {
         TcpFault::FailStop
     }
@@ -60,8 +72,31 @@ impl TcpFailPolicy for FailStop {
 pub enum Lossy {}
 #[sealed::sealed]
 impl TcpFailPolicy for Lossy {
+    type OrderingGuarantee = TotalOrder;
+
     fn tcp_fault() -> TcpFault {
         TcpFault::Lossy
+    }
+}
+
+/// A TCP failure policy that treats dropped messages as indefinitely delayed.
+///
+/// Unlike [`Lossy`], this does not require a [`NonDet`] annotation because the output
+/// stream is always lower in the partial order than the ideal stream (dropped messages
+/// are modeled as infinite delays). The tradeoff is that the output has [`NoOrder`]
+/// guarantees, imposing stricter conditions on downstream consumers.
+///
+/// When using this mode in the Hydro simulator, you must call
+/// [`.test_safety_only()`](crate::sim::flow::SimFlow::test_safety_only) because the
+/// simulator models dropped messages as indefinitely delayed, which only tests safety
+/// properties (not liveness).
+pub enum LossyDelayedForever {}
+#[sealed::sealed]
+impl TcpFailPolicy for LossyDelayedForever {
+    type OrderingGuarantee = NoOrder;
+
+    fn tcp_fault() -> TcpFault {
+        TcpFault::LossyDelayedForever
     }
 }
 
@@ -72,6 +107,8 @@ pub struct Tcp<F> {
 
 #[sealed::sealed]
 impl<F: TcpFailPolicy> TransportKind for Tcp<F> {
+    type OrderingGuarantee = F::OrderingGuarantee;
+
     fn networking_info() -> NetworkingInfo {
         NetworkingInfo::Tcp {
             fault: F::tcp_fault(),
@@ -82,6 +119,11 @@ impl<F: TcpFailPolicy> TransportKind for Tcp<F> {
 /// A networking backend implementation that supports items of type `T`.
 #[sealed::sealed]
 pub trait NetworkFor<T: ?Sized> {
+    /// The ordering guarantee provided by this network configuration.
+    /// When combined with an input stream's ordering `O`, the output ordering
+    /// will be `<O as MinOrder<Self::OrderingGuarantee>>::Min`.
+    type OrderingGuarantee: crate::live_collections::stream::Ordering;
+
     /// Generates serialization logic for sending `T`.
     fn serialize_thunk(is_demux: bool) -> syn::Expr;
 
@@ -102,6 +144,8 @@ pub enum TcpFault {
     FailStop,
     /// Messages may be lost (e.g. due to network partitions).
     Lossy,
+    /// Dropped messages are treated as indefinitely delayed with no ordering guarantee.
+    LossyDelayedForever,
 }
 
 /// Describes the networking configuration for a network channel at the IR level.
@@ -173,6 +217,28 @@ impl<S: ?Sized> NetworkingConfig<Tcp<()>, S> {
             _phantom: (PhantomData, PhantomData),
         }
     }
+
+    /// Configures the TCP transport to treat dropped messages as indefinitely delayed.
+    ///
+    /// This is appropriate for networks where messages may be dropped, such as when
+    /// running under a Maelstrom partition nemesis. Unlike [`Self::lossy`], this does
+    /// *not* require a [`NonDet`] annotation because the output is always lower in the
+    /// partial order than the ideal stream. However, the output stream will have
+    /// [`NoOrder`] guarantees, imposing stricter conditions on downstream consumers.
+    ///
+    /// Unlike [`Self::lossy`], this mode can easily be simulated in exhaustive mode
+    /// without running into fairness issues.
+    ///
+    /// When using this mode in the Hydro simulator, you must call
+    /// [`.test_safety_only()`](crate::sim::flow::SimFlow::test_safety_only) to opt in,
+    /// because the simulator models dropped messages as indefinitely delayed, which only
+    /// tests safety properties (not liveness).
+    pub const fn lossy_delayed_forever(self) -> NetworkingConfig<Tcp<LossyDelayedForever>, S> {
+        NetworkingConfig {
+            name: self.name,
+            _phantom: (PhantomData, PhantomData),
+        }
+    }
 }
 
 #[sealed::sealed]
@@ -181,6 +247,8 @@ where
     Tr: TransportKind,
     S: SerKind<T>,
 {
+    type OrderingGuarantee = Tr::OrderingGuarantee;
+
     fn serialize_thunk(is_demux: bool) -> syn::Expr {
         S::serialize_thunk(is_demux)
     }
@@ -204,6 +272,8 @@ where
     Tr: TransportKind,
     S: SerKind<T>,
 {
+    type OrderingGuarantee = Tr::OrderingGuarantee;
+
     fn serialize_thunk(is_demux: bool) -> syn::Expr {
         S::serialize_thunk(is_demux)
     }

--- a/hydro_lang/src/sim/builder.rs
+++ b/hydro_lang/src/sim/builder.rs
@@ -34,6 +34,7 @@ pub struct SimBuilder {
     pub process_tick_dfirs: BTreeMap<LocationId, FlatGraphBuilder>,
     pub cluster_tick_dfirs: BTreeMap<LocationId, FlatGraphBuilder>,
     pub next_hoff_id: usize,
+    pub test_safety_only: bool,
 }
 
 impl SimBuilder {
@@ -844,7 +845,18 @@ impl DfirBuilder for SimBuilder {
         match networking_info {
             NetworkingInfo::Tcp { fault } => match fault {
                 TcpFault::FailStop => {}
-                _ => todo!("SimBuilder only supports fail-stop TCP networking"),
+                TcpFault::LossyDelayedForever => {
+                    assert!(
+                        self.test_safety_only,
+                        "Simulating `lossy_delayed_forever` requires `.test_safety_only()` on the \
+                         SimFlow because the simulator models dropped messages as indefinitely \
+                         delayed, which only tests safety (not liveness). Call \
+                         `.sim().test_safety_only()` to opt in."
+                    );
+                }
+                _ => todo!(
+                    "SimBuilder only supports fail-stop and lossy-delayed-forever TCP networking"
+                ),
             },
         }
 

--- a/hydro_lang/src/sim/flow.rs
+++ b/hydro_lang/src/sim/flow.rs
@@ -35,6 +35,9 @@ pub struct SimFlow<'a> {
     /// Handle to state handling `external`s' ports.
     pub(crate) externals_port_registry: Rc<RefCell<SimExternalPortRegistry>>,
 
+    /// When true, the simulator only tests safety properties (not liveness).
+    pub(crate) test_safety_only: bool,
+
     pub(crate) _phantom: Invariant<'a>,
 }
 
@@ -42,6 +45,19 @@ impl<'a> SimFlow<'a> {
     /// Sets the maximum size of the given cluster in the simulation.
     pub fn with_cluster_size<C>(mut self, cluster: &Cluster<'a, C>, max_size: usize) -> Self {
         self.cluster_max_sizes.insert(cluster.key, max_size);
+        self
+    }
+
+    /// Opts in to safety-only testing, which is required when using
+    /// [`lossy_delayed_forever`](crate::networking::NetworkingConfig::lossy_delayed_forever)
+    /// networking.
+    ///
+    /// The simulator models dropped messages as indefinitely delayed, which means
+    /// it only tests safety properties—not liveness—since messages may never arrive.
+    /// Calling this method acknowledges that the simulation will not verify that the
+    /// program eventually makes progress.
+    pub fn test_safety_only(mut self) -> Self {
+        self.test_safety_only = true;
         self
     }
 
@@ -92,6 +108,7 @@ impl<'a> SimFlow<'a> {
             extra_stmts_global: vec![],
             extra_stmts_cluster: BTreeMap::new(),
             next_hoff_id: 0,
+            test_safety_only: self.test_safety_only,
         };
 
         // Ensure the default (0) external is always present.


### PR DESCRIPTION
Unlike `.lossy()`, `.lossy_delayed_forever()` does not require a `nondet!` annotation because the output stream is always lower in the partial order than the ideal stream (per Gyatso). The tradeoff is a `NoOrder` output, imposing stricter conditions on downstream consumers. This mode can be easily simulated in exhaustive mode without fairness issues, unblocking simulator tests for Hydro agents that previously relied on `.lossy()`.

- Add `LossyDelayedForever` marker type, `TcpFault::LossyDelayedForever` variant, and `TCP.lossy_delayed_forever()` builder
- Add `OrderingGuarantee` associated type to `TransportKind` and `NetworkFor` traits (`FailStop`/`Lossy` → `TotalOrder`, `LossyDelayedForever` → `NoOrder`)
- Network `send`/`broadcast`/`demux` return types now compute `MinOrder<O, N::OrderingGuarantee>` so `delayed()` automatically weakens to `NoOrder`
- Accept `TcpFault::LossyDelayedForever` in simulator and Maelstrom deploy backends
- Concrete deployment targets (deploy_graph, containerized, ECS) still only support `FailStop` since TCP reconnect is not yet implemented

Closes #2646