### PR TITLE
feat(dfir_rs): port runtime metrics to inline codegen path

### DIFF
--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -2,7 +2,7 @@
 
 extern crate proc_macro;
 
-use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt::Debug;
 use std::iter::FusedIterator;
 
@@ -1389,10 +1389,18 @@ impl DfirGraph {
         prefix: TokenStream,
         diagnostics: &mut Diagnostics,
     ) -> Result<TokenStream, Diagnostics> {
+        // Extract the slot index from a slotmap key for use as a runtime metrics key.
+        // Uses the low 32 bits of `KeyData::as_ffi()` (the idx, ignoring the version).
+        // TODO(cleanup): When scheduled Dfir is removed, DfirMetrics could use slotmap
+        // SecondaryMaps directly, eliminating this conversion.
+        fn slotmap_raw_idx(key: impl Key) -> usize {
+            (key.data().as_ffi() & 0xffff_ffff) as usize
+        }
+
         let df = Ident::new(GRAPH, Span::call_site());
         let context = Ident::new(CONTEXT, Span::call_site());
 
-        // 1. Generate local Vec buffers for each handoff node, and assign metrics indices.
+        // 1. Generate local Vec buffers for each handoff node.
         let handoff_nodes: Vec<_> = self
             .nodes
             .iter()
@@ -1401,17 +1409,6 @@ impl DfirGraph {
                 &GraphNode::Handoff { src_span, dst_span } => Some((node_id, (src_span, dst_span))),
                 GraphNode::ModuleBoundary { .. } => panic!(),
             })
-            .collect();
-
-        // Map from graph node ID to metrics handoff index.
-        // Uses the slotmap idx (low 32 bits of as_ffi) so runtime metrics IDs match the
-        // meta graph for cross-referencing.
-        // TODO(cleanup): When scheduled Dfir is removed, DfirMetrics could use slotmap
-        // SecondaryMap<GraphNodeId, _> directly instead of SecondarySlotVec<HandoffTag, _>,
-        // eliminating this index mapping.
-        let handoff_metrics_idx: HashMap<GraphNodeId, usize> = handoff_nodes
-            .iter()
-            .map(|&(node_id, _)| (node_id, (node_id.data().as_ffi() & 0xffff_ffff) as usize))
             .collect();
 
         let buffer_code: Vec<TokenStream> = handoff_nodes
