### PR TITLE
refactor(dfir_lang): make inline codegen subgraph blocks async (for future instrumentation, concurrency)

### DIFF
--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1854,19 +1854,19 @@ impl DfirGraph {
                     }
                 };
 
-                // Generate a dummy subgraph ID for state lifespan hooks.
-                let sg_ident = subgraph_id.as_ident(Span::call_site());
-
-                // Each subgraph block — .await works because the whole output is async.
+                // Each subgraph block is an async block so it can be individually instrumented.
+                // Note: this ident is for the subgraph future, not a runtime SubgraphId binding
+                // (unlike the scheduled path's `sg_ident`).
+                let sg_fut_ident = subgraph_id.as_ident(Span::call_site());
                 subgraph_blocks.push(quote! {
-                    let #sg_ident: #root::scheduled::SubgraphId = #root::util::slot_vec::Key::from_raw(0);
-                    {
+                    let #sg_fut_ident = async {
                         let #context = &#df;;
                         #( #recv_port_code )*
                         #( #send_port_code )*
                         #( #subgraph_op_iter_code )*
                         #( #subgraph_op_iter_after_code )*
-                    }
+                    };
+                    #sg_fut_ident.await;
                 });
 
                 // Collect per-subgraph prologues into the main prologue lists.

--- a/dfir_lang/src/graph/mod.rs
+++ b/dfir_lang/src/graph/mod.rs
@@ -50,7 +50,7 @@ new_key_type! {
 }
 
 impl GraphSubgraphId {
-    /// Generate a deterministic `Ident` for the given loop ID.
+    /// Generate a deterministic `Ident` for the given subgraph ID.
     pub fn as_ident(self, span: Span) -> Ident {
         use slotmap::Key;
         Ident::new(&format!("sgid_{:?}", self.data()), span)


### PR DESCRIPTION
Wrap each subgraph block in `as_code_inline` with `async { ... }` and assign to a named local (`sgid_<id>`) before `.await`-ing. This makes each subgraph an independently-awaitable future, preparing for per-subgraph metrics instrumentation via `InstrumentSubgraph`.

- Changed subgraph blocks from plain `{ ... }` to `let sgid_X = async { ... }; sgid_X.await;`
- Removed the unused dummy `SubgraphId::from_raw(0)` binding from inline codegen. In the scheduled path, `sg_ident` is a real runtime SubgraphId returned by `df.add_subgraph_full()` and used for `StateLifespan::Subgraph` hooks (state reset before each subgraph run, used by fold, reduce, join, unique, etc. with `Persistence::None`). In the inline path, `InlineContext::set_state_lifespan_hook` stores the lifespan but `__end_tick()` only processes `StateLifespan::Tick` — subgraph-scoped hooks are never executed, making the dummy ID dead code. When loop support is re-added to inline codegen, it will likely be handled entirely in statically generated code without runtime SubgraphId bindings.
- Fixed doc comment on `GraphSubgraphId::as_ident` (said "loop ID", now says "subgraph ID").

Named async locals also enable concurrent subgraph execution within a stratum via `futures::join!` (see hydro-project/hydro#2730).