### PR TITLE
feat: Add `Push::size_hint`, `VecPush` terminal operator, use in dfir codegen [ci-bench]

### DIFF
--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -914,9 +914,8 @@ impl DfirGraph {
                 });
                 let send_port_code = send_ports.iter().map(|ident| {
                     quote_spanned! {ident.span()=>
-                        let #ident = #root::dfir_pipes::push::for_each(|v| {
-                            #ident.give(Some(v));
-                        });
+                        let mut #ident = #ident.borrow_mut_give();
+                        let #ident = #root::dfir_pipes::push::vec_push(&mut *#ident);
                     }
                 });
 
@@ -1216,6 +1215,14 @@ impl DfirGraph {
                                                         ctx: &mut Self::Ctx<'_>,
                                                     ) -> #root::dfir_pipes::push::PushStep<Self::CanPend> {
                                                         #root::dfir_pipes::push::Push::poll_flush(self.project().inner, ctx)
+                                                    }
+
+                                                    #[inline(always)]
+                                                    fn size_hint(
+                                                        self: ::std::pin::Pin<&mut Self>,
+                                                        hint: (usize, Option<usize>),
+                                                    ) {
+                                                        #root::dfir_pipes::push::Push::size_hint(self.project().inner, hint)
                                                     }
                                                 }
 

--- a/dfir_macro/src/lib.rs
+++ b/dfir_macro/src/lib.rs
@@ -288,17 +288,15 @@ pub fn derive_demux_enum(item: proc_macro::TokenStream) -> proc_macro::TokenStre
             }),
     );
 
-    let variant_pats_sink_start_send =
-        variants
-            .iter()
-            .zip(variant_localvars_sink.iter())
-            .map(|(variant, sinkvar)| {
-                let Variant { ident, fields, .. } = variant;
-                let (fields_pat, push_item) = field_pattern_item(fields);
-                quote! {
-                    Self::#ident #fields_pat => #sinkvar.as_mut().start_send(#push_item)
-                }
-            });
+    let variant_pats_sink_start_send = variants.iter().zip(variant_localvars_sink.iter()).map(
+        |(variant, sinkvar)| {
+            let Variant { ident, fields, .. } = variant;
+            let (fields_pat, push_item) = field_pattern_item(fields);
+            quote! {
+                Self::#ident #fields_pat => ::std::pin::Pin::as_mut(#sinkvar).start_send(#push_item)
+            }
+        },
+    );
 
     let (impl_generics_item, ty_generics, where_clause_item) = generics.split_for_impl();
     let (impl_generics_sink, _ty_generics_sink, where_clause_sink) =
@@ -392,11 +390,11 @@ pub fn derive_demux_enum(item: proc_macro::TokenStream) -> proc_macro::TokenStre
                 #(
                     let #headvar = {
                         let __ctx = <<#variant_generics_push as #root::dfir_pipes::push::Push<#variant_output_types, ()>>::Ctx<'_> as #root::dfir_pipes::Context<'_>>::unmerge_self(__ctx);
-                        #root::dfir_pipes::push::Push::#method_name(#headvar.as_mut(), __ctx)
+                        #root::dfir_pipes::push::Push::#method_name(::std::pin::Pin::as_mut(#headvar), __ctx)
                     };
                     let __ctx = <<#variant_generics_push as #root::dfir_pipes::push::Push<#variant_output_types, ()>>::Ctx<'_> as #root::dfir_pipes::Context<'_>>::unmerge_other(__ctx);
                 )*
-                let #lastvar = #root::dfir_pipes::push::Push::#method_name(#lastvar.as_mut(), __ctx);
+                let #lastvar = #root::dfir_pipes::push::Push::#method_name(::std::pin::Pin::as_mut(#lastvar), __ctx);
                 // If any are pending, return pending.
                 #(
                     if #variant_localvars_push.is_pending() {
@@ -530,6 +528,18 @@ pub fn derive_demux_enum(item: proc_macro::TokenStream) -> proc_macro::TokenStre
             ) -> #root::dfir_pipes::push::PushStep<Self::CanPend> {
                 #push_poll_flush_body
                 #root::dfir_pipes::push::PushStep::Done
+            }
+
+            fn size_hint(
+                ( #( #variant_localvars_push, )* ): &mut #variant_generics_pinned_push_all,
+                __size_hint: (usize, ::std::option::Option<usize>),
+            ) {
+                #(
+                    #root::dfir_pipes::push::Push::size_hint(
+                        ::std::pin::Pin::as_mut(#variant_localvars_push),
+                        __size_hint,
+                    );
+                )*
             }
         }
 

