### PR TITLE
test(dfir_pipes): simplify push test utilities to use history-based TestPush, fix #2661

### DIFF
--- a/dfir_pipes/src/pull/send_push.rs
+++ b/dfir_pipes/src/pull/send_push.rs
@@ -94,18 +94,17 @@ mod tests {
     use alloc::vec::Vec;
 
     use super::SendPush;
+    use crate::Yes;
     use crate::pull::test_utils::TestPull;
-    use crate::push::test_utils::PendingFlushPush;
+    use crate::push::PushStep;
+    use crate::push::test_utils::TestPush;
 
     /// SendPush must not re-poll the pull after it returned Ended,
     /// even if poll_flush returns Pending.
     #[test]
     fn send_push_no_repoll_after_ended_on_flush_pending() {
         let pull = TestPull::items(0..2);
-        let push = PendingFlushPush {
-            items: Vec::new(),
-            flush_pending_count: 1,
-        };
+        let push = TestPush::<i32, _, _>::new_fused([], [PushStep::Pending(Yes), PushStep::Done]);
         let mut send = core::pin::pin!(SendPush::new(pull, push));
 
         let waker = Waker::noop();
@@ -117,7 +116,7 @@ mod tests {
         let result = send.as_mut().poll(&mut cx);
         assert!(result.is_ready(), "expected Ready from second poll");
 
-        let items = &send.into_ref().get_ref().push.items;
-        assert_eq!(*items, vec![0, 1]);
+        let items: Vec<i32> = send.into_ref().get_ref().push.items();
+        assert_eq!(items, vec![0, 1]);
     }
 }

--- a/dfir_pipes/src/push/demux_var.rs
+++ b/dfir_pipes/src/push/demux_var.rs
@@ -213,52 +213,57 @@ where
 
 #[cfg(test)]
 mod tests {
-    use alloc::rc::Rc;
     use core::pin::Pin;
 
+    extern crate alloc;
+    use alloc::vec;
+
     use super::*;
-    use crate::push::test_utils::{CollectPush, ReadyGuardPush, assert_can_pend_no};
+    use crate::push::test_utils::{TestPush, assert_can_pend_no};
 
     #[test]
     fn test_demux_var_basic_dispatch() {
-        let pushes = variadics::var_expr!(
-            CollectPush::default(),
-            CollectPush::default(),
-            CollectPush::default(),
-        );
+        let mut tp_a = TestPush::no_pend();
+        let mut tp_b = TestPush::no_pend();
+        let mut tp_c = TestPush::no_pend();
 
-        let items_a = Rc::clone(&pushes.0.items);
-        let items_b = Rc::clone(&pushes.1.0.items);
-        let items_c = Rc::clone(&pushes.1.1.0.items);
+        {
+            let pushes = variadics::var_expr!(&mut tp_a, &mut tp_b, &mut tp_c);
+            let mut demux = demux_var(pushes);
+            let mut demux = Pin::new(&mut demux);
 
-        let mut demux = demux_var(pushes);
-        let mut demux = Pin::new(&mut demux);
+            demux.as_mut().poll_ready(&mut ());
+            demux.as_mut().start_send((0, 10), ());
+            demux.as_mut().poll_ready(&mut ());
+            demux.as_mut().start_send((1, 20), ());
+            demux.as_mut().poll_ready(&mut ());
+            demux.as_mut().start_send((2, 30), ());
+            demux.as_mut().poll_ready(&mut ());
+            demux.as_mut().start_send((0, 40), ());
+            demux.as_mut().poll_ready(&mut ());
+            demux.as_mut().start_send((2, 50), ());
+            demux.as_mut().poll_flush(&mut ());
+        }
 
-        demux.as_mut().poll_ready(&mut ());
-        demux.as_mut().start_send((0, 10), ());
-        demux.as_mut().start_send((1, 20), ());
-        demux.as_mut().start_send((2, 30), ());
-        demux.as_mut().start_send((0, 40), ());
-        demux.as_mut().start_send((2, 50), ());
-        demux.as_mut().poll_flush(&mut ());
-
-        assert_eq!(&*items_a.borrow(), &[10, 40]);
-        assert_eq!(&*items_b.borrow(), &[20]);
-        assert_eq!(&*items_c.borrow(), &[30, 50]);
+        assert_eq!(tp_a.items(), vec![10, 40]);
+        assert_eq!(tp_b.items(), vec![20]);
+        assert_eq!(tp_c.items(), vec![30, 50]);
     }
 
     #[test]
     fn test_demux_var_canpend_is_no_for_sync_pushes() {
-        let pushes =
-            variadics::var_expr!(CollectPush::<i32>::default(), CollectPush::<i32>::default(),);
+        let mut tp_a: TestPush<i32, _, _> = TestPush::no_pend();
+        let mut tp_b: TestPush<i32, _, _> = TestPush::no_pend();
+        let pushes = variadics::var_expr!(&mut tp_a, &mut tp_b);
         let demux = demux_var(pushes);
         assert_can_pend_no(&demux);
     }
 
     #[test]
     fn test_demux_var_readies_all_before_send() {
-        let pushes =
-            variadics::var_expr!(ReadyGuardPush::<i32>::new(), ReadyGuardPush::<i32>::new(),);
+        let mut tp_a = TestPush::no_pend();
+        let mut tp_b = TestPush::no_pend();
+        let pushes = variadics::var_expr!(&mut tp_a, &mut tp_b);
         let mut demux = demux_var(pushes);
         let mut demux = Pin::new(&mut demux);
         demux.as_mut().poll_ready(&mut ());

--- a/dfir_pipes/src/push/fanout.rs
+++ b/dfir_pipes/src/push/fanout.rs
@@ -75,11 +75,13 @@ mod tests {
 
     use super::Fanout;
     use crate::push::Push;
-    use crate::push::test_utils::ReadyGuardPush;
+    use crate::push::test_utils::TestPush;
 
     #[test]
     fn fanout_readies_both_before_send() {
-        let mut f = Fanout::new(ReadyGuardPush::new(), ReadyGuardPush::new());
+        let mut tp_a = TestPush::no_pend();
+        let mut tp_b = TestPush::no_pend();
+        let mut f = Fanout::new(&mut tp_a, &mut tp_b);
         let mut f = Pin::new(&mut f);
         f.as_mut().poll_ready(&mut ());
         f.as_mut().start_send(1, ());

--- a/dfir_pipes/src/push/flat_map.rs
+++ b/dfir_pipes/src/push/flat_map.rs
@@ -92,11 +92,12 @@ mod tests {
     use core::pin::Pin;
 
     use crate::push::Push;
-    use crate::push::test_utils::ReadyGuardPush;
+    use crate::push::test_utils::TestPush;
 
     #[test]
     fn flat_map_readies_downstream_before_each_send() {
-        let mut fm = crate::push::flat_map(|x: i32| [x, x + 10], ReadyGuardPush::new());
+        let mut tp = TestPush::no_pend();
+        let mut fm = crate::push::flat_map(|x: i32| [x, x + 10], &mut tp);
         let mut fm = Pin::new(&mut fm);
         fm.as_mut().poll_ready(&mut ());
         fm.as_mut().start_send(1, ());

--- a/dfir_pipes/src/push/flatten.rs
+++ b/dfir_pipes/src/push/flatten.rs
@@ -90,11 +90,12 @@ mod tests {
     use alloc::vec::Vec;
 
     use crate::push::Push;
-    use crate::push::test_utils::ReadyGuardPush;
+    use crate::push::test_utils::TestPush;
 
     #[test]
     fn flatten_readies_downstream_before_each_send() {
-        let mut fl = crate::push::flatten::<Vec<i32>, (), _>(ReadyGuardPush::new());
+        let mut tp = TestPush::no_pend();
+        let mut fl = crate::push::flatten::<Vec<i32>, (), _>(&mut tp);
         let mut fl = Pin::new(&mut fl);
         fl.as_mut().poll_ready(&mut ());
         fl.as_mut().start_send(vec![1, 2], ());

--- a/dfir_pipes/src/push/persist.rs
+++ b/dfir_pipes/src/push/persist.rs
@@ -97,14 +97,15 @@ mod tests {
     use alloc::vec::Vec;
 
     use crate::push::Push;
-    use crate::push::test_utils::ReadyGuardPush;
+    use crate::push::test_utils::TestPush;
 
     #[test]
     fn persist_readies_downstream_for_replay_and_new() {
         let mut buf = Vec::new();
         // First pass: persist items 1, 2.
         {
-            let mut p = crate::push::persist_state(&mut buf, false, ReadyGuardPush::<i32>::new());
+            let mut tp = TestPush::no_pend();
+            let mut p = crate::push::persist_state(&mut buf, false, &mut tp);
             let mut p = Pin::new(&mut p);
             p.as_mut().poll_ready(&mut ());
             p.as_mut().start_send(1, ());
@@ -114,7 +115,8 @@ mod tests {
         }
         // Second pass: replay=true, should replay 1, 2 then accept new item 3.
         {
-            let mut p = crate::push::persist_state(&mut buf, true, ReadyGuardPush::<i32>::new());
+            let mut tp = TestPush::no_pend();
+            let mut p = crate::push::persist_state(&mut buf, true, &mut tp);
             let mut p = Pin::new(&mut p);
             p.as_mut().poll_ready(&mut ());
             p.as_mut().start_send(3, ());

--- a/dfir_pipes/src/push/resolve_futures.rs
+++ b/dfir_pipes/src/push/resolve_futures.rs
@@ -156,7 +156,7 @@ mod tests {
 
     use super::*;
     use crate::push::Push;
-    use crate::push::test_utils::{AsyncMockPush, ReadyGuardPush};
+    use crate::push::test_utils::{PushCall, TestPush};
 
     type Queue = FuturesUnordered<core::future::Ready<i32>>;
 
@@ -165,19 +165,24 @@ mod tests {
         let waker = Waker::noop();
         let mut cx = Context::from_waker(waker);
 
-        let mock = AsyncMockPush::default();
+        let mut mock = TestPush::no_pend();
         let mut queue: Queue = [1, 2, 3].into_iter().map(core::future::ready).collect();
-        let mut rf = ResolveFutures::<_, _, Queue>::new(&mut queue, None, mock);
+        let mut rf = ResolveFutures::<_, _, Queue>::new(&mut queue, None, &mut mock);
 
         let result = Push::<core::future::Ready<i32>, ()>::poll_ready(Pin::new(&mut rf), &mut cx);
         assert!(result.is_done());
 
+        drop(rf);
         assert!(
-            rf.push.poll_ready_count > 0,
+            mock.history
+                .iter()
+                .any(|c| matches!(c, PushCall::PollReady)),
             "downstream poll_ready was not called"
         );
         assert!(
-            !rf.push.items.is_empty(),
+            mock.history
+                .iter()
+                .any(|c| matches!(c, PushCall::SendItem(_))),
             "downstream should have received items"
         );
     }
@@ -187,15 +192,18 @@ mod tests {
         let waker = Waker::noop();
         let mut cx = Context::from_waker(waker);
 
-        let mock = AsyncMockPush::default();
+        let mut mock = TestPush::no_pend();
         let mut queue: Queue = FuturesUnordered::new();
-        let mut rf = ResolveFutures::<_, _, Queue>::new(&mut queue, None, mock);
+        let mut rf = ResolveFutures::<_, _, Queue>::new(&mut queue, None, &mut mock);
 
         let result = Push::<core::future::Ready<i32>, ()>::poll_flush(Pin::new(&mut rf), &mut cx);
         assert!(result.is_done());
 
+        drop(rf);
         assert!(
-            rf.push.poll_flush_count > 0,
+            mock.history
+                .iter()
+                .any(|c| matches!(c, PushCall::PollFlush)),
             "downstream poll_flush was not called"
         );
     }
@@ -205,9 +213,9 @@ mod tests {
         let waker = Waker::noop();
         let mut cx = Context::from_waker(waker);
 
-        let guard = ReadyGuardPush::<i32>::new();
+        let mut guard = TestPush::no_pend();
         let mut queue: Queue = [1, 2, 3].into_iter().map(core::future::ready).collect();
-        let mut rf = ResolveFutures::<_, _, Queue>::new(&mut queue, None, guard);
+        let mut rf = ResolveFutures::<_, _, Queue>::new(&mut queue, None, &mut guard);
 
         // poll_ready drains resolved futures into downstream, each with poll_ready before start_send.
         let result = Push::<core::future::Ready<i32>, ()>::poll_ready(Pin::new(&mut rf), &mut cx);

--- a/dfir_pipes/src/push/test_utils.rs
+++ b/dfir_pipes/src/push/test_utils.rs
@@ -1,130 +1,138 @@
 //! Shared test utilities for Push tests.
 
-use alloc::rc::Rc;
+use alloc::collections::VecDeque;
 use alloc::vec::Vec;
-use core::cell::RefCell;
 use core::pin::Pin;
 
-use crate::No;
 use crate::push::{Push, PushStep};
+use crate::{No, Toggle};
 
-/// Compile-time assertion that a push has `CanPend = No`.
-pub fn assert_can_pend_no<T, M: Copy>(_push: &impl Push<T, M, CanPend = No>) {}
+/// Records which method was called on a [`TestPush`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PushCall<Item> {
+    /// `poll_ready` was called.
+    PollReady,
+    /// `start_send` was called with the given item.
+    SendItem(Item),
+    /// `poll_flush` was called.
+    PollFlush,
+}
 
-/// A simple push that collects items into a shared `Vec`.
+/// A configurable test push that replays separate logs of [`PushStep`]s for
+/// `poll_ready` and `poll_flush`, records a history of all calls, and enforces
+/// Push protocol invariants.
 ///
-/// Useful for testing push pipelines by inspecting collected output.
-#[derive(Default)]
-pub struct CollectPush<T> {
-    /// Shared storage for collected items.
-    pub items: Rc<RefCell<Vec<T>>>,
-}
-
-impl<T> Push<T, ()> for CollectPush<T> {
-    type Ctx<'ctx> = ();
-    type CanPend = No;
-
-    fn poll_ready(self: Pin<&mut Self>, _ctx: &mut ()) -> PushStep<No> {
-        PushStep::Done
-    }
-    fn start_send(self: Pin<&mut Self>, item: T, _meta: ()) {
-        self.get_mut().items.borrow_mut().push(item);
-    }
-    fn poll_flush(self: Pin<&mut Self>, _ctx: &mut ()) -> PushStep<No> {
-        PushStep::Done
-    }
-}
-
-/// Mock push for testing async push operators.
-#[derive(Default)]
-pub struct AsyncMockPush<T> {
-    pub items: Vec<T>,
-    pub poll_ready_count: usize,
-    pub poll_flush_count: usize,
-}
-
-impl<T> Unpin for AsyncMockPush<T> {}
-
-impl<T> Push<T, ()> for AsyncMockPush<T> {
-    type Ctx<'ctx> = ();
-    type CanPend = No;
-
-    fn poll_ready(self: Pin<&mut Self>, _ctx: &mut Self::Ctx<'_>) -> PushStep<No> {
-        self.get_mut().poll_ready_count += 1;
-        PushStep::Done
-    }
-
-    fn start_send(self: Pin<&mut Self>, item: T, _meta: ()) {
-        self.get_mut().items.push(item);
-    }
-
-    fn poll_flush(self: Pin<&mut Self>, _ctx: &mut Self::Ctx<'_>) -> PushStep<No> {
-        self.get_mut().poll_flush_count += 1;
-        PushStep::Done
-    }
-}
-
-/// A push that collects i32 items and returns Pending from poll_flush a configurable number of times.
-pub struct PendingFlushPush {
-    pub items: Vec<i32>,
-    pub flush_pending_count: usize,
-}
-
-impl Push<i32, ()> for PendingFlushPush {
-    type Ctx<'ctx> = ();
-    type CanPend = crate::Yes;
-
-    fn poll_ready(self: Pin<&mut Self>, _ctx: &mut ()) -> PushStep<crate::Yes> {
-        PushStep::Done
-    }
-    fn start_send(self: Pin<&mut Self>, item: i32, _meta: ()) {
-        self.get_mut().items.push(item);
-    }
-    fn poll_flush(self: Pin<&mut Self>, _ctx: &mut ()) -> PushStep<crate::Yes> {
-        let this = self.get_mut();
-        if this.flush_pending_count > 0 {
-            this.flush_pending_count -= 1;
-            PushStep::Pending(crate::Yes)
-        } else {
-            PushStep::Done
-        }
-    }
-}
-
-/// A push that panics if `start_send` is called without a preceding `poll_ready` returning `Done`.
-/// Collects items for inspection.
-pub struct ReadyGuardPush<T> {
-    pub items: Vec<T>,
+/// # Generic Parameters
+///
+/// - `Item`: The type of items accepted by this push.
+/// - `CanPend`: A [`Toggle`] type (`Yes` or `No`) that statically encodes
+///   whether this push can return [`PushStep::Pending`]. When set to [`No`],
+///   the `Pending` variant cannot be constructed.
+/// - `FUSED`: When `true`, exhausted step logs return [`PushStep::Done`]
+///   instead of panicking. When `false`, polling after the log is exhausted
+///   will panic.
+///
+/// # Panics
+///
+/// - `start_send` is called without a preceding `poll_ready` returning `Done`.
+/// - When `FUSED` is `false`, `poll_ready` or `poll_flush` is called after
+///   the corresponding step log is exhausted.
+pub struct TestPush<Item, CanPend: Toggle, const FUSED: bool> {
+    /// Steps returned by `poll_ready`, consumed in order.
+    ready_steps: VecDeque<PushStep<CanPend>>,
+    /// Steps returned by `poll_flush`, consumed in order.
+    flush_steps: VecDeque<PushStep<CanPend>>,
+    /// Recorded history of calls.
+    pub history: Vec<PushCall<Item>>,
     ready: bool,
 }
 
-impl<T> ReadyGuardPush<T> {
-    pub(crate) fn new() -> Self {
+impl<Item, CanPend: Toggle, const FUSED: bool> TestPush<Item, CanPend, FUSED> {
+    /// Creates a new `TestPush` from separate step logs for `poll_ready` and `poll_flush`.
+    fn new(
+        ready_steps: impl IntoIterator<Item = PushStep<CanPend>>,
+        flush_steps: impl IntoIterator<Item = PushStep<CanPend>>,
+    ) -> Self {
         Self {
-            items: Vec::new(),
+            ready_steps: ready_steps.into_iter().collect(),
+            flush_steps: flush_steps.into_iter().collect(),
+            history: Vec::new(),
             ready: false,
+        }
+    }
+
+    /// Returns the items sent via `start_send`, extracted from the call history.
+    pub fn items(&self) -> Vec<Item>
+    where
+        Item: Clone,
+    {
+        self.history
+            .iter()
+            .filter_map(|c| match c {
+                PushCall::SendItem(x) => Some(x.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+}
+
+impl<Item, CanPend: Toggle> TestPush<Item, CanPend, true> {
+    /// Creates a new `TestPush` from separate step logs for `poll_ready` and `poll_flush`.
+    pub(crate) fn new_fused(
+        ready_steps: impl IntoIterator<Item = PushStep<CanPend>>,
+        flush_steps: impl IntoIterator<Item = PushStep<CanPend>>,
+    ) -> Self {
+        Self::new(ready_steps, flush_steps)
+    }
+}
+
+impl<Item> TestPush<Item, No, true> {
+    /// Creates a `TestPush` with `CanPend = No` and empty step logs.
+    ///
+    /// Always returns `Done` for `poll_ready` and `poll_flush`.
+    pub(crate) fn no_pend() -> Self {
+        Self::new([], [])
+    }
+}
+
+impl<Item, CanPend: Toggle, const FUSED: bool> Unpin for TestPush<Item, CanPend, FUSED> {}
+
+impl<Item, CanPend: Toggle, const FUSED: bool> Push<Item, ()> for TestPush<Item, CanPend, FUSED> {
+    type Ctx<'ctx> = ();
+    type CanPend = CanPend;
+
+    fn poll_ready(self: Pin<&mut Self>, _ctx: &mut ()) -> PushStep<CanPend> {
+        let this = self.get_mut();
+        this.history.push(PushCall::PollReady);
+        let step = match this.ready_steps.pop_front() {
+            Some(step) => step,
+            None if FUSED => PushStep::Done,
+            None => panic!("TestPush: poll_ready after log exhausted",),
+        };
+        this.ready = step.is_done();
+        step
+    }
+
+    fn start_send(self: Pin<&mut Self>, item: Item, _meta: ()) {
+        let this = self.get_mut();
+        assert!(
+            this.ready,
+            "TestPush: start_send called without poll_ready returning Done"
+        );
+        this.ready = false;
+        this.history.push(PushCall::SendItem(item));
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _ctx: &mut ()) -> PushStep<CanPend> {
+        let this = self.get_mut();
+        this.history.push(PushCall::PollFlush);
+        match this.flush_steps.pop_front() {
+            Some(step) => step,
+            None if FUSED => PushStep::Done,
+            None => panic!("TestPush: poll_flush after log exhausted"),
         }
     }
 }
 
-impl<T: Unpin> Push<T, ()> for ReadyGuardPush<T> {
-    type Ctx<'ctx> = ();
-    type CanPend = No;
-
-    fn poll_ready(self: Pin<&mut Self>, _ctx: &mut ()) -> PushStep<No> {
-        self.get_mut().ready = true;
-        PushStep::Done
-    }
-    fn start_send(self: Pin<&mut Self>, item: T, _meta: ()) {
-        let this = self.get_mut();
-        assert!(
-            this.ready,
-            "ReadyGuardPush: start_send called without poll_ready"
-        );
-        this.ready = false;
-        this.items.push(item);
-    }
-    fn poll_flush(self: Pin<&mut Self>, _ctx: &mut ()) -> PushStep<No> {
-        PushStep::Done
-    }
-}
+/// Compile-time assertion that a push has `CanPend = No`.
+pub fn assert_can_pend_no<T, M: Copy>(_push: &impl Push<T, M, CanPend = No>) {}

--- a/dfir_pipes/src/push/unzip.rs
+++ b/dfir_pipes/src/push/unzip.rs
@@ -71,11 +71,13 @@ mod tests {
 
     use super::Unzip;
     use crate::push::Push;
-    use crate::push::test_utils::ReadyGuardPush;
+    use crate::push::test_utils::TestPush;
 
     #[test]
     fn unzip_readies_both_before_send() {
-        let mut u = Unzip::new(ReadyGuardPush::new(), ReadyGuardPush::new());
+        let mut tp_a = TestPush::no_pend();
+        let mut tp_b = TestPush::no_pend();
+        let mut u = Unzip::new(&mut tp_a, &mut tp_b);
         let mut u = Pin::new(&mut u);
         u.as_mut().poll_ready(&mut ());
         u.as_mut().start_send((1, 2), ());


### PR DESCRIPTION
Add TestPush<Item> to push test_utils with separate ready_steps/flush_steps
logs, call history recording via PushCall enum, and protocol invariant checks.

Fixes #2661