### PR TITLE
feat(hydro_lang): add order_preserving property to MapFuncAlgebra for monotonicity propagation

### DIFF
--- a/hydro_lang/src/live_collections/singleton.rs
+++ b/hydro_lang/src/live_collections/singleton.rs
@@ -6,7 +6,7 @@ use std::ops::{Deref, Not};
 use std::rc::Rc;
 
 use sealed::sealed;
-use stageleft::{IntoQuotedMut, QuotedWithContext, q};
+use stageleft::{IntoQuotedMut, QuotedWithContext, QuotedWithContextWithProps, q};
 
 use super::boundedness::{Bounded, Boundedness, IsBounded, Unbounded};
 use super::optional::Optional;
@@ -24,7 +24,9 @@ use crate::location::dynamic::{DynLocation, LocationId};
 use crate::location::tick::{Atomic, NoAtomic};
 use crate::location::{Location, NoTick, Tick, check_matching_location};
 use crate::nondet::{NonDet, nondet};
-use crate::properties::{ApplyMonotoneStream, Proved};
+use crate::properties::{
+    ApplyMonotoneStream, ApplyOrderPreservingSingleton, MapFuncAlgebra, Proved,
+};
 
 /// A marker trait indicating which components of a [`Singleton`] may change.
 ///
@@ -363,11 +365,17 @@ where
     /// # }));
     /// # }
     /// ```
-    pub fn map<U, F>(self, f: impl IntoQuotedMut<'a, F, L>) -> Singleton<U, L, B::UnderlyingBound>
+    pub fn map<U, F, OP, B2: SingletonBound>(
+        self,
+        f: impl IntoQuotedMut<'a, F, L, MapFuncAlgebra<OP>>,
+    ) -> Singleton<U, L, B2>
     where
         F: Fn(T) -> U + 'a,
+        B: ApplyOrderPreservingSingleton<OP, B2>,
     {
-        let f = f.splice_fn1_ctx(&self.location).into();
+        let (f, proof) = f.splice_fn1_ctx_props(&self.location);
+        proof.register_proof(&f);
+        let f = f.into();
         Singleton::new(
             self.location.clone(),
             HydroNode::Map {
@@ -375,7 +383,7 @@ where
                 input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
-                    .new_node_metadata(Singleton::<U, L, B>::collection_kind()),
+                    .new_node_metadata(Singleton::<U, L, B2>::collection_kind()),
             },
         )
     }

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -3906,4 +3906,51 @@ mod tests {
 
         assert_eq!(threshold_out.next().await.unwrap(), 3);
     }
+
+    #[cfg(feature = "deploy")]
+    #[tokio::test]
+    async fn monotone_map_order_preserving_threshold() {
+        use crate::properties::manual_proof;
+
+        let mut deployment = Deployment::new();
+
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<()>();
+        let external = flow.external::<()>();
+
+        let in_unbounded: super::Stream<_, _> =
+            node.source_iter(q!(vec![1i32, 2, 3, 4, 5, 6])).into();
+        let sum = in_unbounded.fold(
+            q!(|| 0),
+            q!(
+                |sum, v| {
+                    *sum += v;
+                },
+                monotone = manual_proof!(/** test */)
+            ),
+        );
+
+        // map with order_preserving should preserve monotonicity
+        let doubled = sum.map(q!(
+            |v| v * 2,
+            order_preserving = manual_proof!(/** doubling preserves order */)
+        ));
+
+        let threshold_out = doubled
+            .threshold_greater_or_equal(node.singleton(q!(14)))
+            .send_bincode_external(&external);
+
+        let nodes = flow
+            .with_process(&node, deployment.Localhost())
+            .with_external(&external, deployment.Localhost())
+            .deploy(&mut deployment);
+
+        deployment.deploy().await.unwrap();
+
+        let mut threshold_out = nodes.connect(threshold_out).await;
+
+        deployment.start().await.unwrap();
+
+        assert_eq!(threshold_out.next().await.unwrap(), 14);
+    }
 }

--- a/hydro_lang/src/properties/mod.rs
+++ b/hydro_lang/src/properties/mod.rs
@@ -36,6 +36,15 @@ pub trait MonotoneProof {
     fn register_proof(&self, expr: &syn::Expr);
 }
 
