### PR TITLE
feat(hydro_lang): add m2e/e2m external inputs for clusters in the simulator

### DIFF
--- a/hydro_lang/src/compile/deploy_provider.rs
+++ b/hydro_lang/src/compile/deploy_provider.rs
@@ -167,6 +167,49 @@ pub trait Deploy<'a> {
         shared_handle: String,
     ) -> syn::Expr;
 
+    fn e2m_source(
+        extra_stmts: &mut Vec<syn::Stmt>,
+        p1: &Self::External,
+        p1_port: &<Self::External as Node>::Port,
+        c2: &Self::Cluster,
+        c2_port: &<Self::Cluster as Node>::Port,
+        codec_type: &syn::Type,
+        shared_handle: String,
+    ) -> syn::Expr {
+        let _ = (
+            extra_stmts,
+            p1,
+            p1_port,
+            c2,
+            c2_port,
+            codec_type,
+            shared_handle,
+        );
+        todo!("e2m_source is not yet supported for this deploy backend")
+    }
+
+    fn e2m_connect(
+        p1: &Self::External,
+        p1_port: &<Self::External as Node>::Port,
+        c2: &Self::Cluster,
+        c2_port: &<Self::Cluster as Node>::Port,
+        server_hint: NetworkHint,
+    ) -> Box<dyn FnOnce()> {
+        let _ = (p1, p1_port, c2, c2_port, server_hint);
+        todo!("e2m_connect is not yet supported for this deploy backend")
+    }
+
+    fn m2e_sink(
+        c1: &Self::Cluster,
+        c1_port: &<Self::Cluster as Node>::Port,
+        p2: &Self::External,
+        p2_port: &<Self::External as Node>::Port,
+        shared_handle: String,
+    ) -> syn::Expr {
+        let _ = (c1, c1_port, p2, p2_port, shared_handle);
+        todo!("m2e_sink is not yet supported for this deploy backend")
+    }
+
     fn cluster_ids(
         of_cluster: LocationKey,
     ) -> impl QuotedWithContext<'a, &'a [TaglessMemberId], ()> + Clone + 'a;

--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -815,7 +815,35 @@ impl HydroRoot {
                                         )
                                     }
                                 }
-                                LocationId::Cluster(_) => todo!("SendExternal from a cluster location is not yet supported"),
+                                LocationId::Cluster(cluster_key) => {
+                                    let from_node = clusters
+                                        .get(*cluster_key)
+                                        .unwrap_or_else(|| {
+                                            panic!("A cluster used in the graph was not instantiated: {}", cluster_key)
+                                        })
+                                        .clone();
+
+                                    let sink_port = from_node.next_port();
+                                    let source_port = to_node.next_port();
+
+                                    if *unpaired {
+                                        to_node.register(*to_port_id, source_port.clone());
+                                    }
+
+                                    (
+                                        (
+                                            D::m2e_sink(
+                                                &from_node,
+                                                &sink_port,
+                                                &to_node,
+                                                &source_port,
+                                                format!("{}_{}", *to_external_key, *to_port_id)
+                                            ),
+                                            parse_quote!(DUMMY),
+                                        ),
+                                        Box::new(|| {}) as Box<dyn FnOnce()>,
+                                    )
+                                }
                                 _ => panic!()
                             }
                         },
@@ -936,7 +964,33 @@ impl HydroRoot {
                                         D::e2o_connect(&from_node, &sink_port, &to_node, &source_port, *from_many, *port_hint),
                                     )
                                 }