--- a/dfir_pipes/src/pull/cross_singleton.rs
+++ b/dfir_pipes/src/pull/cross_singleton.rs
@@ -99,6 +99,14 @@ where
             PullStep::Ended(_) => PullStep::ended(),
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (mut lower, upper) = self.item_pull.size_hint();
+        if self.singleton_state.borrow().is_none() {
+            lower = 0;
+        }
+        (lower, upper)
+    }
 }
 
 impl<ItemPull, SinglePull, SingleState> FusedPull

--- a/dfir_pipes/src/pull/from_fn.rs
+++ b/dfir_pipes/src/pull/from_fn.rs
@@ -49,4 +49,9 @@ where
         let this = self.get_mut();
         (this.func)()
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // Depends on UDF.
+        (0, None)
+    }
 }

--- a/dfir_pipes/src/pull/mod.rs
+++ b/dfir_pipes/src/pull/mod.rs
@@ -84,8 +84,7 @@ pub use stream_ready::StreamReady;
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub use symmetric_hash_join::{
-    NewTickJoinIter, NewTickJoinPull, SymmetricHashJoin, SymmetricHashJoinEither,
-    symmetric_hash_join,
+    NewTickJoinIter, SymmetricHashJoin, SymmetricHashJoinEither, symmetric_hash_join,
 };
 pub use take::Take;
 pub use take_while::TakeWhile;
@@ -220,12 +219,9 @@ pub trait Pull {
     /// That said, the implementation should provide a correct estimation,
     /// because otherwise it would be a violation of the trait's protocol.
     ///
-    /// The default implementation returns `(0, None)` which is correct for any
-    /// pull.
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (0, None)
-    }
+    /// A default implementation should return `(0, None)` which is correct for any
+    /// pull. However this is not provided, to prevent oversight.
+    fn size_hint(&self) -> (usize, Option<usize>);
 
     /// Borrows this pull, allowing it to be used by reference.
     fn by_ref(&mut self) -> &mut Self {

--- a/dfir_pipes/src/pull/poll_fn.rs
+++ b/dfir_pipes/src/pull/poll_fn.rs
@@ -50,4 +50,9 @@ where
         let this = self.get_mut();
         (this.func)(ctx)
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // Depends on UDF.
+        (0, None)
+    }
 }

--- a/dfir_pipes/src/pull/symmetric_hash_join.rs
+++ b/dfir_pipes/src/pull/symmetric_hash_join.rs
@@ -9,8 +9,8 @@ use pin_project_lite::pin_project;
 use smallvec::SmallVec;
 
 use crate::pull::half_join_state::HalfJoinState;
-use crate::pull::{FusedPull, Pull, PullStep};
-use crate::{Context, No, Toggle, Yes};
+use crate::pull::{self, FusedPull, Pull, PullStep};
+use crate::{Context, Toggle};
 
 pin_project! {
     /// Pull combinator for symmetric hash join operations.
@@ -124,6 +124,11 @@ where
             return PullStep::ended();
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // TODO(mingwei): actual estimate
+        (0, None)
+    }
 }
 
 /// Iterator for new tick - iterates over all matches after both sides are drained.
@@ -203,6 +208,11 @@ where
         } else {
             self.next_rhs_smaller()
         }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // TODO(mingwei): proper size hint estimate
+        (0, None)
     }
 }
 
@@ -291,50 +301,9 @@ where
     }
 }
 
-pin_project! {
-    /// Pull wrapper for the new tick iterator case.
-    #[must_use = "`Pull`s do nothing unless polled"]
-    pub struct NewTickJoinPull<'a, Key, V1, V2, LhsState, RhsState>
-    where
-        Key: Clone,
-        V1: Clone,
-        V2: Clone,
-    {
-        iter: NewTickJoinIter<'a, Key, V1, V2, LhsState, RhsState>,
-    }
-}
-
-impl<'a, Key, V1, V2, LhsState, RhsState> Pull
-    for NewTickJoinPull<'a, Key, V1, V2, LhsState, RhsState>
-where
-    Key: Eq + std::hash::Hash + Clone,
-    V1: Clone,
-    V2: Clone,
-    LhsState: HalfJoinState<Key, V1, V2>,
-    RhsState: HalfJoinState<Key, V2, V1>,
-{
-    type Ctx<'ctx> = ();
-
-    type Item = (Key, (V1, V2));
-    type Meta = ();
-    type CanPend = No;
-    type CanEnd = Yes;
-
-    fn pull(
-        self: Pin<&mut Self>,
-        _ctx: &mut Self::Ctx<'_>,
-    ) -> PullStep<Self::Item, Self::Meta, Self::CanPend, Self::CanEnd> {
-        let this = self.project();
-        match this.iter.next() {
-            Some(item) => PullStep::Ready(item, ()),
-            None => PullStep::Ended(Yes),
-        }
-    }
-}
-
 /// Type alias for the `Either` pull returned by [`symmetric_hash_join`].
 pub type SymmetricHashJoinEither<'a, Key, V1, V2, Lhs, Rhs, LhsState, RhsState> = Either<
