### PR TITLE
feat(hydro_lang): add embedded singleton input support

### DIFF
--- a/docs/docs/hydro/reference/deploy/embedded.mdx
+++ b/docs/docs/hydro/reference/deploy/embedded.mdx
@@ -142,6 +142,59 @@ async fn run() {
 The generated function accepts your input streams as `impl Stream<Item = T> + Unpin` parameters and a mutable reference to the `EmbeddedOutputs` struct. It returns a `Dfir` graph that you run with `run_available()` (or tick manually).
 
 
+## Singleton Inputs
+
+In addition to stream inputs, you can pass singleton values into embedded mode. A **singleton input** becomes a plain `T` parameter on the generated function — no stream wrapping needed. This is useful for configuration values, thresholds, or any fixed data that the dataflow needs.
+
+Use `embedded_singleton_input` instead of `embedded_input`:
+
+```rust title="my_hydro_crate/src/lib.rs"
+use hydro_lang::prelude::*;
+
+pub fn greet<'a>(
+    names: Stream<String, Process<'a, ()>, Unbounded, TotalOrder, ExactlyOnce>,
+    greeting: Singleton<String, Process<'a, ()>, Bounded>,
+) {
+    names
+        .cross_singleton(greeting)
+        .map(q!(|(name, greeting)| format!("{greeting}, {name}!")))
+        .embedded_output("output");
+}
+```
+
+In `build.rs`, call `embedded_singleton_input` to create the singleton parameter:
+
+```rust title="my_wrapper_crate/build.rs"
+let process = flow.process::<()>();
+my_hydro_crate::greet(
+    process.embedded_input("names"),
+    process.embedded_singleton_input("greeting"),
+);
+```
+
+The generated function will accept `greeting` as a plain `String` parameter:
+
+```rust,ignore
+pub fn greet<'a, F: FnMut(String) + 'a>(
+    greeting: String,
+    names: impl Stream<Item = String> + Unpin + 'a,
+    __outputs: &'a mut greet::EmbeddedOutputs<F>,
+) -> Dfir<'a> { ... }
+```
+
+Call it like any other Rust function:
+
+```rust,ignore
+let input = futures::stream::iter(vec!["Alice".to_owned(), "Bob".to_owned()]);
+let mut results = vec![];
+let mut outputs = embedded::greet::EmbeddedOutputs {
+    output: |s: String| results.push(s),
+};
+let mut flow = embedded::greet("Hello".to_owned(), input, &mut outputs);
+```
+
+Singleton inputs appear before stream inputs in the generated function signature.
+
 ## Clusters
 
 When a location is a cluster (registered with `with_cluster` in `build.rs`), the generated function receives additional parameters for the cluster's identity and membership information.

--- a/hydro_lang/src/compile/deploy_provider.rs
+++ b/hydro_lang/src/compile/deploy_provider.rs
@@ -179,17 +179,30 @@ pub trait Deploy<'a> {
         location_id: &LocationId,
     ) -> impl QuotedWithContext<'a, Box<dyn Stream<Item = (TaglessMemberId, MembershipEvent)> + Unpin>, ()>;
 
-    /// Registers an embedded input for the given ident and element type.
+    /// Registers an embedded stream input for the given ident and element type.
     ///
     /// Only meaningful for the embedded deployment backend. The default
     /// implementation panics.
