### PR TITLE
feat(hydro_lang): add `singleton_future` convenience method

### DIFF
--- a/hydro_lang/src/location/mod.rs
+++ b/hydro_lang/src/location/mod.rs
@@ -14,6 +14,7 @@
 //! See [the Hydro docs](https://hydro.run/docs/hydro/reference/locations/) for more information.
 
 use std::fmt::Debug;
+use std::future::Future;
 use std::marker::PhantomData;
 use std::num::ParseIntError;
 use std::time::Duration;
@@ -1058,6 +1059,39 @@ pub trait Location<'a>: dynamic::DynLocation {
                 metadata: self.new_node_metadata(Singleton::<T, Self, Bounded>::collection_kind()),
             },
         )
+    }
+
+    /// Constructs a [`Singleton`] by resolving an async [`Future`] to completion.
+    ///
+    /// This is a convenience method equivalent to
+    /// `self.singleton(future_expr).resolve_future_blocking()`, which is a common
+    /// pattern when initializing a singleton from an async computation.
+    ///
+    /// # Example
+    /// ```rust
+    /// # #[cfg(feature = "deploy")] {
+    /// # use hydro_lang::prelude::*;
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
+    /// let singleton = process.singleton_future(q!(async { 42 }));
+    /// singleton.into_stream()
+    /// # }, |mut stream| async move {
+    /// // 42
+    /// # assert_eq!(stream.next().await.unwrap(), 42);
+    /// # }));
+    /// # }
+    /// ```
+    ///
+    /// [`Future`]: std::future::Future
+    fn singleton_future<F>(
+        &self,
+        e: impl QuotedWithContext<'a, F, Self>,
+    ) -> Singleton<F::Output, Self, Bounded>
+    where
+        F: Future,
+        Self: Sized + NoTick,
+    {
+        self.singleton(e).resolve_future_blocking()
     }
 
     /// Generates a stream with values emitted at a fixed interval, with


### PR DESCRIPTION
Add `Location::singleton_future` that initializes a singleton by resolving an async future to completion.

This is equivalent to `self.singleton(expr).resolve_future_blocking()` but provides a more ergonomic API for the common pattern of creating a singleton from an async computation.

Includes a doctest demonstrating usage with `process.singleton_future(q!(async { 42 }))`.

Fixes #2685