### PR TITLE
feat(hydro_lang): connect any dropped live collections to an implicit Null sink

### DIFF
--- a/hydro_lang/src/compile/builder.rs
+++ b/hydro_lang/src/compile/builder.rs
@@ -74,6 +74,12 @@ impl FlowStateInner {
             .expect("Attempted to add a root to a flow that has already been finalized. No roots can be added after the flow has been compiled.")
             .push(root);
     }
+
+    pub fn try_push_root(&mut self, root: HydroRoot) {
+        if let Some(roots) = self.roots.as_mut() {
+            roots.push(root);
+        }
+    }
 }
 
 pub struct FlowBuilder<'a> {

--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -705,6 +705,10 @@ pub enum HydroRoot {
         input: Box<HydroNode>,
         op_metadata: HydroIrOpMetadata,
     },
+    Null {
+        input: Box<HydroNode>,
+        op_metadata: HydroIrOpMetadata,
+    },
 }
 
 impl HydroRoot {
@@ -1042,7 +1046,8 @@ impl HydroRoot {
             | HydroRoot::SendExternal { input, .. }
             | HydroRoot::DestSink { input, .. }
             | HydroRoot::CycleSink { input, .. }
-            | HydroRoot::EmbeddedOutput { input, .. } => {
+            | HydroRoot::EmbeddedOutput { input, .. }
+            | HydroRoot::Null { input, .. } => {
                 transform(input, seen_tees);
             }
         }
@@ -1102,6 +1107,10 @@ impl HydroRoot {
                 op_metadata,
             } => HydroRoot::EmbeddedOutput {
                 ident: ident.clone(),
+                input: Box::new(input.deep_clone(seen_tees)),
+                op_metadata: op_metadata.clone(),
+            },
+            HydroRoot::Null { input, op_metadata } => HydroRoot::Null {
                 input: Box::new(input.deep_clone(seen_tees)),
                 op_metadata: op_metadata.clone(),
             },
@@ -1292,6 +1301,30 @@ impl HydroRoot {
 
                 *next_stmt_id += 1;
             }
+
+            HydroRoot::Null { input, .. } => {
+                let input_ident =
+                    input.emit_core(builders_or_callback, seen_tees, built_tees, next_stmt_id);
+
+                match builders_or_callback {
+                    BuildersOrCallback::Builders(graph_builders) => {
+                        graph_builders
+                            .get_dfir_mut(&input.metadata().location_id)
+                            .add_dfir(
+                                parse_quote! {
+                                    #input_ident -> for_each(|_| {});
+                                },
+                                None,
+                                Some(&next_stmt_id.to_string()),
+                            );
+                    }
+                    BuildersOrCallback::Callback(leaf_callback, _) => {
+                        leaf_callback(self, next_stmt_id);
+                    }
+                }
+
+                *next_stmt_id += 1;
+            }
         }
     }
 
@@ -1301,7 +1334,8 @@ impl HydroRoot {
             | HydroRoot::SendExternal { op_metadata, .. }
             | HydroRoot::DestSink { op_metadata, .. }
             | HydroRoot::CycleSink { op_metadata, .. }
-            | HydroRoot::EmbeddedOutput { op_metadata, .. } => op_metadata,
+            | HydroRoot::EmbeddedOutput { op_metadata, .. }
+            | HydroRoot::Null { op_metadata, .. } => op_metadata,
         }
     }
 
@@ -1311,7 +1345,8 @@ impl HydroRoot {
             | HydroRoot::SendExternal { op_metadata, .. }
             | HydroRoot::DestSink { op_metadata, .. }
             | HydroRoot::CycleSink { op_metadata, .. }
-            | HydroRoot::EmbeddedOutput { op_metadata, .. } => op_metadata,
+            | HydroRoot::EmbeddedOutput { op_metadata, .. }
+            | HydroRoot::Null { op_metadata, .. } => op_metadata,
         }
     }
 
@@ -1321,7 +1356,8 @@ impl HydroRoot {
             | HydroRoot::SendExternal { input, .. }
             | HydroRoot::DestSink { input, .. }
             | HydroRoot::CycleSink { input, .. }
-            | HydroRoot::EmbeddedOutput { input, .. } => input,
+            | HydroRoot::EmbeddedOutput { input, .. }
+            | HydroRoot::Null { input, .. } => input,
         }
     }
 
@@ -1338,6 +1374,7 @@ impl HydroRoot {
             HydroRoot::EmbeddedOutput { ident, .. } => {
                 format!("EmbeddedOutput({})", ident)
             }
+            HydroRoot::Null { .. } => "Null".to_owned(),
         }
     }
 
@@ -1348,7 +1385,8 @@ impl HydroRoot {
             }
             HydroRoot::SendExternal { .. }
             | HydroRoot::CycleSink { .. }
-            | HydroRoot::EmbeddedOutput { .. } => {}
+            | HydroRoot::EmbeddedOutput { .. }
+            | HydroRoot::Null { .. } => {}
         }
     }
 }
