### PR TITLE
test(hydro_lang): update tests to avoid synchronous cycles, #2080

### DIFF
--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -2758,6 +2758,8 @@ mod tests {
     use crate::live_collections::stream::{NoOrder, TotalOrder};
     #[cfg(any(feature = "deploy", feature = "sim"))]
     use crate::location::Location;
+    #[cfg(feature = "sim")]
+    use crate::networking::TCP;
     #[cfg(any(feature = "deploy", feature = "sim"))]
     use crate::nondet::nondet;
     #[cfg(feature = "deploy")]
@@ -3102,6 +3104,7 @@ mod tests {
 
         let mut flow = FlowBuilder::new();
         let node = flow.process::<()>();
+        let node2 = flow.process::<()>();
 
         let (in_send, input) = node.sim_input::<_, NoOrder, _>();
 
@@ -3115,7 +3118,11 @@ mod tests {
             ordered
                 .clone()
                 .map(q!(|v| v + 1))
-                .filter(q!(|v| v % 2 == 1)),
+                .filter(q!(|v| v % 2 == 1))
+                .entries()
+                .send(&node2, TCP.fail_stop().bincode())
+                .send(&node, TCP.fail_stop().bincode())
+                .into_keyed(),
         );
 
         let out_recv = ordered
@@ -3166,6 +3173,7 @@ mod tests {
         // that other key.
         let mut flow = FlowBuilder::new();
         let node = flow.process::<()>();
+        let node2 = flow.process::<()>();
 
         let (in_send, input) = node.sim_input::<_, NoOrder, _>();
 
@@ -3184,6 +3192,8 @@ mod tests {
                 .map(q!(|_| 100))
                 .entries()
                 .map(q!(|(_, v)| (2, v))) // Change key from 1 to 2
+                .send(&node2, TCP.fail_stop().bincode())
+                .send(&node, TCP.fail_stop().bincode())
                 .into_keyed(),
         );
 
@@ -3236,6 +3246,7 @@ mod tests {
 
         let mut flow = FlowBuilder::new();
         let node = flow.process::<()>();
+        let node2 = flow.process::<()>();
 
         let (in_send, input) = node.sim_input::<_, NoOrder, _>();
 
@@ -3251,7 +3262,11 @@ mod tests {
                 .batch(&node.tick(), nondet!(/** test */))
                 .all_ticks()
                 .map(q!(|v| v + 1))
-                .filter(q!(|v| v % 2 == 1)),
+                .filter(q!(|v| v % 2 == 1))
+                .entries()
+                .send(&node2, TCP.fail_stop().bincode())
+                .send(&node, TCP.fail_stop().bincode())
+                .into_keyed(),
         );
 
         let out_recv = ordered

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -2975,6 +2975,8 @@ mod tests {
     use crate::live_collections::stream::TotalOrder;
     #[cfg(any(feature = "deploy", feature = "sim"))]
     use crate::location::Location;
+    #[cfg(feature = "sim")]
+    use crate::networking::TCP;
     #[cfg(any(feature = "deploy", feature = "sim"))]
     use crate::nondet::nondet;
 
@@ -3556,6 +3558,7 @@ mod tests {
     fn sim_top_level_assume_ordering_cycle_back() {
         let mut flow = FlowBuilder::new();
         let node = flow.process::<()>();
+        let node2 = flow.process::<()>();
 
         let (in_send, input) = node.sim_input::<_, NoOrder, _>();
 
@@ -3568,7 +3571,9 @@ mod tests {
             ordered
                 .clone()
                 .map(q!(|v| v + 1))
-                .filter(q!(|v| v % 2 == 1)),
+                .filter(q!(|v| v % 2 == 1))
+                .send(&node2, TCP.fail_stop().bincode())
+                .send(&node, TCP.fail_stop().bincode()),
         );
 
         let out_recv = ordered.sim_output();
@@ -3584,7 +3589,7 @@ mod tests {
         });
 
         assert!(saw, "did not see an instance with 0, 1, 2 in order");
-        assert_eq!(instance_count, 6)
+        assert_eq!(instance_count, 6);
     }
 
     #[cfg(feature = "sim")]
@@ -3592,6 +3597,7 @@ mod tests {
     fn sim_top_level_assume_ordering_cycle_back_tick() {
         let mut flow = FlowBuilder::new();
         let node = flow.process::<()>();
+        let node2 = flow.process::<()>();
 
         let (in_send, input) = node.sim_input::<_, NoOrder, _>();
 
@@ -3606,7 +3612,9 @@ mod tests {
                 .batch(&node.tick(), nondet!(/** test */))
                 .all_ticks()
                 .map(q!(|v| v + 1))
-                .filter(q!(|v| v % 2 == 1)),
+                .filter(q!(|v| v % 2 == 1))
+                .send(&node2, TCP.fail_stop().bincode())
+                .send(&node, TCP.fail_stop().bincode()),
         );
 
         let out_recv = ordered.sim_output();
@@ -3622,7 +3630,7 @@ mod tests {
         });
 
         assert!(saw, "did not see an instance with 0, 1, 2 in order");
-        assert_eq!(instance_count, 58)
+        assert_eq!(instance_count, 58);
     }
 
     #[cfg(feature = "sim")]
@@ -3630,6 +3638,7 @@ mod tests {
     fn sim_top_level_assume_ordering_multiple() {
         let mut flow = FlowBuilder::new();
         let node = flow.process::<()>();
+        let node2 = flow.process::<()>();
 
         let (in_send, input) = node.sim_input::<_, NoOrder, _>();
         let (_, input2) = node.sim_input::<_, NoOrder, _>();
@@ -3647,7 +3656,11 @@ mod tests {
             .merge_unordered(input2)
             .assume_ordering::<TotalOrder>(nondet!(/** test */));
 
-        complete_cycle_back.complete(foo.filter(q!(|v| *v == 3)));
+        complete_cycle_back.complete(
+            foo.filter(q!(|v| *v == 3))
+                .send(&node2, TCP.fail_stop().bincode())
+                .send(&node, TCP.fail_stop().bincode()),
+        );
 
         let out_recv = input1_ordered.sim_output();
 
@@ -3662,7 +3675,7 @@ mod tests {
         });
 
         assert!(saw, "did not see an instance with 0, 3, 1 in order");
-        assert_eq!(instance_count, 24)
+        assert_eq!(instance_count, 24);
     }
 
     #[cfg(feature = "sim")]
@@ -3670,6 +3683,7 @@ mod tests {
     fn sim_atomic_assume_ordering_cycle_back() {
         let mut flow = FlowBuilder::new();
         let node = flow.process::<()>();
+        let node2 = flow.process::<()>();
 
         let (in_send, input) = node.sim_input::<_, NoOrder, _>();
 
@@ -3684,7 +3698,9 @@ mod tests {
             ordered
                 .clone()
                 .map(q!(|v| v + 1))
-                .filter(q!(|v| v % 2 == 1)),
+                .filter(q!(|v| v % 2 == 1))
+                .send(&node2, TCP.fail_stop().bincode())
+                .send(&node, TCP.fail_stop().bincode()),
         );
 
         let out_recv = ordered.sim_output();
@@ -3694,8 +3710,7 @@ mod tests {
             let out = out_recv.collect::<Vec<_>>().await;
             assert_eq!(out.len(), 4);
         });
-
-        assert_eq!(instance_count, 22)
+        assert_eq!(instance_count, 22);
     }
 
     #[cfg(feature = "deploy")]

--- a/hydro_lang/src/location/mod.rs
+++ b/hydro_lang/src/location/mod.rs
@@ -1140,13 +1140,19 @@ pub trait Location<'a>: dynamic::DynLocation {
         )))
     }
 
-    /// Creates a forward reference for defining recursive or mutually-dependent dataflows.
+    /// Creates a forward reference, allowing a stream to be used before its source is defined.
     ///
-    /// Returns a handle that must be completed with the actual stream, and a placeholder
-    /// stream that can be used in the dataflow graph before the actual stream is defined.
+    /// Returns a `(handle, placeholder)` pair. Use the placeholder in the dataflow graph,
+    /// then call `handle.complete(actual_stream)` to wire in the real source.
     ///
-    /// This is useful for implementing feedback loops or recursive computations where
-    /// a stream depends on its own output.
+    /// This is useful for mutually-dependent dataflows or when the definition order
+    /// doesn't match the data flow direction. For feedback loops, prefer [`Tick::cycle`]
+    /// instead, which automatically defers values by one tick.
+    ///
+    /// # Panics
+    /// Panics if the forward reference creates a synchronous cycle (i.e., the completed
+    /// stream transitively depends on the placeholder without a `defer_tick` or network
+    /// hop in between).
     ///
     /// # Example
     /// ```rust
@@ -1155,21 +1161,21 @@ pub trait Location<'a>: dynamic::DynLocation {
     /// # use hydro_lang::live_collections::stream::NoOrder;
     /// # use futures::StreamExt;
     /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
-    /// // Create a forward reference for the feedback stream
-    /// let (complete, feedback) = process.forward_ref::<Stream<i32, _, _, NoOrder>>();
+    /// // Create a forward reference to define a stream that will be completed later
+    /// let (complete, forward_stream) = process.forward_ref::<Stream<i32, _, _, NoOrder>>();
     ///
-    /// // Combine initial input with feedback, then increment
-    /// let input: Stream<_, _, Unbounded> = process.source_iter(q!([1])).into();
-    /// let output: Stream<_, _, _, NoOrder> = input.merge_unordered(feedback).map(q!(|x| x + 1));
+    /// // Use the forward reference as input to another computation
+    /// let output: Stream<_, _, _, NoOrder> = forward_stream.map(q!(|x| x * 2));
     ///
-    /// // Complete the forward reference with the output
-    /// complete.complete(output.clone());
+    /// // Complete the forward reference with the actual source
+    /// let source: Stream<_, _, Unbounded> = process.source_iter(q!([1, 2, 3])).into();
+    /// complete.complete(source);
     /// output
     /// # }, |mut stream| async move {
-    /// // 2, 3, 4, 5, ...
+    /// // 2, 4, 6
     /// # assert_eq!(stream.next().await.unwrap(), 2);
-    /// # assert_eq!(stream.next().await.unwrap(), 3);
     /// # assert_eq!(stream.next().await.unwrap(), 4);
+    /// # assert_eq!(stream.next().await.unwrap(), 6);
     /// # }));
     /// # }
     /// ```

--- a/hydro_lang/src/sim/runtime.rs
+++ b/hydro_lang/src/sim/runtime.rs
@@ -961,6 +961,24 @@ impl<K: Hash + Eq + Clone, V> SimInlineHook for KeyedStreamOrderHook<K, V> {
     }
 }
 
+/// Top-level (outside-tick) `assume_ordering` hooks release elements **one at a
+/// time** rather than shuffling the entire batch. This is the key mechanism for
+/// simulating causality in feedback cycles: when data flows through a network hop
+/// and cycles back (e.g. via `forward_ref`), the cycled-back result can arrive
+/// and interleave with elements that are still pending in the input queue.
+///
+/// For example, given input `[1, 2, 3]` where each element is mapped and sent
+/// through a network cycle, the simulator can explore orderings like
+/// `[1, map(1), 2, map(2), 3, ...]` -- the cycled-back `map(1)` arrives before `2`.
+///
+/// This is the only place where such causality is observable, because top-level
+/// unbounded streams are "maximally async" -- any non-atomic stream can be
+/// arbitrarily decoupled. The in-tick variants (`StreamOrderHook`,
+/// `KeyedStreamOrderHook`) shuffle the full batch instead, since within a tick
+/// all data is available simultaneously.
+///
+/// The `sim_top_level_assume_ordering_*` tests are regression tests ensuring
+/// this one-at-a-time release behavior correctly explores causal interleavings.
 pub struct TopLevelStreamOrderHook<T> {
     pub input: Rc<RefCell<VecDeque<T>>>,
     pub to_release: Option<Vec<T>>,
@@ -1044,6 +1062,9 @@ impl<T> SimHook for TopLevelStreamOrderHook<T> {
     }
 }
 
+/// Keyed variant of [`TopLevelStreamOrderHook`]. Same one-at-a-time release
+/// strategy to simulate causal interleavings -- see the comment on
+/// [`TopLevelStreamOrderHook`] for the full explanation.
 pub struct TopLevelKeyedStreamOrderHook<K: Hash + Eq + Clone, V> {
     pub input: Rc<RefCell<FxHashMap<K, VecDeque<V>>>>,
     pub to_release: Option<Vec<(K, V)>>,


### PR DESCRIPTION
### Documentation (`location/mod.rs`)

- Rewrote `forward_ref` doc comment: clarifies it's for forward references, points to `Tick::cycle()` for feedback, and documents the panic on synchronous cycles.
- Replaced the doctest with a valid DAG-style forward reference (no cycle).

### Test fixes (`stream/mod.rs`, `keyed_stream/mod.rs`)

- Fixed 7 sim tests that created synchronous cycles by routing cycled-back data through a second process via `.send(&node2, TCP.fail_stop().bincode()).send(&node, TCP.fail_stop().bincode())`.

### Simulator docs (`sim/runtime.rs`)

- Added comments on `TopLevelStreamOrderHook` and `TopLevelKeyedStreamOrderHook` explaining why `assume_ordering` outside a tick gets special treatment: it's the only place where causality (cycled-back data interleaving with pending input) can be observed, so the simulator releases elements one at a time to explore all interleavings.