### PR TITLE
fix(dfir_pipes): fix Zip/ZipLongest size_hint and starvation bugs, fix #2664

### DIFF
--- a/dfir_pipes/src/lib.rs
+++ b/dfir_pipes/src/lib.rs
@@ -58,7 +58,7 @@ pub trait Toggle: Sized {
 /// Type-level `true` for [`Toggle`].
 ///
 /// Indicates that a capability is present (e.g., the pull can pend or can end).
-#[derive(Default)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Yes;
 
 #[sealed]

--- a/dfir_pipes/src/pull/collect.rs
+++ b/dfir_pipes/src/pull/collect.rs
@@ -43,8 +43,7 @@ where
         let ctx = <Prev::Ctx<'_> as Context<'_>>::from_task(cx);
 
         #[cfg(nightly)]
-        this.collect
-            .extend_reserve(this.prev.as_ref().get_ref().size_hint().0);
+        this.collect.extend_reserve(this.prev.size_hint().0);
 
         loop {
             return match this.prev.as_mut().pull(ctx) {

--- a/dfir_pipes/src/pull/mod.rs
+++ b/dfir_pipes/src/pull/mod.rs
@@ -102,6 +102,7 @@ pub use zip_longest::ZipLongest;
 /// The `CanPend` and `CanEnd` type parameters use [`Toggle`] to statically encode
 /// which variants are possible. When a variant is impossible (e.g., `CanPend = No`),
 /// its payload type becomes [`No`], making it a compile error to construct.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum PullStep<Item, Meta, CanPend: Toggle, CanEnd: Toggle> {
     /// An item is ready with associated metadata.
     Ready(Item, Meta),
@@ -122,14 +123,19 @@ impl<Item, Meta, CanPend: Toggle, CanEnd: Toggle> PullStep<Item, Meta, CanPend, 
         PullStep::Pending(Toggle::create())
     }
 
-    /// Returns `true` if the step is a [`PullStep::Ended`].
-    pub const fn is_ended(&self) -> bool {
-        matches!(self, PullStep::Ended(_))
+    /// Returns `true` if the step is a [`PullStep::Ready`].
+    pub const fn is_ready(&self) -> bool {
+        matches!(self, PullStep::Ready(_, _))
     }
 
     /// Returns `true` if the step is a [`PullStep::Pending`].
     pub const fn is_pending(&self) -> bool {
         matches!(self, PullStep::Pending(_))
+    }
+
+    /// Returns `true` if the step is a [`PullStep::Ended`].
+    pub const fn is_ended(&self) -> bool {
+        matches!(self, PullStep::Ended(_))
     }
 
     /// Tries to convert the `CanPend` and `CanEnd` type parameters, returning `None` if the conversion is invalid.
@@ -565,6 +571,10 @@ where
     ) -> PullStep<Self::Item, Self::Meta, Self::CanPend, Self::CanEnd> {
         Pin::new(&mut **self).pull(ctx)
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (**self).size_hint()
+    }
 }
 
 /// A marker trait for pulls that are "fused".
@@ -577,6 +587,8 @@ where
 /// Implementors should ensure this invariant is upheld. The [`Pull::fuse`]
 /// adapter can be used to make any pull fused.
 pub trait FusedPull: Pull {}
+
+impl<P> FusedPull for &mut P where P: FusedPull + Unpin + ?Sized {}
 
 /// Creates a pull from an iterator.
 ///

--- a/dfir_pipes/src/pull/test_utils.rs
+++ b/dfir_pipes/src/pull/test_utils.rs
@@ -84,6 +84,11 @@ impl<Item, Meta: Copy, CanPend: Toggle, CanEnd: Toggle, const FUSED: bool> Pull
             None => panic!("TestPull: polled after log exhausted"),
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let size = self.steps.iter().filter(|step| step.is_ready()).count();
+        (size, Some(size))
+    }
 }
 
 impl<Item, Meta: Copy, CanPend: Toggle, CanEnd: Toggle> FusedPull

--- a/dfir_pipes/src/pull/zip.rs
+++ b/dfir_pipes/src/pull/zip.rs
@@ -1,5 +1,6 @@
 use core::pin::Pin;
 
+use itertools::Either;
 use pin_project_lite::pin_project;
 
 use crate::pull::{Pull, PullStep};