@@ -3970,6 +4008,18 @@ impl HydroNode {
             .iter()
             .map(|input_node| input_node.metadata())
             .collect()
+    }
+
+    /// Returns `true` if this node is a Tee or Partition whose inner Rc
+    /// has other live references, meaning the upstream is already driven
+    /// by another consumer and does not need a Null sink.
+    pub fn is_shared_with_others(&self) -> bool {
+        match self {
+            HydroNode::Tee { inner, .. } | HydroNode::Partition { inner, .. } => {
+                Rc::strong_count(&inner.0) > 1
+            }
+            _ => false,
+        }
     }
 
     pub fn print_root(&self) -> String {

--- a/hydro_lang/src/live_collections/keyed_singleton.rs
+++ b/hydro_lang/src/live_collections/keyed_singleton.rs
@@ -14,7 +14,7 @@ use super::keyed_stream::KeyedStream;
 use super::optional::Optional;
 use super::singleton::Singleton;
 use super::stream::{ExactlyOnce, NoOrder, Stream, TotalOrder};
-use crate::compile::builder::CycleId;
+use crate::compile::builder::{CycleId, FlowState};
 use crate::compile::ir::{
     CollectionKind, HydroIrOpMetadata, HydroNode, HydroRoot, KeyedSingletonBoundKind, SharedNode,
 };
@@ -124,8 +124,21 @@ impl KeyedSingletonBound for UnreachableBound {
 pub struct KeyedSingleton<K, V, Loc, Bound: KeyedSingletonBound> {
     pub(crate) location: Loc,
     pub(crate) ir_node: RefCell<HydroNode>,
+    pub(crate) flow_state: FlowState,
 
     _phantom: PhantomData<(K, V, Loc, Bound)>,
+}
+
+impl<K, V, L, B: KeyedSingletonBound> Drop for KeyedSingleton<K, V, L, B> {
+    fn drop(&mut self) {
+        let ir_node = self.ir_node.replace(HydroNode::Placeholder);
+        if !matches!(ir_node, HydroNode::Placeholder) && !ir_node.is_shared_with_others() {
+            self.flow_state.borrow_mut().try_push_root(HydroRoot::Null {
+                input: Box::new(ir_node),
+                op_metadata: HydroIrOpMetadata::new(),
+            });
+        }
+    }
 }
 
 impl<'a, K: Clone, V: Clone, Loc: Location<'a>, Bound: KeyedSingletonBound> Clone
@@ -143,6 +156,7 @@ impl<'a, K: Clone, V: Clone, Loc: Location<'a>, Bound: KeyedSingletonBound> Clon
         if let HydroNode::Tee { inner, metadata } = self.ir_node.borrow().deref() {
             KeyedSingleton {
                 location: self.location.clone(),
+                flow_state: self.flow_state.clone(),
                 ir_node: HydroNode::Tee {
                     inner: SharedNode(inner.0.clone()),
                     metadata: metadata.clone(),
@@ -165,6 +179,7 @@ where
 
     fn create_source(cycle_id: CycleId, location: L) -> Self {
         KeyedSingleton {
+            flow_state: location.flow_state().clone(),
             location: location.clone(),
             ir_node: RefCell::new(HydroNode::CycleSource {
                 cycle_id,
@@ -217,7 +232,7 @@ where
             .borrow_mut()
             .push_root(HydroRoot::CycleSink {
                 cycle_id,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 op_metadata: HydroIrOpMetadata::new(),
             });
     }
@@ -238,7 +253,7 @@ where
             .borrow_mut()
             .push_root(HydroRoot::CycleSink {
                 cycle_id,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 op_metadata: HydroIrOpMetadata::new(),
             });
     }
@@ -249,8 +264,10 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound> KeyedSingleton<K, V, L, 
         debug_assert_eq!(ir_node.metadata().location_id, Location::id(&location));
         debug_assert_eq!(ir_node.metadata().collection_kind, Self::collection_kind());
 
+        let flow_state = location.flow_state().clone();
         KeyedSingleton {
             location,
+            flow_state,
             ir_node: RefCell::new(ir_node),
             _phantom: PhantomData,
         }
@@ -343,7 +360,7 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound> KeyedSingleton<K, V, L, 
             self.location.clone(),
             HydroNode::Map {
                 f: map_f,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .new_node_metadata(KeyedSingleton::<K, U, L, B>::collection_kind()),
@@ -404,7 +421,7 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound> KeyedSingleton<K, V, L, 
             self.location.clone(),
             HydroNode::Map {
                 f: map_f,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .new_node_metadata(KeyedSingleton::<K, U, L, B>::collection_kind()),
@@ -442,8 +459,9 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound> KeyedSingleton<K, V, L, 
     pub fn key_count(self) -> Singleton<usize, L, B::UnderlyingBound> {
         if B::ValueBound::BOUNDED {
             let me: KeyedSingleton<K, V, L, B::WithBoundedValue> = KeyedSingleton {
-                location: self.location,
-                ir_node: self.ir_node,
+                location: self.location.clone(),
+                flow_state: self.flow_state.clone(),
+                ir_node: RefCell::new(self.ir_node.replace(HydroNode::Placeholder)),
                 _phantom: PhantomData,
             };
 
@@ -452,15 +470,19 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound> KeyedSingleton<K, V, L, 
             && let Some(tick) = self.location.try_tick()
         {
             let me: KeyedSingleton<K, V, L, B::WithUnboundedValue> = KeyedSingleton {
-                location: self.location,
-                ir_node: self.ir_node,
+                location: self.location.clone(),
+                flow_state: self.flow_state.clone(),
+                ir_node: RefCell::new(self.ir_node.replace(HydroNode::Placeholder)),
                 _phantom: PhantomData,
             };
 
             let out =
                 key_count_inside_tick(me.snapshot(&tick, nondet!(/** eventually stabilizes */)))
                     .latest();
-            Singleton::new(out.location, out.ir_node.into_inner())
+            Singleton::new(
+                out.location.clone(),
+                out.ir_node.replace(HydroNode::Placeholder),
+            )
         } else {
             panic!("Unbounded KeyedSingleton inside a tick");
         }
@@ -497,8 +519,9 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound> KeyedSingleton<K, V, L, 
     {
         if B::ValueBound::BOUNDED {
             let me: KeyedSingleton<K, V, L, B::WithBoundedValue> = KeyedSingleton {
-                location: self.location,
-                ir_node: self.ir_node,
+                location: self.location.clone(),
+                flow_state: self.flow_state.clone(),
+                ir_node: RefCell::new(self.ir_node.replace(HydroNode::Placeholder)),
                 _phantom: PhantomData,
             };
 
@@ -517,8 +540,9 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound> KeyedSingleton<K, V, L, 
             && let Some(tick) = self.location.try_tick()
         {
             let me: KeyedSingleton<K, V, L, B::WithUnboundedValue> = KeyedSingleton {
-                location: self.location,
-                ir_node: self.ir_node,
+                location: self.location.clone(),
+                flow_state: self.flow_state.clone(),
+                ir_node: RefCell::new(self.ir_node.replace(HydroNode::Placeholder)),
                 _phantom: PhantomData,
             };
 
@@ -526,7 +550,10 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound> KeyedSingleton<K, V, L, 
                 me.snapshot(&tick, nondet!(/** eventually stabilizes */)),
             )
             .latest();
-            Singleton::new(out.location, out.ir_node.into_inner())
+            Singleton::new(
+                out.location.clone(),
+                out.ir_node.replace(HydroNode::Placeholder),
+            )
         } else {
             panic!("Unbounded KeyedSingleton inside a tick");
         }
@@ -549,7 +576,10 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound> KeyedSingleton<K, V, L, 
     where
         B: IsBounded,
     {
-        KeyedSingleton::new(self.location, self.ir_node.into_inner())
+        KeyedSingleton::new(
+            self.location.clone(),
+            self.ir_node.replace(HydroNode::Placeholder),
+        )
     }
 
     /// Gets the value associated with a specific key from the keyed singleton.
@@ -688,7 +718,7 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound> KeyedSingleton<K, V, L, 
         KeyedSingleton::new(
             result_stream.location.clone(),
             HydroNode::Cast {
-                inner: Box::new(result_stream.ir_node.into_inner()),
+                inner: Box::new(result_stream.ir_node.replace(HydroNode::Placeholder)),
                 metadata: result_stream.location.new_node_metadata(KeyedSingleton::<
                     K,
                     (V, V2),
@@ -756,7 +786,7 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound> KeyedSingleton<K, V, L, 
         KeyedSingleton::new(
             result_stream.location.clone(),
             HydroNode::Cast {
-                inner: Box::new(result_stream.ir_node.into_inner()),
+                inner: Box::new(result_stream.ir_node.replace(HydroNode::Placeholder)),
                 metadata: result_stream.location.new_node_metadata(KeyedSingleton::<
                     K,
                     (V, Option<V2>),
@@ -896,7 +926,7 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound<ValueBound = Bounded>>
             self.location.clone(),
             HydroNode::Map {
                 f: map_f,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.new_node_metadata(Stream::<
                     V,
                     L,
@@ -982,8 +1012,8 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound<ValueBound = Bounded>>
         KeyedSingleton::new(
             self.location.clone(),
             HydroNode::AntiJoin {
-                pos: Box::new(self.ir_node.into_inner()),
-                neg: Box::new(other.ir_node.into_inner()),
+                pos: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                neg: Box::new(other.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.new_node_metadata(Self::collection_kind()),
             },
         )
@@ -1031,7 +1061,7 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound<ValueBound = Bounded>>
             self.location.clone(),
             HydroNode::Inspect {
                 f: inspect_f,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.new_node_metadata(Self::collection_kind()),
             },
         )
@@ -1073,7 +1103,7 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound<ValueBound = Bounded>>
             self.location.clone(),
             HydroNode::Inspect {
                 f: inspect_f,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.new_node_metadata(Self::collection_kind()),
             },
         )
@@ -1163,7 +1193,7 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound<ValueBound = Bounded>>
         KeyedStream::new(
             self.location.clone(),
             HydroNode::Cast {
-                inner: Box::new(self.ir_node.into_inner()),
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.new_node_metadata(KeyedStream::<
                     K,
                     V,
@@ -1194,7 +1224,7 @@ where
         KeyedSingleton::new(
             out_location.clone(),
             HydroNode::BeginAtomic {
-                inner: Box::new(self.ir_node.into_inner()),
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: out_location
                     .new_node_metadata(KeyedSingleton::<K, V, Atomic<L>, B>::collection_kind()),
             },
@@ -1212,7 +1242,7 @@ where
         KeyedSingleton::new(
             self.location.tick.l.clone(),
             HydroNode::EndAtomic {
-                inner: Box::new(self.ir_node.into_inner()),
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .tick
@@ -1268,7 +1298,7 @@ impl<'a, K, V, L: Location<'a>> KeyedSingleton<K, V, Tick<L>, Bounded> {
         KeyedSingleton::new(
             self.location.clone(),
             HydroNode::DeferTick {
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .new_node_metadata(KeyedSingleton::<K, V, Tick<L>, Bounded>::collection_kind()),
@@ -1296,7 +1326,7 @@ where
         KeyedSingleton::new(
             tick.clone(),
             HydroNode::Batch {
-                inner: Box::new(self.ir_node.into_inner()),
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: tick
                     .new_node_metadata(KeyedSingleton::<K, V, Tick<L>, Bounded>::collection_kind()),
             },
@@ -1318,7 +1348,7 @@ where
         KeyedSingleton::new(
             self.location.clone().tick,
             HydroNode::Batch {
-                inner: Box::new(self.ir_node.into_inner()),
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.tick.new_node_metadata(KeyedSingleton::<
                     K,
                     V,
@@ -1385,7 +1415,7 @@ where
             self.location.clone(),
             HydroNode::Filter {
                 f: filter_f,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .new_node_metadata(KeyedSingleton::<K, V, L, B>::collection_kind()),
@@ -1443,7 +1473,7 @@ where
             self.location.clone(),
             HydroNode::FilterMap {
                 f: filter_map_f,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .new_node_metadata(KeyedSingleton::<K, U, L, B>::collection_kind()),
@@ -1486,7 +1516,7 @@ where
         KeyedSingleton::new(
             self.location.clone().tick,
             HydroNode::Batch {
-                inner: Box::new(self.ir_node.into_inner()),
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.tick.new_node_metadata(KeyedSingleton::<
                     K,
                     V,

--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -15,7 +15,7 @@ use super::optional::Optional;
 use super::stream::{
     ExactlyOnce, IsExactlyOnce, IsOrdered, MinOrder, MinRetries, NoOrder, Stream, TotalOrder,
 };
-use crate::compile::builder::CycleId;
+use crate::compile::builder::{CycleId, FlowState};
 use crate::compile::ir::{
     CollectionKind, HydroIrOpMetadata, HydroNode, HydroRoot, SharedNode, StreamOrder, StreamRetry,
 };
@@ -64,8 +64,21 @@ pub struct KeyedStream<
 > {
     pub(crate) location: Loc,
     pub(crate) ir_node: RefCell<HydroNode>,
+    pub(crate) flow_state: FlowState,
 
     _phantom: PhantomData<(K, V, Loc, Bound, Order, Retry)>,
+}
+
+impl<K, V, L, B: Boundedness, O: Ordering, R: Retries> Drop for KeyedStream<K, V, L, B, O, R> {
+    fn drop(&mut self) {
+        let ir_node = self.ir_node.replace(HydroNode::Placeholder);
+        if !matches!(ir_node, HydroNode::Placeholder) && !ir_node.is_shared_with_others() {
+            self.flow_state.borrow_mut().try_push_root(HydroRoot::Null {
+                input: Box::new(ir_node),
+                op_metadata: HydroIrOpMetadata::new(),
+            });
+        }
+    }
 }
 
 impl<'a, K, V, L, O: Ordering, R: Retries> From<KeyedStream<K, V, L, Bounded, O, R>>
@@ -79,9 +92,10 @@ where
             .new_node_metadata(KeyedStream::<K, V, L, Unbounded, O, R>::collection_kind());
 
         KeyedStream {
-            location: stream.location,
+            location: stream.location.clone(),
+            flow_state: stream.flow_state.clone(),
             ir_node: RefCell::new(HydroNode::Cast {
-                inner: Box::new(stream.ir_node.into_inner()),
+                inner: Box::new(stream.ir_node.replace(HydroNode::Placeholder)),
                 metadata: new_meta,
             }),
             _phantom: PhantomData,
@@ -117,6 +131,7 @@ where
 
     fn create_source(cycle_id: CycleId, location: Tick<L>) -> Self {
         KeyedStream {
+            flow_state: location.flow_state().clone(),
             location: location.clone(),
             ir_node: RefCell::new(HydroNode::CycleSource {
                 cycle_id,
@@ -146,7 +161,7 @@ where
             .borrow_mut()
             .push_root(HydroRoot::CycleSink {
                 cycle_id,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 op_metadata: HydroIrOpMetadata::new(),
             });
     }
@@ -161,6 +176,7 @@ where
 
     fn create_source(cycle_id: CycleId, location: L) -> Self {
         KeyedStream {
+            flow_state: location.flow_state().clone(),
             location: location.clone(),
             ir_node: RefCell::new(HydroNode::CycleSource {
                 cycle_id,
@@ -188,7 +204,7 @@ where
             .borrow_mut()
             .push_root(HydroRoot::CycleSink {
                 cycle_id,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 op_metadata: HydroIrOpMetadata::new(),
             });
     }
@@ -209,6 +225,7 @@ impl<'a, K: Clone, V: Clone, Loc: Location<'a>, Bound: Boundedness, Order: Order
         if let HydroNode::Tee { inner, metadata } = self.ir_node.borrow().deref() {
             KeyedStream {
                 location: self.location.clone(),
+                flow_state: self.flow_state.clone(),
                 ir_node: HydroNode::Tee {
                     inner: SharedNode(inner.0.clone()),
                     metadata: metadata.clone(),
@@ -242,8 +259,10 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
         debug_assert_eq!(ir_node.metadata().location_id, Location::id(&location));
         debug_assert_eq!(ir_node.metadata().collection_kind, Self::collection_kind());
 
+        let flow_state = location.flow_state().clone();
         KeyedStream {
             location,
+            flow_state,
             ir_node: RefCell::new(ir_node),
             _phantom: PhantomData,
         }
@@ -275,13 +294,16 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     /// for the rest of the program.
     pub fn assume_ordering<O2: Ordering>(self, _nondet: NonDet) -> KeyedStream<K, V, L, B, O2, R> {
         if O::ORDERING_KIND == O2::ORDERING_KIND {
-            KeyedStream::new(self.location, self.ir_node.into_inner())
+            KeyedStream::new(
+                self.location.clone(),
+                self.ir_node.replace(HydroNode::Placeholder),
+            )
         } else if O2::ORDERING_KIND == StreamOrder::NoOrder {
             // We can always weaken the ordering guarantee
             KeyedStream::new(
                 self.location.clone(),
                 HydroNode::Cast {
-                    inner: Box::new(self.ir_node.into_inner()),
+                    inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                     metadata: self
                         .location
                         .new_node_metadata(KeyedStream::<K, V, L, B, O2, R>::collection_kind()),
@@ -291,7 +313,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
             KeyedStream::new(
                 self.location.clone(),
                 HydroNode::ObserveNonDet {
-                    inner: Box::new(self.ir_node.into_inner()),
+                    inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                     trusted: false,
                     metadata: self
                         .location
@@ -306,13 +328,16 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
         _nondet: NonDet,
     ) -> KeyedStream<K, V, L, B, O2, R> {
         if O::ORDERING_KIND == O2::ORDERING_KIND {
-            KeyedStream::new(self.location, self.ir_node.into_inner())
+            KeyedStream::new(
+                self.location.clone(),
+                self.ir_node.replace(HydroNode::Placeholder),
+            )
         } else if O2::ORDERING_KIND == StreamOrder::NoOrder {
             // We can always weaken the ordering guarantee
             KeyedStream::new(
                 self.location.clone(),
                 HydroNode::Cast {
-                    inner: Box::new(self.ir_node.into_inner()),
+                    inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                     metadata: self
                         .location
                         .new_node_metadata(KeyedStream::<K, V, L, B, O2, R>::collection_kind()),
@@ -322,7 +347,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
             KeyedStream::new(
                 self.location.clone(),
                 HydroNode::ObserveNonDet {
-                    inner: Box::new(self.ir_node.into_inner()),
+                    inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                     trusted: true,
                     metadata: self
                         .location
@@ -356,13 +381,16 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     /// for the rest of the program.
     pub fn assume_retries<R2: Retries>(self, _nondet: NonDet) -> KeyedStream<K, V, L, B, O, R2> {
         if R::RETRIES_KIND == R2::RETRIES_KIND {
-            KeyedStream::new(self.location, self.ir_node.into_inner())
+            KeyedStream::new(
+                self.location.clone(),
+                self.ir_node.replace(HydroNode::Placeholder),
+            )
         } else if R2::RETRIES_KIND == StreamRetry::AtLeastOnce {
             // We can always weaken the retries guarantee
             KeyedStream::new(
                 self.location.clone(),
                 HydroNode::Cast {
-                    inner: Box::new(self.ir_node.into_inner()),
+                    inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                     metadata: self
                         .location
                         .new_node_metadata(KeyedStream::<K, V, L, B, O, R2>::collection_kind()),
@@ -372,7 +400,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
             KeyedStream::new(
                 self.location.clone(),
                 HydroNode::ObserveNonDet {
-                    inner: Box::new(self.ir_node.into_inner()),
+                    inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                     trusted: false,
                     metadata: self
                         .location
@@ -420,7 +448,10 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     where
         B: IsBounded,
     {
-        KeyedStream::new(self.location, self.ir_node.into_inner())
+        KeyedStream::new(
+            self.location.clone(),
+            self.ir_node.replace(HydroNode::Placeholder),
+        )
     }
 
     /// Flattens the keyed stream into an unordered stream of key-value pairs.
@@ -450,7 +481,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
         Stream::new(
             self.location.clone(),
             HydroNode::Cast {
-                inner: Box::new(self.ir_node.into_inner()),
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .new_node_metadata(Stream::<(K, V), L, B, NoOrder, R>::collection_kind()),
@@ -559,7 +590,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
             self.location.clone(),
             HydroNode::Map {
                 f: map_f,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .new_node_metadata(KeyedStream::<K, U, L, B, O, R>::collection_kind()),
@@ -618,7 +649,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
             self.location.clone(),
             HydroNode::Map {
                 f: map_f,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .new_node_metadata(KeyedStream::<K, U, L, B, O, R>::collection_kind()),
@@ -674,7 +705,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
             self.location.clone(),
             HydroNode::Map {
                 f: map_f,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .new_node_metadata(KeyedStream::<(K2, K), V, L, B, O, R>::collection_kind()),
@@ -727,7 +758,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
             self.location.clone(),
             HydroNode::Filter {
                 f: filter_f,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.new_node_metadata(Self::collection_kind()),
             },
         )
@@ -777,7 +808,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
             self.location.clone(),
             HydroNode::Filter {
                 f: filter_f,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.new_node_metadata(Self::collection_kind()),
             },
         )
@@ -828,7 +859,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
             self.location.clone(),
             HydroNode::FilterMap {
                 f: filter_map_f,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .new_node_metadata(KeyedStream::<K, U, L, B, O, R>::collection_kind()),
@@ -885,7 +916,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
             self.location.clone(),
             HydroNode::FilterMap {
                 f: filter_map_f,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .new_node_metadata(KeyedStream::<K, U, L, B, O, R>::collection_kind()),
@@ -934,8 +965,8 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
         Stream::new(
             self.location.clone(),
             HydroNode::CrossSingleton {
-                left: Box::new(self.ir_node.into_inner()),
-                right: Box::new(other.ir_node.into_inner()),
+                left: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                right: Box::new(other.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .new_node_metadata(Stream::<((K, V), O2), L, B, O, R>::collection_kind()),
@@ -996,7 +1027,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
             self.location.clone(),
             HydroNode::FlatMap {
                 f: flat_map_f,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .new_node_metadata(KeyedStream::<K, U, L, B, O, R>::collection_kind()),
@@ -1053,7 +1084,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
             self.location.clone(),
             HydroNode::FlatMap {
                 f: flat_map_f,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .new_node_metadata(KeyedStream::<K, U, L, B, NoOrder, R>::collection_kind()),
@@ -1175,7 +1206,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
             self.location.clone(),
             HydroNode::Inspect {
                 f: inspect_f,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.new_node_metadata(Self::collection_kind()),
             },
         )
@@ -1216,7 +1247,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
             self.location.clone(),
             HydroNode::Inspect {
                 f: inspect_f,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.new_node_metadata(Self::collection_kind()),
             },
         )
@@ -1392,7 +1423,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
         let scan_node = HydroNode::Scan {
             init: scan_init,
             acc: scan_f,
-            input: Box::new(this.ir_node.into_inner()),
+            input: Box::new(this.ir_node.replace(HydroNode::Placeholder)),
             metadata: this.location.new_node_metadata(Stream::<
                 Option<(K, U)>,
                 L,
@@ -1418,7 +1449,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
             >::collection_kind()),
         };
 
-        KeyedStream::new(this.location, flatten_node)
+        KeyedStream::new(this.location.clone(), flatten_node)
     }
 
     /// A variant of [`Stream::fold`], intended for keyed streams. The aggregation is executed
@@ -1488,7 +1519,11 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
         KeyedSingleton::new(
             out_without_bound_cast.location.clone(),
             HydroNode::Cast {
-                inner: Box::new(out_without_bound_cast.ir_node.into_inner()),
+                inner: Box::new(
+                    out_without_bound_cast
+                        .ir_node
+                        .replace(HydroNode::Placeholder),
+                ),
                 metadata: out_without_bound_cast
                     .location
                     .new_node_metadata(
@@ -1684,7 +1719,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
             HydroNode::FoldKeyed {
                 init,
                 acc: comb.into(),
-                input: Box::new(ordered.ir_node.into_inner()),
+                input: Box::new(ordered.ir_node.replace(HydroNode::Placeholder)),
                 metadata: ordered.location.new_node_metadata(KeyedSingleton::<
                     K,
                     A,
@@ -1749,7 +1784,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
             ordered.location.clone(),
             HydroNode::ReduceKeyed {
                 f: f.into(),
-                input: Box::new(ordered.ir_node.into_inner()),
+                input: Box::new(ordered.ir_node.replace(HydroNode::Placeholder)),
                 metadata: ordered.location.new_node_metadata(KeyedSingleton::<
                     K,
                     V,
@@ -1813,8 +1848,8 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
             ordered.location.clone(),
             HydroNode::ReduceKeyedWatermark {
                 f: f.into(),
-                input: Box::new(ordered.ir_node.into_inner()),
-                watermark: Box::new(other.ir_node.into_inner()),
+                input: Box::new(ordered.ir_node.replace(HydroNode::Placeholder)),
+                watermark: Box::new(other.ir_node.replace(HydroNode::Placeholder)),
                 metadata: ordered.location.new_node_metadata(KeyedSingleton::<
                     K,
                     V,
@@ -1867,8 +1902,8 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
         KeyedStream::new(
             self.location.clone(),
             HydroNode::AntiJoin {
-                pos: Box::new(self.ir_node.into_inner()),
-                neg: Box::new(other.ir_node.into_inner()),
+                pos: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                neg: Box::new(other.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.new_node_metadata(Self::collection_kind()),
             },
         )
@@ -2042,8 +2077,8 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
         KeyedStream::new(
             this.location.clone(),
             HydroNode::Chain {
-                first: Box::new(this.ir_node.into_inner()),
-                second: Box::new(other.ir_node.into_inner()),
+                first: Box::new(this.ir_node.replace(HydroNode::Placeholder)),
+                second: Box::new(other.ir_node.replace(HydroNode::Placeholder)),
                 metadata: this.location.new_node_metadata(KeyedStream::<
                     K,
                     V,
@@ -2275,7 +2310,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
         KeyedStream::new(
             out_location.clone(),
             HydroNode::BeginAtomic {
-                inner: Box::new(self.ir_node.into_inner()),
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: out_location
                     .new_node_metadata(KeyedStream::<K, V, Atomic<L>, B, O, R>::collection_kind()),
             },
@@ -2298,7 +2333,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
         KeyedStream::new(
             tick.clone(),
             HydroNode::Batch {
-                inner: Box::new(self.ir_node.into_inner()),
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: tick.new_node_metadata(
                     KeyedStream::<K, V, Tick<L>, Bounded, O, R>::collection_kind(),
                 ),
@@ -2388,8 +2423,8 @@ impl<'a, K, V, L: Location<'a> + NoTick, O: Ordering, R: Retries>
         KeyedStream::new(
             self.location.clone(),
             HydroNode::Chain {
-                first: Box::new(self.ir_node.into_inner()),
-                second: Box::new(other.ir_node.into_inner()),
+                first: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                second: Box::new(other.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.new_node_metadata(KeyedStream::<
                     K,
                     V,
@@ -2419,7 +2454,7 @@ where
         KeyedStream::new(
             self.location.clone().tick,
             HydroNode::Batch {
-                inner: Box::new(self.ir_node.into_inner()),
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.tick.new_node_metadata(KeyedStream::<
                     K,
                     V,
@@ -2439,7 +2474,7 @@ where
         KeyedStream::new(
             self.location.tick.l.clone(),
             HydroNode::EndAtomic {
-                inner: Box::new(self.ir_node.into_inner()),
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .tick
@@ -2461,7 +2496,7 @@ where
         KeyedStream::new(
             self.location.outer().clone(),
             HydroNode::YieldConcat {
-                inner: Box::new(self.ir_node.into_inner()),
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.outer().new_node_metadata(KeyedStream::<
                     K,
                     V,
@@ -2490,7 +2525,7 @@ where
         KeyedStream::new(
             out_location.clone(),
             HydroNode::YieldConcat {
-                inner: Box::new(self.ir_node.into_inner()),
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: out_location.new_node_metadata(KeyedStream::<
                     K,
                     V,
@@ -2619,7 +2654,7 @@ where
         KeyedStream::new(
             self.location.clone(),
             HydroNode::DeferTick {
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.new_node_metadata(KeyedStream::<
                     K,
                     V,

--- a/hydro_lang/src/live_collections/keyed_stream/networking.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/networking.rs
@@ -129,7 +129,7 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
                 serialize_fn: serialize_pipeline.map(|e| e.into()),
                 instantiate_fn: DebugInstantiate::Building,
                 deserialize_fn: deserialize_pipeline.map(|e| e.into()),
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: to.new_node_metadata(
                     Stream::<T, Cluster<'a, L2>, Unbounded, O, R>::collection_kind(),
                 ),
@@ -251,7 +251,7 @@ impl<'a, K, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
                     self.entries()
                         .map(q!(|((id, k), v)| (id, (k, v))))
                         .ir_node
-                        .into_inner(),
+                        .replace(HydroNode::Placeholder),
                 ),
                 metadata: to.new_node_metadata(
                     KeyedStream::<K, T, Cluster<'a, L2>, Unbounded, O, R>::collection_kind(),
@@ -396,7 +396,7 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
                 serialize_fn: serialize_pipeline.map(|e| e.into()),
                 instantiate_fn: DebugInstantiate::Building,
                 deserialize_fn: deserialize_pipeline.map(|e| e.into()),
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: to.new_node_metadata(Stream::<
                     (MemberId<L>, T),
                     Cluster<'a, L2>,
@@ -565,7 +565,7 @@ impl<'a, K, V, L, B: Boundedness, O: Ordering, R: Retries>
                     serialize_fn: serialize_pipeline.map(|e| e.into()),
                     instantiate_fn: DebugInstantiate::Building,
                     deserialize_fn: deserialize_pipeline.map(|e| e.into()),
-                    input: Box::new(self.ir_node.into_inner()),
+                    input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                     metadata: to.new_node_metadata(Stream::<
                         (MemberId<L>, (K, V)),
                         Cluster<'a, L2>,

--- a/hydro_lang/src/live_collections/optional.rs
+++ b/hydro_lang/src/live_collections/optional.rs
@@ -11,7 +11,7 @@ use syn::parse_quote;
 use super::boundedness::{Bounded, Boundedness, IsBounded, Unbounded};
 use super::singleton::Singleton;
 use super::stream::{AtLeastOnce, ExactlyOnce, NoOrder, Stream, TotalOrder};
-use crate::compile::builder::CycleId;
+use crate::compile::builder::{CycleId, FlowState};
 use crate::compile::ir::{CollectionKind, HydroIrOpMetadata, HydroNode, HydroRoot, SharedNode};
 #[cfg(stageleft_runtime)]
 use crate::forward_handle::{CycleCollection, CycleCollectionWithInitial, ReceiverComplete};
@@ -38,8 +38,21 @@ use crate::nondet::{NonDet, nondet};
 pub struct Optional<Type, Loc, Bound: Boundedness> {
     pub(crate) location: Loc,
     pub(crate) ir_node: RefCell<HydroNode>,
+    pub(crate) flow_state: FlowState,
 
     _phantom: PhantomData<(Type, Loc, Bound)>,
+}
+
+impl<T, L, B: Boundedness> Drop for Optional<T, L, B> {
+    fn drop(&mut self) {
+        let ir_node = self.ir_node.replace(HydroNode::Placeholder);
+        if !matches!(ir_node, HydroNode::Placeholder) && !ir_node.is_shared_with_others() {
+            self.flow_state.borrow_mut().try_push_root(HydroRoot::Null {
+                input: Box::new(ir_node),
+                op_metadata: HydroIrOpMetadata::new(),
+            });
+        }
+    }
 }
 
 impl<'a, T, L> From<Optional<T, L, Bounded>> for Optional<T, L, Unbounded>
@@ -117,7 +130,7 @@ where
             .borrow_mut()
             .push_root(HydroRoot::CycleSink {
                 cycle_id,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 op_metadata: HydroIrOpMetadata::new(),
             });
     }
@@ -155,7 +168,7 @@ where
             .borrow_mut()
             .push_root(HydroRoot::CycleSink {
                 cycle_id,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 op_metadata: HydroIrOpMetadata::new(),
             });
     }
@@ -193,7 +206,7 @@ where
             .borrow_mut()
             .push_root(HydroRoot::CycleSink {
                 cycle_id,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 op_metadata: HydroIrOpMetadata::new(),
             });
     }
@@ -207,7 +220,7 @@ where
         Optional::new(
             singleton.location.clone(),
             HydroNode::Cast {
-                inner: Box::new(singleton.ir_node.into_inner()),
+                inner: Box::new(singleton.ir_node.replace(HydroNode::Placeholder)),
                 metadata: singleton
                     .location
                     .new_node_metadata(Self::collection_kind()),
@@ -226,8 +239,8 @@ pub(super) fn zip_inside_tick<'a, T, O, L: Location<'a>, B: Boundedness>(
     Optional::new(
         me.location.clone(),
         HydroNode::CrossSingleton {
-            left: Box::new(me.ir_node.into_inner()),
-            right: Box::new(other.ir_node.into_inner()),
+            left: Box::new(me.ir_node.replace(HydroNode::Placeholder)),
+            right: Box::new(other.ir_node.replace(HydroNode::Placeholder)),
             metadata: me
                 .location
                 .new_node_metadata(Optional::<(T, O), L, B>::collection_kind()),
@@ -245,8 +258,8 @@ fn or_inside_tick<'a, T, L: Location<'a>, B: Boundedness>(
     Optional::new(
         me.location.clone(),
         HydroNode::ChainFirst {
-            first: Box::new(me.ir_node.into_inner()),
-            second: Box::new(other.ir_node.into_inner()),
+            first: Box::new(me.ir_node.replace(HydroNode::Placeholder)),
+            second: Box::new(other.ir_node.replace(HydroNode::Placeholder)),
             metadata: me
                 .location
                 .new_node_metadata(Optional::<T, L, B>::collection_kind()),
@@ -271,6 +284,7 @@ where
         if let HydroNode::Tee { inner, metadata } = self.ir_node.borrow().deref() {
             Optional {
                 location: self.location.clone(),
+                flow_state: self.flow_state.clone(),
                 ir_node: HydroNode::Tee {
                     inner: SharedNode(inner.0.clone()),
                     metadata: metadata.clone(),
@@ -291,8 +305,10 @@ where
     pub(crate) fn new(location: L, ir_node: HydroNode) -> Self {
         debug_assert_eq!(ir_node.metadata().location_id, Location::id(&location));
         debug_assert_eq!(ir_node.metadata().collection_kind, Self::collection_kind());
+        let flow_state = location.flow_state().clone();
         Optional {
             location,
+            flow_state,
             ir_node: RefCell::new(ir_node),
             _phantom: PhantomData,
         }
@@ -339,7 +355,7 @@ where
             self.location.clone(),
             HydroNode::Map {
                 f,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .new_node_metadata(Optional::<U, L, B>::collection_kind()),
@@ -388,7 +404,7 @@ where
             self.location.clone(),
             HydroNode::FlatMap {
                 f,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.new_node_metadata(
                     Stream::<U, L, B, TotalOrder, ExactlyOnce>::collection_kind(),
                 ),
@@ -438,7 +454,7 @@ where
             self.location.clone(),
             HydroNode::FlatMap {
                 f,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .new_node_metadata(Stream::<U, L, B, NoOrder, ExactlyOnce>::collection_kind()),
@@ -550,7 +566,7 @@ where
             self.location.clone(),
             HydroNode::Filter {
                 f,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.new_node_metadata(Self::collection_kind()),
             },
         )
@@ -589,7 +605,7 @@ where
             self.location.clone(),
             HydroNode::FilterMap {
                 f,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .new_node_metadata(Optional::<U, L, B>::collection_kind()),
@@ -639,7 +655,10 @@ where
             )
             .latest();
 
-            Optional::new(out.location, out.ir_node.into_inner())
+            Optional::new(
+                out.location.clone(),
+                out.ir_node.replace(HydroNode::Placeholder),
+            )
         } else {
             zip_inside_tick(self, other)
         }
@@ -688,13 +707,16 @@ where
             )
             .latest();
 
-            Optional::new(out.location, out.ir_node.into_inner())
+            Optional::new(
+                out.location.clone(),
+                out.ir_node.replace(HydroNode::Placeholder),
+            )
         } else {
             Optional::new(
                 self.location.clone(),
                 HydroNode::ChainFirst {
-                    first: Box::new(self.ir_node.into_inner()),
-                    second: Box::new(other.ir_node.into_inner()),
+                    first: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                    second: Box::new(other.ir_node.replace(HydroNode::Placeholder)),
                     metadata: self.location.new_node_metadata(Self::collection_kind()),
                 },
             )
@@ -736,7 +758,7 @@ where
         Singleton::new(
             res_option.location.clone(),
             HydroNode::Cast {
-                inner: Box::new(res_option.ir_node.into_inner()),
+                inner: Box::new(res_option.ir_node.replace(HydroNode::Placeholder)),
                 metadata: res_option
                     .location
                     .new_node_metadata(Singleton::<T, L, B>::collection_kind()),
@@ -839,7 +861,10 @@ where
     where
         B: IsBounded,
     {
-        Optional::new(self.location, self.ir_node.into_inner())
+        Optional::new(
+            self.location.clone(),
+            self.ir_node.replace(HydroNode::Placeholder),
+        )
     }
 
     /// Clones this bounded optional into a tick, returning a optional that has the
@@ -898,7 +923,7 @@ where
         Stream::new(
             self.location.clone(),
             HydroNode::Cast {
-                inner: Box::new(self.ir_node.into_inner()),
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.new_node_metadata(Stream::<
                     T,
                     Tick<L>,
@@ -1055,7 +1080,7 @@ where
         Optional::new(
             self.location.clone().tick,
             HydroNode::Batch {
-                inner: Box::new(self.ir_node.into_inner()),
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .tick
@@ -1070,7 +1095,7 @@ where
         Optional::new(
             self.location.tick.l.clone(),
             HydroNode::EndAtomic {
-                inner: Box::new(self.ir_node.into_inner()),
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .tick
@@ -1101,7 +1126,7 @@ where
         Optional::new(
             out_location.clone(),
             HydroNode::BeginAtomic {
-                inner: Box::new(self.ir_node.into_inner()),
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: out_location
                     .new_node_metadata(Optional::<T, Atomic<L>, B>::collection_kind()),
             },
@@ -1121,7 +1146,7 @@ where
         Optional::new(
             tick.clone(),
             HydroNode::Batch {
-                inner: Box::new(self.ir_node.into_inner()),
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: tick
                     .new_node_metadata(Optional::<T, Tick<L>, Bounded>::collection_kind()),
             },
@@ -1266,7 +1291,7 @@ where
         Optional::new(
             self.location.outer().clone(),
             HydroNode::YieldConcat {
-                inner: Box::new(self.ir_node.into_inner()),
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .outer()
@@ -1289,7 +1314,7 @@ where
         Optional::new(
             out_location.clone(),
             HydroNode::YieldConcat {
-                inner: Box::new(self.ir_node.into_inner()),
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: out_location
                     .new_node_metadata(Optional::<T, Atomic<L>, Unbounded>::collection_kind()),
             },
@@ -1339,7 +1364,7 @@ where
         Optional::new(
             self.location.clone(),
             HydroNode::DeferTick {
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.new_node_metadata(Self::collection_kind()),
             },
         )

--- a/hydro_lang/src/live_collections/singleton.rs
+++ b/hydro_lang/src/live_collections/singleton.rs
@@ -11,7 +11,7 @@ use super::boundedness::{Bounded, Boundedness, IsBounded, Unbounded};
 use super::optional::Optional;
 use super::sliced::sliced;
 use super::stream::{AtLeastOnce, ExactlyOnce, NoOrder, Stream, TotalOrder};
-use crate::compile::builder::CycleId;
+use crate::compile::builder::{CycleId, FlowState};
 use crate::compile::ir::{CollectionKind, HydroIrOpMetadata, HydroNode, HydroRoot, SharedNode};
 #[cfg(stageleft_runtime)]
 use crate::forward_handle::{CycleCollection, CycleCollectionWithInitial, ReceiverComplete};
@@ -39,8 +39,21 @@ use crate::nondet::{NonDet, nondet};
 pub struct Singleton<Type, Loc, Bound: Boundedness> {
     pub(crate) location: Loc,
     pub(crate) ir_node: RefCell<HydroNode>,
+    pub(crate) flow_state: FlowState,
 
     _phantom: PhantomData<(Type, Loc, Bound)>,
+}
+
+impl<T, L, B: Boundedness> Drop for Singleton<T, L, B> {
+    fn drop(&mut self) {
+        let ir_node = self.ir_node.replace(HydroNode::Placeholder);
+        if !matches!(ir_node, HydroNode::Placeholder) && !ir_node.is_shared_with_others() {
+            self.flow_state.borrow_mut().try_push_root(HydroRoot::Null {
+                input: Box::new(ir_node),
+                op_metadata: HydroIrOpMetadata::new(),
+            });
+        }
+    }
 }
 
 impl<'a, T, L> From<Singleton<T, L, Bounded>> for Singleton<T, L, Unbounded>
@@ -92,7 +105,7 @@ where
             .borrow_mut()
             .push_root(HydroRoot::CycleSink {
                 cycle_id,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 op_metadata: HydroIrOpMetadata::new(),
             });
     }
@@ -130,7 +143,7 @@ where
             .borrow_mut()
             .push_root(HydroRoot::CycleSink {
                 cycle_id,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 op_metadata: HydroIrOpMetadata::new(),
             });
     }
@@ -168,7 +181,7 @@ where
             .borrow_mut()
             .push_root(HydroRoot::CycleSink {
                 cycle_id,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 op_metadata: HydroIrOpMetadata::new(),
             });
     }
@@ -191,6 +204,7 @@ where
         if let HydroNode::Tee { inner, metadata } = self.ir_node.borrow().deref() {
             Singleton {
                 location: self.location.clone(),
+                flow_state: self.flow_state.clone(),
                 ir_node: HydroNode::Tee {
                     inner: SharedNode(inner.0.clone()),
                     metadata: metadata.clone(),
@@ -220,8 +234,10 @@ where
     pub(crate) fn new(location: L, ir_node: HydroNode) -> Self {
         debug_assert_eq!(ir_node.metadata().location_id, Location::id(&location));
         debug_assert_eq!(ir_node.metadata().collection_kind, Self::collection_kind());
+        let flow_state = location.flow_state().clone();
         Singleton {
             location,
+            flow_state,
             ir_node: RefCell::new(ir_node),
             _phantom: PhantomData,
         }
@@ -266,7 +282,7 @@ where
             self.location.clone(),
             HydroNode::Map {
                 f,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .new_node_metadata(Singleton::<U, L, B>::collection_kind()),
@@ -314,7 +330,7 @@ where
             self.location.clone(),
             HydroNode::FlatMap {
                 f,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.new_node_metadata(
                     Stream::<U, L, B, TotalOrder, ExactlyOnce>::collection_kind(),
                 ),
@@ -363,7 +379,7 @@ where
             self.location.clone(),
             HydroNode::FlatMap {
                 f,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .new_node_metadata(Stream::<U, L, B, NoOrder, ExactlyOnce>::collection_kind()),
@@ -472,7 +488,7 @@ where
             self.location.clone(),
             HydroNode::Filter {
                 f,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .new_node_metadata(Optional::<T, L, B>::collection_kind()),
@@ -512,7 +528,7 @@ where
             self.location.clone(),
             HydroNode::FilterMap {
                 f,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .new_node_metadata(Optional::<U, L, B>::collection_kind()),
@@ -576,12 +592,15 @@ where
             )
             .latest();
 
-            Self::make(out.location, out.ir_node.into_inner())
+            Self::make(
+                out.location.clone(),
+                out.ir_node.replace(HydroNode::Placeholder),
+            )
         } else {
             Self::make(
                 self.location.clone(),
                 HydroNode::CrossSingleton {
-                    left: Box::new(self.ir_node.into_inner()),
+                    left: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                     right: Box::new(Self::other_ir_node(other)),
                     metadata: self.location.new_node_metadata(CollectionKind::Optional {
                         bound: B::BOUND_KIND,
@@ -746,7 +765,7 @@ where
         Singleton::new(
             self.location.clone().tick,
             HydroNode::Batch {
-                inner: Box::new(self.ir_node.into_inner()),
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .tick
@@ -761,7 +780,7 @@ where
         Singleton::new(
             self.location.tick.l.clone(),
             HydroNode::EndAtomic {
-                inner: Box::new(self.ir_node.into_inner()),
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .tick
@@ -792,7 +811,7 @@ where
         Singleton::new(
             out_location.clone(),
             HydroNode::BeginAtomic {
-                inner: Box::new(self.ir_node.into_inner()),
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: out_location
                     .new_node_metadata(Singleton::<T, Atomic<L>, B>::collection_kind()),
             },
@@ -812,7 +831,7 @@ where
         Singleton::new(
             tick.clone(),
             HydroNode::Batch {
-                inner: Box::new(self.ir_node.into_inner()),
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: tick
                     .new_node_metadata(Singleton::<T, Tick<L>, Bounded>::collection_kind()),
             },
@@ -870,7 +889,10 @@ where
     where
         B: IsBounded,
     {
-        Singleton::new(self.location, self.ir_node.into_inner())
+        Singleton::new(
+            self.location.clone(),
+            self.ir_node.replace(HydroNode::Placeholder),
+        )
     }
 
     /// Clones this bounded singleton into a tick, returning a singleton that has the
@@ -918,7 +940,7 @@ where
         Stream::new(
             self.location.clone(),
             HydroNode::Cast {
-                inner: Box::new(self.ir_node.into_inner()),
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.new_node_metadata(Stream::<
                     T,
                     Tick<L>,
@@ -1024,7 +1046,7 @@ where
         Singleton::new(
             self.location.outer().clone(),
             HydroNode::YieldConcat {
-                inner: Box::new(self.ir_node.into_inner()),
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .outer()
@@ -1046,7 +1068,7 @@ where
         Singleton::new(
             out_location.clone(),
             HydroNode::YieldConcat {
-                inner: Box::new(self.ir_node.into_inner()),
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: out_location
                     .new_node_metadata(Singleton::<T, Atomic<L>, Unbounded>::collection_kind()),
             },
@@ -1094,7 +1116,7 @@ where
     }
 
     fn other_ir_node(other: Singleton<U, L, B>) -> HydroNode {
-        other.ir_node.into_inner()
+        other.ir_node.replace(HydroNode::Placeholder)
     }
 
     fn make(location: L, ir_node: HydroNode) -> Self::Out {
@@ -1123,7 +1145,7 @@ where
     }
 
     fn other_ir_node(other: Optional<U, L, B>) -> HydroNode {
-        other.ir_node.into_inner()
+        other.ir_node.replace(HydroNode::Placeholder)
     }
 
     fn make(location: L, ir_node: HydroNode) -> Self::Out {

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -15,7 +15,7 @@ use super::keyed_singleton::KeyedSingleton;
 use super::keyed_stream::KeyedStream;
 use super::optional::Optional;
 use super::singleton::Singleton;
-use crate::compile::builder::CycleId;
+use crate::compile::builder::{CycleId, FlowState};
 use crate::compile::ir::{
     CollectionKind, HydroIrOpMetadata, HydroNode, HydroRoot, SharedNode, StreamOrder, StreamRetry,
 };
@@ -197,8 +197,21 @@ pub struct Stream<
 > {
     pub(crate) location: Loc,
     pub(crate) ir_node: RefCell<HydroNode>,
+    pub(crate) flow_state: FlowState,
 
     _phantom: PhantomData<(Type, Loc, Bound, Order, Retry)>,
+}
+
+impl<T, L, B: Boundedness, O: Ordering, R: Retries> Drop for Stream<T, L, B, O, R> {
+    fn drop(&mut self) {
+        let ir_node = self.ir_node.replace(HydroNode::Placeholder);
+        if !matches!(ir_node, HydroNode::Placeholder) && !ir_node.is_shared_with_others() {
+            self.flow_state.borrow_mut().try_push_root(HydroRoot::Null {
+                input: Box::new(ir_node),
+                op_metadata: HydroIrOpMetadata::new(),
+            });
+        }
+    }
 }
 
 impl<'a, T, L, O: Ordering, R: Retries> From<Stream<T, L, Bounded, O, R>>
@@ -212,9 +225,10 @@ where
             .new_node_metadata(Stream::<T, L, Unbounded, O, R>::collection_kind());
 
         Stream {
-            location: stream.location,
+            location: stream.location.clone(),
+            flow_state: stream.flow_state.clone(),
             ir_node: RefCell::new(HydroNode::Cast {
-                inner: Box::new(stream.ir_node.into_inner()),
+                inner: Box::new(stream.ir_node.replace(HydroNode::Placeholder)),
                 metadata: new_meta,
             }),
             _phantom: PhantomData,
@@ -308,7 +322,7 @@ where
             .borrow_mut()
             .push_root(HydroRoot::CycleSink {
                 cycle_id,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 op_metadata: HydroIrOpMetadata::new(),
             });
     }
@@ -348,7 +362,7 @@ where
             .borrow_mut()
             .push_root(HydroRoot::CycleSink {
                 cycle_id,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 op_metadata: HydroIrOpMetadata::new(),
             });
     }
@@ -371,6 +385,7 @@ where
         if let HydroNode::Tee { inner, metadata } = self.ir_node.borrow().deref() {
             Stream {
                 location: self.location.clone(),
+                flow_state: self.flow_state.clone(),
                 ir_node: HydroNode::Tee {
                     inner: SharedNode(inner.0.clone()),
                     metadata: metadata.clone(),
@@ -392,8 +407,10 @@ where
         debug_assert_eq!(ir_node.metadata().location_id, Location::id(&location));
         debug_assert_eq!(ir_node.metadata().collection_kind, Self::collection_kind());
 
+        let flow_state = location.flow_state().clone();
         Stream {
             location,
+            flow_state,
             ir_node: RefCell::new(ir_node),
             _phantom: PhantomData,
         }
@@ -441,7 +458,7 @@ where
             self.location.clone(),
             HydroNode::Map {
                 f,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .new_node_metadata(Stream::<U, L, B, O, R>::collection_kind()),
@@ -483,7 +500,7 @@ where
             self.location.clone(),
             HydroNode::FlatMap {
                 f,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .new_node_metadata(Stream::<U, L, B, O, R>::collection_kind()),
@@ -530,7 +547,7 @@ where
             self.location.clone(),
             HydroNode::FlatMap {
                 f,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .new_node_metadata(Stream::<U, L, B, NoOrder, R>::collection_kind()),
@@ -633,7 +650,7 @@ where
             self.location.clone(),
             HydroNode::Filter {
                 f,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.new_node_metadata(Self::collection_kind()),
             },
         )
@@ -685,7 +702,9 @@ where
         F: Fn(&T) -> bool + 'a,
     {
         let f: crate::compile::ir::DebugExpr = f.splice_fn1_borrow_ctx(&self.location).into();
-        let shared = SharedNode(Rc::new(RefCell::new(self.ir_node.into_inner())));
+        let shared = SharedNode(Rc::new(RefCell::new(
+            self.ir_node.replace(HydroNode::Placeholder),
+        )));
 
         let true_stream = Stream::new(
             self.location.clone(),
@@ -738,7 +757,7 @@ where
             self.location.clone(),
             HydroNode::FilterMap {
                 f,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .new_node_metadata(Stream::<U, L, B, O, R>::collection_kind()),
@@ -783,8 +802,8 @@ where
         Stream::new(
             self.location.clone(),
             HydroNode::CrossSingleton {
-                left: Box::new(self.ir_node.into_inner()),
-                right: Box::new(other.ir_node.into_inner()),
+                left: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                right: Box::new(other.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .new_node_metadata(Stream::<(T, O2), L, B, O, R>::collection_kind()),
@@ -907,8 +926,8 @@ where
         Stream::new(
             self.location.clone(),
             HydroNode::CrossProduct {
-                left: Box::new(self.ir_node.into_inner()),
-                right: Box::new(other.ir_node.into_inner()),
+                left: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                right: Box::new(other.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .new_node_metadata(Stream::<(T, T2), L, B, NoOrder, R>::collection_kind()),
@@ -941,7 +960,7 @@ where
         Stream::new(
             self.location.clone(),
             HydroNode::Unique {
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .new_node_metadata(Stream::<T, L, B, O, ExactlyOnce>::collection_kind()),
@@ -984,8 +1003,8 @@ where
         Stream::new(
             self.location.clone(),
             HydroNode::Difference {
-                pos: Box::new(self.ir_node.into_inner()),
-                neg: Box::new(other.ir_node.into_inner()),
+                pos: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                neg: Box::new(other.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .new_node_metadata(Stream::<T, L, Bounded, O, R>::collection_kind()),
@@ -1023,7 +1042,7 @@ where
             self.location.clone(),
             HydroNode::Inspect {
                 f,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.new_node_metadata(Self::collection_kind()),
             },
         )
@@ -1045,7 +1064,7 @@ where
             .flow_state()
             .borrow_mut()
             .push_root(HydroRoot::ForEach {
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 f,
                 op_metadata: HydroIrOpMetadata::new(),
             });
@@ -1067,7 +1086,7 @@ where
             .borrow_mut()
             .push_root(HydroRoot::DestSink {
                 sink: sink.splice_typed_ctx(&self.location).into(),
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 op_metadata: HydroIrOpMetadata::new(),
             });
     }
@@ -1099,7 +1118,7 @@ where
         Stream::new(
             self.location.clone(),
             HydroNode::Enumerate {
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.new_node_metadata(Stream::<
                     (usize, T),
                     L,
@@ -1155,13 +1174,13 @@ where
         let core = HydroNode::Fold {
             init,
             acc: comb.into(),
-            input: Box::new(ordered_etc.ir_node.into_inner()),
+            input: Box::new(ordered_etc.ir_node.replace(HydroNode::Placeholder)),
             metadata: ordered_etc
                 .location
                 .new_node_metadata(Singleton::<A, L, B>::collection_kind()),
         };
 
-        Singleton::new(ordered_etc.location, core)
+        Singleton::new(ordered_etc.location.clone(), core)
     }
 
     /// Combines elements of the stream into an [`Optional`], by starting with the first element in the stream,
@@ -1203,13 +1222,13 @@ where
 
         let core = HydroNode::Reduce {
             f: f.into(),
-            input: Box::new(ordered_etc.ir_node.into_inner()),
+            input: Box::new(ordered_etc.ir_node.replace(HydroNode::Placeholder)),
             metadata: ordered_etc
                 .location
                 .new_node_metadata(Optional::<T, L, B>::collection_kind()),
         };
 
-        Optional::new(ordered_etc.location, core)
+        Optional::new(ordered_etc.location.clone(), core)
     }
 
     /// Computes the maximum element in the stream as an [`Optional`], which
@@ -1459,7 +1478,7 @@ where
             HydroNode::Scan {
                 init,
                 acc: f,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.new_node_metadata(
                     Stream::<U, L, B, TotalOrder, ExactlyOnce>::collection_kind(),
                 ),
@@ -1550,7 +1569,7 @@ where
         Stream::new(
             out_location.clone(),
             HydroNode::BeginAtomic {
-                inner: Box::new(self.ir_node.into_inner()),
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: out_location
                     .new_node_metadata(Stream::<T, Atomic<L>, B, O, R>::collection_kind()),
             },
@@ -1569,7 +1588,7 @@ where
         Stream::new(
             tick.clone(),
             HydroNode::Batch {
-                inner: Box::new(self.ir_node.into_inner()),
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: tick
                     .new_node_metadata(Stream::<T, Tick<L>, Bounded, O, R>::collection_kind()),
             },
@@ -1597,13 +1616,16 @@ where
     /// for the rest of the program.
     pub fn assume_ordering<O2: Ordering>(self, _nondet: NonDet) -> Stream<T, L, B, O2, R> {
         if O::ORDERING_KIND == O2::ORDERING_KIND {
-            Stream::new(self.location, self.ir_node.into_inner())
+            Stream::new(
+                self.location.clone(),
+                self.ir_node.replace(HydroNode::Placeholder),
+            )
         } else if O2::ORDERING_KIND == StreamOrder::NoOrder {
             // We can always weaken the ordering guarantee
             Stream::new(
                 self.location.clone(),
                 HydroNode::Cast {
-                    inner: Box::new(self.ir_node.into_inner()),
+                    inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                     metadata: self
                         .location
                         .new_node_metadata(Stream::<T, L, B, O2, R>::collection_kind()),
@@ -1613,7 +1635,7 @@ where
             Stream::new(
                 self.location.clone(),
                 HydroNode::ObserveNonDet {
-                    inner: Box::new(self.ir_node.into_inner()),
+                    inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                     trusted: false,
                     metadata: self
                         .location
@@ -1643,13 +1665,16 @@ where
         _nondet: NonDet,
     ) -> Stream<T, L, B, O2, R> {
         if O::ORDERING_KIND == O2::ORDERING_KIND {
-            Stream::new(self.location, self.ir_node.into_inner())
+            Stream::new(
+                self.location.clone(),
+                self.ir_node.replace(HydroNode::Placeholder),
+            )
         } else if O2::ORDERING_KIND == StreamOrder::NoOrder {
             // We can always weaken the ordering guarantee
             Stream::new(
                 self.location.clone(),
                 HydroNode::Cast {
-                    inner: Box::new(self.ir_node.into_inner()),
+                    inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                     metadata: self
                         .location
                         .new_node_metadata(Stream::<T, L, B, O2, R>::collection_kind()),
@@ -1659,7 +1684,7 @@ where
             Stream::new(
                 self.location.clone(),
                 HydroNode::ObserveNonDet {
-                    inner: Box::new(self.ir_node.into_inner()),
+                    inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                     trusted: true,
                     metadata: self
                         .location
@@ -1702,13 +1727,16 @@ where
     /// for the rest of the program.
     pub fn assume_retries<R2: Retries>(self, _nondet: NonDet) -> Stream<T, L, B, O, R2> {
         if R::RETRIES_KIND == R2::RETRIES_KIND {
-            Stream::new(self.location, self.ir_node.into_inner())
+            Stream::new(
+                self.location.clone(),
+                self.ir_node.replace(HydroNode::Placeholder),
+            )
         } else if R2::RETRIES_KIND == StreamRetry::AtLeastOnce {
             // We can always weaken the retries guarantee
             Stream::new(
                 self.location.clone(),
                 HydroNode::Cast {
-                    inner: Box::new(self.ir_node.into_inner()),
+                    inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                     metadata: self
                         .location
                         .new_node_metadata(Stream::<T, L, B, O, R2>::collection_kind()),
@@ -1718,7 +1746,7 @@ where
             Stream::new(
                 self.location.clone(),
                 HydroNode::ObserveNonDet {
-                    inner: Box::new(self.ir_node.into_inner()),
+                    inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                     trusted: false,
                     metadata: self
                         .location
@@ -1732,13 +1760,16 @@ where
     // is not observable
     fn assume_retries_trusted<R2: Retries>(self, _nondet: NonDet) -> Stream<T, L, B, O, R2> {
         if R::RETRIES_KIND == R2::RETRIES_KIND {
-            Stream::new(self.location, self.ir_node.into_inner())
+            Stream::new(
+                self.location.clone(),
+                self.ir_node.replace(HydroNode::Placeholder),
+            )
         } else if R2::RETRIES_KIND == StreamRetry::AtLeastOnce {
             // We can always weaken the retries guarantee
             Stream::new(
                 self.location.clone(),
                 HydroNode::Cast {
-                    inner: Box::new(self.ir_node.into_inner()),
+                    inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                     metadata: self
                         .location
                         .new_node_metadata(Stream::<T, L, B, O, R2>::collection_kind()),
@@ -1748,7 +1779,7 @@ where
             Stream::new(
                 self.location.clone(),
                 HydroNode::ObserveNonDet {
-                    inner: Box::new(self.ir_node.into_inner()),
+                    inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                     trusted: true,
                     metadata: self
                         .location
@@ -1787,7 +1818,10 @@ where
     where
         B: IsBounded,
     {
-        Stream::new(self.location, self.ir_node.into_inner())
+        Stream::new(
+            self.location.clone(),
+            self.ir_node.replace(HydroNode::Placeholder),
+        )
     }
 }
 
@@ -1884,8 +1918,8 @@ impl<'a, T, L: Location<'a> + NoTick, O: Ordering, R: Retries> Stream<T, L, Unbo
         Stream::new(
             self.location.clone(),
             HydroNode::Chain {
-                first: Box::new(self.ir_node.into_inner()),
-                second: Box::new(other.ir_node.into_inner()),
+                first: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                second: Box::new(other.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.new_node_metadata(Stream::<
                     T,
                     L,
@@ -1939,8 +1973,8 @@ impl<'a, T, L: Location<'a> + NoTick, R: Retries> Stream<T, L, Unbounded, TotalO
         Stream::new(
             self.location.clone(),
             HydroNode::Chain {
-                first: Box::new(self.ir_node.into_inner()),
-                second: Box::new(other.ir_node.into_inner()),
+                first: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                second: Box::new(other.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.new_node_metadata(Stream::<
                     T,
                     L,
@@ -1991,7 +2025,7 @@ where
         Stream::new(
             this.location.clone(),
             HydroNode::Sort {
-                input: Box::new(this.ir_node.into_inner()),
+                input: Box::new(this.ir_node.replace(HydroNode::Placeholder)),
                 metadata: this
                     .location
                     .new_node_metadata(Stream::<T, L, Bounded, TotalOrder, R>::collection_kind()),
@@ -2040,8 +2074,8 @@ where
         Stream::new(
             self.location.clone(),
             HydroNode::Chain {
-                first: Box::new(self.ir_node.into_inner()),
-                second: Box::new(other.ir_node.into_inner()),
+                first: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                second: Box::new(other.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.new_node_metadata(Stream::<
                     T,
                     L,
@@ -2071,8 +2105,8 @@ where
         Stream::new(
             this.location.clone(),
             HydroNode::CrossProduct {
-                left: Box::new(this.ir_node.into_inner()),
-                right: Box::new(other.ir_node.into_inner()),
+                left: Box::new(this.ir_node.replace(HydroNode::Placeholder)),
+                right: Box::new(other.ir_node.replace(HydroNode::Placeholder)),
                 metadata: this.location.new_node_metadata(Stream::<
                     (T, T2),
                     L,
@@ -2178,8 +2212,8 @@ where
         Stream::new(
             self.location.clone(),
             HydroNode::Join {
-                left: Box::new(self.ir_node.into_inner()),
-                right: Box::new(n.ir_node.into_inner()),
+                left: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                right: Box::new(n.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.new_node_metadata(Stream::<
                     (K, (V1, V2)),
                     L,
@@ -2228,8 +2262,8 @@ where
         Stream::new(
             self.location.clone(),
             HydroNode::AntiJoin {
-                pos: Box::new(self.ir_node.into_inner()),
-                neg: Box::new(n.ir_node.into_inner()),
+                pos: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                neg: Box::new(n.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .new_node_metadata(Stream::<(K, V1), L, B, O, R>::collection_kind()),
@@ -2271,7 +2305,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
         KeyedStream::new(
             self.location.clone(),
             HydroNode::Cast {
-                inner: Box::new(self.ir_node.into_inner()),
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .new_node_metadata(KeyedStream::<K, V, L, B, O, R>::collection_kind()),
@@ -2331,7 +2365,7 @@ where
         Stream::new(
             self.location.clone().tick,
             HydroNode::Batch {
-                inner: Box::new(self.ir_node.into_inner()),
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .tick
@@ -2346,7 +2380,7 @@ where
         Stream::new(
             self.location.tick.l.clone(),
             HydroNode::EndAtomic {
-                inner: Box::new(self.ir_node.into_inner()),
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .tick
@@ -2396,7 +2430,7 @@ where
         Stream::new(
             self.location.clone(),
             HydroNode::ResolveFutures {
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .new_node_metadata(Stream::<T, L, Unbounded, NoOrder, R>::collection_kind()),
@@ -2438,7 +2472,7 @@ where
         Stream::new(
             self.location.clone(),
             HydroNode::ResolveFuturesOrdered {
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .new_node_metadata(Stream::<T, L, Unbounded, O, R>::collection_kind()),
@@ -2457,7 +2491,7 @@ where
         Stream::new(
             self.location.outer().clone(),
             HydroNode::YieldConcat {
-                inner: Box::new(self.ir_node.into_inner()),
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .outer()
@@ -2480,7 +2514,7 @@ where
         Stream::new(
             out_location.clone(),
             HydroNode::YieldConcat {
-                inner: Box::new(self.ir_node.into_inner()),
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: out_location
                     .new_node_metadata(Stream::<T, Atomic<L>, Unbounded, O, R>::collection_kind()),
             },
@@ -2571,7 +2605,7 @@ where
         Stream::new(
             self.location.clone(),
             HydroNode::DeferTick {
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
                     .new_node_metadata(Stream::<T, Tick<L>, Bounded, O, R>::collection_kind()),
@@ -3365,5 +3399,47 @@ mod tests {
         }
         odd_results.sort();
         assert_eq!(odd_results, vec![1, 3, 5]);
+    }
+
+    #[cfg(feature = "deploy")]
+    #[tokio::test]
+    async fn unconsumed_inspect_still_runs() {
+        use crate::deploy::DeployCrateWrapper;
+
+        let mut deployment = Deployment::new();
+
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<()>();
+
+        // The return value of .inspect() is intentionally dropped.
+        // Before the Null-root fix, this would silently do nothing.
+        node.source_iter(q!(0..5))
+            .inspect(q!(|x| println!("inspect: {}", x)));
+
+        let nodes = flow
+            .with_process(&node, deployment.Localhost())
+            .deploy(&mut deployment);
+
+        deployment.deploy().await.unwrap();
+
+        let mut stdout = nodes.get_process(&node).stdout();
+
+        deployment.start().await.unwrap();
+
+        let mut lines = Vec::new();
+        for _ in 0..5 {
+            lines.push(stdout.recv().await.unwrap());
+        }
+        lines.sort();
+        assert_eq!(
+            lines,
+            vec![
+                "inspect: 0",
+                "inspect: 1",
+                "inspect: 2",
+                "inspect: 3",
+                "inspect: 4",
+            ]
+        );
     }
 }

--- a/hydro_lang/src/live_collections/stream/networking.rs
+++ b/hydro_lang/src/live_collections/stream/networking.rs
@@ -183,7 +183,7 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Process<'a, L>
                 serialize_fn: serialize_pipeline.map(|e| e.into()),
                 instantiate_fn: DebugInstantiate::Building,
                 deserialize_fn: deserialize_pipeline.map(|e| e.into()),
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: to.new_node_metadata(
                     Stream::<T, Process<'a, L2>, Unbounded, O, R>::collection_kind(),
                 ),
@@ -353,7 +353,7 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Process<'a, L>
             unpaired: true,
             serialize_fn: serialize_pipeline.map(|e| e.into()),
             instantiate_fn: DebugInstantiate::Building,
-            input: Box::new(self.ir_node.into_inner()),
+            input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
             op_metadata: HydroIrOpMetadata::new(),
         });
 
@@ -398,7 +398,7 @@ impl<'a, T, L: Location<'a> + NoTick, B: Boundedness> Stream<T, L, B, TotalOrder
             .borrow_mut()
             .push_root(HydroRoot::EmbeddedOutput {
                 ident,
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 op_metadata: HydroIrOpMetadata::new(),
             });
     }
@@ -922,7 +922,7 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Cluster<'a, L>
                 serialize_fn: serialize_pipeline.map(|e| e.into()),
                 instantiate_fn: DebugInstantiate::Building,
                 deserialize_fn: deserialize_pipeline.map(|e| e.into()),
-                input: Box::new(self.ir_node.into_inner()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: to.new_node_metadata(Stream::<
                     (MemberId<L>, T),
                     Process<'a, L2>,

--- a/hydro_lang/src/location/mod.rs
+++ b/hydro_lang/src/location/mod.rs
@@ -626,7 +626,7 @@ pub trait Location<'a>: dynamic::DynLocation {
             unpaired: false,
             serialize_fn: None,
             instantiate_fn: DebugInstantiate::Building,
-            input: Box::new(to_sink.ir_node.into_inner()),
+            input: Box::new(to_sink.ir_node.replace(HydroNode::Placeholder)),
             op_metadata: HydroIrOpMetadata::new(),
         });
 
@@ -710,7 +710,7 @@ pub trait Location<'a>: dynamic::DynLocation {
             unpaired: false,
             serialize_fn: Some(ser_fn.into()),
             instantiate_fn: DebugInstantiate::Building,
-            input: Box::new(to_sink.ir_node.into_inner()),
+            input: Box::new(to_sink.ir_node.replace(HydroNode::Placeholder)),
             op_metadata: HydroIrOpMetadata::new(),
         });
 
@@ -792,7 +792,7 @@ pub trait Location<'a>: dynamic::DynLocation {
             unpaired: false,
             serialize_fn: None,
             instantiate_fn: DebugInstantiate::Building,
-            input: Box::new(to_sink.entries().ir_node.into_inner()),
+            input: Box::new(to_sink.entries().ir_node.replace(HydroNode::Placeholder)),
             op_metadata: HydroIrOpMetadata::new(),
         });
 
@@ -922,7 +922,7 @@ pub trait Location<'a>: dynamic::DynLocation {
             unpaired: false,
             serialize_fn: Some(ser_fn.into()),
             instantiate_fn: DebugInstantiate::Building,
-            input: Box::new(to_sink.entries().ir_node.into_inner()),
+            input: Box::new(to_sink.entries().ir_node.replace(HydroNode::Placeholder)),
             op_metadata: HydroIrOpMetadata::new(),
         });
 

--- a/hydro_lang/src/viz/render.rs
+++ b/hydro_lang/src/viz/render.rs
@@ -905,6 +905,15 @@ impl HydroRoot {
                 None,
                 NodeLabel::static_label(format!("embedded_output({})", ident)),
             ),
+
+            HydroRoot::Null { input, .. } => build_sink_node(
+                structure,
+                seen_tees,
+                config,
+                input,
+                None,
+                NodeLabel::static_label("null".to_owned()),
+            ),
         }
     }
 }

--- a/hydro_test/src/cluster/snapshots/paxos_ir.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir.snap
@@ -5740,6 +5740,80 @@ expression: built.ir()
         },
         op_metadata: HydroIrOpMetadata,
     },
+    Null {
+        input: YieldConcat {
+            inner: Cast {
+                inner: Map {
+                    f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , ()) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _signal) | d }),
+                    input: CrossSingleton {
+                        left: Tee {
+                            inner: <shared 4>,
+                            metadata: HydroIrMetadata {
+                                location_id: Tick(1, Cluster(loc1v1)),
+                                collection_kind: Singleton {
+                                    bound: Bounded,
+                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                },
+                            },
+                        },
+                        right: Map {
+                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | _u | () }),
+                            input: Tee {
+                                inner: <shared 19>,
+                                metadata: HydroIrMetadata {
+                                    location_id: Tick(1, Cluster(loc1v1)),
+                                    collection_kind: Optional {
+                                        bound: Bounded,
+                                        element_type: (),
+                                    },
+                                },
+                            },
+                            metadata: HydroIrMetadata {
+                                location_id: Tick(1, Cluster(loc1v1)),
+                                collection_kind: Optional {
+                                    bound: Bounded,
+                                    element_type: (),
+                                },
+                            },
+                        },
+                        metadata: HydroIrMetadata {
+                            location_id: Tick(1, Cluster(loc1v1)),
+                            collection_kind: Optional {
+                                bound: Bounded,
+                                element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , ()),
+                            },
+                        },
+                    },
+                    metadata: HydroIrMetadata {
+                        location_id: Tick(1, Cluster(loc1v1)),
+                        collection_kind: Optional {
+                            bound: Bounded,
+                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                        },
+                    },
+                },
+                metadata: HydroIrMetadata {
+                    location_id: Tick(1, Cluster(loc1v1)),
+                    collection_kind: Stream {
+                        bound: Bounded,
+                        order: TotalOrder,
+                        retry: ExactlyOnce,
+                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                    },
+                },
+            },
+            metadata: HydroIrMetadata {
+                location_id: Cluster(loc1v1),
+                collection_kind: Stream {
+                    bound: Unbounded,
+                    order: TotalOrder,
+                    retry: ExactlyOnce,
+                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                },
+            },
+        },
+        op_metadata: HydroIrOpMetadata,
+    },
     CycleSink {
         cycle_id: CycleId(
             16,
@@ -7405,6 +7479,33 @@ expression: built.ir()
                     order: NoOrder,
                     retry: ExactlyOnce,
                     element_type: (u32 , i32),
+                },
+            },
+        },
+        op_metadata: HydroIrOpMetadata,
+    },
+    Null {
+        input: FilterMap {
+            f: stageleft :: runtime_support :: fn1_type_hint :: < ((u32 , i32) , core :: result :: Result < () , () >) , core :: option :: Option < ((u32 , i32) , ()) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | (key , res) | match res { Ok (_) => None , Err (e) => Some ((key , e)) , } }),
+            input: Tee {
+                inner: <shared 43>,
+                metadata: HydroIrMetadata {
+                    location_id: Cluster(loc3v1),
+                    collection_kind: Stream {
+                        bound: Unbounded,
+                        order: NoOrder,
+                        retry: ExactlyOnce,
+                        element_type: ((u32 , i32) , core :: result :: Result < () , () >),
+                    },
+                },
+            },
+            metadata: HydroIrMetadata {
+                location_id: Cluster(loc3v1),
+                collection_kind: Stream {
+                    bound: Unbounded,
+                    order: NoOrder,
+                    retry: ExactlyOnce,
+                    element_type: ((u32 , i32) , ()),
                 },
             },
         },

--- a/hydro_test/src/cluster/snapshots/paxos_ir@acceptor_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir@acceptor_mermaid.snap
@@ -243,44 +243,44 @@ subgraph var_stream_509 ["var <tt>stream_509</tt>"]
     style var_stream_509 fill:transparent
     39v1
 end
-subgraph var_stream_614 ["var <tt>stream_614</tt>"]
-    style var_stream_614 fill:transparent
+subgraph var_stream_622 ["var <tt>stream_622</tt>"]
+    style var_stream_622 fill:transparent
     41v1
     42v1
 end
-subgraph var_stream_616 ["var <tt>stream_616</tt>"]
-    style var_stream_616 fill:transparent
+subgraph var_stream_624 ["var <tt>stream_624</tt>"]
+    style var_stream_624 fill:transparent
     43v1
-end
-subgraph var_stream_618 ["var <tt>stream_618</tt>"]
-    style var_stream_618 fill:transparent
-    44v1
-end
-subgraph var_stream_625 ["var <tt>stream_625</tt>"]
-    style var_stream_625 fill:transparent
-    45v1
 end
 subgraph var_stream_626 ["var <tt>stream_626</tt>"]
     style var_stream_626 fill:transparent
+    44v1
+end
+subgraph var_stream_633 ["var <tt>stream_633</tt>"]
+    style var_stream_633 fill:transparent
+    45v1
+end
+subgraph var_stream_634 ["var <tt>stream_634</tt>"]
+    style var_stream_634 fill:transparent
     46v1
 end
-subgraph var_stream_627 ["var <tt>stream_627</tt>"]
-    style var_stream_627 fill:transparent
+subgraph var_stream_635 ["var <tt>stream_635</tt>"]
+    style var_stream_635 fill:transparent
     47v1
 end
-subgraph var_stream_628 ["var <tt>stream_628</tt>"]
-    style var_stream_628 fill:transparent
+subgraph var_stream_636 ["var <tt>stream_636</tt>"]
+    style var_stream_636 fill:transparent
     48v1
 end
-subgraph var_stream_629 ["var <tt>stream_629</tt>"]
-    style var_stream_629 fill:transparent
+subgraph var_stream_637 ["var <tt>stream_637</tt>"]
+    style var_stream_637 fill:transparent
     49v1
 end
-subgraph var_stream_630 ["var <tt>stream_630</tt>"]
-    style var_stream_630 fill:transparent
+subgraph var_stream_638 ["var <tt>stream_638</tt>"]
+    style var_stream_638 fill:transparent
     50v1
 end
-subgraph var_stream_632 ["var <tt>stream_632</tt>"]
-    style var_stream_632 fill:transparent
+subgraph var_stream_640 ["var <tt>stream_640</tt>"]
+    style var_stream_640 fill:transparent
     51v1
 end

--- a/hydro_test/src/cluster/snapshots/paxos_ir@proposer_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir@proposer_mermaid.snap
@@ -136,6 +136,7 @@ linkStyle default stroke:#aaa
 127v1["<div style=text-align:center>(127v1)</div> <code><br>map({<br>    |_u| ()<br>})</code>"]:::otherClass
 128v1["<div style=text-align:center>(128v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
 129v1["<div style=text-align:center>(129v1)</div> <code><br>map({<br>    |(d, _signal)| d<br>})</code>"]:::otherClass
+130v1["<div style=text-align:center>(130v1)</div> <code><br>tee()</code>"]:::otherClass
 131v1["<div style=text-align:center>(131v1)</div> <code><br>map({<br>    |_u| ()<br>})</code>"]:::otherClass
 132v1["<div style=text-align:center>(132v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
 133v1["<div style=text-align:center>(133v1)</div> <code><br>map({<br>    |(d, _signal)| d<br>})</code>"]:::otherClass
@@ -237,25 +238,29 @@ linkStyle default stroke:#aaa
 229v1["<div style=text-align:center>(229v1)</div> <code><br>filter_map({<br>    move |(key, res)| match res {<br>        Ok(_) =&gt; None,<br>        Err(e) =&gt; Some((key, e)),<br>    }<br>})</code>"]:::otherClass
 230v1["<div style=text-align:center>(230v1)</div> <code><br>map({<br>    |(_, ballot)| ballot<br>})</code>"]:::otherClass
 231v1["<div style=text-align:center>(231v1)</div> <code><br>identity::&lt;hydro_test::__staged::cluster::paxos::Ballot&gt;()</code>"]:::otherClass
-232v1["<div style=text-align:center>(232v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
-233v1["<div style=text-align:center>(233v1)</div> <code><br>map({<br>    |(k, v)| (MemberId::from_tagless(k), v)<br>})</code>"]:::otherClass
-234v1["<div style=text-align:center>(234v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        || false<br>    },<br>    {<br>        |present, event| {<br>            match event {<br>                MembershipEvent::Joined =&gt; *present = true,<br>                MembershipEvent::Left =&gt; *present = false,<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
-235v1["<div style=text-align:center>(235v1)</div> <code><br>filter({<br>    let f__free = {<br>        |b| *b<br>    };<br>    {<br>        let orig = f__free;<br>        move |t: &amp;(_, _)| orig(&amp;t.1)<br>    }<br>})</code>"]:::otherClass
-236v1["<div style=text-align:center>(236v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
-237v1["<div style=text-align:center>(237v1)</div> <code><br>join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-238v1["<div style=text-align:center>(238v1)</div> <code><br>map({<br>    |(key, (meta, resp))| (key, (meta, resp))<br>})</code>"]:::otherClass
-239v1["<div style=text-align:center>(239v1)</div> <code><br>map({<br>    |((slot, _ballot), (value, _))| (slot, value)<br>})</code>"]:::otherClass
-240v1["<div style=text-align:center>(240v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-241v1["<div style=text-align:center>(241v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
-242v1["<div style=text-align:center>(242v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-338v1["<div style=text-align:center>(338v1)</div> <code><br>identity()</code>"]:::otherClass
-340v1["<div style=text-align:center>(340v1)</div> <code><br>identity()</code>"]:::otherClass
-342v1["<div style=text-align:center>(342v1)</div> <code><br>identity()</code>"]:::otherClass
-344v1["<div style=text-align:center>(344v1)</div> <code><br>identity()</code>"]:::otherClass
-346v1["<div style=text-align:center>(346v1)</div> <code><br>identity()</code>"]:::otherClass
-348v1["<div style=text-align:center>(348v1)</div> <code><br>identity()</code>"]:::otherClass
-350v1["<div style=text-align:center>(350v1)</div> <code><br>identity()</code>"]:::otherClass
-352v1["<div style=text-align:center>(352v1)</div> <code><br>identity()</code>"]:::otherClass
+232v1["<div style=text-align:center>(232v1)</div> <code><br>map({<br>    |_u| ()<br>})</code>"]:::otherClass
+233v1["<div style=text-align:center>(233v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+234v1["<div style=text-align:center>(234v1)</div> <code><br>map({<br>    |(d, _signal)| d<br>})</code>"]:::otherClass
+235v1["<div style=text-align:center>(235v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
+236v1["<div style=text-align:center>(236v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
+237v1["<div style=text-align:center>(237v1)</div> <code><br>map({<br>    |(k, v)| (MemberId::from_tagless(k), v)<br>})</code>"]:::otherClass
+238v1["<div style=text-align:center>(238v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        || false<br>    },<br>    {<br>        |present, event| {<br>            match event {<br>                MembershipEvent::Joined =&gt; *present = true,<br>                MembershipEvent::Left =&gt; *present = false,<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
+239v1["<div style=text-align:center>(239v1)</div> <code><br>filter({<br>    let f__free = {<br>        |b| *b<br>    };<br>    {<br>        let orig = f__free;<br>        move |t: &amp;(_, _)| orig(&amp;t.1)<br>    }<br>})</code>"]:::otherClass
+240v1["<div style=text-align:center>(240v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
+241v1["<div style=text-align:center>(241v1)</div> <code><br>join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+242v1["<div style=text-align:center>(242v1)</div> <code><br>map({<br>    |(key, (meta, resp))| (key, (meta, resp))<br>})</code>"]:::otherClass
+243v1["<div style=text-align:center>(243v1)</div> <code><br>map({<br>    |((slot, _ballot), (value, _))| (slot, value)<br>})</code>"]:::otherClass
+244v1["<div style=text-align:center>(244v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+245v1["<div style=text-align:center>(245v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+246v1["<div style=text-align:center>(246v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+345v1["<div style=text-align:center>(345v1)</div> <code><br>identity()</code>"]:::otherClass
+347v1["<div style=text-align:center>(347v1)</div> <code><br>identity()</code>"]:::otherClass
+349v1["<div style=text-align:center>(349v1)</div> <code><br>identity()</code>"]:::otherClass
+351v1["<div style=text-align:center>(351v1)</div> <code><br>identity()</code>"]:::otherClass
+353v1["<div style=text-align:center>(353v1)</div> <code><br>identity()</code>"]:::otherClass
+355v1["<div style=text-align:center>(355v1)</div> <code><br>identity()</code>"]:::otherClass
+357v1["<div style=text-align:center>(357v1)</div> <code><br>identity()</code>"]:::otherClass
+359v1["<div style=text-align:center>(359v1)</div> <code><br>identity()</code>"]:::otherClass
 1v1-->2v1
 114v1--x|0|3v1; linkStyle 1 stroke:red
 231v1-->|1|3v1
@@ -266,7 +271,7 @@ linkStyle default stroke:#aaa
 5v1--x|0|8v1; linkStyle 7 stroke:red
 7v1-->|1|8v1
 8v1-->9v1
-17v1-->338v1
+17v1-->345v1
 11v1-->12v1
 10v1--x|0|13v1; linkStyle 12 stroke:red
 12v1-->|1|13v1
@@ -300,7 +305,7 @@ linkStyle default stroke:#aaa
 39v1-->40v1
 40v1-->41v1
 41v1-->42v1
-85v1-->340v1
+85v1-->347v1
 44v1-->45v1
 45v1--x46v1; linkStyle 46 stroke:red
 46v1-->47v1
@@ -355,7 +360,7 @@ linkStyle default stroke:#aaa
 90v1-->91v1
 78v1-->|pos|92v1
 91v1--x|neg|92v1; linkStyle 98 stroke:red
-89v1-->342v1
+89v1-->349v1
 92v1-->|pos|94v1
 93v1--x|neg|94v1; linkStyle 101 stroke:red
 94v1-->95v1
@@ -384,7 +389,7 @@ linkStyle default stroke:#aaa
 116v1--x117v1; linkStyle 125 stroke:red
 117v1-->118v1
 118v1-->119v1
-110v1-->344v1
+110v1-->351v1
 120v1-->121v1
 121v1-->122v1
 123v1-->124v1
@@ -395,9 +400,10 @@ linkStyle default stroke:#aaa
 110v1-->|input|128v1
 127v1--x|single|128v1; linkStyle 137 stroke:red
 128v1-->129v1
-129v1-->131v1
+129v1-->130v1
+130v1-->131v1
 25v1-->|input|132v1
-131v1--x|single|132v1; linkStyle 141 stroke:red
+131v1--x|single|132v1; linkStyle 142 stroke:red
 132v1-->133v1
 119v1-->|0|134v1
 133v1-->|1|134v1
@@ -407,72 +413,72 @@ linkStyle default stroke:#aaa
 138v1-->139v1
 110v1-->140v1
 139v1-->|input|141v1
-140v1--x|single|141v1; linkStyle 151 stroke:red
+140v1--x|single|141v1; linkStyle 152 stroke:red
 141v1-->142v1
 142v1-->143v1
 101v1-->144v1
 144v1-->145v1
 145v1-->146v1
 146v1-->147v1
-147v1--x148v1; linkStyle 158 stroke:red
+147v1--x148v1; linkStyle 159 stroke:red
 148v1-->149v1
 149v1-->150v1
 150v1-->151v1
-151v1--x152v1; linkStyle 162 stroke:red
+151v1--x152v1; linkStyle 163 stroke:red
 152v1-->153v1
 153v1-->154v1
-167v1-->346v1
+167v1-->353v1
 156v1-->157v1
-155v1--x|0|158v1; linkStyle 167 stroke:red
+155v1--x|0|158v1; linkStyle 168 stroke:red
 157v1-->|1|158v1
-154v1--x|0|159v1; linkStyle 169 stroke:red
+154v1--x|0|159v1; linkStyle 170 stroke:red
 158v1-->|1|159v1
 159v1-->160v1
 143v1-->|input|161v1
-160v1--x|single|161v1; linkStyle 173 stroke:red
+160v1--x|single|161v1; linkStyle 174 stroke:red
 161v1-->162v1
 162v1-->163v1
-163v1--x164v1; linkStyle 176 stroke:red
+163v1--x164v1; linkStyle 177 stroke:red
 164v1-->|input|165v1
-160v1--x|single|165v1; linkStyle 178 stroke:red
+160v1--x|single|165v1; linkStyle 179 stroke:red
 165v1-->166v1
 166v1-->167v1
-214v1-->348v1
+214v1-->355v1
 169v1-->170v1
-170v1--x171v1; linkStyle 183 stroke:red
+170v1--x171v1; linkStyle 184 stroke:red
 171v1-->172v1
 172v1-->173v1
 163v1-->|input|174v1
-25v1--x|single|174v1; linkStyle 187 stroke:red
+25v1--x|single|174v1; linkStyle 188 stroke:red
 174v1-->175v1
 150v1-->|input|176v1
-25v1--x|single|176v1; linkStyle 190 stroke:red
+25v1--x|single|176v1; linkStyle 191 stroke:red
 145v1-->177v1
-177v1--x178v1; linkStyle 192 stroke:red
+177v1--x178v1; linkStyle 193 stroke:red
 178v1-->179v1
 180v1-->181v1
-179v1--x|0|182v1; linkStyle 195 stroke:red
+179v1--x|0|182v1; linkStyle 196 stroke:red
 181v1-->|1|182v1
 182v1-->183v1
 176v1-->|input|184v1
-183v1--x|single|184v1; linkStyle 199 stroke:red
+183v1--x|single|184v1; linkStyle 200 stroke:red
 184v1-->185v1
 153v1-->|input|186v1
-183v1--x|single|186v1; linkStyle 202 stroke:red
+183v1--x|single|186v1; linkStyle 203 stroke:red
 186v1-->187v1
 150v1-->188v1
 187v1-->|pos|189v1
-188v1--x|neg|189v1; linkStyle 206 stroke:red
+188v1--x|neg|189v1; linkStyle 207 stroke:red
 189v1-->|input|190v1
-25v1--x|single|190v1; linkStyle 208 stroke:red
+25v1--x|single|190v1; linkStyle 209 stroke:red
 190v1-->191v1
-185v1--x|0|192v1; linkStyle 210 stroke:red
+185v1--x|0|192v1; linkStyle 211 stroke:red
 191v1-->|1|192v1
-175v1--x|0|193v1; linkStyle 212 stroke:red
+175v1--x|0|193v1; linkStyle 213 stroke:red
 192v1-->|1|193v1
 110v1-->194v1
 193v1-->|input|195v1
-194v1--x|single|195v1; linkStyle 216 stroke:red
+194v1--x|single|195v1; linkStyle 217 stroke:red
 195v1-->196v1
 196v1-->197v1
 197v1-->198v1
@@ -483,58 +489,63 @@ linkStyle default stroke:#aaa
 202v1-->203v1
 203v1-->204v1
 204v1-->205v1
-168v1--x|0|206v1; linkStyle 227 stroke:red
+168v1--x|0|206v1; linkStyle 228 stroke:red
 205v1-->|1|206v1
 206v1-->207v1
-207v1--x208v1; linkStyle 230 stroke:red
+207v1--x208v1; linkStyle 231 stroke:red
 208v1-->209v1
 209v1-->210v1
 210v1-->211v1
 211v1-->212v1
 207v1-->|pos|213v1
-212v1--x|neg|213v1; linkStyle 236 stroke:red
+212v1--x|neg|213v1; linkStyle 237 stroke:red
 213v1-->214v1
 209v1-->215v1
 215v1-->216v1
 216v1-->|pos|217v1
-212v1--x|neg|217v1; linkStyle 241 stroke:red
+212v1--x|neg|217v1; linkStyle 242 stroke:red
 217v1-->218v1
-228v1-->350v1
-219v1--x|0|220v1; linkStyle 244 stroke:red
+228v1-->357v1
+219v1--x|0|220v1; linkStyle 245 stroke:red
 197v1-->|1|220v1
 220v1-->221v1
-218v1-->352v1
+218v1-->359v1
 216v1-->|pos|223v1
-222v1--x|neg|223v1; linkStyle 249 stroke:red
+222v1--x|neg|223v1; linkStyle 250 stroke:red
 223v1-->224v1
 224v1-->225v1
 225v1-->226v1
 221v1-->|pos|227v1
-226v1--x|neg|227v1; linkStyle 254 stroke:red
+226v1--x|neg|227v1; linkStyle 255 stroke:red
 227v1-->228v1
 205v1-->229v1
 229v1-->230v1
 230v1-->231v1
-232v1-->233v1
-233v1--x234v1; linkStyle 260 stroke:red
+130v1-->232v1
+25v1-->|input|233v1
+232v1--x|single|233v1; linkStyle 262 stroke:red
+233v1-->234v1
 234v1-->235v1
-235v1-->236v1
-221v1-->|0|237v1
-225v1-->|1|237v1
-237v1-->238v1
+236v1-->237v1
+237v1--x238v1; linkStyle 266 stroke:red
 238v1-->239v1
-236v1-->|0|240v1
-239v1-->|1|240v1
+239v1-->240v1
+221v1-->|0|241v1
+225v1-->|1|241v1
 241v1-->242v1
-240v1-->241v1
-338v1--o10v1; linkStyle 271 stroke:red
-340v1--o43v1; linkStyle 272 stroke:red
-342v1--o93v1; linkStyle 273 stroke:red
-344v1--o120v1; linkStyle 274 stroke:red
-346v1--o155v1; linkStyle 275 stroke:red
-348v1--o168v1; linkStyle 276 stroke:red
-350v1--o219v1; linkStyle 277 stroke:red
-352v1--o222v1; linkStyle 278 stroke:red
+242v1-->243v1
+240v1-->|0|244v1
+243v1-->|1|244v1
+245v1-->246v1
+244v1-->245v1
+345v1--o10v1; linkStyle 277 stroke:red
+347v1--o43v1; linkStyle 278 stroke:red
+349v1--o93v1; linkStyle 279 stroke:red
+351v1--o120v1; linkStyle 280 stroke:red
+353v1--o155v1; linkStyle 281 stroke:red
+355v1--o168v1; linkStyle 282 stroke:red
+357v1--o219v1; linkStyle 283 stroke:red
+359v1--o222v1; linkStyle 284 stroke:red
 2v1
 36v1
 37v1
@@ -544,16 +555,17 @@ linkStyle default stroke:#aaa
 136v1
 200v1
 201v1
-241v1
-242v1
-338v1
-340v1
-342v1
-344v1
-346v1
-348v1
-350v1
-352v1
+235v1
+245v1
+246v1
+345v1
+347v1
+349v1
+351v1
+353v1
+355v1
+357v1
+359v1
 subgraph var_cycle_10 ["var <tt>cycle_10</tt>"]
     style var_cycle_10 fill:transparent
     89v1
@@ -904,6 +916,10 @@ end
 subgraph var_stream_276 ["var <tt>stream_276</tt>"]
     style var_stream_276 fill:transparent
     129v1
+end
+subgraph var_stream_277 ["var <tt>stream_277</tt>"]
+    style var_stream_277 fill:transparent
+    130v1
 end
 subgraph var_stream_278 ["var <tt>stream_278</tt>"]
     style var_stream_278 fill:transparent
@@ -1310,45 +1326,57 @@ subgraph var_stream_515 ["var <tt>stream_515</tt>"]
     style var_stream_515 fill:transparent
     230v1
 end
-subgraph var_stream_516 ["var <tt>stream_516</tt>"]
-    style var_stream_516 fill:transparent
+subgraph var_stream_518 ["var <tt>stream_518</tt>"]
+    style var_stream_518 fill:transparent
     232v1
-end
-subgraph var_stream_517 ["var <tt>stream_517</tt>"]
-    style var_stream_517 fill:transparent
-    233v1
 end
 subgraph var_stream_519 ["var <tt>stream_519</tt>"]
     style var_stream_519 fill:transparent
-    234v1
+    233v1
 end
-subgraph var_stream_521 ["var <tt>stream_521</tt>"]
-    style var_stream_521 fill:transparent
-    235v1
+subgraph var_stream_520 ["var <tt>stream_520</tt>"]
+    style var_stream_520 fill:transparent
+    234v1
 end
 subgraph var_stream_524 ["var <tt>stream_524</tt>"]
     style var_stream_524 fill:transparent
     236v1
 end
-subgraph var_stream_528 ["var <tt>stream_528</tt>"]
-    style var_stream_528 fill:transparent
+subgraph var_stream_525 ["var <tt>stream_525</tt>"]
+    style var_stream_525 fill:transparent
     237v1
+end
+subgraph var_stream_527 ["var <tt>stream_527</tt>"]
+    style var_stream_527 fill:transparent
+    238v1
 end
 subgraph var_stream_529 ["var <tt>stream_529</tt>"]
     style var_stream_529 fill:transparent
-    238v1
+    239v1
 end
 subgraph var_stream_53 ["var <tt>stream_53</tt>"]
     style var_stream_53 fill:transparent
     20v1
 end
-subgraph var_stream_531 ["var <tt>stream_531</tt>"]
-    style var_stream_531 fill:transparent
-    239v1
-end
-subgraph var_stream_533 ["var <tt>stream_533</tt>"]
-    style var_stream_533 fill:transparent
+subgraph var_stream_532 ["var <tt>stream_532</tt>"]
+    style var_stream_532 fill:transparent
     240v1
+end
+subgraph var_stream_536 ["var <tt>stream_536</tt>"]
+    style var_stream_536 fill:transparent
+    241v1
+end
+subgraph var_stream_537 ["var <tt>stream_537</tt>"]
+    style var_stream_537 fill:transparent
+    242v1
+end
+subgraph var_stream_539 ["var <tt>stream_539</tt>"]
+    style var_stream_539 fill:transparent
+    243v1
+end
+subgraph var_stream_541 ["var <tt>stream_541</tt>"]
+    style var_stream_541 fill:transparent
+    244v1
 end
 subgraph var_stream_55 ["var <tt>stream_55</tt>"]
     style var_stream_55 fill:transparent

--- a/hydro_test/src/cluster/snapshots/two_pc_ir.snap
+++ b/hydro_test/src/cluster/snapshots/two_pc_ir.snap
@@ -800,6 +800,33 @@ expression: built.ir()
         },
         op_metadata: HydroIrOpMetadata,
     },
+    Null {
+        input: FilterMap {
+            f: stageleft :: runtime_support :: fn1_type_hint :: < ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) , core :: result :: Result < () , () >) , core :: option :: Option < ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) , ()) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | (key , res) | match res { Ok (_) => None , Err (e) => Some ((key , e)) , } }),
+            input: Tee {
+                inner: <shared 2>,
+                metadata: HydroIrMetadata {
+                    location_id: Process(loc1v1),
+                    collection_kind: Stream {
+                        bound: Unbounded,
+                        order: NoOrder,
+                        retry: ExactlyOnce,
+                        element_type: ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) , core :: result :: Result < () , () >),
+                    },
+                },
+            },
+            metadata: HydroIrMetadata {
+                location_id: Process(loc1v1),
+                collection_kind: Stream {
+                    bound: Unbounded,
+                    order: NoOrder,
+                    retry: ExactlyOnce,
+                    element_type: ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) , ()),
+                },
+            },
+        },
+        op_metadata: HydroIrOpMetadata,
+    },
     CycleSink {
         cycle_id: CycleId(
             4,
@@ -1296,6 +1323,33 @@ expression: built.ir()
                     order: NoOrder,
                     retry: ExactlyOnce,
                     element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)),
+                },
+            },
+        },
+        op_metadata: HydroIrOpMetadata,
+    },
+    Null {
+        input: FilterMap {
+            f: stageleft :: runtime_support :: fn1_type_hint :: < ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) , core :: result :: Result < () , () >) , core :: option :: Option < ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) , ()) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | (key , res) | match res { Ok (_) => None , Err (e) => Some ((key , e)) , } }),
+            input: Tee {
+                inner: <shared 7>,
+                metadata: HydroIrMetadata {
+                    location_id: Process(loc1v1),
+                    collection_kind: Stream {
+                        bound: Unbounded,
+                        order: NoOrder,
+                        retry: ExactlyOnce,
+                        element_type: ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) , core :: result :: Result < () , () >),
+                    },
+                },
+            },
+            metadata: HydroIrMetadata {
+                location_id: Process(loc1v1),
+                collection_kind: Stream {
+                    bound: Unbounded,
+                    order: NoOrder,
+                    retry: ExactlyOnce,
+                    element_type: ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) , ()),
                 },
             },
         },

--- a/hydro_test/src/cluster/snapshots/two_pc_ir@coordinator_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/two_pc_ir@coordinator_mermaid.snap
@@ -23,6 +23,7 @@ linkStyle default stroke:#aaa
 13v1["<div style=text-align:center>(13v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::two_pc::Participant,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            (<br>                hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                    hydro_test::__staged::cluster::two_pc_bench::Client,<br>                &gt;,<br>                (u32, i32),<br>            ),<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
 14v1["<div style=text-align:center>(14v1)</div> <code><br>map({<br>    |(_, v)| v<br>})</code>"]:::otherClass
 15v1["<div style=text-align:center>(15v1)</div> <code><br>map({<br>    |kv| (kv, Ok::&lt;(), ()&gt;(()))<br>})</code>"]:::otherClass
+16v1["<div style=text-align:center>(16v1)</div> <code><br>tee()</code>"]:::otherClass
 17v1["<div style=text-align:center>(17v1)</div> <code><br>chain()</code>"]:::otherClass
 18v1["<div style=text-align:center>(18v1)</div> <code><br>tee()</code>"]:::otherClass
 19v1["<div style=text-align:center>(19v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        move || (0, 0)<br>    },<br>    {<br>        move |accum, value| {<br>            if value.is_ok() {<br>                accum.0 += 1;<br>            } else {<br>                accum.1 += 1;<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
@@ -32,35 +33,40 @@ linkStyle default stroke:#aaa
 24v1["<div style=text-align:center>(24v1)</div> <code><br>identity::&lt;<br>    (<br>        (<br>            hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                hydro_test::__staged::cluster::two_pc_bench::Client,<br>            &gt;,<br>            (u32, i32),<br>        ),<br>        core::result::Result&lt;(), ()&gt;,<br>    ),<br>&gt;()</code>"]:::otherClass
 25v1["<div style=text-align:center>(25v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
 26v1["<div style=text-align:center>(26v1)</div> <code><br>identity::&lt;<br>    (<br>        hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>            hydro_test::__staged::cluster::two_pc_bench::Client,<br>        &gt;,<br>        (u32, i32),<br>    ),<br>&gt;()</code>"]:::otherClass
-27v1["<div style=text-align:center>(27v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-28v1["<div style=text-align:center>(28v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
-29v1["<div style=text-align:center>(29v1)</div> <code><br>map({<br>    |(k, v)| (MemberId::from_tagless(k), v)<br>})</code>"]:::otherClass
-30v1["<div style=text-align:center>(30v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        || false<br>    },<br>    {<br>        |present, event| {<br>            match event {<br>                MembershipEvent::Joined =&gt; *present = true,<br>                MembershipEvent::Left =&gt; *present = false,<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
-31v1["<div style=text-align:center>(31v1)</div> <code><br>filter({<br>    let f__free = {<br>        |b| *b<br>    };<br>    {<br>        let orig = f__free;<br>        move |t: &amp;(_, _)| orig(&amp;t.1)<br>    }<br>})</code>"]:::otherClass
-32v1["<div style=text-align:center>(32v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
-33v1["<div style=text-align:center>(33v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-34v1["<div style=text-align:center>(34v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
-35v1["<div style=text-align:center>(35v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-36v1["<div style=text-align:center>(36v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
-37v1["<div style=text-align:center>(37v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::two_pc::Participant,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            (<br>                hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                    hydro_test::__staged::cluster::two_pc_bench::Client,<br>                &gt;,<br>                (u32, i32),<br>            ),<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
-38v1["<div style=text-align:center>(38v1)</div> <code><br>map({<br>    |(_, v)| v<br>})</code>"]:::otherClass
-39v1["<div style=text-align:center>(39v1)</div> <code><br>map({<br>    |kv| (kv, Ok::&lt;(), ()&gt;(()))<br>})</code>"]:::otherClass
-41v1["<div style=text-align:center>(41v1)</div> <code><br>chain()</code>"]:::otherClass
+27v1["<div style=text-align:center>(27v1)</div> <code><br>filter_map({<br>    move |(key, res)| match res {<br>        Ok(_) =&gt; None,<br>        Err(e) =&gt; Some((key, e)),<br>    }<br>})</code>"]:::otherClass
+28v1["<div style=text-align:center>(28v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
+29v1["<div style=text-align:center>(29v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+30v1["<div style=text-align:center>(30v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
+31v1["<div style=text-align:center>(31v1)</div> <code><br>map({<br>    |(k, v)| (MemberId::from_tagless(k), v)<br>})</code>"]:::otherClass
+32v1["<div style=text-align:center>(32v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        || false<br>    },<br>    {<br>        |present, event| {<br>            match event {<br>                MembershipEvent::Joined =&gt; *present = true,<br>                MembershipEvent::Left =&gt; *present = false,<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
+33v1["<div style=text-align:center>(33v1)</div> <code><br>filter({<br>    let f__free = {<br>        |b| *b<br>    };<br>    {<br>        let orig = f__free;<br>        move |t: &amp;(_, _)| orig(&amp;t.1)<br>    }<br>})</code>"]:::otherClass
+34v1["<div style=text-align:center>(34v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
+35v1["<div style=text-align:center>(35v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+36v1["<div style=text-align:center>(36v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+37v1["<div style=text-align:center>(37v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+38v1["<div style=text-align:center>(38v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
+39v1["<div style=text-align:center>(39v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::two_pc::Participant,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            (<br>                hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                    hydro_test::__staged::cluster::two_pc_bench::Client,<br>                &gt;,<br>                (u32, i32),<br>            ),<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
+40v1["<div style=text-align:center>(40v1)</div> <code><br>map({<br>    |(_, v)| v<br>})</code>"]:::otherClass
+41v1["<div style=text-align:center>(41v1)</div> <code><br>map({<br>    |kv| (kv, Ok::&lt;(), ()&gt;(()))<br>})</code>"]:::otherClass
 42v1["<div style=text-align:center>(42v1)</div> <code><br>tee()</code>"]:::otherClass
-43v1["<div style=text-align:center>(43v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        move || (0, 0)<br>    },<br>    {<br>        move |accum, value| {<br>            if value.is_ok() {<br>                accum.0 += 1;<br>            } else {<br>                accum.1 += 1;<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
-45v1["<div style=text-align:center>(45v1)</div> <code><br>filter_map({<br>    let min__free = 3usize;<br>    move |(key, (success, _error))| {<br>        if success &gt;= min__free { Some(key) } else { None }<br>    }<br>})</code>"]:::otherClass
-46v1["<div style=text-align:center>(46v1)</div> <code><br>tee()</code>"]:::otherClass
-47v1["<div style=text-align:center>(47v1)</div> <code><br>anti_join::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-48v1["<div style=text-align:center>(48v1)</div> <code><br>identity::&lt;<br>    (<br>        (<br>            hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                hydro_test::__staged::cluster::two_pc_bench::Client,<br>            &gt;,<br>            (u32, i32),<br>        ),<br>        core::result::Result&lt;(), ()&gt;,<br>    ),<br>&gt;()</code>"]:::otherClass
-49v1["<div style=text-align:center>(49v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-50v1["<div style=text-align:center>(50v1)</div> <code><br>identity::&lt;<br>    (<br>        hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>            hydro_test::__staged::cluster::two_pc_bench::Client,<br>        &gt;,<br>        (u32, i32),<br>    ),<br>&gt;()</code>"]:::otherClass
-51v1["<div style=text-align:center>(51v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
-52v1["<div style=text-align:center>(52v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-66v1["<div style=text-align:center>(66v1)</div> <code><br>identity()</code>"]:::otherClass
-68v1["<div style=text-align:center>(68v1)</div> <code><br>identity()</code>"]:::otherClass
-70v1["<div style=text-align:center>(70v1)</div> <code><br>identity()</code>"]:::otherClass
-72v1["<div style=text-align:center>(72v1)</div> <code><br>identity()</code>"]:::otherClass
-24v1-->66v1
+43v1["<div style=text-align:center>(43v1)</div> <code><br>chain()</code>"]:::otherClass
+44v1["<div style=text-align:center>(44v1)</div> <code><br>tee()</code>"]:::otherClass
+45v1["<div style=text-align:center>(45v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        move || (0, 0)<br>    },<br>    {<br>        move |accum, value| {<br>            if value.is_ok() {<br>                accum.0 += 1;<br>            } else {<br>                accum.1 += 1;<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
+47v1["<div style=text-align:center>(47v1)</div> <code><br>filter_map({<br>    let min__free = 3usize;<br>    move |(key, (success, _error))| {<br>        if success &gt;= min__free { Some(key) } else { None }<br>    }<br>})</code>"]:::otherClass
+48v1["<div style=text-align:center>(48v1)</div> <code><br>tee()</code>"]:::otherClass
+49v1["<div style=text-align:center>(49v1)</div> <code><br>anti_join::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+50v1["<div style=text-align:center>(50v1)</div> <code><br>identity::&lt;<br>    (<br>        (<br>            hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                hydro_test::__staged::cluster::two_pc_bench::Client,<br>            &gt;,<br>            (u32, i32),<br>        ),<br>        core::result::Result&lt;(), ()&gt;,<br>    ),<br>&gt;()</code>"]:::otherClass
+51v1["<div style=text-align:center>(51v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+52v1["<div style=text-align:center>(52v1)</div> <code><br>identity::&lt;<br>    (<br>        hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>            hydro_test::__staged::cluster::two_pc_bench::Client,<br>        &gt;,<br>        (u32, i32),<br>    ),<br>&gt;()</code>"]:::otherClass
+53v1["<div style=text-align:center>(53v1)</div> <code><br>filter_map({<br>    move |(key, res)| match res {<br>        Ok(_) =&gt; None,<br>        Err(e) =&gt; Some((key, e)),<br>    }<br>})</code>"]:::otherClass
+54v1["<div style=text-align:center>(54v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
+55v1["<div style=text-align:center>(55v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+56v1["<div style=text-align:center>(56v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+74v1["<div style=text-align:center>(74v1)</div> <code><br>identity()</code>"]:::otherClass
+76v1["<div style=text-align:center>(76v1)</div> <code><br>identity()</code>"]:::otherClass
+78v1["<div style=text-align:center>(78v1)</div> <code><br>identity()</code>"]:::otherClass
+80v1["<div style=text-align:center>(80v1)</div> <code><br>identity()</code>"]:::otherClass
+24v1-->74v1
 2v1-->3v1
 3v1--x4v1; linkStyle 2 stroke:red
 4v1-->5v1
@@ -73,56 +79,64 @@ linkStyle default stroke:#aaa
 12v1-->13v1
 13v1-->14v1
 14v1-->15v1
-1v1--x|0|17v1; linkStyle 13 stroke:red
-15v1-->|1|17v1
+15v1-->16v1
+1v1--x|0|17v1; linkStyle 14 stroke:red
+16v1-->|1|17v1
 17v1-->18v1
-18v1--x19v1; linkStyle 16 stroke:red
+18v1--x19v1; linkStyle 17 stroke:red
 19v1-->21v1
 21v1-->22v1
 18v1-->|pos|23v1
-22v1--x|neg|23v1; linkStyle 20 stroke:red
+22v1--x|neg|23v1; linkStyle 21 stroke:red
 23v1-->24v1
-26v1-->68v1
+26v1-->76v1
 25v1-->26v1
-48v1-->70v1
-28v1-->29v1
-29v1--x30v1; linkStyle 26 stroke:red
+16v1-->27v1
+27v1-->28v1
+50v1-->78v1
 30v1-->31v1
-31v1-->32v1
-32v1-->|0|33v1
-22v1-->|1|33v1
-34v1-->35v1
+31v1--x32v1; linkStyle 29 stroke:red
+32v1-->33v1
 33v1-->34v1
+34v1-->|0|35v1
+22v1-->|1|35v1
 36v1-->37v1
-37v1-->38v1
+35v1-->36v1
 38v1-->39v1
-27v1--x|0|41v1; linkStyle 36 stroke:red
-39v1-->|1|41v1
+39v1-->40v1
+40v1-->41v1
 41v1-->42v1
-42v1--x43v1; linkStyle 39 stroke:red
-43v1-->45v1
-45v1-->46v1
-42v1-->|pos|47v1
-46v1--x|neg|47v1; linkStyle 43 stroke:red
+29v1--x|0|43v1; linkStyle 40 stroke:red
+42v1-->|1|43v1
+43v1-->44v1
+44v1--x45v1; linkStyle 43 stroke:red
+45v1-->47v1
 47v1-->48v1
-50v1-->72v1
+44v1-->|pos|49v1
+48v1--x|neg|49v1; linkStyle 47 stroke:red
 49v1-->50v1
+52v1-->80v1
 51v1-->52v1
-46v1-->51v1
-66v1--o1v1; linkStyle 49 stroke:red
-68v1--o25v1; linkStyle 50 stroke:red
-70v1--o27v1; linkStyle 51 stroke:red
-72v1--o49v1; linkStyle 52 stroke:red
+42v1-->53v1
+53v1-->54v1
+55v1-->56v1
+48v1-->55v1
+74v1--o1v1; linkStyle 55 stroke:red
+76v1--o25v1; linkStyle 56 stroke:red
+78v1--o29v1; linkStyle 57 stroke:red
+80v1--o51v1; linkStyle 58 stroke:red
 10v1
 11v1
-34v1
-35v1
-51v1
-52v1
-66v1
-68v1
-70v1
-72v1
+28v1
+36v1
+37v1
+54v1
+55v1
+56v1
+74v1
+76v1
+78v1
+80v1
 subgraph var_cycle_2 ["var <tt>cycle_2</tt>"]
     style var_cycle_2 fill:transparent
     24v1
@@ -133,27 +147,35 @@ subgraph var_cycle_3 ["var <tt>cycle_3</tt>"]
 end
 subgraph var_cycle_4 ["var <tt>cycle_4</tt>"]
     style var_cycle_4 fill:transparent
-    48v1
+    50v1
 end
 subgraph var_cycle_5 ["var <tt>cycle_5</tt>"]
     style var_cycle_5 fill:transparent
-    50v1
+    52v1
 end
-subgraph var_stream_101 ["var <tt>stream_101</tt>"]
-    style var_stream_101 fill:transparent
+subgraph var_stream_100 ["var <tt>stream_100</tt>"]
+    style var_stream_100 fill:transparent
     45v1
 end
-subgraph var_stream_102 ["var <tt>stream_102</tt>"]
-    style var_stream_102 fill:transparent
-    46v1
-end
-subgraph var_stream_103 ["var <tt>stream_103</tt>"]
-    style var_stream_103 fill:transparent
+subgraph var_stream_104 ["var <tt>stream_104</tt>"]
+    style var_stream_104 fill:transparent
     47v1
 end
 subgraph var_stream_105 ["var <tt>stream_105</tt>"]
     style var_stream_105 fill:transparent
+    48v1
+end
+subgraph var_stream_106 ["var <tt>stream_106</tt>"]
+    style var_stream_106 fill:transparent
     49v1
+end
+subgraph var_stream_108 ["var <tt>stream_108</tt>"]
+    style var_stream_108 fill:transparent
+    51v1
+end
+subgraph var_stream_110 ["var <tt>stream_110</tt>"]
+    style var_stream_110 fill:transparent
+    53v1
 end
 subgraph var_stream_16 ["var <tt>stream_16</tt>"]
     style var_stream_16 fill:transparent
@@ -190,8 +212,8 @@ subgraph var_stream_41 ["var <tt>stream_41</tt>"]
 end
 subgraph var_stream_45 ["var <tt>stream_45</tt>"]
     style var_stream_45 fill:transparent
-    13v1
     12v1
+    13v1
 end
 subgraph var_stream_48 ["var <tt>stream_48</tt>"]
     style var_stream_48 fill:transparent
@@ -200,6 +222,10 @@ end
 subgraph var_stream_49 ["var <tt>stream_49</tt>"]
     style var_stream_49 fill:transparent
     15v1
+end
+subgraph var_stream_50 ["var <tt>stream_50</tt>"]
+    style var_stream_50 fill:transparent
+    16v1
 end
 subgraph var_stream_52 ["var <tt>stream_52</tt>"]
     style var_stream_52 fill:transparent
@@ -233,42 +259,42 @@ subgraph var_stream_67 ["var <tt>stream_67</tt>"]
     style var_stream_67 fill:transparent
     27v1
 end
-subgraph var_stream_68 ["var <tt>stream_68</tt>"]
-    style var_stream_68 fill:transparent
-    28v1
-end
-subgraph var_stream_69 ["var <tt>stream_69</tt>"]
-    style var_stream_69 fill:transparent
+subgraph var_stream_70 ["var <tt>stream_70</tt>"]
+    style var_stream_70 fill:transparent
     29v1
 end
 subgraph var_stream_71 ["var <tt>stream_71</tt>"]
     style var_stream_71 fill:transparent
     30v1
 end
-subgraph var_stream_73 ["var <tt>stream_73</tt>"]
-    style var_stream_73 fill:transparent
+subgraph var_stream_72 ["var <tt>stream_72</tt>"]
+    style var_stream_72 fill:transparent
     31v1
+end
+subgraph var_stream_74 ["var <tt>stream_74</tt>"]
+    style var_stream_74 fill:transparent
+    32v1
 end
 subgraph var_stream_76 ["var <tt>stream_76</tt>"]
     style var_stream_76 fill:transparent
-    32v1
-end
-subgraph var_stream_81 ["var <tt>stream_81</tt>"]
-    style var_stream_81 fill:transparent
     33v1
 end
-subgraph var_stream_85 ["var <tt>stream_85</tt>"]
-    style var_stream_85 fill:transparent
-    37v1
-    36v1
+subgraph var_stream_79 ["var <tt>stream_79</tt>"]
+    style var_stream_79 fill:transparent
+    34v1
+end
+subgraph var_stream_84 ["var <tt>stream_84</tt>"]
+    style var_stream_84 fill:transparent
+    35v1
 end
 subgraph var_stream_88 ["var <tt>stream_88</tt>"]
     style var_stream_88 fill:transparent
     38v1
-end
-subgraph var_stream_89 ["var <tt>stream_89</tt>"]
-    style var_stream_89 fill:transparent
     39v1
+end
+subgraph var_stream_91 ["var <tt>stream_91</tt>"]
+    style var_stream_91 fill:transparent
+    40v1
 end
 subgraph var_stream_92 ["var <tt>stream_92</tt>"]
     style var_stream_92 fill:transparent
@@ -278,7 +304,11 @@ subgraph var_stream_93 ["var <tt>stream_93</tt>"]
     style var_stream_93 fill:transparent
     42v1
 end
-subgraph var_stream_97 ["var <tt>stream_97</tt>"]
-    style var_stream_97 fill:transparent
+subgraph var_stream_95 ["var <tt>stream_95</tt>"]
+    style var_stream_95 fill:transparent
     43v1
+end
+subgraph var_stream_96 ["var <tt>stream_96</tt>"]
+    style var_stream_96 fill:transparent
+    44v1
 end

--- a/hydro_test/src/cluster/snapshots/two_pc_ir@participants_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/two_pc_ir@participants_mermaid.snap
@@ -31,8 +31,8 @@ subgraph var_stream_44 ["var <tt>stream_44</tt>"]
     1v1
     2v1
 end
-subgraph var_stream_84 ["var <tt>stream_84</tt>"]
-    style var_stream_84 fill:transparent
+subgraph var_stream_87 ["var <tt>stream_87</tt>"]
+    style var_stream_87 fill:transparent
     5v1
     6v1
 end


### PR DESCRIPTION
When a live collection (Stream, Singleton, Optional, KeyedStream, KeyedSingleton) is dropped without its IR node being consumed — e.g. calling `.inspect()` without using the returned value — the upstream pipeline would silently never execute.

Now, each live collection's `Drop` impl automatically adds the unconsumed IR node to the dataflow graph as a `HydroRoot::Null` root. In codegen, Null roots compile to `for_each(|_| {})`, a no-op sink that still drives the upstream pipeline so side effects like `inspect` and `println!` are preserved.

Changes:
- Added `HydroRoot::Null { input, op_metadata }` variant, handled in all IR match arms (transform, clone, emit, viz, metadata accessors)
- Added `FlowStateInner::try_push_root()` which silently no-ops if the flow is already finalized
- Added `flow_state: FlowState` field to all 5 live collection types
- Added `Drop` impl to all 5 types that pushes a Null root when the IR node hasn't been consumed (detected via `HydroNode::Placeholder`)
- Changed `ir_node.into_inner()` to `ir_node.replace(HydroNode::Placeholder)` throughout, since types with Drop can't move fields out of self
- Added deploy test `unconsumed_inspect_still_runs` verifying the fix end-to-end

Fixes #2174