-    NewTickJoinPull<'a, Key, V1, V2, LhsState, RhsState>,
+    pull::Iter<NewTickJoinIter<'a, Key, V1, V2, LhsState, RhsState>>,
     SymmetricHashJoin<Lhs, Rhs, &'a mut LhsState, &'a mut RhsState, LhsState, RhsState>,
 >;
 
@@ -370,7 +339,7 @@ where
         } else {
             NewTickJoinIter::new_rhs_smaller(lhs_state, rhs_state)
         };
-        SymmetricHashJoinEither::Left(NewTickJoinPull { iter })
+        SymmetricHashJoinEither::Left(pull::iter(iter))
     } else {
         SymmetricHashJoinEither::Right(SymmetricHashJoin::new(lhs, rhs, lhs_state, rhs_state))
     }

--- a/dfir_pipes/src/push/demux_var.rs
+++ b/dfir_pipes/src/push/demux_var.rs
@@ -70,6 +70,9 @@ where
     /// unmerged context slice. All pushes are flushed even if one returns
     /// pending, so that all wakers are registered.
     fn poll_flush(self: Pin<&mut Self>, ctx: &mut Self::Ctx<'_>) -> PushStep<Self::CanPend>;
+
+    /// Inform all downstream pushes that approximately `hint` items are about to be sent.
+    fn size_hint(self: Pin<&mut Self>, hint: (usize, Option<usize>));
 }
 
 /// Recursive case: a push `P` followed by the rest of the variadic `Rest`.
@@ -108,6 +111,12 @@ where
         );
         PushStep::Done
     }
+
+    fn size_hint(self: Pin<&mut Self>, hint: (usize, Option<usize>)) {
+        let (push, rest) = pin_project_pair(self);
+        push.size_hint(hint);
+        rest.size_hint(hint);
+    }
 }
 
 /// Base case: the empty variadic. Always ready, panics on send.
@@ -130,6 +139,8 @@ where
     fn poll_flush(self: Pin<&mut Self>, _ctx: &mut Self::Ctx<'_>) -> PushStep<No> {
         PushStep::Done
     }
+
+    fn size_hint(self: Pin<&mut Self>, _hint: (usize, Option<usize>)) {}
 }
 
 /// Pin-projects a pair `(A, B)` into its two pinned components.
@@ -198,6 +209,10 @@ where
 
     fn poll_flush(self: Pin<&mut Self>, ctx: &mut Self::Ctx<'_>) -> PushStep<Self::CanPend> {
         self.project().pushes.poll_flush(ctx)
+    }
+
+    fn size_hint(self: Pin<&mut Self>, hint: (usize, Option<usize>)) {
+        self.project().pushes.size_hint(hint);
     }
 }
 

--- a/dfir_pipes/src/push/fanout.rs
+++ b/dfir_pipes/src/push/fanout.rs
@@ -67,6 +67,12 @@ where
         );
         PushStep::Done
     }
+
+    fn size_hint(self: Pin<&mut Self>, hint: (usize, Option<usize>)) {
+        let this = self.project();
+        this.push_0.size_hint(hint);
+        this.push_1.size_hint(hint);
+    }
 }
 
 #[cfg(test)]

--- a/dfir_pipes/src/push/filter.rs
+++ b/dfir_pipes/src/push/filter.rs
@@ -50,4 +50,8 @@ where
     fn poll_flush(self: Pin<&mut Self>, ctx: &mut Self::Ctx<'_>) -> PushStep<Self::CanPend> {
         self.project().next.poll_flush(ctx)
     }
+
+    fn size_hint(self: Pin<&mut Self>, hint: (usize, Option<usize>)) {
+        self.project().next.size_hint((0, hint.1));
+    }
 }

--- a/dfir_pipes/src/push/filter_map.rs
+++ b/dfir_pipes/src/push/filter_map.rs
@@ -50,4 +50,8 @@ where
     fn poll_flush(self: Pin<&mut Self>, ctx: &mut Self::Ctx<'_>) -> PushStep<Self::CanPend> {
         self.project().next.poll_flush(ctx)
     }
+
+    fn size_hint(self: Pin<&mut Self>, hint: (usize, Option<usize>)) {
+        self.project().next.size_hint((0, hint.1));
+    }
 }

--- a/dfir_pipes/src/push/flat_map.rs
+++ b/dfir_pipes/src/push/flat_map.rs
@@ -85,6 +85,10 @@ where
         ready!(self.as_mut().poll_ready(ctx));
         self.project().next.poll_flush(ctx)
     }