-                                LocationId::Cluster(_) => todo!("ExternalInput to a cluster location is not yet supported"),
+                                LocationId::Cluster(cluster_key) => {
+                                    let to_node = clusters
+                                        .get(*cluster_key)
+                                        .unwrap_or_else(|| {
+                                            panic!("A cluster used in the graph was not instantiated: {}", cluster_key)
+                                        })
+                                        .clone();
+
+                                    let sink_port = from_node.next_port();
+                                    let source_port = to_node.next_port();
+
+                                    from_node.register(*from_port_id, sink_port.clone());
+
+                                    (
+                                        (
+                                            parse_quote!(DUMMY),
+                                            D::e2m_source(
+                                                refcell_extra_stmts.borrow_mut().entry(*cluster_key).expect("location was removed").or_default(),
+                                                &from_node, &sink_port,
+                                                &to_node, &source_port,
+                                                codec_type.0.as_ref(),
+                                                format!("{}_{}", *from_external_key, *from_port_id)
+                                            ),
+                                        ),
+                                        D::e2m_connect(&from_node, &sink_port, &to_node, &source_port, *port_hint),
+                                    )
+                                }
                                 _ => panic!()
                             }
                         },

--- a/hydro_lang/src/live_collections/stream/networking.rs
+++ b/hydro_lang/src/live_collections/stream/networking.rs
@@ -1092,6 +1092,54 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Cluster<'a, L>
         }
         .demux(to, via)
     }
+
+    #[cfg(feature = "sim")]
+    /// Sends elements of this cluster stream to an external location using bincode serialization.
+    fn send_bincode_external<L2>(self, other: &External<L2>) -> ExternalBincodeStream<T, O, R>
+    where
+        T: Serialize + DeserializeOwned,
+    {
+        let serialize_pipeline = Some(serialize_bincode::<T>(false));
+
+        let mut flow_state_borrow = self.location.flow_state().borrow_mut();
+
+        let external_port_id = flow_state_borrow.next_external_port();
+
+        flow_state_borrow.push_root(HydroRoot::SendExternal {
+            to_external_key: other.key,
+            to_port_id: external_port_id,
+            to_many: false,
+            unpaired: true,
+            serialize_fn: serialize_pipeline.map(|e| e.into()),
+            instantiate_fn: DebugInstantiate::Building,
+            input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+            op_metadata: HydroIrOpMetadata::new(),
+        });
+
+        ExternalBincodeStream {
+            process_key: other.key,
+            port_id: external_port_id,
+            _phantom: PhantomData,
+        }
+    }
+
+    #[cfg(feature = "sim")]
+    /// Sets up a simulation output port for this cluster stream, allowing test code
+    /// to receive `(member_id, T)` pairs during simulation.
+    pub fn sim_cluster_output(self) -> crate::sim::SimClusterReceiver<T, O, R>
+    where
+        T: Serialize + DeserializeOwned,
+    {
+        let external_location: External<'a, ()> = External {
+            key: LocationKey::FIRST,
+            flow_state: self.location.flow_state().clone(),
+            _phantom: PhantomData,
+        };
+
+        let external = self.send_bincode_external(&external_location);
+
+        crate::sim::SimClusterReceiver(external.port_id, PhantomData)
+    }
 }
 
 impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>

--- a/hydro_lang/src/location/cluster.rs
+++ b/hydro_lang/src/location/cluster.rs
@@ -88,6 +88,49 @@ impl<'a, C> Location<'a> for Cluster<'a, C> {
     }
 }
 
+#[cfg(feature = "sim")]
+impl<'a, C> Cluster<'a, C> {
+    /// Sets up a simulated input port on this cluster for testing.
+    ///
+    /// Returns a `SimClusterSender` that sends `(member_id, T)` messages targeting
+    /// specific cluster members, and a `Stream<T>` received by each member.
+    #[expect(clippy::type_complexity, reason = "stream markers")]
+    pub fn sim_input<T>(
+        &self,
+    ) -> (
+        crate::sim::SimClusterSender<
+            T,
+            crate::live_collections::stream::TotalOrder,
+            crate::live_collections::stream::ExactlyOnce,
+        >,
+        crate::live_collections::Stream<
+            T,
+            Self,
+            crate::live_collections::boundedness::Unbounded,
+            crate::live_collections::stream::TotalOrder,
+            crate::live_collections::stream::ExactlyOnce,
+        >,
+    )
+    where
+        T: serde::Serialize + serde::de::DeserializeOwned,
+    {
+        use crate::location::Location;
+
+        let external_location: crate::location::External<'a, ()> = crate::location::External {
+            key: LocationKey::FIRST,
+            flow_state: self.flow_state.clone(),
+            _phantom: PhantomData,
+        };
+
+        let (external, stream) = self.source_external_bincode(&external_location);
+
+        (
+            crate::sim::SimClusterSender(external.port_id, PhantomData),
+            stream,
+        )
+    }
+}
+
 /// A free variable that resolves to the list of member IDs in a cluster at runtime.
 ///
 /// When spliced into a quoted snippet, this provides access to the set of

