### PR TITLE
refactor(dfir_pipes): remove `Pin<&Self>`, use `&self` in `Pull::size_hint`, fix #2652

### DIFF
--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1156,8 +1156,8 @@ impl DfirGraph {
                                                     }
 
                                                     #[inline(always)]
-                                                    fn size_hint(self: ::std::pin::Pin<&Self>) -> (usize, Option<usize>) {
-                                                        #root::dfir_pipes::pull::Pull::size_hint(self.project_ref().inner)
+                                                    fn size_hint(&self) -> (usize, Option<usize>) {
+                                                        #root::dfir_pipes::pull::Pull::size_hint(&self.inner)
                                                     }
                                                 }
 

--- a/dfir_pipes/src/pull/chain.rs
+++ b/dfir_pipes/src/pull/chain.rs
@@ -63,10 +63,9 @@ where
             .convert_into()
     }
 
-    fn size_hint(self: Pin<&Self>) -> (usize, Option<usize>) {
-        let this = self.project_ref();
-        let (a_lower, a_upper) = this.first.size_hint();
-        let (b_lower, b_upper) = this.second.size_hint();
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (a_lower, a_upper) = self.first.size_hint();
+        let (b_lower, b_upper) = self.second.size_hint();
 
         let lower = a_lower.saturating_add(b_lower);
         let upper = a_upper.zip(b_upper).and_then(|(a, b)| a.checked_add(b));

--- a/dfir_pipes/src/pull/collect.rs
+++ b/dfir_pipes/src/pull/collect.rs
@@ -44,7 +44,7 @@ where
 
         #[cfg(nightly)]
         this.collect
-            .extend_reserve(this.prev.as_ref().size_hint().0);
+            .extend_reserve(this.prev.as_ref().get_ref().size_hint().0);
 
         loop {
             return match this.prev.as_mut().pull(ctx) {

--- a/dfir_pipes/src/pull/either.rs
+++ b/dfir_pipes/src/pull/either.rs
@@ -31,8 +31,8 @@ where
         }
     }
 
-    fn size_hint(self: Pin<&Self>) -> (usize, Option<usize>) {
-        match self.as_pin_ref() {
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self.as_ref() {
             Either::Left(left) => left.size_hint(),
             Either::Right(right) => right.size_hint(),
         }

--- a/dfir_pipes/src/pull/empty.rs
+++ b/dfir_pipes/src/pull/empty.rs
@@ -33,7 +33,7 @@ impl<Item> Pull for Empty<Item> {
         PullStep::Ended(Yes)
     }
 
-    fn size_hint(self: core::pin::Pin<&Self>) -> (usize, Option<usize>) {
+    fn size_hint(&self) -> (usize, Option<usize>) {
         (0, Some(0))
     }
 

--- a/dfir_pipes/src/pull/enumerate.rs
+++ b/dfir_pipes/src/pull/enumerate.rs
@@ -51,8 +51,8 @@ where
         }
     }
 
-    fn size_hint(self: Pin<&Self>) -> (usize, Option<usize>) {
-        self.project_ref().prev.size_hint()
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.prev.size_hint()
     }
 }
 

--- a/dfir_pipes/src/pull/filter.rs
+++ b/dfir_pipes/src/pull/filter.rs
@@ -56,8 +56,8 @@ where
         }
     }
 
-    fn size_hint(self: Pin<&Self>) -> (usize, Option<usize>) {
-        let (_, upper) = self.project_ref().prev.size_hint();
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, upper) = self.prev.size_hint();
         (0, upper)
     }
 }

--- a/dfir_pipes/src/pull/filter_map.rs
+++ b/dfir_pipes/src/pull/filter_map.rs
@@ -56,8 +56,8 @@ where
         }
     }
 
-    fn size_hint(self: Pin<&Self>) -> (usize, Option<usize>) {
-        let (_, upper) = self.project_ref().prev.size_hint();
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, upper) = self.prev.size_hint();
         (0, upper)
     }
 }

--- a/dfir_pipes/src/pull/flat_map.rs
+++ b/dfir_pipes/src/pull/flat_map.rs
@@ -70,9 +70,8 @@ where
         }
     }
 
-    fn size_hint(self: Pin<&Self>) -> (usize, Option<usize>) {
-        let this = self.project_ref();
-        let current_len = this
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let current_len = self
             .current
             .as_ref()
             .map(|(iter, _)| iter.size_hint().0)

--- a/dfir_pipes/src/pull/flatten.rs
+++ b/dfir_pipes/src/pull/flatten.rs
@@ -67,9 +67,8 @@ where
         }
     }
 
-    fn size_hint(self: Pin<&Self>) -> (usize, Option<usize>) {
-        let this = self.project_ref();
-        let current_len = this
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let current_len = self
             .current
             .as_ref()
             .map(|(iter, _)| iter.size_hint().0)

--- a/dfir_pipes/src/pull/fuse.rs
+++ b/dfir_pipes/src/pull/fuse.rs
@@ -55,9 +55,8 @@ where
         }
     }
 