+
+    fn size_hint(self: Pin<&mut Self>, _hint: (usize, Option<usize>)) {
+        self.project().next.size_hint((0, None));
+    }
 }
 
 #[cfg(test)]

--- a/dfir_pipes/src/push/flatten.rs
+++ b/dfir_pipes/src/push/flatten.rs
@@ -79,6 +79,10 @@ where
         ready!(self.as_mut().poll_ready(ctx));
         self.project().next.poll_flush(ctx)
     }
+
+    fn size_hint(self: Pin<&mut Self>, _hint: (usize, Option<usize>)) {
+        self.project().next.size_hint((0, None));
+    }
 }
 
 #[cfg(test)]

--- a/dfir_pipes/src/push/for_each.rs
+++ b/dfir_pipes/src/push/for_each.rs
@@ -48,4 +48,8 @@ where
     fn poll_flush(self: Pin<&mut Self>, _ctx: &mut Self::Ctx<'_>) -> PushStep<Self::CanPend> {
         PushStep::Done
     }
+
+    fn size_hint(self: Pin<&mut Self>, _hint: (usize, Option<usize>)) {
+        // unused
+    }
 }

--- a/dfir_pipes/src/push/inspect.rs
+++ b/dfir_pipes/src/push/inspect.rs
@@ -49,4 +49,8 @@ where
     fn poll_flush(self: Pin<&mut Self>, ctx: &mut Self::Ctx<'_>) -> PushStep<Self::CanPend> {
         self.project().next.poll_flush(ctx)
     }
+
+    fn size_hint(self: Pin<&mut Self>, hint: (usize, Option<usize>)) {
+        self.project().next.size_hint(hint);
+    }
 }

--- a/dfir_pipes/src/push/map.rs
+++ b/dfir_pipes/src/push/map.rs
@@ -49,4 +49,8 @@ where
     fn poll_flush(self: Pin<&mut Self>, ctx: &mut Self::Ctx<'_>) -> PushStep<Self::CanPend> {
         self.project().next.poll_flush(ctx)
     }
+
+    fn size_hint(self: Pin<&mut Self>, hint: (usize, Option<usize>)) {
+        self.project().next.size_hint(hint);
+    }
 }

--- a/dfir_pipes/src/push/mod.rs
+++ b/dfir_pipes/src/push/mod.rs
@@ -23,6 +23,9 @@ mod resolve_futures;
 mod sink;
 mod sink_compat;
 mod unzip;
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+mod vec_push;
 
 #[cfg(test)]
 pub(crate) mod test_utils;
@@ -50,6 +53,9 @@ pub use resolve_futures::ResolveFutures;
 pub use sink::Sink;
 pub use sink_compat::SinkCompat;
 pub use unzip::Unzip;
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub use vec_push::VecPush;
 
 /// The result of pushing an item into a [`Push`].
 ///
@@ -143,6 +149,20 @@ where
 
     /// Flushes any buffered items in this push pipeline.
     fn poll_flush(self: Pin<&mut Self>, ctx: &mut Self::Ctx<'_>) -> PushStep<Self::CanPend>;
+
+    /// Informs this push how many items are about to be sent.
+    ///
+    /// The semantics match [`crate::pull::Pull::size_hint`] / [`Iterator::size_hint`]:
+    /// the first element is a lower bound, the second is an optional upper bound.
+    ///
+    /// Combinators should propagate this downstream, adjusting bounds where
+    /// appropriate (e.g. [`Filter`] sets the lower bound to 0).
+    ///
+    /// Under normal usage expect this to be called once before items are pushed. However
+    /// this may be called multiple times or never at all. It is an error to call this multiple
+    /// times with size hints that conflict--each size hint should match or narrow the estimated
+    /// range (after accounting for already-sent items).
+    fn size_hint(self: Pin<&mut Self>, hint: (usize, Option<usize>));
 }
 
 impl<P, Item, Meta> Push<Item, Meta> for &mut P
@@ -164,6 +184,10 @@ where
 
     fn poll_flush(mut self: Pin<&mut Self>, ctx: &mut Self::Ctx<'_>) -> PushStep<Self::CanPend> {
         Pin::new(&mut **self).poll_flush(ctx)
+    }
+
+    fn size_hint(mut self: Pin<&mut Self>, hint: (usize, Option<usize>)) {
+        Pin::new(&mut **self).size_hint(hint)
     }
 }
 
