### PR TITLE
feat(hydro_lang): rename `interleave` to `merge_unordered` for symmetry with `merge_ordered`

### DIFF
--- a/hydro_lang/src/live_collections/keyed_singleton.rs
+++ b/hydro_lang/src/live_collections/keyed_singleton.rs
@@ -1175,7 +1175,7 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound<ValueBound = Bounded>>
     /// keyed_singleton
     ///     .clone()
     ///     .into_keyed_stream()
-    ///     .interleave(
+    ///     .merge_unordered(
     ///         keyed_singleton.into_keyed_stream()
     ///     )
     /// #   .entries()

--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -2400,7 +2400,7 @@ impl<'a, K, V, L: Location<'a> + NoTick, O: Ordering, R: Retries>
     /// # process.source_iter(q!(vec![(1, 2), (3, 4)])).into_keyed().into();
     /// let numbers2: KeyedStream<i32, i32, _> = // { 1: [3], 3: [5] }
     /// # process.source_iter(q!(vec![(1, 3), (3, 5)])).into_keyed().into();
-    /// numbers1.interleave(numbers2)
+    /// numbers1.merge_unordered(numbers2)
     /// #   .entries()
     /// # }, |mut stream| async move {
     /// // { 1: [2, 3], 3: [4, 5] } with each group in unknown order
@@ -2413,7 +2413,7 @@ impl<'a, K, V, L: Location<'a> + NoTick, O: Ordering, R: Retries>
     /// # }));
     /// # }
     /// ```
-    pub fn interleave<O2: Ordering, R2: Retries>(
+    pub fn merge_unordered<O2: Ordering, R2: Retries>(
         self,
         other: KeyedStream<K, V, L, Unbounded, O2, R2>,
     ) -> KeyedStream<K, V, L, Unbounded, NoOrder, <R as MinRetries<R2>>::Min>
@@ -2435,6 +2435,18 @@ impl<'a, K, V, L: Location<'a> + NoTick, O: Ordering, R: Retries>
                 >::collection_kind()),
             },
         )
+    }
+
+    /// Deprecated: use [`KeyedStream::merge_unordered`] instead.
+    #[deprecated(note = "use `merge_unordered` instead")]
+    pub fn interleave<O2: Ordering, R2: Retries>(
+        self,
+        other: KeyedStream<K, V, L, Unbounded, O2, R2>,
+    ) -> KeyedStream<K, V, L, Unbounded, NoOrder, <R as MinRetries<R2>>::Min>
+    where
+        R: MinRetries<R2>,
+    {
+        self.merge_unordered(other)
     }
 }
 
@@ -2808,7 +2820,7 @@ mod tests {
                 (2, 102),
                 (2, 102)
             ])))