-    fn size_hint(self: Pin<&Self>) -> (usize, Option<usize>) {
-        let this = self.project_ref();
-        if let Some(prev) = this.prev.as_pin_ref() {
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        if let Some(prev) = self.prev.as_ref() {
             prev.size_hint()
         } else {
             (0, Some(0))

--- a/dfir_pipes/src/pull/inspect.rs
+++ b/dfir_pipes/src/pull/inspect.rs
@@ -51,8 +51,8 @@ where
         }
     }
 
-    fn size_hint(self: Pin<&Self>) -> (usize, Option<usize>) {
-        self.project_ref().prev.size_hint()
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.prev.size_hint()
     }
 }
 

--- a/dfir_pipes/src/pull/iter.rs
+++ b/dfir_pipes/src/pull/iter.rs
@@ -43,7 +43,7 @@ where
         }
     }
 
-    fn size_hint(self: Pin<&Self>) -> (usize, Option<usize>) {
+    fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
     }
 }

--- a/dfir_pipes/src/pull/map.rs
+++ b/dfir_pipes/src/pull/map.rs
@@ -48,8 +48,8 @@ where
         }
     }
 
-    fn size_hint(self: Pin<&Self>) -> (usize, Option<usize>) {
-        self.project_ref().prev.size_hint()
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.prev.size_hint()
     }
 }
 

--- a/dfir_pipes/src/pull/mod.rs
+++ b/dfir_pipes/src/pull/mod.rs
@@ -217,7 +217,7 @@ pub trait Pull {
     /// The default implementation returns `(0, None)` which is correct for any
     /// pull.
     #[inline]
-    fn size_hint(self: Pin<&Self>) -> (usize, Option<usize>) {
+    fn size_hint(&self) -> (usize, Option<usize>) {
         (0, None)
     }
 

--- a/dfir_pipes/src/pull/once.rs
+++ b/dfir_pipes/src/pull/once.rs
@@ -37,7 +37,7 @@ impl<Item> Pull for Once<Item> {
         }
     }
 
-    fn size_hint(self: core::pin::Pin<&Self>) -> (usize, Option<usize>) {
+    fn size_hint(&self) -> (usize, Option<usize>) {
         let n = if self.item.is_some() { 1 } else { 0 };
         (n, Some(n))
     }

--- a/dfir_pipes/src/pull/pending.rs
+++ b/dfir_pipes/src/pull/pending.rs
@@ -42,7 +42,7 @@ impl<Item> Pull for Pending<Item> {
         PullStep::Pending(Yes)
     }
 
-    fn size_hint(self: Pin<&Self>) -> (usize, Option<usize>) {
+    fn size_hint(&self) -> (usize, Option<usize>) {
         (0, Some(0))
     }
 

--- a/dfir_pipes/src/pull/repeat.rs
+++ b/dfir_pipes/src/pull/repeat.rs
@@ -37,7 +37,7 @@ where
         PullStep::Ready(self.item.clone(), ())
     }
 
-    fn size_hint(self: core::pin::Pin<&Self>) -> (usize, Option<usize>) {
+    fn size_hint(&self) -> (usize, Option<usize>) {
         (usize::MAX, None)
     }
 

--- a/dfir_pipes/src/pull/skip.rs
+++ b/dfir_pipes/src/pull/skip.rs
@@ -56,10 +56,9 @@ where
         }
     }
 
-    fn size_hint(self: Pin<&Self>) -> (usize, Option<usize>) {
-        let this = self.project_ref();
-        let (lower, upper) = this.prev.size_hint();
-        let remaining = *this.remaining;
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (lower, upper) = self.prev.size_hint();
+        let remaining = self.remaining;
         (
             lower.saturating_sub(remaining),
             upper.map(|u| u.saturating_sub(remaining)),

--- a/dfir_pipes/src/pull/skip_while.rs
+++ b/dfir_pipes/src/pull/skip_while.rs
@@ -62,15 +62,14 @@ where
         }
     }
 
-    fn size_hint(self: Pin<&Self>) -> (usize, Option<usize>) {
-        let this = self.project_ref();
-        let (_, upper) = this.prev.size_hint();
-        if *this.skipping {
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, upper) = self.prev.size_hint();
+        if self.skipping {
             // Still skipping, so lower bound is 0
             (0, upper)
         } else {
             // Done skipping, pass through
-            this.prev.size_hint()
+            self.prev.size_hint()
         }
     }
 }

--- a/dfir_pipes/src/pull/stream.rs
+++ b/dfir_pipes/src/pull/stream.rs
@@ -49,8 +49,8 @@ where
         }
     }
 
