### PR TITLE
refactor(dfir_pipes)!: TakeWhile should not do its own fusing, fix #2659

### DIFF
--- a/dfir_pipes/src/pull/take_while.rs
+++ b/dfir_pipes/src/pull/take_while.rs
@@ -3,7 +3,7 @@ use core::pin::Pin;
 use pin_project_lite::pin_project;
 
 use crate::Yes;
-use crate::pull::{FusedPull, Pull, PullStep, fuse_self};
+use crate::pull::{Pull, PullStep};
 
 pin_project! {
     /// Pull combinator that yields items while a predicate returns `true`.
@@ -13,7 +13,6 @@ pin_project! {
         #[pin]
         prev: Prev,
         func: Func,
-        done: bool,
     }
 }
 
@@ -22,11 +21,7 @@ where
     Self: Pull,
 {
     pub(crate) const fn new(prev: Prev, func: Func) -> Self {
-        Self {
-            prev,
-            func,
-            done: false,
-        }
+        Self { prev, func }
     }
 }
 
@@ -48,57 +43,21 @@ where
     ) -> PullStep<Self::Item, Self::Meta, Self::CanPend, Self::CanEnd> {
         let this = self.project();
 
-        if *this.done {
-            return PullStep::Ended(Yes);
-        }
-
         match this.prev.pull(ctx) {
             PullStep::Ready(item, meta) => {
                 if (this.func)(&item) {
                     PullStep::Ready(item, meta)
                 } else {
-                    *this.done = true;
                     PullStep::Ended(Yes)
                 }
             }
             PullStep::Pending(can_pend) => PullStep::Pending(can_pend),
-            PullStep::Ended(_) => {
-                *this.done = true;
-                PullStep::Ended(Yes)
-            }
+            PullStep::Ended(_) => PullStep::Ended(Yes),
         }
     }
 
     fn size_hint(self: Pin<&Self>) -> (usize, Option<usize>) {
-        let this = self.project_ref();
-        if *this.done {
-            (0, Some(0))
-        } else {
-            let (_, upper) = this.prev.size_hint();
-            (0, upper)
-        }
-    }
-
-    fuse_self!();
-}
-
-impl<Prev, Func> FusedPull for TakeWhile<Prev, Func>
-where
-    Prev: Pull,
-    Func: FnMut(&Prev::Item) -> bool,
-{
-}
-
-#[cfg(test)]
-mod tests {
-    use core::pin::pin;
-
-    use crate::pull::Pull;
-    use crate::pull::test_utils::{PanicsAfterEndPull, assert_fused_runtime};
-
-    #[test]
-    fn take_while_fused_shields_upstream() {
-        let p = pin!(PanicsAfterEndPull::new(2).take_while(|x| *x < 1));
-        assert_fused_runtime(p);
+        let (_, upper) = self.project_ref().prev.size_hint();
+        (0, upper)
     }
 }


### PR DESCRIPTION
Remove self-fusing behavior from TakeWhile pull combinator:
- Remove done: bool field and FusedPull impl
- Remove fuse_self!() macro invocation
- Simplify pull() and size_hint() by removing done tracking
- Remove test (fusing is already covered by Fuse's own tests)

Users who need fused behavior should now call .fuse() explicitly.

#2659