@@ -313,4 +337,13 @@ where
 /// Creates an [`Unzip`] push that splits tuple items into two separate pushes.
 pub const fn unzip<P0, P1>(push0: P0, push1: P1) -> Unzip<P0, P1> {
     Unzip::new(push0, push1)
+}
+
+/// Creates a [`VecPush`] that pushes items into the given `Vec`.
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub const fn vec_push<Item>(
+    buf: &mut alloc::vec::Vec<Item>,
+) -> VecPush<&mut alloc::vec::Vec<Item>> {
+    VecPush::new(buf)
 }

--- a/dfir_pipes/src/push/persist.rs
+++ b/dfir_pipes/src/push/persist.rs
@@ -87,6 +87,12 @@ where
         // Then flush the downstream push.
         self.project().push.poll_flush(ctx)
     }
+
+    fn size_hint(self: Pin<&mut Self>, hint: (usize, Option<usize>)) {
+        let this = self.project();
+        this.buf.borrow_mut().reserve(hint.0);
+        this.push.size_hint(hint);
+    }
 }
 
 #[cfg(test)]

--- a/dfir_pipes/src/push/resolve_futures.rs
+++ b/dfir_pipes/src/push/resolve_futures.rs
@@ -145,6 +145,11 @@ where
             .poll_flush(crate::Context::from_task(ctx))
             .convert_into()
     }
+
+    fn size_hint(self: Pin<&mut Self>, hint: (usize, Option<usize>)) {
+        // Each future input produces one value output.
+        self.project().push.size_hint(hint);
+    }
 }
 
 #[cfg(test)]

--- a/dfir_pipes/src/push/sink.rs
+++ b/dfir_pipes/src/push/sink.rs
@@ -59,4 +59,8 @@ where
             Poll::Pending => PushStep::Pending(Yes),
         }
     }
+
+    fn size_hint(self: Pin<&mut Self>, _hint: (usize, Option<usize>)) {
+        // unused
+    }
 }

--- a/dfir_pipes/src/push/test_utils.rs
+++ b/dfir_pipes/src/push/test_utils.rs
@@ -16,6 +16,8 @@ pub enum PushCall<Item> {
     SendItem(Item),
     /// `poll_flush` was called.
     PollFlush,
+    /// `size_hint` was called.
+    SizeHint(usize, Option<usize>),
 }
 
 /// A configurable test push that replays separate logs of [`PushStep`]s for
@@ -42,9 +44,10 @@ pub struct TestPush<Item, CanPend: Toggle, const FUSED: bool> {
     ready_steps: VecDeque<PushStep<CanPend>>,
     /// Steps returned by `poll_flush`, consumed in order.
     flush_steps: VecDeque<PushStep<CanPend>>,
+    /// Whether `poll_ready` has returned `Done`, indicating `start_send` may be called.
+    ready: bool,
     /// Recorded history of calls.
     pub history: Vec<PushCall<Item>>,
-    ready: bool,
 }
 
 impl<Item, CanPend: Toggle, const FUSED: bool> TestPush<Item, CanPend, FUSED> {
@@ -56,8 +59,8 @@ impl<Item, CanPend: Toggle, const FUSED: bool> TestPush<Item, CanPend, FUSED> {
         Self {
             ready_steps: ready_steps.into_iter().collect(),
             flush_steps: flush_steps.into_iter().collect(),
-            history: Vec::new(),
             ready: false,
+            history: Vec::new(),
         }
     }
 
@@ -131,6 +134,12 @@ impl<Item, CanPend: Toggle, const FUSED: bool> Push<Item, ()> for TestPush<Item,
             None if FUSED => PushStep::Done,
             None => panic!("TestPush: poll_flush after log exhausted"),
         }
+    }
+
+    fn size_hint(self: Pin<&mut Self>, hint: (usize, Option<usize>)) {
+        self.get_mut()
+            .history
+            .push(PushCall::SizeHint(hint.0, hint.1));
     }
 }
 

--- a/dfir_pipes/src/push/unzip.rs
+++ b/dfir_pipes/src/push/unzip.rs
@@ -63,6 +63,12 @@ where
         );
         PushStep::Done
     }
+
+    fn size_hint(self: Pin<&mut Self>, hint: (usize, Option<usize>)) {
+        let this = self.project();
+        this.push_0.size_hint(hint);
+        this.push_1.size_hint(hint);
+    }
 }
 
 #[cfg(test)]