-    fn size_hint(self: Pin<&Self>) -> (usize, Option<usize>) {
-        self.project_ref().stream.size_hint()
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.stream.size_hint()
     }
 }
 

--- a/dfir_pipes/src/pull/stream_ready.rs
+++ b/dfir_pipes/src/pull/stream_ready.rs
@@ -59,7 +59,7 @@ where
         }
     }
 
-    fn size_hint(self: Pin<&Self>) -> (usize, Option<usize>) {
+    fn size_hint(&self) -> (usize, Option<usize>) {
         self.stream.size_hint()
     }
 }

--- a/dfir_pipes/src/pull/take.rs
+++ b/dfir_pipes/src/pull/take.rs
@@ -59,10 +59,9 @@ where
         }
     }
 
-    fn size_hint(self: Pin<&Self>) -> (usize, Option<usize>) {
-        let this = self.project_ref();
-        let (lower, upper) = this.prev.size_hint();
-        let remaining = *this.remaining;
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (lower, upper) = self.prev.size_hint();
+        let remaining = self.remaining;
         (
             lower.min(remaining),
             upper.map(|u| u.min(remaining)).or(Some(remaining)),

--- a/dfir_pipes/src/pull/take_while.rs
+++ b/dfir_pipes/src/pull/take_while.rs
@@ -56,8 +56,8 @@ where
         }
     }
 
-    fn size_hint(self: Pin<&Self>) -> (usize, Option<usize>) {
-        let (_, upper) = self.project_ref().prev.size_hint();
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, upper) = self.prev.size_hint();
         (0, upper)
     }
 }

--- a/dfir_pipes/src/pull/test_utils.rs
+++ b/dfir_pipes/src/pull/test_utils.rs
@@ -55,7 +55,7 @@ impl Pull for AsyncPull {
         }
     }
 
-    fn size_hint(self: Pin<&Self>) -> (usize, Option<usize>) {
+    fn size_hint(&self) -> (usize, Option<usize>) {
         if self.ended {
             (0, Some(0))
         } else {
@@ -111,7 +111,7 @@ impl Pull for SyncPull {
         }
     }
 
-    fn size_hint(self: Pin<&Self>) -> (usize, Option<usize>) {
+    fn size_hint(&self) -> (usize, Option<usize>) {
         if self.ended {
             (0, Some(0))
         } else {

--- a/dfir_pipes/src/pull/zip.rs
+++ b/dfir_pipes/src/pull/zip.rs
@@ -93,11 +93,9 @@ where
         }
     }
 
-    fn size_hint(self: Pin<&Self>) -> (usize, Option<usize>) {
-        let this = self.project_ref();
-
-        let (min1, max1) = this.prev1.size_hint();
-        let (min2, max2) = this.prev2.size_hint();
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (min1, max1) = self.prev1.size_hint();
+        let (min2, max2) = self.prev2.size_hint();
 
         // Lower bound is the min of the two (we end when either ends)
         let lower = min1.min(min2);

--- a/dfir_pipes/src/pull/zip_longest.rs
+++ b/dfir_pipes/src/pull/zip_longest.rs
@@ -99,11 +99,9 @@ where
         }
     }
 
-    fn size_hint(self: Pin<&Self>) -> (usize, Option<usize>) {
-        let this = self.project_ref();
-
-        let (min1, max1) = this.prev1.size_hint();
-        let (min2, max2) = this.prev2.size_hint();
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (min1, max1) = self.prev1.size_hint();
+        let (min2, max2) = self.prev2.size_hint();
 
         // Lower bound is the max of the two (we continue until both end)
         let lower = min1.max(min2);


### PR DESCRIPTION
Fix #2652

Changed the `size_hint` method signature in the `Pull` trait from `fn size_hint(self: Pin<&Self>)` to `fn size_hint(&self)`.

`Pin<&...>` is somewhat silly -- really we only need `Pin` when we want to project it inwards to be able to call `poll` or `poll_next` on a `Future` or `Stream`, in an async context (literally has `std::task::Context` as an argument). That doesn't apply for `size_hint` whatsoever.

---

Updated all implementations in dfir_pipes/src/pull/:
- Trait definition in mod.rs
- Simple implementations (once, repeat, empty, pending, iter, stream_ready, test_utils) - signature-only change
- Implementations using project_ref() (map, inspect, enumerate, filter, filter_map, take_while, stream, take, skip, chain, zip, zip_longest, skip_while, flatten, flat_map) - replaced pin projection with direct field access
- fuse.rs: replaced project_ref()/as_pin_ref() with as_ref()
- either.rs: replaced as_pin_ref() with as_ref()
- collect.rs: updated caller to use .get_ref() to obtain &Prev from Pin

Also updated codegen in dfir_lang/src/graph/meta_graph.rs to use &self instead of Pin<&Self> for the generated Pull wrapper's size_hint.

Resolves hydro-project/hydro#2652