+/// A trait for proof mechanisms that can validate order-preservation (monotonicity of a map function).
+#[sealed::sealed]
+pub trait OrderPreservingProof {
+    /// Registers the expression with the proof mechanism.
+    ///
+    /// This should not perform any blocking analysis; it is only intended to record the expression for later processing.
+    fn register_proof(&self, expr: &syn::Expr);
+}
+
 /// A hand-written human proof of the correctness property.
 ///
 /// To create a manual proof, use the [`manual_proof!`] macro, which takes in a doc comment
@@ -51,6 +60,10 @@ impl IdempotentProof for ManualProof {
 }
 #[sealed::sealed]
 impl MonotoneProof for ManualProof {
+    fn register_proof(&self, _expr: &syn::Expr) {}
+}
+#[sealed::sealed]
+impl OrderPreservingProof for ManualProof {
     fn register_proof(&self, _expr: &syn::Expr) {}
 }
 
@@ -154,6 +167,39 @@ impl<C, I, M> Property for AggFuncAlgebra<C, I, M> {
     }
 }
 
+/// Algebraic properties for a map function of type T -> U.
+///
+/// Order-preserving means that if the input grows monotonically, the output also grows monotonically.
+pub struct MapFuncAlgebra<OrderPreserving = NotProved>(
+    Option<Box<dyn OrderPreservingProof>>,
+    PhantomData<OrderPreserving>,
+);
+
+impl<O> MapFuncAlgebra<O> {
+    /// Marks the function as being order-preserving, with the given proof mechanism.
+    pub fn order_preserving(
+        self,
+        proof: impl OrderPreservingProof + 'static,
+    ) -> MapFuncAlgebra<Proved> {
+        MapFuncAlgebra(Some(Box::new(proof)), PhantomData)
+    }
+
+    /// Registers the expression with the underlying proof mechanisms.
+    pub(crate) fn register_proof(self, expr: &syn::Expr) {
+        if let Some(proof) = self.0 {
+            proof.register_proof(expr);
+        }
+    }
+}
+
+impl<O> Property for MapFuncAlgebra<O> {
+    type Root = MapFuncAlgebra;
+
+    fn make_root(_target: &mut Option<Self>) -> Self::Root {
+        MapFuncAlgebra(None, PhantomData)
+    }
+}
+
 /// Marker trait identifying that the commutativity property is valid for the given stream ordering.
 #[diagnostic::on_unimplemented(
     message = "Because the input stream has ordering `{O}`, the closure must demonstrate commutativity with a `commutative = ...` annotation.",
@@ -201,3 +247,14 @@ impl<B: Boundedness> ApplyMonotoneKeyedStream<NotProved, B> for B {}
 
 #[sealed::sealed]
 impl<B: Boundedness> ApplyMonotoneKeyedStream<Proved, B::KeyedStreamToMonotone> for B {}
+
+/// Marker trait identifying the boundedness of a singleton after a map operation,
+/// given an order-preserving property.
+#[sealed::sealed]
+pub trait ApplyOrderPreservingSingleton<P, B2: SingletonBound> {}
+
+#[sealed::sealed]
+impl<B: SingletonBound> ApplyOrderPreservingSingleton<NotProved, B::UnderlyingBound> for B {}
+
+#[sealed::sealed]
+impl<B: SingletonBound> ApplyOrderPreservingSingleton<Proved, B> for B {}


### PR DESCRIPTION
## Summary

Previously, `Singleton::map()` always dropped monotonicity (returning `B::UnderlyingBound`). This PR adds a new `MapFuncAlgebra` property type with an `order_preserving` annotation that, when proved, preserves monotonicity through map operations.

## Changes

- **`properties/mod.rs`**: Added `OrderPreservingProof` sealed trait, `MapFuncAlgebra<OrderPreserving>` struct with `order_preserving()` builder, and `ApplyOrderPreservingSingleton` trait (preserves bound when `Proved`, drops to `UnderlyingBound` when `NotProved`)
- **`singleton.rs`**: Changed `map()` to accept `MapFuncAlgebra<OP>` properties and use `ApplyOrderPreservingSingleton` for conditional monotonicity propagation
- **`stream/mod.rs`**: Added `monotone_map_order_preserving_threshold` test showing that `map` with `order_preserving` preserves monotonicity through to `threshold_greater_or_equal`

## Backward Compatibility

Existing callers of `map(q!(...))` without annotations continue to work — `MapFuncAlgebra` defaults to `NotProved`, which drops monotonicity as before.