--- a/dfir_pipes/src/push/vec_push.rs
+++ b/dfir_pipes/src/push/vec_push.rs
@@ -1,0 +1,54 @@
+//! [`VecPush`] terminal push operator that collects items into a `Vec`.
+use alloc::vec::Vec;
+use core::borrow::BorrowMut;
+use core::pin::Pin;
+
+use pin_project_lite::pin_project;
+
+use crate::No;
+use crate::push::{Push, PushStep};
+
+pin_project! {
+    /// Terminal push operator that collects items into a `Vec`.
+    ///
+    /// Uses [`Push::size_hint`] to pre-allocate capacity via [`Vec::reserve`].
+    #[must_use = "`Push`es do nothing unless items are pushed into them"]
+    pub struct VecPush<Buf> {
+        buf: Buf,
+    }
+}
+
+impl<Buf> VecPush<Buf> {
+    /// Creates a new [`VecPush`] writing into the given buffer.
+    pub(crate) const fn new<Item>(buf: Buf) -> Self
+    where
+        Buf: BorrowMut<Vec<Item>>,
+    {
+        Self { buf }
+    }
+}
+
+impl<Buf, Item, Meta> Push<Item, Meta> for VecPush<Buf>
+where
+    Buf: BorrowMut<Vec<Item>>,
+    Meta: Copy,
+{
+    type Ctx<'ctx> = ();
+    type CanPend = No;
+
+    fn poll_ready(self: Pin<&mut Self>, _ctx: &mut Self::Ctx<'_>) -> PushStep<Self::CanPend> {
+        PushStep::Done
+    }
+
+    fn start_send(self: Pin<&mut Self>, item: Item, _meta: Meta) {
+        self.project().buf.borrow_mut().push(item);
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _ctx: &mut Self::Ctx<'_>) -> PushStep<Self::CanPend> {
+        PushStep::Done
+    }
+
+    fn size_hint(self: Pin<&mut Self>, hint: (usize, Option<usize>)) {
+        self.project().buf.borrow_mut().reserve(hint.0);
+    }
+}

--- a/dfir_rs/src/compiled/pull/lattice_bimorphism.rs
+++ b/dfir_rs/src/compiled/pull/lattice_bimorphism.rs
@@ -134,4 +134,9 @@ where
             }
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // Depends on UDF.
+        (0, None)
+    }
 }

--- a/dfir_rs/src/compiled/push/demux_enum.rs
+++ b/dfir_rs/src/compiled/push/demux_enum.rs
@@ -40,4 +40,8 @@ where
     fn poll_flush(self: Pin<&mut Self>, ctx: &mut Self::Ctx<'_>) -> PushStep<Self::CanPend> {
         Item::poll_flush(self.project().outputs, ctx)
     }
+
+    fn size_hint(self: Pin<&mut Self>, hint: (usize, Option<usize>)) {
+        Item::size_hint(self.project().outputs, hint)
+    }
 }

--- a/dfir_rs/src/scheduled/handoff/mod.rs
+++ b/dfir_rs/src/scheduled/handoff/mod.rs
@@ -58,6 +58,9 @@ pub trait Handoff: Default + HandoffMeta {
     /// For better performance over [`Self::take_inner`].
     fn borrow_mut_swap(&self) -> RefMut<'_, Self::Inner>;
 
+    /// Borrow a mutable inner to give items to.
+    fn borrow_mut_give(&self) -> RefMut<'_, Self::Inner>;
+
     /// See [`CanReceive::give`].
     fn give<T>(&self, item: T) -> T
     where

--- a/dfir_rs/src/scheduled/handoff/tee.rs
+++ b/dfir_rs/src/scheduled/handoff/tee.rs
@@ -102,6 +102,10 @@ impl<T> Handoff for TeeingHandoff<T> {
     fn borrow_mut_swap(&self) -> std::cell::RefMut<'_, Self::Inner> {
         todo!()
     }
+
+    fn borrow_mut_give(&self) -> std::cell::RefMut<'_, Self::Inner> {
+        todo!()
+    }
 }
 
 impl<T> CanReceive<Vec<T>> for TeeingHandoff<T>

--- a/dfir_rs/src/scheduled/handoff/vector.rs
+++ b/dfir_rs/src/scheduled/handoff/vector.rs
@@ -11,6 +11,7 @@ where
     pub(crate) input: Rc<RefCell<Vec<T>>>,
     pub(crate) output: Rc<RefCell<Vec<T>>>,
 }
+
 impl<T> Default for VecHandoff<T>
 where
     T: 'static,
@@ -22,6 +23,7 @@ where
         }
     }
 }
+
 impl<T> Handoff for VecHandoff<T> {
     type Inner = Vec<T>;
 
@@ -36,6 +38,10 @@ impl<T> Handoff for VecHandoff<T> {
         std::mem::swap(&mut *input, &mut *output);
 
         output
+    }
+
+    fn borrow_mut_give(&self) -> RefMut<'_, Self::Inner> {
+        self.input.borrow_mut()
     }
 }
 