-            .interleave(tick_triggered_input)
+            .merge_unordered(tick_triggered_input)
             .into_keyed()
             .reduce_watermark(
                 watermark,
@@ -3035,7 +3047,7 @@ mod tests {
             node.forward_ref::<super::KeyedStream<_, _, _, _, NoOrder>>();
         let ordered = input
             .into_keyed()
-            .interleave(cycle_back)
+            .merge_unordered(cycle_back)
             .assume_ordering::<TotalOrder>(nondet!(/** test */));
         complete_cycle_back.complete(
             ordered
@@ -3099,7 +3111,7 @@ mod tests {
             node.forward_ref::<super::KeyedStream<_, _, _, _, NoOrder>>();
         let ordered = input
             .into_keyed()
-            .interleave(cycle_back)
+            .merge_unordered(cycle_back)
             .assume_ordering::<TotalOrder>(nondet!(/** test */));
 
         // Cycle back: when we see (1, 10), emit (2, 100) to key 2
@@ -3169,7 +3181,7 @@ mod tests {
             node.forward_ref::<super::KeyedStream<_, _, _, _, NoOrder>>();
         let ordered = input
             .into_keyed()
-            .interleave(cycle_back)
+            .merge_unordered(cycle_back)
             .assume_ordering::<TotalOrder>(nondet!(/** test */));
         complete_cycle_back.complete(
             ordered

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -679,7 +679,7 @@ where
     /// let (evens, odds) = numbers.partition(q!(|&x| x % 2 == 0));
     /// // evens: 2, 4, 6 tagged with true; odds: 1, 3, 5 tagged with false
     /// evens.map(q!(|x| (x, true)))
-    ///     .interleave(odds.map(q!(|x| (x, false))))
+    ///     .merge_unordered(odds.map(q!(|x| (x, false))))
     /// # }, |mut stream| async move {
     /// # let mut results = Vec::new();
     /// # for _ in 0..6 {
@@ -1885,8 +1885,8 @@ where
 }
 
 impl<'a, T, L: Location<'a> + NoTick, O: Ordering, R: Retries> Stream<T, L, Unbounded, O, R> {
-    /// Produces a new stream that interleaves the elements of the two input streams.
-    /// The result has [`NoOrder`] because the order of interleaving is not guaranteed.
+    /// Produces a new stream that merges the elements of the two input streams.
+    /// The result has [`NoOrder`] because the order of merging is not guaranteed.
     ///
     /// Currently, both input streams must be [`Unbounded`]. When the streams are
     /// [`Bounded`], you can use [`Stream::chain`] instead.
@@ -1899,16 +1899,16 @@ impl<'a, T, L: Location<'a> + NoTick, O: Ordering, R: Retries> Stream<T, L, Unbo
     /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
     /// let numbers: Stream<i32, _, Unbounded> = // 1, 2, 3, 4
     /// # process.source_iter(q!(vec![1, 2, 3, 4])).into();
-    /// numbers.clone().map(q!(|x| x + 1)).interleave(numbers)
+    /// numbers.clone().map(q!(|x| x + 1)).merge_unordered(numbers)
     /// # }, |mut stream| async move {
-    /// // 2, 3, 4, 5, and 1, 2, 3, 4 interleaved in unknown order
+    /// // 2, 3, 4, 5, and 1, 2, 3, 4 merged in unknown order
     /// # for w in vec![2, 3, 4, 5, 1, 2, 3, 4] {
     /// #     assert_eq!(stream.next().await.unwrap(), w);
     /// # }
     /// # }));
     /// # }
     /// ```
-    pub fn interleave<O2: Ordering, R2: Retries>(
+    pub fn merge_unordered<O2: Ordering, R2: Retries>(
         self,
         other: Stream<T, L, Unbounded, O2, R2>,
     ) -> Stream<T, L, Unbounded, NoOrder, <R as MinRetries<R2>>::Min>
@@ -1930,6 +1930,18 @@ impl<'a, T, L: Location<'a> + NoTick, O: Ordering, R: Retries> Stream<T, L, Unbo
             },
         )
     }
+
+    /// Deprecated: use [`Stream::merge_unordered`] instead.
+    #[deprecated(note = "use `merge_unordered` instead")]
+    pub fn interleave<O2: Ordering, R2: Retries>(
+        self,
+        other: Stream<T, L, Unbounded, O2, R2>,
+    ) -> Stream<T, L, Unbounded, NoOrder, <R as MinRetries<R2>>::Min>
+    where
+        R: MinRetries<R2>,
+    {
+        self.merge_unordered(other)
+    }
 }
 
 impl<'a, T, L: Location<'a> + NoTick, R: Retries> Stream<T, L, Unbounded, TotalOrder, R> {
@@ -1942,7 +1954,7 @@ impl<'a, T, L: Location<'a> + NoTick, R: Retries> Stream<T, L, Unbounded, TotalO
     /// # Non-Determinism
     /// The order in which elements *across* the two streams will be interleaved is
     /// non-deterministic, so the order of elements will vary across runs. If the output order
-    /// is irrelevant, use [`Stream::interleave`] instead, which is deterministic but emits an
+    /// is irrelevant, use [`Stream::merge_unordered`] instead, which is deterministic but emits an
     /// unordered stream.
     ///
     /// # Example
@@ -3224,7 +3236,7 @@ mod tests {
         let (complete_cycle_back, cycle_back) =
             node.forward_ref::<super::Stream<_, _, _, NoOrder>>();
         let ordered = input
-            .interleave(cycle_back)
+            .merge_unordered(cycle_back)
             .assume_ordering::<TotalOrder>(nondet!(/** test */));
         complete_cycle_back.complete(
             ordered
@@ -3260,7 +3272,7 @@ mod tests {
         let (complete_cycle_back, cycle_back) =
             node.forward_ref::<super::Stream<_, _, _, NoOrder>>();
         let ordered = input
-            .interleave(cycle_back)
+            .merge_unordered(cycle_back)
             .assume_ordering::<TotalOrder>(nondet!(/** test */));
         complete_cycle_back.complete(
             ordered
@@ -3300,13 +3312,13 @@ mod tests {
             node.forward_ref::<super::Stream<_, _, _, NoOrder>>();
         let input1_ordered = input
             .clone()
-            .interleave(cycle_back)
+            .merge_unordered(cycle_back)
             .assume_ordering::<TotalOrder>(nondet!(/** test */));
         let foo = input1_ordered
             .clone()
             .map(q!(|v| v + 3))
             .weaken_ordering::<NoOrder>()
-            .interleave(input2)
+            .merge_unordered(input2)
             .assume_ordering::<TotalOrder>(nondet!(/** test */));
 
         complete_cycle_back.complete(foo.filter(q!(|v| *v == 3)));
@@ -3338,7 +3350,7 @@ mod tests {
         let (complete_cycle_back, cycle_back) =
             node.forward_ref::<super::Stream<_, _, _, NoOrder>>();
         let ordered = input
-            .interleave(cycle_back)
+            .merge_unordered(cycle_back)
             .atomic(&node.tick())
             .assume_ordering::<TotalOrder>(nondet!(/** test */))
             .end_atomic();

--- a/hydro_lang/src/location/cluster.rs
+++ b/hydro_lang/src/location/cluster.rs
@@ -229,7 +229,7 @@ mod tests {
             .source_iter(q!(vec![CLUSTER_SELF_ID]))
             .send(&node, TCP.fail_stop().bincode())
             .values()
-            .interleave(
+            .merge_unordered(
                 cluster2
                     .source_iter(q!(vec![CLUSTER_SELF_ID]))
                     .send(&node, TCP.fail_stop().bincode())

--- a/hydro_lang/src/location/mod.rs
+++ b/hydro_lang/src/location/mod.rs
@@ -1105,7 +1105,7 @@ pub trait Location<'a>: dynamic::DynLocation {
     ///
     /// // Combine initial input with feedback, then increment
     /// let input: Stream<_, _, Unbounded> = process.source_iter(q!([1])).into();
-    /// let output: Stream<_, _, _, NoOrder> = input.interleave(feedback).map(q!(|x| x + 1));
+    /// let output: Stream<_, _, _, NoOrder> = input.merge_unordered(feedback).map(q!(|x| x + 1));
     ///
     /// // Complete the forward reference with the output
     /// complete.complete(output.clone());

--- a/hydro_std/src/bench_client/mod.rs
+++ b/hydro_std/src/bench_client/mod.rs
@@ -89,7 +89,7 @@ where
         clients.forward_ref::<KeyedStream<u32, Output, Cluster<'a, Client>, Unbounded, NoOrder>>();
     // Use new payload IDS and previous outputs to generate new payloads
     let protocol_inputs = workload_generator(
-        new_payload_ids.interleave(protocol_outputs.map(q!(|payload| Some(payload)))),
+        new_payload_ids.merge_unordered(protocol_outputs.map(q!(|payload| Some(payload)))),
     );
     // Feed new payloads to the protocol
     let protocol_outputs = protocol(protocol_inputs.clone());

--- a/hydro_test/src/cluster/paxos.rs
+++ b/hydro_test/src/cluster/paxos.rs
@@ -268,8 +268,8 @@ pub fn leader_election<'a, L: Clone + Debug + Serialize + DeserializeOwned>(
     // c_to_proposers.clone().for_each(q!(|payload: ClientPayload| println!("Client sent proposer payload: {:?}", payload)));
 
     let p_received_max_ballot = p1b_fail
-        .interleave(p_received_p2b_ballots)
-        .interleave(p_to_proposers_i_am_leader_forward_ref)
+        .merge_unordered(p_received_p2b_ballots)
+        .merge_unordered(p_to_proposers_i_am_leader_forward_ref)
         .max()
         .unwrap_or(
             proposers

--- a/hydro_test/src/external_client/http_counter.rs
+++ b/hydro_test/src/external_client/http_counter.rs
@@ -151,6 +151,6 @@ pub fn http_counter_server<'a, P>(
     }));
 
     get_responses
-        .interleave(increment_responses.into_keyed_stream())
-        .interleave(invalid_responses.into_keyed_stream())
+        .merge_unordered(increment_responses.into_keyed_stream())
+        .merge_unordered(invalid_responses.into_keyed_stream())
 }

--- a/hydro_test/src/maelstrom/broadcast.rs
+++ b/hydro_test/src/maelstrom/broadcast.rs
@@ -133,8 +133,8 @@ pub fn broadcast_server<'a, C: 'a>(
     }));
 
     broadcast_response
-        .interleave(read_response)
-        .interleave(topology_response)
+        .merge_unordered(read_response)
+        .merge_unordered(topology_response)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Added `merge_unordered` as the new primary method name on both `Stream` and `KeyedStream`, and updated all internal call sites and doc references to use it.

To avoid a breaking change, the old `interleave` method is preserved as a deprecated forwarding wrapper on both types, marked with `#[deprecated(note = "use `merge_unordered` instead")]`.

Files changed:
- hydro_lang/src/live_collections/stream/mod.rs: New method + deprecated wrapper, updated docs/examples/tests
- hydro_lang/src/live_collections/keyed_stream/mod.rs: New method + deprecated wrapper, updated docs/examples/tests
- hydro_lang/src/live_collections/keyed_singleton.rs: Doc example
- hydro_lang/src/location/cluster.rs: Call site
- hydro_lang/src/location/mod.rs: Doc example
- hydro_std/src/bench_client/mod.rs: Call site
- hydro_test/src/external_client/http_counter.rs: Call sites
- hydro_test/src/maelstrom/broadcast.rs: Call sites
- hydro_test/src/cluster/paxos.rs: Call sites

Closes hydro-project/hydro#2392.