@@ -1443,11 +1440,7 @@ impl DfirGraph {
         let mut subgraph_blocks = Vec::new();
         {
             for &(subgraph_id, subgraph_nodes) in all_subgraphs.iter() {
-                // Use the slotmap idx (low 32 bits of as_ffi) so runtime metrics IDs match
-                // the meta graph for cross-referencing.
-                // TODO(cleanup): When scheduled Dfir is removed, DfirMetrics could use slotmap
-                // SecondaryMap<GraphSubgraphId, _> directly, eliminating this ffi conversion.
-                let sg_metrics_idx = (subgraph_id.data().as_ffi() & 0xffff_ffff) as usize;
+                let sg_metrics_idx = slotmap_raw_idx(subgraph_id);
                 let (recv_hoffs, send_hoffs) = &subgraph_handoffs[subgraph_id];
 
                 // Generate buffer ident helpers for this subgraph's handoffs.
@@ -1483,7 +1476,7 @@ impl DfirGraph {
                     .zip(recv_buf_idents.iter())
                     .zip(recv_hoffs.iter())
                     .map(|((port_ident, buf_ident), &hoff_id)| {
-                        let hoff_idx = handoff_metrics_idx[&hoff_id];
+                        let hoff_idx = slotmap_raw_idx(hoff_id);
                         quote_spanned! {port_ident.span()=>
                             {
                                 let hoff_len = #buf_ident.len();
@@ -1895,7 +1888,7 @@ impl DfirGraph {
                     .iter()
                     .zip(send_buf_idents.iter())
                     .map(|(&hoff_id, buf_ident)| {
-                        let hoff_idx = handoff_metrics_idx[&hoff_id];
+                        let hoff_idx = slotmap_raw_idx(hoff_id);
                         quote! {
                             __dfir_metrics.handoffs[
                                 #root::util::slot_vec::Key::<#root::scheduled::HandoffTag>::from_raw(#hoff_idx)
@@ -1942,12 +1935,9 @@ impl DfirGraph {
         let diagnostics_json = Literal::string(&diagnostics_json);
 
         // Generate metrics initialization: one entry per handoff and per subgraph.
-        // Uses slotmap ffi keys so runtime metrics IDs match the meta graph for cross-referencing.
-        // TODO(cleanup): When scheduled Dfir is removed, use slotmap SecondaryMaps directly
-        // instead of converting ffi keys to SecondarySlotVec indices.
         let metrics_init_code = {
             let handoff_inits = handoff_nodes.iter().map(|&(node_id, _)| {
-                let idx = (node_id.data().as_ffi() & 0xffff_ffff) as usize;
+                let idx = slotmap_raw_idx(node_id);
                 quote! {
                     dfir_metrics.handoffs.insert(
                         #root::util::slot_vec::Key::from_raw(#idx),
@@ -1956,7 +1946,7 @@ impl DfirGraph {
                 }
             });
             let subgraph_inits = all_subgraphs.iter().map(|&(sg_id, _)| {
-                let idx = (sg_id.data().as_ffi() & 0xffff_ffff) as usize;
+                let idx = slotmap_raw_idx(sg_id);
                 quote! {
                     dfir_metrics.subgraphs.insert(
                         #root::util::slot_vec::Key::from_raw(#idx),

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1404,10 +1404,14 @@ impl DfirGraph {
             .collect();
 
         // Map from graph node ID to metrics handoff index.
+        // Uses the slotmap idx (low 32 bits of as_ffi) so runtime metrics IDs match the
+        // meta graph for cross-referencing.
+        // TODO(cleanup): When scheduled Dfir is removed, DfirMetrics could use slotmap
+        // SecondaryMap<GraphNodeId, _> directly instead of SecondarySlotVec<HandoffTag, _>,
+        // eliminating this index mapping.
         let handoff_metrics_idx: HashMap<GraphNodeId, usize> = handoff_nodes
             .iter()
-            .enumerate()
-            .map(|(idx, &(node_id, _))| (node_id, idx))
+            .map(|&(node_id, _)| (node_id, (node_id.data().as_ffi() & 0xFFFF_FFFF) as usize))
             .collect();
 
         let buffer_code: Vec<TokenStream> = handoff_nodes
@@ -1438,8 +1442,12 @@ impl DfirGraph {
         let mut op_prologue_after_code = Vec::new();
         let mut subgraph_blocks = Vec::new();
         {
-            for (sg_metrics_idx, &(subgraph_id, subgraph_nodes)) in all_subgraphs.iter().enumerate()
-            {
+            for &(subgraph_id, subgraph_nodes) in all_subgraphs.iter() {
+                // Use the slotmap idx (low 32 bits of as_ffi) so runtime metrics IDs match
+                // the meta graph for cross-referencing.
+                // TODO(cleanup): When scheduled Dfir is removed, DfirMetrics could use slotmap
+                // SecondaryMap<GraphSubgraphId, _> directly, eliminating this ffi conversion.
+                let sg_metrics_idx = (subgraph_id.data().as_ffi() & 0xFFFF_FFFF) as usize;
                 let (recv_hoffs, send_hoffs) = &subgraph_handoffs[subgraph_id];
 
                 // Generate buffer ident helpers for this subgraph's handoffs.
@@ -1932,21 +1940,24 @@ impl DfirGraph {
         let diagnostics_json = Literal::string(&diagnostics_json);
 
         // Generate metrics initialization: one entry per handoff and per subgraph.
-        let num_handoffs = handoff_nodes.len();
-        let num_subgraphs = all_subgraphs.len();
+        // Uses slotmap ffi keys so runtime metrics IDs match the meta graph for cross-referencing.
+        // TODO(cleanup): When scheduled Dfir is removed, use slotmap SecondaryMaps directly
+        // instead of converting ffi keys to SecondarySlotVec indices.
         let metrics_init_code = {
-            let handoff_inits = (0..num_handoffs).map(|i| {
+            let handoff_inits = handoff_nodes.iter().map(|&(node_id, _)| {
+                let idx = (node_id.data().as_ffi() & 0xFFFF_FFFF) as usize;
                 quote! {
                     __m.handoffs.insert(
-                        #root::util::slot_vec::Key::from_raw(#i),
+                        #root::util::slot_vec::Key::from_raw(#idx),
                         ::std::default::Default::default(),
                     );
                 }
             });
-            let subgraph_inits = (0..num_subgraphs).map(|i| {
+            let subgraph_inits = all_subgraphs.iter().map(|&(sg_id, _)| {
+                let idx = (sg_id.data().as_ffi() & 0xFFFF_FFFF) as usize;
                 quote! {
                     __m.subgraphs.insert(
-                        #root::util::slot_vec::Key::from_raw(#i),
+                        #root::util::slot_vec::Key::from_raw(#idx),
                         ::std::default::Default::default(),
                     );
                 }

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1411,7 +1411,7 @@ impl DfirGraph {
         // eliminating this index mapping.
         let handoff_metrics_idx: HashMap<GraphNodeId, usize> = handoff_nodes
             .iter()
-            .map(|&(node_id, _)| (node_id, (node_id.data().as_ffi() & 0xFFFF_FFFF) as usize))
+            .map(|&(node_id, _)| (node_id, (node_id.data().as_ffi() & 0xffff_ffff) as usize))
             .collect();
 
         let buffer_code: Vec<TokenStream> = handoff_nodes
@@ -1447,7 +1447,7 @@ impl DfirGraph {
                 // the meta graph for cross-referencing.
                 // TODO(cleanup): When scheduled Dfir is removed, DfirMetrics could use slotmap
                 // SecondaryMap<GraphSubgraphId, _> directly, eliminating this ffi conversion.
-                let sg_metrics_idx = (subgraph_id.data().as_ffi() & 0xFFFF_FFFF) as usize;
+                let sg_metrics_idx = (subgraph_id.data().as_ffi() & 0xffff_ffff) as usize;
                 let (recv_hoffs, send_hoffs) = &subgraph_handoffs[subgraph_id];
 
                 // Generate buffer ident helpers for this subgraph's handoffs.
@@ -1486,15 +1486,15 @@ impl DfirGraph {
                         let hoff_idx = handoff_metrics_idx[&hoff_id];
                         quote_spanned! {port_ident.span()=>
                             {
-                                let __hoff_len = #buf_ident.len();
-                                if __hoff_len > 0 {
+                                let hoff_len = #buf_ident.len();
+                                if hoff_len > 0 {
                                     __dfir_work_done = true;
                                 }
-                                let __hoff_metrics = &__dfir_metrics.handoffs[
+                                let hoff_metrics = &__dfir_metrics.handoffs[
                                     #root::util::slot_vec::Key::<#root::scheduled::HandoffTag>::from_raw(#hoff_idx)
                                 ];
-                                __hoff_metrics.total_items_count.update(|__x| __x + __hoff_len);
-                                __hoff_metrics.curr_items_count.set(__hoff_len);
+                                hoff_metrics.total_items_count.update(|x| x + hoff_len);
+                                hoff_metrics.curr_items_count.set(hoff_len);
                             }
                             let #port_ident = #root::dfir_pipes::pull::iter(#buf_ident.drain(..));
                         }
@@ -1906,19 +1906,21 @@ impl DfirGraph {
 
                 subgraph_blocks.push(quote! {
                     let #sg_fut_ident = async {
-                        let #context = &#df;;
+                        let #context = &#df;
                         #( #recv_port_code )*
                         #( #send_port_code )*
                         #( #subgraph_op_iter_code )*
                         #( #subgraph_op_iter_after_code )*
                     };
-                    let __sg_metrics = &__dfir_metrics.subgraphs[
-                        #root::util::slot_vec::Key::<#root::scheduled::SubgraphTag>::from_raw(#sg_metrics_idx)
-                    ];
-                    #root::scheduled::metrics::InstrumentSubgraph::new(
-                        #sg_fut_ident, __sg_metrics
-                    ).await;
-                    __sg_metrics.total_run_count.update(|__x| __x + 1);
+                    {
+                        let sg_metrics = &__dfir_metrics.subgraphs[
+                            #root::util::slot_vec::Key::<#root::scheduled::SubgraphTag>::from_raw(#sg_metrics_idx)
+                        ];
+                        #root::scheduled::metrics::InstrumentSubgraph::new(
+                            #sg_fut_ident, sg_metrics
+                        ).await;
+                        sg_metrics.total_run_count.update(|x| x + 1);
+                    }
                     #( #send_metrics_code )*
                 });
 
@@ -1945,18 +1947,18 @@ impl DfirGraph {
         // instead of converting ffi keys to SecondarySlotVec indices.
         let metrics_init_code = {
             let handoff_inits = handoff_nodes.iter().map(|&(node_id, _)| {
-                let idx = (node_id.data().as_ffi() & 0xFFFF_FFFF) as usize;
+                let idx = (node_id.data().as_ffi() & 0xffff_ffff) as usize;
                 quote! {
-                    __m.handoffs.insert(
+                    dfir_metrics.handoffs.insert(
                         #root::util::slot_vec::Key::from_raw(#idx),
                         ::std::default::Default::default(),
                     );
                 }
             });
             let subgraph_inits = all_subgraphs.iter().map(|&(sg_id, _)| {
-                let idx = (sg_id.data().as_ffi() & 0xFFFF_FFFF) as usize;
+                let idx = (sg_id.data().as_ffi() & 0xffff_ffff) as usize;
                 quote! {
-                    __m.subgraphs.insert(
+                    dfir_metrics.subgraphs.insert(
                         #root::util::slot_vec::Key::from_raw(#idx),
                         ::std::default::Default::default(),
                     );
@@ -1978,9 +1980,9 @@ impl DfirGraph {
                 );
 
                 let __dfir_metrics = {
-                    let mut __m = #root::scheduled::metrics::DfirMetrics::default();
+                    let mut dfir_metrics = #root::scheduled::metrics::DfirMetrics::default();
                     #( #metrics_init_code )*
-                    ::std::rc::Rc::new(__m)
+                    ::std::rc::Rc::new(dfir_metrics)
                 };
 
                 #[allow(unused_mut)]

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -2,7 +2,7 @@
 
 extern crate proc_macro;
 
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 use std::fmt::Debug;
 use std::iter::FusedIterator;
 
@@ -1392,8 +1392,8 @@ impl DfirGraph {
         let df = Ident::new(GRAPH, Span::call_site());
         let context = Ident::new(CONTEXT, Span::call_site());
 
-        // 1. Generate local Vec buffers for each handoff node.
-        let buffer_code: Vec<TokenStream> = self
+        // 1. Generate local Vec buffers for each handoff node, and assign metrics indices.
+        let handoff_nodes: Vec<_> = self
             .nodes
             .iter()
             .filter_map(|(node_id, node)| match node {
@@ -1401,7 +1401,18 @@ impl DfirGraph {
                 &GraphNode::Handoff { src_span, dst_span } => Some((node_id, (src_span, dst_span))),
                 GraphNode::ModuleBoundary { .. } => panic!(),
             })
-            .map(|(node_id, (src_span, dst_span))| {
+            .collect();
+
+        // Map from graph node ID to metrics handoff index.
+        let handoff_metrics_idx: HashMap<GraphNodeId, usize> = handoff_nodes
+            .iter()
+            .enumerate()
+            .map(|(idx, &(node_id, _))| (node_id, idx))
+            .collect();
+
+        let buffer_code: Vec<TokenStream> = handoff_nodes
+            .iter()
+            .map(|&(node_id, (src_span, dst_span))| {
                 let span = src_span.join(dst_span).unwrap_or(src_span);
                 let buf_ident = Ident::new(&format!("hoff_{:?}_buf", node_id.data()), span);
                 quote_spanned! {span=>
@@ -1427,7 +1438,8 @@ impl DfirGraph {
         let mut op_prologue_after_code = Vec::new();
         let mut subgraph_blocks = Vec::new();
         {
-            for &(subgraph_id, subgraph_nodes) in all_subgraphs.iter() {
+            for (sg_metrics_idx, &(subgraph_id, subgraph_nodes)) in all_subgraphs.iter().enumerate()
+            {
                 let (recv_hoffs, send_hoffs) = &subgraph_handoffs[subgraph_id];
 
                 // Generate buffer ident helpers for this subgraph's handoffs.
@@ -1457,13 +1469,24 @@ impl DfirGraph {
                     .collect();
 
                 // Recv port code: drain from buffer into iterator, tracking if non-empty.
+                // Also update handoff metrics (measured at recv, not send — see graph.rs).
                 let recv_port_code: Vec<TokenStream> = recv_port_idents
                     .iter()
                     .zip(recv_buf_idents.iter())
-                    .map(|(port_ident, buf_ident)| {
+                    .zip(recv_hoffs.iter())
+                    .map(|((port_ident, buf_ident), &hoff_id)| {
+                        let hoff_idx = handoff_metrics_idx[&hoff_id];
                         quote_spanned! {port_ident.span()=>
-                            if !#buf_ident.is_empty() {
-                                __dfir_work_done = true;
+                            {
+                                let __hoff_len = #buf_ident.len();
+                                if __hoff_len > 0 {
+                                    __dfir_work_done = true;
+                                }
+                                let __hoff_metrics = &__dfir_metrics.handoffs[
+                                    #root::util::slot_vec::Key::<#root::scheduled::HandoffTag>::from_raw(#hoff_idx)
+                                ];
+                                __hoff_metrics.total_items_count.update(|__x| __x + __hoff_len);
+                                __hoff_metrics.curr_items_count.set(__hoff_len);
                             }
                             let #port_ident = #root::dfir_pipes::pull::iter(#buf_ident.drain(..));
                         }
@@ -1858,6 +1881,21 @@ impl DfirGraph {
                 // Note: this ident is for the subgraph future, not a runtime SubgraphId binding
                 // (unlike the scheduled path's `sg_ident`).
                 let sg_fut_ident = subgraph_id.as_ident(Span::call_site());
+
+                // Generate send-side curr_items_count updates (after subgraph runs).
+                let send_metrics_code: Vec<TokenStream> = send_hoffs
+                    .iter()
+                    .zip(send_buf_idents.iter())
+                    .map(|(&hoff_id, buf_ident)| {
+                        let hoff_idx = handoff_metrics_idx[&hoff_id];
+                        quote! {
+                            __dfir_metrics.handoffs[
+                                #root::util::slot_vec::Key::<#root::scheduled::HandoffTag>::from_raw(#hoff_idx)
+                            ].curr_items_count.set(#buf_ident.len());
+                        }
+                    })
+                    .collect();
+
                 subgraph_blocks.push(quote! {
                     let #sg_fut_ident = async {
                         let #context = &#df;;
@@ -1866,7 +1904,14 @@ impl DfirGraph {
                         #( #subgraph_op_iter_code )*
                         #( #subgraph_op_iter_after_code )*
                     };
-                    #sg_fut_ident.await;
+                    let __sg_metrics = &__dfir_metrics.subgraphs[
+                        #root::util::slot_vec::Key::<#root::scheduled::SubgraphTag>::from_raw(#sg_metrics_idx)
+                    ];
+                    #root::scheduled::metrics::InstrumentSubgraph::new(
+                        #sg_fut_ident, __sg_metrics
+                    ).await;
+                    __sg_metrics.total_run_count.update(|__x| __x + 1);
+                    #( #send_metrics_code )*
                 });
 
                 // Collect per-subgraph prologues into the main prologue lists.
@@ -1886,6 +1931,29 @@ impl DfirGraph {
         let diagnostics_json = serde_json::to_string(&*serde_diagnostics).unwrap();
         let diagnostics_json = Literal::string(&diagnostics_json);
 
+        // Generate metrics initialization: one entry per handoff and per subgraph.
+        let num_handoffs = handoff_nodes.len();
+        let num_subgraphs = all_subgraphs.len();
+        let metrics_init_code = {
+            let handoff_inits = (0..num_handoffs).map(|i| {
+                quote! {
+                    __m.handoffs.insert(
+                        #root::util::slot_vec::Key::from_raw(#i),
+                        ::std::default::Default::default(),
+                    );
+                }
+            });
+            let subgraph_inits = (0..num_subgraphs).map(|i| {
+                quote! {
+                    __m.subgraphs.insert(
+                        #root::util::slot_vec::Key::from_raw(#i),
+                        ::std::default::Default::default(),
+                    );
+                }
+            });
+            handoff_inits.chain(subgraph_inits).collect::<Vec<_>>()
+        };
+
         // Prologues and buffer declarations persist across ticks (outside the closure).
         // Subgraph blocks run each tick (inside the closure).
         Ok(quote! {
@@ -1898,9 +1966,15 @@ impl DfirGraph {
                     #root::scheduled::context::InlineWakeState::default()
                 );
 
+                let __dfir_metrics = {
+                    let mut __m = #root::scheduled::metrics::DfirMetrics::default();
+                    #( #metrics_init_code )*
+                    ::std::rc::Rc::new(__m)
+                };
+
                 #[allow(unused_mut)]
                 let mut #df = #root::scheduled::context::InlineContext::new(
-                    ::std::clone::Clone::clone(&__dfir_wake_state)
+                    ::std::clone::Clone::clone(&__dfir_wake_state),
                 );
 
                 #( #buffer_code )*
@@ -1912,6 +1986,7 @@ impl DfirGraph {
                 // start false (from take()) and are set true by recv port code
                 // if any handoff buffer has data.
                 let mut __dfir_work_done = true;
+                let __dfir_metrics_outer = ::std::clone::Clone::clone(&__dfir_metrics);
                 #[allow(unused_qualifications, unused_mut, unused_variables, clippy::await_holding_refcell_ref)]
                 let __dfir_inline_tick = async move || {
                     #( #subgraph_blocks )*
@@ -1922,6 +1997,7 @@ impl DfirGraph {
                 #root::scheduled::context::InlineDfir::new(
                     __dfir_inline_tick,
                     __dfir_wake_state,
+                    __dfir_metrics_outer,
                     Some(#meta_graph_json),
                     Some(#diagnostics_json),
                 )

--- a/dfir_macro/src/lib.rs
+++ b/dfir_macro/src/lib.rs
@@ -128,6 +128,7 @@ fn dfir_syntax_inline_internal(
                 #root::scheduled::context::InlineDfir::new(
                     async move || { false },
                     ::std::sync::Arc::new(#root::scheduled::context::InlineWakeState::default()),
+                    ::std::rc::Rc::new(#root::scheduled::metrics::DfirMetrics::default()),
                     None,
                     None,
                 )

--- a/dfir_rs/src/scheduled/context.rs
+++ b/dfir_rs/src/scheduled/context.rs
@@ -633,6 +633,7 @@ pub struct InlineDfir<Tick> {
     /// See [`Self::diagnostics()`].
     diagnostics: Option<Vec<Diagnostic<SerdeSpan>>>,
 
+    /// Live-updating DFIR runtime metrics via interior mutability.
     metrics: Rc<DfirMetrics>,
 }
 
@@ -728,13 +729,19 @@ impl<Tick: TickClosure> InlineDfir<Tick> {
         self.diagnostics.as_deref()
     }
 
-    /// Returns a reference-counted handle to the continually-updated runtime metrics.
+    /// Returns a reference-counted handle to the continually-updated runtime metrics for this DFIR instance.
     pub fn metrics(&self) -> Rc<DfirMetrics> {
         Rc::clone(&self.metrics)
     }
 
     /// Returns a [`DfirMetricsIntervals`] handle where each call to
     /// [`DfirMetricsIntervals::take_interval`] ends the current interval and returns its metrics.
+    ///
+    /// The first call to `take_interval` returns metrics since this DFIR instance was created. Each subsequent call to
+    /// `take_interval` returns metrics since the previous call.
+    ///
+    /// Cloning the handle "forks" it from the original, as afterwards each interval may return different metrics
+    /// depending on when exactly `take_interval` is called.
     pub fn metrics_intervals(&self) -> DfirMetricsIntervals {
         DfirMetricsIntervals {
             curr: self.metrics(),

--- a/dfir_rs/src/scheduled/context.rs
+++ b/dfir_rs/src/scheduled/context.rs
@@ -22,7 +22,7 @@ use tokio::task::JoinHandle;
 use web_time::SystemTime;
 
 use super::graph::StateLifespan;
-use super::metrics::{DfirMetrics, DfirMetricsIntervals, HasMetrics};
+use super::metrics::{DfirMetrics, DfirMetricsIntervals};
 use super::state::StateHandle;
 use super::{LoopId, LoopTag, StateId, StateTag, SubgraphId, SubgraphTag};
 use crate::scheduled::ticks::TickInstant;
@@ -740,16 +740,6 @@ impl<Tick: TickClosure> InlineDfir<Tick> {
             curr: self.metrics(),
             prev: None,
         }
-    }
-}
-
-impl<Tick: TickClosure> HasMetrics for InlineDfir<Tick> {
-    fn metrics(&self) -> Rc<DfirMetrics> {
-        self.metrics()
-    }
-
-    fn metrics_intervals(&self) -> DfirMetricsIntervals {
-        self.metrics_intervals()
     }
 }
 

--- a/dfir_rs/src/scheduled/context.rs
+++ b/dfir_rs/src/scheduled/context.rs
@@ -9,6 +9,7 @@ use std::future::Future;
 use std::marker::PhantomData;
 use std::ops::DerefMut;
 use std::pin::Pin;
+use std::rc::Rc;
 use std::sync::atomic::Ordering;
 use std::task::Wake;
 
@@ -21,6 +22,7 @@ use tokio::task::JoinHandle;
 use web_time::SystemTime;
 
 use super::graph::StateLifespan;
+use super::metrics::{DfirMetrics, DfirMetricsIntervals, HasMetrics};
 use super::state::StateHandle;
 use super::{LoopId, LoopTag, StateId, StateTag, SubgraphId, SubgraphTag};
 use crate::scheduled::ticks::TickInstant;
@@ -630,6 +632,8 @@ pub struct InlineDfir<Tick> {
     #[cfg(feature = "meta")]
     /// See [`Self::diagnostics()`].
     diagnostics: Option<Vec<Diagnostic<SerdeSpan>>>,
+
+    metrics: Rc<DfirMetrics>,
 }
 
 /// Trait for tick closures — abstracts over both concrete async closures
@@ -674,12 +678,13 @@ impl TickClosure for TickClosureErased {
 pub type InlineDfirErased = InlineDfir<TickClosureErased>;
 
 impl<Tick: TickClosure> InlineDfir<Tick> {
-    /// Create a new `InlineDfir` from a tick closure, shared wake state, and
-    /// meta graph / diagnostics JSON strings.
+    /// Create a new `InlineDfir` from a tick closure, shared wake state,
+    /// meta graph / diagnostics JSON strings, and metrics.
     #[doc(hidden)]
     pub fn new(
         tick_closure: Tick,
         wake_state: std::sync::Arc<InlineWakeState>,
+        metrics: Rc<DfirMetrics>,
         meta_graph_json: Option<&str>,
         diagnostics_json: Option<&str>,
     ) -> Self {
@@ -705,6 +710,7 @@ impl<Tick: TickClosure> InlineDfir<Tick> {
             diagnostics: diagnostics_json.map(|json| {
                 serde_json::from_str(json).expect("Failed to deserialize diagnostics.")
             }),
+            metrics,
         }
     }
 
@@ -722,11 +728,36 @@ impl<Tick: TickClosure> InlineDfir<Tick> {
         self.diagnostics.as_deref()
     }
 
+    /// Returns a reference-counted handle to the continually-updated runtime metrics.
+    pub fn metrics(&self) -> Rc<DfirMetrics> {
+        Rc::clone(&self.metrics)
+    }
+
+    /// Returns a [`DfirMetricsIntervals`] handle where each call to
+    /// [`DfirMetricsIntervals::take_interval`] ends the current interval and returns its metrics.
+    pub fn metrics_intervals(&self) -> DfirMetricsIntervals {
+        DfirMetricsIntervals {
+            curr: self.metrics(),
+            prev: None,
+        }
+    }
+}
+
+impl<Tick: TickClosure> HasMetrics for InlineDfir<Tick> {
+    fn metrics(&self) -> Rc<DfirMetrics> {
+        self.metrics()
+    }
+
+    fn metrics_intervals(&self) -> DfirMetricsIntervals {
+        self.metrics_intervals()
+    }
+}
+
+impl<Tick: TickClosure> InlineDfir<Tick> {
     /// Run a single tick. Returns `true` if any subgraph received input data.
     ///
     /// Checks both handoff buffers (via `work_done` flag set in generated recv port code)
-    /// and external events (via `can_start_tick` set by wakers/schedule_subgraph),
-    /// Run a single tick. Returns `true` if any subgraph received input data.
+    /// and external events (via `can_start_tick` set by wakers/schedule_subgraph).
     pub async fn run_tick(&mut self) -> bool {
         let had_external = self
             .wake_state
@@ -806,6 +837,7 @@ impl<Tick: AsyncFnMut() -> bool + 'static> InlineDfir<Tick> {
             meta_graph: self.meta_graph,
             #[cfg(feature = "meta")]
             diagnostics: self.diagnostics,
+            metrics: self.metrics,
         }
     }
 }

--- a/dfir_rs/src/scheduled/graph.rs
+++ b/dfir_rs/src/scheduled/graph.rs
@@ -20,7 +20,7 @@ use web_time::SystemTime;
 use super::context::Context;
 use super::handoff::handoff_list::PortList;
 use super::handoff::{Handoff, HandoffMeta, TeeingHandoff};
-use super::metrics::{DfirMetrics, DfirMetricsIntervals, InstrumentSubgraph};
+use super::metrics::{DfirMetrics, DfirMetricsIntervals, HasMetrics, InstrumentSubgraph};
 use super::port::{RECV, RecvCtx, RecvPort, SEND, SendCtx, SendPort};
 use super::reactor::Reactor;
 use super::state::StateHandle;
@@ -1082,6 +1082,16 @@ impl<'a> Dfir<'a> {
             curr: self.metrics(),
             prev: None,
         }
+    }
+}
+
+impl HasMetrics for Dfir<'_> {
+    fn metrics(&self) -> Rc<DfirMetrics> {
+        self.metrics()
+    }
+
+    fn metrics_intervals(&self) -> DfirMetricsIntervals {
+        self.metrics_intervals()
     }
 }
 

--- a/dfir_rs/src/scheduled/graph.rs
+++ b/dfir_rs/src/scheduled/graph.rs
@@ -20,7 +20,7 @@ use web_time::SystemTime;
 use super::context::Context;
 use super::handoff::handoff_list::PortList;
 use super::handoff::{Handoff, HandoffMeta, TeeingHandoff};
-use super::metrics::{DfirMetrics, DfirMetricsIntervals, HasMetrics, InstrumentSubgraph};
+use super::metrics::{DfirMetrics, DfirMetricsIntervals, InstrumentSubgraph};
 use super::port::{RECV, RecvCtx, RecvPort, SEND, SendCtx, SendPort};
 use super::reactor::Reactor;
 use super::state::StateHandle;
@@ -1082,16 +1082,6 @@ impl<'a> Dfir<'a> {
             curr: self.metrics(),
             prev: None,
         }
-    }
-}
-
-impl HasMetrics for Dfir<'_> {
-    fn metrics(&self) -> Rc<DfirMetrics> {
-        self.metrics()
-    }
-
-    fn metrics_intervals(&self) -> DfirMetricsIntervals {
-        self.metrics_intervals()
     }
 }
 

--- a/dfir_rs/src/scheduled/metrics.rs
+++ b/dfir_rs/src/scheduled/metrics.rs
@@ -80,6 +80,18 @@ impl DfirMetricsIntervals {
     }
 }
 
+/// Trait for types that expose DFIR runtime metrics.
+///
+/// Implemented by both [`Dfir`] (scheduled codegen) and
+/// [`super::context::InlineDfir`] (inline codegen).
+pub trait HasMetrics {
+    /// Returns a reference-counted handle to the continually-updated runtime metrics.
+    fn metrics(&self) -> Rc<DfirMetrics>;
+
+    /// Returns a [`DfirMetricsIntervals`] handle for interval-based metric snapshots.
+    fn metrics_intervals(&self) -> DfirMetricsIntervals;
+}
+
 /// Declarative macro to generate metrics structs with Cell-based fields and getter methods.
 macro_rules! define_metrics {
     (
@@ -98,6 +110,7 @@ macro_rules! define_metrics {
         #[non_exhaustive] // May add more metrics later.
         pub struct $struct_name {
             $(
+                #[doc(hidden)] // Public for codegen access; use the getter method instead.
                 $(#[$field_attr])*
                 $field_vis $field_name: Cell<$field_type>,
             )*
@@ -133,11 +146,11 @@ define_metrics! {
     pub struct HandoffMetrics {
         /// Number of items currently in the handoff.
         #[diff(curr)]
-        pub(super) curr_items_count: Cell<usize>,
+        pub curr_items_count: Cell<usize>,
 
         /// Total number of items read out of the handoff.
         #[diff(total)]
-        pub(super) total_items_count: Cell<usize>,
+        pub total_items_count: Cell<usize>,
     }
 }
 
@@ -146,29 +159,30 @@ define_metrics! {
     pub struct SubgraphMetrics {
         /// Number of times the subgraph has run.
         #[diff(total)]
-        pub(super) total_run_count: Cell<usize>,
+        pub total_run_count: Cell<usize>,
 
         /// Time elapsed during polling (when the subgraph is actively doing work).
         #[diff(total)]
-        pub(super) total_poll_duration: Cell<Duration>,
+        pub total_poll_duration: Cell<Duration>,
 
         /// Number of times the subgraph has been polled.
         #[diff(total)]
-        pub(super) total_poll_count: Cell<usize>,
+        pub total_poll_count: Cell<usize>,
 
         /// Time elapsed during idle (when the subgraph has yielded and is waiting for async events).
         #[diff(total)]
-        pub(super) total_idle_duration: Cell<Duration>,
+        pub total_idle_duration: Cell<Duration>,
 
         /// Number of times the subgraph has been idle.
         #[diff(total)]
-        pub(super) total_idle_count: Cell<usize>,
+        pub total_idle_count: Cell<usize>,
     }
 }
 
 pin_project! {
     /// Helper struct which instruments a future to track polling times.
-    pub(crate) struct InstrumentSubgraph<'a, Fut> {
+    #[doc(hidden)]
+    pub struct InstrumentSubgraph<'a, Fut> {
         #[pin]
         future: Fut,
         idle_start: Option<Instant>,
@@ -177,7 +191,8 @@ pin_project! {
 }
 
 impl<'a, Fut> InstrumentSubgraph<'a, Fut> {
-    pub(crate) fn new(future: Fut, metrics: &'a SubgraphMetrics) -> Self {
+    /// Wrap a future to track per-subgraph poll and idle durations.
+    pub fn new(future: Fut, metrics: &'a SubgraphMetrics) -> Self {
         Self {
             future,
             idle_start: None,

--- a/dfir_rs/src/scheduled/metrics.rs
+++ b/dfir_rs/src/scheduled/metrics.rs
@@ -101,7 +101,7 @@ macro_rules! define_metrics {
                 $( #[doc = $doc:literal] )*
                 #[diff($diff:ident)]
                 $( #[$field_attr:meta] )*
-                $field_vis:vis $field_name:ident: Cell<$field_type:ty>,
+                $field_name:ident: Cell<$field_type:ty>,
             )*
         }
     ) => {
@@ -112,7 +112,7 @@ macro_rules! define_metrics {
             $(
                 #[doc(hidden)] // Public for codegen access; use the getter method instead.
                 $(#[$field_attr])*
-                $field_vis $field_name: Cell<$field_type>,
+                pub $field_name: Cell<$field_type>,
             )*
         }
 
@@ -146,11 +146,11 @@ define_metrics! {
     pub struct HandoffMetrics {
         /// Number of items currently in the handoff.
         #[diff(curr)]
-        pub curr_items_count: Cell<usize>,
+        curr_items_count: Cell<usize>,
 
         /// Total number of items read out of the handoff.
         #[diff(total)]
-        pub total_items_count: Cell<usize>,
+        total_items_count: Cell<usize>,
     }
 }
 
@@ -159,23 +159,23 @@ define_metrics! {
     pub struct SubgraphMetrics {
         /// Number of times the subgraph has run.
         #[diff(total)]
-        pub total_run_count: Cell<usize>,
+        total_run_count: Cell<usize>,
 
         /// Time elapsed during polling (when the subgraph is actively doing work).
         #[diff(total)]
-        pub total_poll_duration: Cell<Duration>,
+        total_poll_duration: Cell<Duration>,
 
         /// Number of times the subgraph has been polled.
         #[diff(total)]
-        pub total_poll_count: Cell<usize>,
+        total_poll_count: Cell<usize>,
 
         /// Time elapsed during idle (when the subgraph has yielded and is waiting for async events).
         #[diff(total)]
-        pub total_idle_duration: Cell<Duration>,
+        total_idle_duration: Cell<Duration>,
 
         /// Number of times the subgraph has been idle.
         #[diff(total)]
-        pub total_idle_count: Cell<usize>,
+        total_idle_count: Cell<usize>,
     }
 }
 

--- a/dfir_rs/src/scheduled/metrics.rs
+++ b/dfir_rs/src/scheduled/metrics.rs
@@ -80,18 +80,6 @@ impl DfirMetricsIntervals {
     }
 }
 
-/// Trait for types that expose DFIR runtime metrics.
-///
-/// Implemented by both [`Dfir`] (scheduled codegen) and
-/// [`super::context::InlineDfir`] (inline codegen).
-pub trait HasMetrics {
-    /// Returns a reference-counted handle to the continually-updated runtime metrics.
-    fn metrics(&self) -> Rc<DfirMetrics>;
-
-    /// Returns a [`DfirMetricsIntervals`] handle for interval-based metric snapshots.
-    fn metrics_intervals(&self) -> DfirMetricsIntervals;
-}
-
 /// Declarative macro to generate metrics structs with Cell-based fields and getter methods.
 macro_rules! define_metrics {
     (

--- a/dfir_rs/tests/metrics_inline.rs
+++ b/dfir_rs/tests/metrics_inline.rs
@@ -1,0 +1,175 @@
+//! Integration tests for runtime metrics on the inline codegen path (`dfir_syntax_inline!`).
+//!
+//! TODO(cleanup): These are near-duplicates of `metrics.rs` (which tests the scheduled `Dfir` path).
+//! Once scheduled DFIR is removed, consolidate into a single test file.
+
+use dfir_rs::dfir_syntax_inline;
+use dfir_rs::util::collect_ready_async;
+use web_time::Duration;
+
+/// Tests that everything is initially zero.
+#[dfir_rs::test]
+async fn test_initial() {
+    let mut output = Vec::<i32>::new();
+    let out = &mut output;
+
+    let flow = dfir_syntax_inline! {
+        source_iter(0..5_i32)
+            -> map(|x: i32| x * 2)
+            -> for_each(|x: i32| out.push(x));
+    };
+
+    let metrics = flow.metrics();
+
+    // Should have one subgraph
+    assert_eq!(1, metrics.subgraphs.len());
+
+    // Initial metrics should be zero
+    for sg_id in metrics.subgraphs.keys() {
+        let sg_metrics = &metrics.subgraphs[sg_id];
+        assert_eq!(0, sg_metrics.total_run_count());
+        assert_eq!(0, sg_metrics.total_poll_count());
+        assert_eq!(0, sg_metrics.total_idle_count());
+        assert_eq!(Duration::ZERO, sg_metrics.total_poll_duration());
+        assert_eq!(Duration::ZERO, sg_metrics.total_idle_duration());
+    }
+
+    for handoff_id in metrics.handoffs.keys() {
+        let handoff_metrics = &metrics.handoffs[handoff_id];
+        assert_eq!(0, handoff_metrics.total_items_count());
+    }
+}
+
+#[dfir_rs::test]
+async fn test_subgraph_metrics() {
+    let mut output = Vec::<i32>::new();
+    let out = &mut output;
+    let mut flow = dfir_syntax_inline! {
+        source_iter(0..3_i32) -> for_each(|x: i32| out.push(x));
+    };
+
+    flow.run_tick().await;
+
+    let metrics = flow.metrics();
+
+    assert_eq!(1, metrics.subgraphs.len());
+    let sg_id = metrics.subgraphs.keys().next().unwrap();
+    let sg_metrics = &metrics.subgraphs[sg_id];
+
+    assert_eq!(1, sg_metrics.total_run_count());
+    assert!(0 < sg_metrics.total_poll_count());
+}
+
+#[dfir_rs::test]
+async fn test_handoff_metrics() {
+    let mut output = Vec::<i32>::new();
+    let out = &mut output;
+
+    let mut flow = dfir_syntax_inline! {
+        source_iter(0..5_i32)
+            -> fold(|| 0_i32, |acc: &mut i32, x: i32| *acc += x)
+            -> for_each(|x: i32| out.push(x));
+    };
+
+    flow.run_tick().await;
+
+    let metrics = flow.metrics();
+
+    assert_eq!(1, metrics.handoffs.len());
+    let handoff_id = metrics.handoffs.keys().next().unwrap();
+    let handoff_metrics = &metrics.handoffs[handoff_id];
+    assert_eq!(5, handoff_metrics.total_items_count());
+
+    drop(flow);
+    assert_eq!(output, vec![10]);
+}
+
+#[dfir_rs::test]
+async fn test_multiple_ticks() {
+    let (input_send, input_recv) = dfir_rs::util::unbounded_channel::<i32>();
+    let (output_send, mut output_recv) = dfir_rs::util::unbounded_channel::<i32>();
+
+    let mut flow = dfir_syntax_inline! {
+        source_stream(input_recv)
+            -> map(|x: i32| x + 1)
+            -> for_each(|x: i32| output_send.send(x).unwrap());
+    };
+
+    input_send.send(1).unwrap();
+    input_send.send(2).unwrap();
+    flow.run_tick().await;
+
+    let metrics = flow.metrics();
+    assert_eq!(1, metrics.subgraphs.len());
+    let sg_id = metrics.subgraphs.keys().next().unwrap();
+    assert_eq!(1, metrics.subgraphs[sg_id].total_run_count());
+    // TODO(https://github.com/hydro-project/hydro/issues/2741): assert current_tick once
+    // InlineDfir exposes it.
+
+    input_send.send(3).unwrap();
+    input_send.send(4).unwrap();
+    flow.run_tick().await;
+
+    let metrics = flow.metrics();
+    assert_eq!(2, metrics.subgraphs[sg_id].total_run_count());
+    // TODO(https://github.com/hydro-project/hydro/issues/2741): assert current_tick == 2.
+
+    let output: Vec<_> = collect_ready_async(&mut output_recv).await;
+    assert_eq!(output, vec![2, 3, 4, 5]);
+}
+
+#[dfir_rs::test]
+async fn test_metrics_intervals() {
+    let (input_send, input_recv) = dfir_rs::util::unbounded_channel::<i32>();
+    let (output_send, mut output_recv) = dfir_rs::util::unbounded_channel::<i32>();
+
+    let mut flow = dfir_syntax_inline! {
+        source_stream(input_recv)
+            -> map(|x: i32| x + 1)
+            -> for_each(|x: i32| output_send.send(x).unwrap());
+    };
+    let mut metrics_intervals = flow.metrics_intervals();
+
+    // Zero at start
+    let metrics = metrics_intervals.take_interval();
+    assert_eq!(1, metrics.subgraphs.len());
+    let sg_id = metrics.subgraphs.keys().next().unwrap();
+    let sg_metrics = &metrics.subgraphs[sg_id];
+    assert_eq!(0, sg_metrics.total_run_count());
+    assert_eq!(0, sg_metrics.total_poll_count());
+    assert_eq!(Duration::ZERO, sg_metrics.total_poll_duration());
+
+    // Send some data and run first tick
+    input_send.send(1).unwrap();
+    input_send.send(2).unwrap();
+    flow.run_tick().await;
+
+    // After first tick, metrics should be updated
+    let metrics = metrics_intervals.take_interval();
+    let sg_metrics = &metrics.subgraphs[sg_id];
+    assert_eq!(1, sg_metrics.total_run_count());
+    assert_eq!(1, sg_metrics.total_poll_count());
+    let poll_duration_1 = sg_metrics.total_poll_duration();
+
+    // Send some more data
+    for x in 0..10_000 {
+        input_send.send(x).unwrap();
+    }
+    flow.run_tick().await;
+
+    // After second tick, metrics updated
+    let metrics = metrics_intervals.take_interval();
+    let sg_metrics = &metrics.subgraphs[sg_id];
+    assert_eq!(1, sg_metrics.total_run_count());
+    assert_eq!(1, sg_metrics.total_poll_count());
+    let poll_duration_2 = sg_metrics.total_poll_duration();
+
+    // Total duration matches sum of intervals
+    assert_eq!(
+        poll_duration_1 + poll_duration_2,
+        flow.metrics().subgraphs[sg_id].total_poll_duration()
+    );
+
+    let output: Vec<_> = collect_ready_async(&mut output_recv).await;
+    assert_eq!(output[..10], vec![2, 3, 1, 2, 3, 4, 5, 6, 7, 8]);
+}

--- a/hydro_lang/src/telemetry/emf.rs
+++ b/hydro_lang/src/telemetry/emf.rs
@@ -12,9 +12,7 @@ use std::time::SystemTime;
 #[cfg(feature = "runtime_support")]
 use dfir_rs::Never;
 #[cfg(feature = "runtime_support")]
-use dfir_rs::scheduled::metrics::DfirMetrics;
-#[cfg(feature = "runtime_support")]
-use dfir_rs::scheduled::metrics::HasMetrics;
+use dfir_rs::scheduled::metrics::{DfirMetrics, DfirMetricsIntervals};
 #[cfg(feature = "runtime_support")]
 use futures::FutureExt;
 use quote::quote;
@@ -76,7 +74,7 @@ impl Sidecar for RecordMetricsSidecar {
         };
 
         parse_quote! {
-            #root::telemetry::emf::record_metrics_sidecar(&#dfir_ident, #namespace, #location_name, #file_path, #interval)
+            #root::telemetry::emf::record_metrics_sidecar(#dfir_ident.metrics_intervals(), #namespace, #location_name, #file_path, #interval)
         }
     }
 }
@@ -85,15 +83,13 @@ impl Sidecar for RecordMetricsSidecar {
 #[cfg(feature = "runtime_support")]
 #[doc(hidden)]
 pub fn record_metrics_sidecar(
-    dfir: &impl HasMetrics,
+    mut dfir_intervals: DfirMetricsIntervals,
     namespace: &'static str,
     location_name: &'static str,
     file_path: &'static str,
     interval: Duration,
 ) -> impl 'static + Future<Output = Never> {
     assert!(!namespace.contains(char::is_whitespace));
-
-    let mut dfir_intervals = dfir.metrics_intervals();
 
     async move {
         // Attempt to create log file parent dir.

--- a/hydro_lang/src/telemetry/emf.rs
+++ b/hydro_lang/src/telemetry/emf.rs
@@ -12,9 +12,9 @@ use std::time::SystemTime;
 #[cfg(feature = "runtime_support")]
 use dfir_rs::Never;
 #[cfg(feature = "runtime_support")]
-use dfir_rs::scheduled::graph::Dfir;
-#[cfg(feature = "runtime_support")]
 use dfir_rs::scheduled::metrics::DfirMetrics;
+#[cfg(feature = "runtime_support")]
+use dfir_rs::scheduled::metrics::HasMetrics;
 #[cfg(feature = "runtime_support")]
 use futures::FutureExt;
 use quote::quote;
@@ -85,7 +85,7 @@ impl Sidecar for RecordMetricsSidecar {
 #[cfg(feature = "runtime_support")]
 #[doc(hidden)]
 pub fn record_metrics_sidecar(
-    dfir: &Dfir<'_>,
+    dfir: &impl HasMetrics,
     namespace: &'static str,
     location_name: &'static str,
     file_path: &'static str,


### PR DESCRIPTION
### Summary

Ports per-subgraph and per-handoff runtime metrics from the scheduled `Dfir<'_>` codegen path to the new `InlineDfir` inline codegen path, and updates the EMF telemetry sidecar to work with both.

### Changes

**`dfir_rs/src/scheduled/context.rs`**
- Added `Rc<DfirMetrics>` to `InlineDfir` with `metrics()` and `metrics_intervals()` accessors, threaded through `into_erased()`.

**`dfir_rs/src/scheduled/metrics.rs`**
- Made `InstrumentSubgraph` and its constructor `pub #[doc(hidden)]` for codegen access.
- `define_metrics!` macro now hardcodes `pub #[doc(hidden)]` on fields internally instead of accepting a visibility specifier at the call site.

**`dfir_lang/src/graph/meta_graph.rs`**
- Inline codegen now builds `DfirMetrics` with pre-initialized entries for each subgraph and handoff, using slotmap raw indices (`KeyData::as_ffi() & 0xFFFF_FFFF`) so runtime metrics IDs match the meta graph for cross-referencing with Mermaid/Dot visualizations.
- Recv port code instruments handoff metrics (`total_items_count`, `curr_items_count`) before draining, matching the scheduled path's "measure at recv" strategy.
- Each subgraph async block is wrapped with `InstrumentSubgraph` for per-subgraph `total_poll_duration`/`total_poll_count`/`total_idle_duration`/`total_idle_count` tracking, with `total_run_count` incremented after each run.
- Send-side `curr_items_count` updated after each subgraph completes.

**`hydro_lang/src/telemetry/emf.rs`**
- `record_metrics_sidecar` now takes `DfirMetricsIntervals` directly instead of `&Dfir<'_>`. The generated sidecar code calls `.metrics_intervals()` on the dfir instance, which works for both `Dfir` and `InlineDfir`.

**`dfir_macro/src/lib.rs`**
- Updated error fallback to pass default metrics `Rc` to `InlineDfir::new`.