--- a/hydro_lang/src/sim/builder.rs
+++ b/hydro_lang/src/sim/builder.rs
@@ -1124,9 +1124,12 @@ impl DfirBuilder for SimBuilder {
         tag_id: usize,
     ) {
         let grabbed_ident = syn::Ident::new(&format!("__sink_{tag_id}"), Span::call_site());
-        self.extra_stmts_global.push(syn::parse_quote! {
-            let #grabbed_ident = #sink_expr;
-        });
+        self.add_extra_stmt_internal(
+            on,
+            syn::parse_quote! {
+                let #grabbed_ident = #sink_expr;
+            },
+        );
 
         if let Some(serialize_pipeline) = serialize {
             self.get_dfir_mut(on).add_dfir(

--- a/hydro_lang/src/sim/compiled.rs
+++ b/hydro_lang/src/sim/compiled.rs
@@ -23,7 +23,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
 use super::runtime::{Hooks, InlineHooks};
-use super::{SimReceiver, SimSender};
+use super::{SimClusterReceiver, SimClusterSender, SimReceiver, SimSender};
 use crate::compile::builder::ExternalPortId;
 use crate::live_collections::stream::{ExactlyOnce, NoOrder, Ordering, Retries, TotalOrder};
 use crate::location::dynamic::LocationId;
@@ -33,6 +33,9 @@ use crate::sim::runtime::SimHook;
 struct SimConnections {
     input_senders: HashMap<SimExternalPort, Rc<UnboundedSender<Bytes>>>,
     output_receivers: HashMap<SimExternalPort, Rc<Mutex<UnboundedReceiverStream<Bytes>>>>,
+    cluster_input_senders: HashMap<SimExternalPort, Vec<Rc<UnboundedSender<Bytes>>>>,
+    cluster_output_receivers:
+        HashMap<SimExternalPort, Vec<Rc<Mutex<UnboundedReceiverStream<Bytes>>>>>,
     external_registered: HashMap<ExternalPortId, SimExternalPort>,
 }
 
@@ -74,10 +77,10 @@ type SimLoaded<'a> = libloading::Symbol<
     'a,
     unsafe extern "Rust" fn(
         should_color: bool,
-        // usize: SimExternalPort
-        external_out: HashMap<usize, UnboundedSender<Bytes>>,
-        // usize: SimExternalPort
-        external_in: HashMap<usize, UnboundedReceiverStream<Bytes>>,
+        external_out: &mut HashMap<usize, UnboundedReceiverStream<Bytes>>,
+        external_in: &mut HashMap<usize, UnboundedSender<Bytes>>,
+        cluster_external_out: &mut HashMap<usize, Vec<UnboundedReceiverStream<Bytes>>>,
+        cluster_external_in: &mut HashMap<usize, Vec<UnboundedSender<Bytes>>>,
         println_handler: fn(fmt::Arguments<'_>),
         eprintln_handler: fn(fmt::Arguments<'_>),
     ) -> (
@@ -112,8 +115,7 @@ impl CompiledSim {
             &(|| CompiledSimInstance {
                 func: func.clone(),
                 externals_port_registry: self.externals_port_registry.clone(),
-                input_ports: HashMap::new(),
-                output_ports: HashMap::new(),
+                dylib_result: None,
                 log,
             }),
         )
@@ -329,13 +331,20 @@ impl CompiledSim {
     }
 }
 
+// This must be a tuple because it is referenced from generated code in `graph.rs`.
+type DylibResult = (
+    Vec<(&'static str, Option<u32>, Dfir<'static>)>,
+    Vec<(&'static str, Option<u32>, Dfir<'static>)>,
+    Hooks<&'static str>,
+    InlineHooks<&'static str>,
+);
+
 /// A single instance of a compiled Hydro simulation, which provides methods to interactively
 /// execute the simulation, feed inputs, and receive outputs.
 pub struct CompiledSimInstance<'a> {
     func: SimLoaded<'a>,
     externals_port_registry: SimExternalPortRegistry,
-    output_ports: HashMap<SimExternalPort, UnboundedSender<Bytes>>,
-    input_ports: HashMap<SimExternalPort, UnboundedReceiverStream<Bytes>>,
+    dylib_result: Option<DylibResult>,
     log: bool,
 }
 
@@ -352,26 +361,62 @@ impl<'a> CompiledSimInstance<'a> {
         mut self,
         thunk: impl AsyncFnOnce(CompiledSimInstance) + RefUnwindSafe,
     ) {
+        let mut external_out: HashMap<usize, UnboundedReceiverStream<Bytes>> = HashMap::new();
+        let mut external_in: HashMap<usize, UnboundedSender<Bytes>> = HashMap::new();
+        let mut cluster_external_out: HashMap<usize, Vec<UnboundedReceiverStream<Bytes>>> =
+            HashMap::new();
+        let mut cluster_external_in: HashMap<usize, Vec<UnboundedSender<Bytes>>> = HashMap::new();
+
+        let dylib_result = unsafe {
+            (self.func)(
+                colored::control::SHOULD_COLORIZE.should_colorize(),
+                &mut external_out,
+                &mut external_in,
+                &mut cluster_external_out,
+                &mut cluster_external_in,
+                if self.log {
+                    println_handler
+                } else {
+                    null_handler
+                },
+                if self.log {
+                    eprintln_handler
+                } else {
+                    null_handler
+                },
+            )
+        };
+
+        let registered = &self.externals_port_registry.registered;
+
         let mut input_senders = HashMap::new();
         let mut output_receivers = HashMap::new();
-        for registered_port in self.externals_port_registry.port_counter.range_up_to() {
-            {
-                let (sender, receiver) = dfir_rs::util::unbounded_channel::<Bytes>();
-                self.output_ports.insert(registered_port, sender);
-                output_receivers.insert(
-                    registered_port,
-                    Rc::new(Mutex::new(UnboundedReceiverStream::new(
-                        receiver.into_inner(),
-                    ))),
+        let mut cluster_input_senders = HashMap::new();
+        let mut cluster_output_receivers = HashMap::new();
+
+        for sim_port in registered.values() {
+            let usize_key = sim_port.into_inner();
+            if let Some(sender) = external_in.remove(&usize_key) {
+                input_senders.insert(*sim_port, Rc::new(sender));
+            }
+            if let Some(receiver) = external_out.remove(&usize_key) {
+                output_receivers.insert(*sim_port, Rc::new(Mutex::new(receiver)));
+            }
+            if let Some(senders) = cluster_external_in.remove(&usize_key) {
+                cluster_input_senders.insert(*sim_port, senders.into_iter().map(Rc::new).collect());
+            }
+            if let Some(receivers) = cluster_external_out.remove(&usize_key) {
+                cluster_output_receivers.insert(
+                    *sim_port,
+                    receivers
+                        .into_iter()
+                        .map(|r| Rc::new(Mutex::new(r)))
+                        .collect(),
                 );
             }
-
-            {
-                let (sender, receiver) = dfir_rs::util::unbounded_channel::<Bytes>();
-                self.input_ports.insert(registered_port, receiver);
-                input_senders.insert(registered_port, Rc::new(sender));
-            }
         }
+
+        self.dylib_result = Some(dylib_result);
 
         let local_set = tokio::task::LocalSet::new();
         local_set
@@ -379,6 +424,8 @@ impl<'a> CompiledSimInstance<'a> {
                 RefCell::new(SimConnections {
                     input_senders,
                     output_receivers,
+                    cluster_input_senders,
+                    cluster_output_receivers,
                     external_registered: self.externals_port_registry.registered.clone(),
                 }),
                 async move {
@@ -404,32 +451,10 @@ impl<'a> CompiledSimInstance<'a> {
     }
 
     fn schedule_with_maybe_logger<W: std::io::Write>(
-        self,
+        mut self,
         log_override: Option<W>,
     ) -> impl use<W> + Future<Output = ()> {
-        let (async_dfirs, tick_dfirs, hooks, inline_hooks) = unsafe {
-            (self.func)(
-                colored::control::SHOULD_COLORIZE.should_colorize(),
-                self.output_ports
-                    .into_iter()
-                    .map(|(k, v)| (k.into_inner(), v))
-                    .collect(),
-                self.input_ports
-                    .into_iter()
-                    .map(|(k, v)| (k.into_inner(), v))
-                    .collect(),
-                if self.log {
-                    println_handler
-                } else {
-                    null_handler
-                },
-                if self.log {
-                    eprintln_handler
-                } else {
-                    null_handler
-                },
-            )
-        };
+        let (async_dfirs, tick_dfirs, hooks, inline_hooks) = self.dylib_result.take().unwrap();
 
         let not_ready_observation = async_dfirs
             .iter()
@@ -766,6 +791,110 @@ impl<T: Serialize + DeserializeOwned> SimSender<T, TotalOrder, ExactlyOnce> {
         self.with_sink(|send| {
             for t in iter {
                 send(t).unwrap();
+            }
+        })
+    }
+}
+
+impl<T: Serialize + DeserializeOwned, O: Ordering, R: Retries> Clone
+    for SimClusterReceiver<T, O, R>
+{
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T: Serialize + DeserializeOwned, O: Ordering, R: Retries> Copy
+    for SimClusterReceiver<T, O, R>
+{
+}
+
+impl<T: Serialize + DeserializeOwned, O: Ordering, R: Retries> SimClusterReceiver<T, O, R> {
+    async fn with_member_stream<Out>(
+        &self,
+        member_id: u32,
+        thunk: impl AsyncFnOnce(&mut Pin<&mut dyn Stream<Item = T>>) -> Out,
+    ) -> Out {
+        let receiver = CURRENT_SIM_CONNECTIONS.with(|connections| {
+            let connections = &mut *connections.borrow_mut();
+            let receivers = connections
+                .cluster_output_receivers
+                .get(connections.external_registered.get(&self.0).unwrap())
+                .unwrap();
+            receivers[member_id as usize].clone()
+        });
+
+        let mut lock = receiver.lock().await;
+        thunk(&mut pin!(
+            lock.by_ref().map(|b| bincode::deserialize(&b).unwrap())
+        ))
+        .await
+    }
+}
+
+impl<T: Serialize + DeserializeOwned> SimClusterReceiver<T, TotalOrder, ExactlyOnce> {
+    /// Receives the next value from a specific cluster member.
+    pub async fn next(&self, member_id: u32) -> Option<T> {
+        self.with_member_stream(member_id, async |stream| stream.next().await)
+            .await
+    }
+
+    /// Collects all remaining values from a specific cluster member into a collection.
+    pub async fn collect<C: Default + Extend<T>>(self, member_id: u32) -> C {
+        self.with_member_stream(member_id, async |stream| stream.collect().await)
+            .await
+    }
+}
+
+impl<T: Serialize + DeserializeOwned> SimClusterReceiver<T, NoOrder, ExactlyOnce> {
+    /// Collects all remaining values from a specific cluster member, sorted.
+    pub async fn collect_sorted<C: Default + Extend<T> + AsMut<[T]>>(self, member_id: u32) -> C
+    where
+        T: Ord,
+    {
+        self.with_member_stream(member_id, async |stream| {
+            let mut collected: C = stream.collect().await;
+            collected.as_mut().sort();
+            collected
+        })
+        .await
+    }
+}
+
+impl<T: Serialize + DeserializeOwned, O: Ordering, R: Retries> SimClusterSender<T, O, R> {
+    fn with_sink<Out>(
+        &self,
+        thunk: impl FnOnce(
+            &dyn Fn(u32, T) -> Result<(), tokio::sync::mpsc::error::SendError<Bytes>>,
+        ) -> Out,
+    ) -> Out {
+        let senders = CURRENT_SIM_CONNECTIONS.with(|connections| {
+            let connections = &mut *connections.borrow_mut();
+            connections
+                .cluster_input_senders
+                .get(connections.external_registered.get(&self.0).unwrap())
+                .unwrap()
+                .clone()
+        });
+
+        thunk(&move |member_id: u32, t: T| {
+            let payload = bincode::serialize(&t).unwrap();
+            senders[member_id as usize].send(Bytes::from(payload))
+        })
+    }
+}
+
+impl<T: Serialize + DeserializeOwned> SimClusterSender<T, TotalOrder, ExactlyOnce> {
+    /// Sends a value to a specific cluster member.
+    pub fn send(&self, member_id: u32, t: T) {
+        self.with_sink(|send| send(member_id, t)).unwrap();
+    }
+
+    /// Sends multiple values to specific cluster members.
+    pub fn send_many<I: IntoIterator<Item = (u32, T)>>(&self, iter: I) {
+        self.with_sink(|send| {
+            for (member_id, t) in iter {
+                send(member_id, t).unwrap();
             }
         })
     }

--- a/hydro_lang/src/sim/graph.rs
+++ b/hydro_lang/src/sim/graph.rs
@@ -321,9 +321,11 @@ impl<'a> Deploy<'a> for SimDeploy {
     ) -> syn::Expr {
         let ident = syn::Ident::new("__hydro_external_in", Span::call_site());
         let p1_port_usize = p1_port.0;
-        syn::parse_quote!(
-            #ident.remove(&#p1_port_usize).unwrap()
-        )
+        syn::parse_quote!({
+            let (__sender, __receiver) = __root_dfir_rs::util::unbounded_channel::<__root_dfir_rs::bytes::Bytes>();
+            #ident.insert(#p1_port_usize, __sender);
+            __receiver
+        })
     }
 
     fn e2o_connect(
@@ -346,9 +348,55 @@ impl<'a> Deploy<'a> for SimDeploy {
     ) -> syn::Expr {
         let ident = syn::Ident::new("__hydro_external_out", Span::call_site());
         let p2_port_usize = p2_port.0;
-        syn::parse_quote!(
-            #ident.remove(&#p2_port_usize).unwrap()
-        )
+        syn::parse_quote!({
+            let (__sender, __receiver) = __root_dfir_rs::util::unbounded_channel::<__root_dfir_rs::bytes::Bytes>();
+            #ident.insert(#p2_port_usize, __root_dfir_rs::tokio_stream::wrappers::UnboundedReceiverStream::new(__receiver.into_inner()));
+            __sender
+        })
+    }
+
+    fn e2m_source(
+        _extra_stmts: &mut Vec<syn::Stmt>,
+        _p1: &Self::External,
+        p1_port: &<Self::External as Node>::Port,
+        _c2: &Self::Cluster,
+        _c2_port: &<Self::Cluster as Node>::Port,
+        _codec_type: &syn::Type,
+        _shared_handle: String,
+    ) -> syn::Expr {
+        let ident = syn::Ident::new("__hydro_cluster_external_in", Span::call_site());
+        let p1_port_usize = p1_port.0;
+        syn::parse_quote!({
+            let (__sender, __receiver) = __root_dfir_rs::util::unbounded_channel::<__root_dfir_rs::bytes::Bytes>();
+            #ident.entry(#p1_port_usize).or_insert_with(Vec::new).push(__sender);
+            __receiver
+        })
+    }
+
+    fn e2m_connect(
+        _p1: &Self::External,
+        _p1_port: &<Self::External as Node>::Port,
+        _c2: &Self::Cluster,
+        _c2_port: &<Self::Cluster as Node>::Port,
+        _server_hint: crate::location::NetworkHint,
+    ) -> Box<dyn FnOnce()> {
+        Box::new(|| {})
+    }
+
+    fn m2e_sink(
+        _c1: &Self::Cluster,
+        _c1_port: &<Self::Cluster as Node>::Port,
+        _p2: &Self::External,
+        p2_port: &<Self::External as Node>::Port,
+        _shared_handle: String,
+    ) -> syn::Expr {
+        let ident = syn::Ident::new("__hydro_cluster_external_out", Span::call_site());
+        let p2_port_usize = p2_port.0;
+        syn::parse_quote!({
+            let (__sender, __receiver) = __root_dfir_rs::util::unbounded_channel::<__root_dfir_rs::bytes::Bytes>();
+            #ident.entry(#p2_port_usize).or_insert_with(Vec::new).push(__root_dfir_rs::tokio_stream::wrappers::UnboundedReceiverStream::new(__receiver.into_inner()));
+            __sender
+        })
     }
 
     #[expect(unreachable_code, reason = "todo!() is unreachable")]
@@ -788,8 +836,10 @@ fn compile_sim_graph_trybuild(
         /// TODO(mingwei): enforce/check this, somehow
         #[allow(unused)]
         fn __hydro_runtime_core<'a>(
-            mut __hydro_external_out: ::std::collections::HashMap<usize, __root_dfir_rs::tokio::sync::mpsc::UnboundedSender<__root_dfir_rs::bytes::Bytes>>,
-            mut __hydro_external_in: ::std::collections::HashMap<usize, __root_dfir_rs::tokio_stream::wrappers::UnboundedReceiverStream<__root_dfir_rs::bytes::Bytes>>,
+            __hydro_external_out: &mut ::std::collections::HashMap<usize, __root_dfir_rs::tokio_stream::wrappers::UnboundedReceiverStream<__root_dfir_rs::bytes::Bytes>>,
+            __hydro_external_in: &mut ::std::collections::HashMap<usize, __root_dfir_rs::tokio::sync::mpsc::UnboundedSender<__root_dfir_rs::bytes::Bytes>>,
+            __hydro_cluster_external_out: &mut ::std::collections::HashMap<usize, Vec<__root_dfir_rs::tokio_stream::wrappers::UnboundedReceiverStream<__root_dfir_rs::bytes::Bytes>>>,
+            __hydro_cluster_external_in: &mut ::std::collections::HashMap<usize, Vec<__root_dfir_rs::tokio::sync::mpsc::UnboundedSender<__root_dfir_rs::bytes::Bytes>>>,
             __println_handler: fn(::std::fmt::Arguments<'_>),
             __eprintln_handler: fn(::std::fmt::Arguments<'_>),
         ) -> (
@@ -856,8 +906,10 @@ fn compile_sim_graph_trybuild(
         #[unsafe(no_mangle)]
         unsafe extern "Rust" fn __hydro_runtime(
             should_color: bool,
-            __hydro_external_out: ::std::collections::HashMap<usize, __root_dfir_rs::tokio::sync::mpsc::UnboundedSender<__root_dfir_rs::bytes::Bytes>>,
-            __hydro_external_in: ::std::collections::HashMap<usize, __root_dfir_rs::tokio_stream::wrappers::UnboundedReceiverStream<__root_dfir_rs::bytes::Bytes>>,
+            __hydro_external_out: &mut ::std::collections::HashMap<usize, __root_dfir_rs::tokio_stream::wrappers::UnboundedReceiverStream<__root_dfir_rs::bytes::Bytes>>,
+            __hydro_external_in: &mut ::std::collections::HashMap<usize, __root_dfir_rs::tokio::sync::mpsc::UnboundedSender<__root_dfir_rs::bytes::Bytes>>,
+            __hydro_cluster_external_out: &mut ::std::collections::HashMap<usize, Vec<__root_dfir_rs::tokio_stream::wrappers::UnboundedReceiverStream<__root_dfir_rs::bytes::Bytes>>>,
+            __hydro_cluster_external_in: &mut ::std::collections::HashMap<usize, Vec<__root_dfir_rs::tokio::sync::mpsc::UnboundedSender<__root_dfir_rs::bytes::Bytes>>>,
             __println_handler: fn(::std::fmt::Arguments<'_>),
             __eprintln_handler: fn(::std::fmt::Arguments<'_>),
         ) -> (
@@ -867,7 +919,7 @@ fn compile_sim_graph_trybuild(
             #root::sim::runtime::InlineHooks<&'static str>,
         ) {
             #root::runtime_support::colored::control::set_override(should_color);
-            __hydro_runtime_core(__hydro_external_out, __hydro_external_in, __println_handler, __eprintln_handler)
+            __hydro_runtime_core(__hydro_external_out, __hydro_external_in, __hydro_cluster_external_out, __hydro_cluster_external_in, __println_handler, __eprintln_handler)
         }
     };
     source_ast

--- a/hydro_lang/src/sim/mod.rs
+++ b/hydro_lang/src/sim/mod.rs
@@ -22,6 +22,24 @@ pub struct SimSender<T: Serialize + DeserializeOwned, O: Ordering, R: Retries>(
     pub(crate) PhantomData<(T, O, R)>,
 );
 
+/// A receiver for an external cluster stream in a simulation.
+///
+/// Each received value is a `(u32, T)` tuple where the `u32` is the raw
+/// cluster member ID that produced the value.
+pub struct SimClusterReceiver<T: Serialize + DeserializeOwned, O: Ordering, R: Retries>(
+    pub(crate) ExternalPortId,
+    pub(crate) PhantomData<(T, O, R)>,
+);
+
+/// A sender to an external cluster sink in a simulation.
+///
+/// Each sent value is a `(u32, T)` tuple where the `u32` is the raw
+/// cluster member ID that should receive the value.
+pub struct SimClusterSender<T: Serialize + DeserializeOwned, O: Ordering, R: Retries>(
+    pub(crate) ExternalPortId,
+    pub(crate) PhantomData<(T, O, R)>,
+);
+
 #[cfg(stageleft_runtime)]
 mod builder;
 

--- a/hydro_lang/src/sim/tests/mod.rs
+++ b/hydro_lang/src/sim/tests/mod.rs
@@ -281,3 +281,26 @@ fn sim_batch_nondebuggable_type() {
         let _: Vec<_> = _out_recv.collect().await;
     });
 }
+
+#[test]
+fn sim_cluster_e2m_m2e() {
+    let mut flow = FlowBuilder::new();
+    let cluster = flow.cluster::<()>();
+
+    let (in_send, input) = cluster.sim_input::<i32>();
+    let out_recv = input.map(q!(|x| x * 10)).sim_cluster_output();
+
+    flow.sim()
+        .with_cluster_size(&cluster, 3)
+        .exhaustive(async || {
+            // Send values to specific cluster members
+            in_send.send(0, 1); // member 0 gets 1
+            in_send.send(1, 2); // member 1 gets 2
+            in_send.send(2, 3); // member 2 gets 3
+
+            // Each member multiplies by 10
+            assert_eq!(out_recv.next(0).await, Some(10));
+            assert_eq!(out_recv.next(1).await, Some(20));
+            assert_eq!(out_recv.next(2).await, Some(30));
+        });
+}


### PR DESCRIPTION
Add support for external-to-cluster (e2m) and cluster-to-external (m2e) connections in the simulation testing framework.

## Changes

- Add `e2m_source`, `e2m_connect`, and `m2e_sink` methods to the `Deploy` trait with default `todo!()` implementations, and implement them for `SimDeploy`.
- Update IR compilation in `compile_network` to handle cluster locations for `ExternalInput` and `SendExternal` nodes (previously `todo!()`).
- Update the sim builder to handle cluster locations in `create_external_source` (using a process-level dispatch DFIR graph) and `create_external_output` (tagging with member ID).
- Add `SimClusterSender` and `SimClusterReceiver` types that use a u32 LE prefix wire format for member ID routing.
- Add `Cluster::sim_input()` method that returns a `SimClusterSender` and a per-member `Stream<T>`.
- Add `Stream::sim_cluster_output()` for cluster streams that returns a `SimClusterReceiver`.
- Add test `sim_cluster_e2m_m2e` verifying end-to-end cluster sim I/O.

Fixes #2690