--- a/dfir_rs/src/scheduled/port.rs
+++ b/dfir_rs/src/scheduled/port.rs
@@ -94,6 +94,11 @@ impl<H: Handoff> SendCtx<H> {
     {
         <H as TryCanReceive<T>>::try_give(&self.handoff, item)
     }
+
+    /// See [`Handoff::borrow_mut_give`].
+    pub fn borrow_mut_give(&self) -> RefMut<'_, H::Inner> {
+        self.handoff.borrow_mut_give()
+    }
 }
 
 /// Context provided to a subgraph for reading from a handoff. Corresponds to a [`RecvPort`].

--- a/dfir_rs/src/util/demux_enum.rs
+++ b/dfir_rs/src/util/demux_enum.rs
@@ -59,6 +59,9 @@ pub trait DemuxEnumPush<Outputs, Meta: Copy>: DemuxEnumBase {
 
     /// Flushes all output pushes.
     fn poll_flush(outputs: &mut Outputs, ctx: &mut Self::Ctx<'_>) -> PushStep<Self::CanPend>;
+
+    /// Supplies all outputs with bounds on the number of items about to be sent.
+    fn size_hint(outputs: &mut Outputs, hint: (usize, Option<usize>));
 }
 /// Special case of [`DemuxEnum`] for when there is only one variant.
 #[diagnostic::on_unimplemented(

--- a/dfir_rs/tests/compile-fail-stable/surface_demuxenum_wrongenum.stderr
+++ b/dfir_rs/tests/compile-fail-stable/surface_demuxenum_wrongenum.stderr
@@ -87,11 +87,11 @@ error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<std::option:
              `&mut P` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `DemuxEnum<Outputs>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `ResolveFutures<Psh, Queue, QueueInner>` implements `dfir_rs::dfir_pipes::push::Push<Fut, ()>`
+             `VecPush<Buf>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::DemuxVar<Pushes>` implements `dfir_rs::dfir_pipes::push::Push<(usize, Item), Meta>`
              `dfir_rs::dfir_pipes::push::Fanout<P0, P1>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::Filter<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::FilterMap<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<In, Meta>`
-             `dfir_rs::dfir_pipes::push::FlatMap<Next, Func, IntoIter, Meta>` implements `dfir_rs::dfir_pipes::push::Push<In, Meta>`
            and $N others
 note: required by a bound in `pivot_run_sg_1v1`
   --> tests/compile-fail-stable/surface_demuxenum_wrongenum.rs:17:15

--- a/dfir_rs/tests/compile-fail-stable/surface_demuxenum_wrongfields_1.stderr
+++ b/dfir_rs/tests/compile-fail-stable/surface_demuxenum_wrongfields_1.stderr
@@ -9,11 +9,11 @@ error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<u32, (), Can
              `&mut P` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `DemuxEnum<Outputs>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `ResolveFutures<Psh, Queue, QueueInner>` implements `dfir_rs::dfir_pipes::push::Push<Fut, ()>`
+             `VecPush<Buf>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::DemuxVar<Pushes>` implements `dfir_rs::dfir_pipes::push::Push<(usize, Item), Meta>`
              `dfir_rs::dfir_pipes::push::Fanout<P0, P1>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::Filter<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::FilterMap<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<In, Meta>`
-             `dfir_rs::dfir_pipes::push::FlatMap<Next, Func, IntoIter, Meta>` implements `dfir_rs::dfir_pipes::push::Push<In, Meta>`
            and $N others
 note: required for `Shape` to implement `DemuxEnumPush<(Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64,)) {std::mem::drop::<(f64,)>}> as dfir_rs::dfir_pipes::push::Push<(f64,), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64, f64), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64, f64)) {std::mem::drop::<(f64, f64)>}> as dfir_rs::dfir_pipes::push::Push<(f64, f64), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<u32, (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<{closure@$DIR/tests/compile-fail-stable/surface_demuxenum_wrongfields_1.rs:20:38: 20:49}> as dfir_rs::dfir_pipes::push::Push<u32, ()>>::CanPend>>), ()>`
   --> tests/compile-fail-stable/surface_demuxenum_wrongfields_1.rs:5:14
@@ -40,11 +40,11 @@ error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<u32, (), Can
              `&mut P` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `DemuxEnum<Outputs>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `ResolveFutures<Psh, Queue, QueueInner>` implements `dfir_rs::dfir_pipes::push::Push<Fut, ()>`
+             `VecPush<Buf>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::DemuxVar<Pushes>` implements `dfir_rs::dfir_pipes::push::Push<(usize, Item), Meta>`
              `dfir_rs::dfir_pipes::push::Fanout<P0, P1>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::Filter<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::FilterMap<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<In, Meta>`
-             `dfir_rs::dfir_pipes::push::FlatMap<Next, Func, IntoIter, Meta>` implements `dfir_rs::dfir_pipes::push::Push<In, Meta>`
            and $N others
 note: required for `Shape` to implement `DemuxEnumPush<(Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64,)) {std::mem::drop::<(f64,)>}> as dfir_rs::dfir_pipes::push::Push<(f64,), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64, f64), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64, f64)) {std::mem::drop::<(f64, f64)>}> as dfir_rs::dfir_pipes::push::Push<(f64, f64), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<u32, (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<{closure@$DIR/tests/compile-fail-stable/surface_demuxenum_wrongfields_1.rs:20:38: 20:49}> as dfir_rs::dfir_pipes::push::Push<u32, ()>>::CanPend>>), ()>`
   --> tests/compile-fail-stable/surface_demuxenum_wrongfields_1.rs:5:14

--- a/dfir_rs/tests/compile-fail-stable/surface_demuxenum_wrongfields_2.stderr
+++ b/dfir_rs/tests/compile-fail-stable/surface_demuxenum_wrongfields_2.stderr
@@ -9,11 +9,11 @@ error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<(u32,), (), 
              `&mut P` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `DemuxEnum<Outputs>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `ResolveFutures<Psh, Queue, QueueInner>` implements `dfir_rs::dfir_pipes::push::Push<Fut, ()>`