-    fn register_embedded_input(
+    fn register_embedded_stream_input(
         _env: &mut Self::InstantiateEnv,
         _location_key: LocationKey,
         _ident: &syn::Ident,
         _element_type: &syn::Type,
     ) {
-        panic!("register_embedded_input is only supported by EmbeddedDeploy");
+        panic!("register_embedded_stream_input is only supported by EmbeddedDeploy");
+    }
+
+    /// Registers an embedded singleton input for the given ident and element type.
+    ///
+    /// Only meaningful for the embedded deployment backend. The default
+    /// implementation panics.
+    fn register_embedded_singleton_input(
+        _env: &mut Self::InstantiateEnv,
+        _location_key: LocationKey,
+        _ident: &syn::Ident,
+        _element_type: &syn::Type,
+    ) {
+        panic!("register_embedded_singleton_input is only supported by EmbeddedDeploy");
     }
 
     /// Registers an embedded output for the given ident and element type.

--- a/hydro_lang/src/compile/embedded.rs
+++ b/hydro_lang/src/compile/embedded.rs
@@ -165,6 +165,8 @@ impl<S: Into<String>> ExternalSpec<'_, EmbeddedDeploy> for S {
 pub struct EmbeddedInstantiateEnv {
     /// (ident name, element type) pairs per location key, for inputs.
     pub inputs: SparseSecondaryMap<LocationKey, Vec<(syn::Ident, syn::Type)>>,
+    /// (ident name, element type) pairs per location key, for singleton inputs.
+    pub singleton_inputs: SparseSecondaryMap<LocationKey, Vec<(syn::Ident, syn::Type)>>,
     /// (ident name, element type) pairs per location key, for outputs.
     pub outputs: SparseSecondaryMap<LocationKey, Vec<(syn::Ident, syn::Type)>>,
     /// Network output port names per location key (sender side of channels).
@@ -426,13 +428,26 @@ impl<'a> Deploy<'a> for EmbeddedDeploy {
         super::embedded_runtime::embedded_cluster_membership_stream(idx)
     }
 
-    fn register_embedded_input(
+    fn register_embedded_stream_input(
         env: &mut Self::InstantiateEnv,
         location_key: LocationKey,
         ident: &syn::Ident,
         element_type: &syn::Type,
     ) {
         env.inputs
+            .entry(location_key)
+            .unwrap()
+            .or_default()
+            .push((ident.clone(), element_type.clone()));
+    }
+
+    fn register_embedded_singleton_input(
+        env: &mut Self::InstantiateEnv,
+        location_key: LocationKey,
+        ident: &syn::Ident,
+        element_type: &syn::Type,
+    ) {
+        env.singleton_inputs
             .entry(location_key)
             .unwrap()
             .or_default()
@@ -620,6 +635,21 @@ impl super::deploy::DeployFlow<'_, EmbeddedDeploy> {
                 .iter()
                 .map(|(ident, element_type)| {
                     quote! { #ident: impl __root_dfir_rs::futures::Stream<Item = #element_type> + Unpin + 'a }
+                })
+                .collect();
+
+            // Embedded singleton inputs (plain value parameters).
+            let mut loc_singleton_inputs = env
+                .singleton_inputs
+                .get(location_key)
+                .cloned()
+                .unwrap_or_default();
+            loc_singleton_inputs.sort_by(|a, b| a.0.to_string().cmp(&b.0.to_string()));
+
+            let singleton_input_params: Vec<proc_macro2::TokenStream> = loc_singleton_inputs
+                .iter()
+                .map(|(ident, element_type)| {
+                    quote! { #ident: #element_type }
                 })
                 .collect();
 
@@ -815,6 +845,7 @@ impl super::deploy::DeployFlow<'_, EmbeddedDeploy> {
             // Build the function.
             let all_params: Vec<proc_macro2::TokenStream> = cluster_params
                 .into_iter()
+                .chain(singleton_input_params)
                 .chain(input_params)
                 .chain(output_params)
                 .chain(net_in_params)

--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -330,6 +330,7 @@ pub enum HydroSource {
     Spin(),
     ClusterMembers(LocationId, ClusterMembersState),
     Embedded(syn::Ident),
+    EmbeddedSingleton(syn::Ident),
 }
 
 #[cfg(feature = "build")]
@@ -956,7 +957,22 @@ impl HydroRoot {
                         LocationId::Process(key) | LocationId::Cluster(key) => *key,
                         _ => panic!("Embedded source must be on a process or cluster"),
                     };
-                    D::register_embedded_input(
+                    D::register_embedded_stream_input(
+                        &mut refcell_env.borrow_mut(),
+                        location_key,
+                        ident,
+                        &element_type,
+                    );
+                } else if let HydroNode::Source { source: HydroSource::EmbeddedSingleton(ident), metadata } = n {
+                    let element_type = match &metadata.collection_kind {
+                        CollectionKind::Singleton { element_type, .. } => element_type.0.as_ref().clone(),
+                        _ => panic!("EmbeddedSingleton source must have Singleton collection kind"),
+                    };
+                    let location_key = match metadata.location_id.root() {
+                        LocationId::Process(key) | LocationId::Cluster(key) => *key,
+                        _ => panic!("EmbeddedSingleton source must be on a process or cluster"),
+                    };
+                    D::register_embedded_singleton_input(
                         &mut refcell_env.borrow_mut(),
                         location_key,
                         ident,
@@ -2600,6 +2616,12 @@ impl HydroNode {
                                         #source_ident = source_stream(#ident);
                                     }
                                 }
+
+                                HydroSource::EmbeddedSingleton(ident) => {
+                                    parse_quote! {
+                                        #source_ident = source_iter([#ident]);
+                                    }
+                                }
                             };
 
                             match builders_or_callback {
@@ -3775,7 +3797,8 @@ impl HydroNode {
                 HydroSource::ExternalNetwork()
                 | HydroSource::Spin()
                 | HydroSource::ClusterMembers(_, _)
-                | HydroSource::Embedded(_) => {} // TODO: what goes here?
+                | HydroSource::Embedded(_)
+                | HydroSource::EmbeddedSingleton(_) => {} // TODO: what goes here?
             },
             HydroNode::SingletonSource { value, .. } => {
                 transform(value);

--- a/hydro_lang/src/location/mod.rs
+++ b/hydro_lang/src/location/mod.rs
@@ -556,6 +556,26 @@ pub trait Location<'a>: dynamic::DynLocation {
         )
     }
 
+    /// Creates an embedded singleton input for embedded deployment mode.
+    ///
+    /// The `name` parameter specifies the name of the generated function parameter
+    /// that will supply data to this singleton at runtime. The generated function will
+    /// accept a plain `T` parameter with this name.
+    fn embedded_singleton_input<T>(&self, name: impl Into<String>) -> Singleton<T, Self, Bounded>
+    where
+        Self: Sized + NoTick,
+    {
+        let ident = syn::Ident::new(&name.into(), Span::call_site());
+
+        Singleton::new(
+            self.clone(),
+            HydroNode::Source {
+                source: HydroSource::EmbeddedSingleton(ident),
+                metadata: self.new_node_metadata(Singleton::<T, Self, Bounded>::collection_kind()),
+            },
+        )
+    }
+
     /// Establishes a server on this location to receive a bidirectional connection from a single
     /// client, identified by the given `External` handle. Returns a port handle for the external
     /// process to connect to, a stream of incoming messages, and a handle to send outgoing

--- a/hydro_lang/src/viz/render.rs
+++ b/hydro_lang/src/viz/render.rs
@@ -1064,6 +1064,9 @@ impl HydroNode {
                     HydroSource::Embedded(ident) => {
                         format!("embedded_input({})", ident)
                     }
+                    HydroSource::EmbeddedSingleton(ident) => {
+                        format!("embedded_singleton_input({})", ident)
+                    }
                 };
                 build_source_node(structure, metadata, label)
             }

--- a/hydro_test/src/local/mod.rs
+++ b/hydro_test/src/local/mod.rs
@@ -3,3 +3,4 @@ pub mod chat_app;
 pub mod count_elems;
 pub mod futures;
 pub mod graph_reachability;
+pub mod singleton_input;

--- a/hydro_test/src/local/singleton_input.rs
+++ b/hydro_test/src/local/singleton_input.rs
@@ -1,0 +1,11 @@
+use hydro_lang::prelude::*;
+
+pub fn prefix_names<'a>(
+    names: Stream<String, Process<'a, ()>>,
+    prefix: Singleton<String, Process<'a, ()>, Bounded>,
+) {
+    names
+        .cross_singleton(prefix)
+        .map(q!(|(name, prefix)| format!("{prefix} {name}")))
+        .embedded_output("output");
+}

--- a/hydro_test_embedded/build.rs
+++ b/hydro_test_embedded/build.rs
@@ -29,6 +29,26 @@ fn generate_embedded() {
         .unwrap();
     }
 
+    // --- singleton_input (local, singleton + stream) ---
+    {
+        let mut flow = hydro_lang::compile::builder::FlowBuilder::new();
+        let process = flow.process::<()>();
+        hydro_test::local::singleton_input::prefix_names(
+            process.embedded_input("names"),
+            process.embedded_singleton_input("prefix"),
+        );
+
+        let code = flow
+            .with_process(&process, "prefix_names")
+            .generate_embedded("hydro_test");
+
+        std::fs::write(
+            format!("{out_dir}/singleton_input.rs"),
+            prettyplease::unparse(&code),
+        )
+        .unwrap();
+    }
+
     // --- echo_network (o2o networking) ---
     {
         let mut flow = hydro_lang::compile::builder::FlowBuilder::new();

--- a/hydro_test_embedded/src/lib.rs
+++ b/hydro_test_embedded/src/lib.rs
@@ -16,6 +16,17 @@ pub mod embedded {
     reason = "generated code"
 )]
 #[allow(unused_imports, unused_qualifications, missing_docs, non_snake_case)]
+pub mod singleton_input {
+    include!(concat!(env!("OUT_DIR"), "/singleton_input.rs"));
+}
+
+#[cfg(feature = "test_embedded")]
+#[expect(
+    clippy::allow_attributes,
+    clippy::allow_attributes_without_reason,
+    reason = "generated code"
+)]
+#[allow(unused_imports, unused_qualifications, missing_docs, non_snake_case)]
 pub mod echo_network {
     include!(concat!(env!("OUT_DIR"), "/echo_network.rs"));
 }
@@ -82,6 +93,20 @@ mod tests {
         let flow = crate::embedded::capitalize(input, &mut outputs);
         run_dfir(flow).await;
         assert_eq!(collected, vec!["HELLO", "WORLD", "HYDRO"]);
+    }
+
+    // --- singleton_input (singleton + stream, no networking) ---
+    // Order: (singleton_inputs, inputs, outputs)
+    #[tokio::test]
+    async fn test_embedded_singleton_input() {
+        let names = stream::iter(vec!["Alice".to_owned(), "Bob".to_owned()]);
+        let mut collected = vec![];
+        let mut outputs = crate::singleton_input::prefix_names::EmbeddedOutputs {
+            output: |s: String| collected.push(s),
+        };
+        let flow = crate::singleton_input::prefix_names("Hello".to_owned(), names, &mut outputs);
+        run_dfir(flow).await;
+        assert_eq!(collected, vec!["Hello Alice", "Hello Bob"]);
     }
 
     // --- echo_network (o2o) ---


### PR DESCRIPTION
Added support for singleton inputs in embedded deployment mode. A singleton input becomes a plain `T` parameter on the generated function, rather than requiring a `Stream` wrapper. This is useful for passing configuration values, thresholds, or any fixed data into a dataflow.

API:
- `process.embedded_singleton_input::<T>("name")` returns a `Singleton<T, Self, Bounded>` for use in the Hydro program
- The generated function receives `name: T` as a plain parameter (appearing before stream inputs in the signature)

Implementation:
- `HydroSource::EmbeddedSingleton(syn::Ident)` variant added to IR
- `embedded_singleton_input()` method added to `Location` trait
- `register_embedded_singleton_input` added to `Deploy` trait
- `singleton_inputs` field added to `EmbeddedInstantiateEnv`
- Code generation emits `source_iter([#ident])` for singleton sources
- `generate_embedded` produces plain `#ident: #element_type` params

Files changed:
- hydro_lang/src/compile/ir/mod.rs — new source variant + codegen
- hydro_lang/src/location/mod.rs — new Location method
- hydro_lang/src/compile/deploy_provider.rs — new trait method
- hydro_lang/src/compile/embedded.rs — registration + param generation
- hydro_lang/src/viz/render.rs — visualization label
- docs/docs/hydro/reference/deploy/embedded.mdx — documentation