### PR TITLE
feat(dfir_pipes): Add StreamCompat type in dfir_pipes/pull, mirroring SinkCompat in push

### DIFF
--- a/dfir_pipes/src/pull/mod.rs
+++ b/dfir_pipes/src/pull/mod.rs
@@ -39,6 +39,7 @@ mod send_sink;
 mod skip;
 mod skip_while;
 mod stream;
+mod stream_compat;
 mod stream_ready;
 #[cfg(feature = "std")]
 mod symmetric_hash_join;
@@ -80,6 +81,7 @@ pub use send_sink::SendSink;
 pub use skip::Skip;
 pub use skip_while::SkipWhile;
 pub use stream::Stream;
+pub use stream_compat::StreamCompat;
 pub use stream_ready::StreamReady;
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
@@ -604,6 +606,11 @@ pub fn iter<I: IntoIterator>(iter: I) -> Iter<I::IntoIter> {
 /// pend and end.
 pub const fn stream<S: futures_core::stream::Stream>(stream: S) -> Stream<S> {
     Stream::new(stream)
+}
+
+/// Creates a [`StreamCompat`] adapter that wraps a [`Pull`] and implements [`futures_core::stream::Stream`].
+pub const fn stream_compat<Pul: Pull>(pull: Pul) -> StreamCompat<Pul> {
+    StreamCompat::new(pull)
 }
 
 /// Creates a pull from a `futures::Stream` with a custom waker.

--- a/dfir_pipes/src/pull/stream_compat.rs
+++ b/dfir_pipes/src/pull/stream_compat.rs
@@ -1,0 +1,73 @@
+//! [`StreamCompat`] adapter wrapping a [`Pull`] into a [`futures_core::stream::Stream`].
+use core::pin::Pin;
+use core::task::Poll;
+
+use pin_project_lite::pin_project;
+
+use crate::Context;
+use crate::pull::Pull;
+
+pin_project! {
+    /// Adapter that wraps a [`Pull`] to implement the [`Stream`](futures_core::stream::Stream) trait.
+    #[must_use = "`Stream`s do nothing unless polled"]
+    pub struct StreamCompat<Pul> {
+        #[pin]
+        pull: Pul,
+    }
+}
+
+impl<Pul> StreamCompat<Pul> {
+    /// Creates a new [`StreamCompat`] wrapping the given [`Pull`].
+    pub(crate) const fn new(pull: Pul) -> Self {
+        Self { pull }
+    }
+
+    /// Returns the wrapped [`Pull`].
+    pub fn into_inner(self) -> Pul {
+        self.pull
+    }
+
+    /// Returns a pinned mutable reference to the wrapped [`Pull`].
+    pub fn as_pin_mut(self: Pin<&mut Self>) -> Pin<&mut Pul> {
+        self.project().pull
+    }
+
+    /// Returns a pinned reference to the wrapped [`Pull`].
+    pub fn as_pin_ref(self: Pin<&Self>) -> Pin<&Pul> {
+        self.project_ref().pull
+    }
+}
+
+impl<Pul> AsMut<Pul> for StreamCompat<Pul> {
+    fn as_mut(&mut self) -> &mut Pul {
+        &mut self.pull
+    }
+}
+
+impl<Pul> AsRef<Pul> for StreamCompat<Pul> {
+    fn as_ref(&self) -> &Pul {
+        &self.pull
+    }
+}
+
+impl<Pul> futures_core::stream::Stream for StreamCompat<Pul>
+where
+    Pul: Pull,
+    for<'ctx> Pul::Ctx<'ctx>: Context<'ctx>,
+{
+    type Item = Pul::Item;
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut core::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        self.as_pin_mut()
+            .pull(Context::from_task(cx))
+            .into_poll()
+            .map(|opt| opt.map(|(item, _meta)| item))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.pull.size_hint()
+    }
+}


### PR DESCRIPTION
Created `dfir_pipes/src/pull/stream_compat.rs` with a `StreamCompat<Pul>` adapter that wraps a `Pull` (with `Meta = ()`, `CanPend = Yes`, `CanEnd = Yes`) and implements `futures_core::stream::Stream`. Follows the same structure as `SinkCompat` in the push module: pin-projected inner field, `into_inner`, `as_pin_mut`, `as_pin_ref`, `AsRef`, and `AsMut` impls.

Also added to `pull/mod.rs`:
- `mod stream_compat` declaration
- `pub use stream_compat::StreamCompat` re-export
- `pub const fn stream_compat()` constructor function