@@ -13,20 +14,22 @@ pin_project! {
     #[derive(Clone, Debug)]
     pub struct Zip<Prev1, Prev2>
     where
-        Prev1: Pull
+        Prev1: Pull,
+        Prev2: Pull,
     {
         #[pin]
         prev1: Prev1,
         #[pin]
         prev2: Prev2,
-        // Store the first stream's item when the second stream is not ready.
-        item1: Option<(Prev1::Item, Prev1::Meta)>,
+        // Buffer an item from whichever stream was ready first, to prevent starvation.
+        buffer: Option<Either<(Prev1::Item, Prev1::Meta), (Prev2::Item, Prev2::Meta)>>,
     }
 }
 
 impl<Prev1, Prev2> Zip<Prev1, Prev2>
 where
     Prev1: Pull,
+    Prev2: Pull,
     Self: Pull,
 {
     /// Create a new `Zip` stream from two source streams.
@@ -34,7 +37,7 @@ where
         Self {
             prev1,
             prev2,
-            item1: None,
+            buffer: None,
         }
     }
 }
@@ -57,45 +60,66 @@ where
     ) -> PullStep<Self::Item, Self::Meta, Self::CanPend, Self::CanEnd> {
         let mut this = self.project();
 
-        // Store `item1` so it is not dropped if `prev2` returns `Pending`.
-        if this.item1.is_none() {
-            *this.item1 = match this
-                .prev1
+        let (pull_left, pull_right) = match this.buffer.take() {
+            Some(Either::Left((left_item, left_meta))) => {
+                (Some(PullStep::Ready(left_item, left_meta)), None)
+            }
+            Some(Either::Right((right_item, right_meta))) => {
+                (None, Some(PullStep::Ready(right_item, right_meta)))
+            }
+            None => (None, None),
+        };
+
+        let pull_left = pull_left.unwrap_or_else(|| {
+            this.prev1
                 .as_mut()
                 .pull(<Prev1::Ctx<'_> as Context<'_>>::unmerge_self(ctx))
-            {
-                PullStep::Ready(item, meta) => Some((item, meta)),
-                PullStep::Pending(_) => {
-                    return PullStep::pending();
-                }
-                PullStep::Ended(_) => {
-                    return PullStep::ended();
-                }
-            };
-        }
-        let item2 = this
-            .prev2
-            .as_mut()
-            .pull(<Prev1::Ctx<'_> as Context<'_>>::unmerge_other(ctx));
-        if let PullStep::Pending(_) = item2 {
-            return PullStep::pending();
-        }
+        });
+        let pull_right = pull_right.unwrap_or_else(|| {
+            this.prev2
+                .as_mut()
+                .pull(<Prev1::Ctx<'_> as Context<'_>>::unmerge_other(ctx))
+        });
 
-        match (this.item1.take(), item2) {
-            (Some((item1, meta1)), PullStep::Ready(item2, _meta2)) => {
-                PullStep::Ready((item1, item2), meta1)
-            } // TODO(mingwei): use _meta2
-            (_, PullStep::Pending(_)) => PullStep::pending(),
-            (_, PullStep::Ended(_)) => PullStep::ended(),
-            (None, PullStep::Ready(_, _)) => {
-                unreachable!("item1 is always Some when reaching this match")
+        match (pull_left, pull_right) {
+            (PullStep::Ready(left_item, left_meta), PullStep::Ready(right_item, _right_meta)) => {
+                PullStep::Ready((left_item, right_item), left_meta)
+            } // TODO(mingwei): use right_meta
+            (PullStep::Ready(left_item, left_meta), PullStep::Pending(_)) => {
+                *this.buffer = Some(Either::Left((left_item, left_meta)));
+                PullStep::pending()
             }
+            (PullStep::Pending(_), PullStep::Ready(right_item, right_meta)) => {
+                *this.buffer = Some(Either::Right((right_item, right_meta)));
+                PullStep::pending()
+            }
+            (PullStep::Pending(_), PullStep::Pending(_)) => PullStep::pending(),
+            // Any Ended → whole zip ends.
+            (PullStep::Ready(..), PullStep::Ended(_))
+            | (PullStep::Ended(_), PullStep::Ready(..))
+            | (PullStep::Pending(_), PullStep::Ended(_))
+            | (PullStep::Ended(_), PullStep::Pending(_))
+            | (PullStep::Ended(_), PullStep::Ended(_)) => PullStep::ended(),
         }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let (min1, max1) = self.prev1.size_hint();
-        let (min2, max2) = self.prev2.size_hint();
+        let (mut min1, mut max1) = self.prev1.size_hint();
+        let (mut min2, mut max2) = self.prev2.size_hint();
+
+        // Account for the buffered item: if we have a buffered item from one side,
+        // that side effectively has one more item remaining.
+        match self.buffer {
+            Some(Either::Left(_)) => {
+                min1 = min1.saturating_add(1);
+                max1 = max1.and_then(|m| m.checked_add(1));
+            }
+            Some(Either::Right(_)) => {
+                min2 = min2.saturating_add(1);
+                max2 = max2.and_then(|m| m.checked_add(1));
+            }
+            None => {}
+        }
 
         // Lower bound is the min of the two (we end when either ends)
         let lower = min1.min(min2);
@@ -122,6 +146,7 @@ mod tests {
     use super::*;
     use crate::pull::test_utils::TestPull;
     use crate::pull::{Pull, PullStep};
+    use crate::{No, Yes};
 
     #[test]
     fn zip_functional_same_length() {
@@ -169,5 +194,73 @@ mod tests {
         }
 
         assert_eq!(results, vec![(0, 0)]);
+    }
+
+    #[test]
+    fn zip_size_hint_includes_buffer() {
+        // After one pair consumed and prev1's item buffered as Left,
+        // prev1's raw size_hint is (0, Some(0)) but the buffer adds 1,
+        // making the effective hint (1, Some(1)) instead of (0, Some(0)).
+        let mut prev1 = TestPull::<_, _, No, Yes, true>::new([
+            PullStep::Ready(0, ()),
+            PullStep::Ready(1, ()),
+            PullStep::ended(),
+        ]);
+        let mut prev2 = TestPull::<_, _, Yes, Yes, true>::new([
+            PullStep::Ready(0, ()),
+            PullStep::pending(),
+            PullStep::Ready(1, ()),
+            PullStep::pending(),
+            PullStep::ended(),
+        ]);
+        let mut zip = pin!(Zip::new(&mut prev1, &mut prev2));
+
+        // Initial: prev1=(2,Some(2)), prev2=(2,Some(2)) → min = (2, Some(2))
+        assert_eq!(zip.size_hint(), (2, Some(2)));
+
+        // Pull 1: prev1 Ready(0), prev2 Ready(0) → Ready((0,0))
+        assert_eq!(zip.as_mut().pull(&mut ()), PullStep::Ready((0, 0), ()));
+
+        // Pull 2: prev1 Ready(1), prev2 Pending → buffer Left(1), Pending
+        assert!(zip.as_mut().pull(&mut ()).is_pending());
+
+        // prev1 raw=(0,Some(0)) + buffer Left → effective (1,Some(1))
+        // prev2 raw=(1,Some(1))
+        // Without buffer accounting this would be (0, Some(0)).
+        assert_eq!(zip.size_hint(), (1, Some(1)));
+    }
+
+    #[test]
+    fn zip_no_starvation() {
+        // When prev1 is Pending, prev2 should still be polled and its item buffered.
+        let mut prev1 = TestPull::<_, _, Yes, Yes, true>::new([
+            PullStep::Ready(0, ()),
+            PullStep::pending(),
+            PullStep::Ready(1, ()),
+            PullStep::pending(),
+            PullStep::ended(),
+        ]);
+        let mut prev2 = TestPull::<_, _, No, Yes, true>::new([
+            PullStep::Ready(0, ()),
+            PullStep::Ready(1, ()),
+            PullStep::ended(),
+        ]);
+        let mut zip = pin!(Zip::new(&mut prev1, &mut prev2));
+
+        // Pull 1: both Ready → Ready((0, 0))
+        assert!(matches!(
+            zip.as_mut().pull(&mut ()),
+            PullStep::Ready((0, 0), _)
+        ));
+
+        // Pull 2: prev1 Pending, prev2 Ready(1) → buffered as Right, Pending
+        assert!(zip.as_mut().pull(&mut ()).is_pending());
+
+        // Pull 3: prev1 Ready(1) pairs with buffered Right(1) → Ready((1, 1))
+        // This proves prev2 was polled (not starved) when prev1 was Pending.
+        assert!(matches!(
+            zip.as_mut().pull(&mut ()),
+            PullStep::Ready((1, 1), _)
+        ));
     }
 }

--- a/dfir_pipes/src/pull/zip_longest.rs
+++ b/dfir_pipes/src/pull/zip_longest.rs
@@ -1,6 +1,6 @@
 use core::pin::Pin;
 
-use itertools::EitherOrBoth;
+use itertools::{Either, EitherOrBoth};
 use pin_project_lite::pin_project;
 
 use crate::pull::{FusedPull, Pull, PullStep, fuse_self};
@@ -18,20 +18,23 @@ pin_project! {
     #[derive(Clone, Debug)]
     pub struct ZipLongest<Prev1, Prev2>
     where
-        Prev1: Pull
+        Prev1: Pull,
+        Prev2: Pull,
     {
         #[pin]
         prev1: Prev1,
         #[pin]
         prev2: Prev2,
-        // Store the first stream's item when the second stream is not ready.
-        item1: Option<(Prev1::Item, Prev1::Meta)>,
+        // Store an item from whichever stream was ready first, while waiting for the other.
+        // `Left` = item from prev1, `Right` = item from prev2.
+        buffer: Option<Either<(Prev1::Item, Prev1::Meta), (Prev2::Item, Prev2::Meta)>>,
     }
 }
 
 impl<Prev1, Prev2> ZipLongest<Prev1, Prev2>
 where
     Prev1: Pull,
+    Prev2: Pull,
     Self: Pull,
 {
     /// Create a new `ZipLongest` stream from two source streams.
@@ -39,7 +42,7 @@ where
         Self {
             prev1,
             prev2,
-            item1: None,
+            buffer: None,
         }
     }
 }
@@ -62,46 +65,68 @@ where
     ) -> PullStep<Self::Item, Self::Meta, Self::CanPend, Self::CanEnd> {
         let mut this = self.project();
 
-        // Store `item1` so it is not dropped if `stream2` returns `Poll::Pending`.
-        if this.item1.is_none() {
-            *this.item1 = match this
-                .prev1
+        let (pull_left, pull_right) = match this.buffer.take() {
+            Some(Either::Left((left_item, left_meta))) => {
+                (Some(PullStep::Ready(left_item, left_meta)), None)
+            }
+            Some(Either::Right((right_item, right_meta))) => {
+                (None, Some(PullStep::Ready(right_item, right_meta)))
+            }
+            None => (None, None),
+        };
+
+        let pull_left = pull_left.unwrap_or_else(|| {
+            this.prev1
                 .as_mut()
                 .pull(<Prev1::Ctx<'_> as Context<'_>>::unmerge_self(ctx))
-            {
-                PullStep::Ready(item, meta) => Some((item, meta)),
-                PullStep::Pending(_) => {
-                    return PullStep::pending();
-                }
-                PullStep::Ended(_) => None,
-            };
-        }
-        let item2 = this
-            .prev2
-            .as_mut()
-            .pull(<Prev1::Ctx<'_> as Context<'_>>::unmerge_other(ctx));
-        if let PullStep::Pending(_) = item2 {
-            return PullStep::pending();
-        }
+        });
+        let pull_right = pull_right.unwrap_or_else(|| {
+            this.prev2
+                .as_mut()
+                .pull(<Prev1::Ctx<'_> as Context<'_>>::unmerge_other(ctx))
+        });
 
-        match (this.item1.take(), item2) {
-            (_, PullStep::Pending(_)) => unreachable!(),
-            (None, PullStep::Ready(item2, meta2)) => {
-                PullStep::Ready(EitherOrBoth::Right(item2), meta2)
+        match (pull_left, pull_right) {
+            (PullStep::Ready(left_item, left_meta), PullStep::Ready(right_item, _right_meta)) => {
+                PullStep::Ready(EitherOrBoth::Both(left_item, right_item), left_meta)
+            } // TODO(mingwei): use right_meta
+            (PullStep::Ready(left_item, left_meta), PullStep::Ended(_)) => {
+                PullStep::Ready(EitherOrBoth::Left(left_item), left_meta)
             }
-            (None, PullStep::Ended(_)) => PullStep::ended(),
-            (Some((item1, meta1)), PullStep::Ready(item2, _meta2)) => {
-                PullStep::Ready(EitherOrBoth::Both(item1, item2), meta1)
-            } // TODO(mingwei): use _meta2
-            (Some((item1, meta1)), PullStep::Ended(_)) => {
-                PullStep::Ready(EitherOrBoth::Left(item1), meta1)
+            (PullStep::Ended(_), PullStep::Ready(right_item, right_meta)) => {
+                PullStep::Ready(EitherOrBoth::Right(right_item), right_meta)
             }
+            (PullStep::Ready(left_item, left_meta), PullStep::Pending(_)) => {
+                *this.buffer = Some(Either::Left((left_item, left_meta)));
+                PullStep::pending()
+            }
+            (PullStep::Pending(_), PullStep::Ready(right_item, right_meta)) => {
+                *this.buffer = Some(Either::Right((right_item, right_meta)));
+                PullStep::pending()
+            }
+            (PullStep::Pending(_), PullStep::Pending(_)) => PullStep::pending(),
+            (PullStep::Pending(_), PullStep::Ended(_)) => PullStep::pending(),
+            (PullStep::Ended(_), PullStep::Pending(_)) => PullStep::pending(),
+            (PullStep::Ended(_), PullStep::Ended(_)) => PullStep::ended(),
         }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let (min1, max1) = self.prev1.size_hint();
-        let (min2, max2) = self.prev2.size_hint();
+        let (mut min1, mut max1) = self.prev1.size_hint();
+        let (mut min2, mut max2) = self.prev2.size_hint();
+
+        // Account for a buffered item: it adds 1 to the respective stream's remaining count.
+        match self.buffer {
+            Some(Either::Left(_)) => {
+                min1 = min1.saturating_add(1);
+                max1 = max1.and_then(|m| m.checked_add(1));
+            }
+            Some(Either::Right(_)) => {
+                min2 = min2.saturating_add(1);
+                max2 = max2.and_then(|m| m.checked_add(1));
+            }
+            None => {}
+        }
 
         // Lower bound is the max of the two (we continue until both end)
         let lower = min1.max(min2);
@@ -134,6 +159,7 @@ mod tests {
     use super::*;
     use crate::pull::test_utils::{TestPull, assert_is_fused};
     use crate::pull::{Pull, PullStep};
+    use crate::{No, Yes};
 
     #[test]
     fn zip_longest_functional_same_length() {
@@ -219,5 +245,113 @@ mod tests {
             TestPull::items(0..2).fuse()
         ));
         assert_fused_runtime(p);
+    }
+
+    #[test]
+    fn zip_longest_size_hint_basic() {
+        let mut prev1 = TestPull::<_, _, Yes, Yes, true>::new([
+            PullStep::Ready(0, ()),
+            PullStep::pending(),
+            PullStep::Ready(1, ()),
+            PullStep::pending(),
+            PullStep::ended(),
+        ]);
+        let mut prev2 = TestPull::<_, _, Yes, Yes, true>::new([
+            PullStep::Ready(0, ()),
+            PullStep::pending(),
+            PullStep::ended(),
+        ]);
+        let mut zip = pin!(ZipLongest::new(&mut prev1, &mut prev2));
+
+        assert_eq!(zip.size_hint(), (2, Some(2)));
+
+        // Both Ready → Both(0, 0)
+        assert!(matches!(zip.as_mut().pull(&mut ()), PullStep::Ready(..)));
+        assert_eq!(zip.size_hint(), (1, Some(1)));
+
+        // Both Pending
+        assert!(zip.as_mut().pull(&mut ()).is_pending());
+
+        // prev1 Ready(1), prev2 Ended → Left(1)
+        assert!(matches!(zip.as_mut().pull(&mut ()), PullStep::Ready(..)));
+
+        // prev1 Pending, prev2 Ended → Pending
+        assert!(zip.as_mut().pull(&mut ()).is_pending());
+
+        // Both Ended
+        assert!(zip.as_mut().pull(&mut ()).is_ended());
+    }
+
+    #[test]
+    fn zip_longest_size_hint_with_buffered_item() {
+        let mut prev1 = TestPull::<_, _, No, Yes, true>::new([
+            PullStep::Ready(0, ()),
+            PullStep::Ready(1, ()),
+            PullStep::Ready(2, ()),
+            PullStep::ended(),
+        ]);
+        let mut prev2 = TestPull::<_, _, Yes, Yes, true>::new([
+            PullStep::Ready(0, ()),
+            PullStep::pending(),
+            PullStep::Ready(1, ()),
+            PullStep::pending(),
+            PullStep::Ready(2, ()),
+            PullStep::pending(),
+            PullStep::ended(),
+        ]);
+        let mut zip = pin!(ZipLongest::new(&mut prev1, &mut prev2));
+
+        // Pull 1: prev1 Ready(0), prev2 Ready(0) => Both(0, 0)
+        assert!(matches!(
+            zip.as_mut().pull(&mut ()),
+            PullStep::Ready(EitherOrBoth::Both(0, 0), ())
+        ));
+
+        // Pull 2: prev1 Ready(1), prev2 Pending => buffer Left(1), Pending
+        assert!(zip.as_mut().pull(&mut ()).is_pending());
+
+        // Now buffer has Left(item1). prev1 reports (1, Some(1)), prev2 reports (2, Some(2)).
+        // With buffer: prev1 effective = (2, Some(2)), prev2 = (2, Some(2)) => (2, Some(2))
+        assert_eq!(zip.size_hint(), (2, Some(2)));
+    }
+
+    #[test]
+    fn zip_longest_no_starvation() {
+        // When prev1 is Pending, prev2 should still be polled and its item buffered.
+        let mut prev1 = TestPull::<_, _, Yes, Yes, true>::new([
+            PullStep::Ready(0, ()),
+            PullStep::pending(),
+            PullStep::Ready(1, ()),
+            PullStep::pending(),
+            PullStep::ended(),
+        ]);
+        let mut prev2 = TestPull::<_, _, No, Yes, true>::new([
+            PullStep::Ready(0, ()),
+            PullStep::Ready(1, ()),
+            PullStep::ended(),
+        ]);
+        let mut zip = pin!(ZipLongest::new(&mut prev1, &mut prev2));
+
+        // prev1 Ready(0), prev2 Ready(0) → Both(0, 0)
+        assert!(matches!(
+            zip.as_mut().pull(&mut ()),
+            PullStep::Ready(EitherOrBoth::Both(0, 0), _)
+        ));
+
+        // prev1 Pending, prev2 Ready(1) → buffer Right(1), Pending
+        // This proves prev2 was polled even though prev1 was Pending.
+        assert!(zip.as_mut().pull(&mut ()).is_pending());
+
+        // Buffered Right(1) pairs with prev1 Ready(1) → Both(1, 1)
+        assert!(matches!(
+            zip.as_mut().pull(&mut ()),
+            PullStep::Ready(EitherOrBoth::Both(1, 1), _)
+        ));
+
+        // prev1 Pending, prev2 Ended → Pending
+        assert!(zip.as_mut().pull(&mut ()).is_pending());
+
+        // prev1 Ended, prev2 Ended → Ended
+        assert!(zip.as_mut().pull(&mut ()).is_ended());
     }
 }

--- a/dfir_pipes/src/push/mod.rs
+++ b/dfir_pipes/src/push/mod.rs
@@ -58,6 +58,7 @@ pub use unzip::Unzip;
 /// The `CanPend` type parameter uses [`Toggle`] to statically encode whether pending
 /// is possible. When `CanPend = No`, the `Pending` variant cannot be constructed,
 /// and the push is guaranteed to always accept items immediately.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum PushStep<CanPend>
 where
     CanPend: Toggle,


### PR DESCRIPTION
Both `Zip` and `ZipLongest` had two bugs:

1. `size_hint()` did not account for the buffered `item1` field, so the reported remaining count could be off by one when an item was already fetched from one stream but the other stream returned Pending.

2. The buffer only ever stored items from stream 1 (`item1`), meaning stream 2 could starve if stream 1 was always pending — stream 2 would never get polled.

Fix: Changed `item1: Option<(Prev1::Item, Prev1::Meta)>` to `buffer: Option<Either<(Prev1::Item, Prev1::Meta), (Prev2::Item, Prev2::Meta)>>` in both operators. When prev1 returns Pending, we now try prev2 and buffer its item as `Right`, preventing starvation. The `size_hint()` methods now add 1 to the appropriate stream's counts when a buffered item exists.

Added tests for size_hint accuracy with buffered items and starvation prevention in both operators.

Fix #2664