+             `VecPush<Buf>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::DemuxVar<Pushes>` implements `dfir_rs::dfir_pipes::push::Push<(usize, Item), Meta>`
              `dfir_rs::dfir_pipes::push::Fanout<P0, P1>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::Filter<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::FilterMap<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<In, Meta>`
-             `dfir_rs::dfir_pipes::push::FlatMap<Next, Func, IntoIter, Meta>` implements `dfir_rs::dfir_pipes::push::Push<In, Meta>`
            and $N others
 note: required for `Shape` to implement `DemuxEnumPush<(Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64,)) {std::mem::drop::<(f64,)>}> as dfir_rs::dfir_pipes::push::Push<(f64,), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64, f64), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64, f64)) {std::mem::drop::<(f64, f64)>}> as dfir_rs::dfir_pipes::push::Push<(f64, f64), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(u32,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<{closure@$DIR/tests/compile-fail-stable/surface_demuxenum_wrongfields_2.rs:20:38: 20:52}> as dfir_rs::dfir_pipes::push::Push<(u32,), ()>>::CanPend>>), ()>`
   --> tests/compile-fail-stable/surface_demuxenum_wrongfields_2.rs:5:14
@@ -40,11 +40,11 @@ error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<(u32,), (), 
              `&mut P` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `DemuxEnum<Outputs>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `ResolveFutures<Psh, Queue, QueueInner>` implements `dfir_rs::dfir_pipes::push::Push<Fut, ()>`
+             `VecPush<Buf>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::DemuxVar<Pushes>` implements `dfir_rs::dfir_pipes::push::Push<(usize, Item), Meta>`
              `dfir_rs::dfir_pipes::push::Fanout<P0, P1>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::Filter<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::FilterMap<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<In, Meta>`
-             `dfir_rs::dfir_pipes::push::FlatMap<Next, Func, IntoIter, Meta>` implements `dfir_rs::dfir_pipes::push::Push<In, Meta>`
            and $N others
 note: required for `Shape` to implement `DemuxEnumPush<(Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64,)) {std::mem::drop::<(f64,)>}> as dfir_rs::dfir_pipes::push::Push<(f64,), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64, f64), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64, f64)) {std::mem::drop::<(f64, f64)>}> as dfir_rs::dfir_pipes::push::Push<(f64, f64), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(u32,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<{closure@$DIR/tests/compile-fail-stable/surface_demuxenum_wrongfields_2.rs:20:38: 20:52}> as dfir_rs::dfir_pipes::push::Push<(u32,), ()>>::CanPend>>), ()>`
   --> tests/compile-fail-stable/surface_demuxenum_wrongfields_2.rs:5:14


### PR DESCRIPTION
Added `size_hint(self: Pin<&mut Self>, hint: (usize, Option<usize>))` to the `Push` trait as the push-side analog of `Pull::size_hint`. This allows producers to announce how many items they're about to send, enabling downstream operators and sinks to pre-allocate.

New terminal operator:
- `VecPush<Buf>`: pushes items into a `Vec`, uses `size_hint` to call `Vec::reserve(hint.0)` for pre-allocation. Gated on `alloc` feature.
- Constructor: `push::vec_push(buf)` creates a VecPush from a `&mut Vec<T>`.

BREAKING CHANGE: Updates the `Handoff` trait to allow pushing to `&mut Vec<T>` directly instead of one-by-one, and allows pre-allocating.