### PR TITLE
style: change hex_literal_case to Upper in rustfmt.toml

### DIFF
--- a/benches/benches/cross_join_multiset.rs
+++ b/benches/benches/cross_join_multiset.rs
@@ -172,8 +172,8 @@ fn ops(c: &mut Criterion) {
             let mut x: u32 = 123;
             std::iter::from_fn(move || {
                 x = x.wrapping_mul(16843009).wrapping_add(3014898611);
-                let l = ((x & 0x00ff0000) >> 16) ^ (x & 0x000000ff);
-                let u = ((x & 0xff000000) >> 16) ^ (x & 0x0000ff00);
+                let l = ((x & 0x00FF0000) >> 16) ^ (x & 0x000000FF);
+                let u = ((x & 0xFF000000) >> 16) ^ (x & 0x0000FF00);
                 Some((l << 8) | (u >> 8))
             })
             .take(n)

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1394,7 +1394,7 @@ impl DfirGraph {
         // TODO(cleanup): When scheduled Dfir is removed, DfirMetrics could use slotmap
         // SecondaryMaps directly, eliminating this conversion.
         fn slotmap_raw_idx(key: impl Key) -> usize {
-            (key.data().as_ffi() & 0xffff_ffff) as usize
+            (key.data().as_ffi() & 0xFFFF_FFFF) as usize
         }
 
         let df = Ident::new(GRAPH, Span::call_site());

--- a/hydro_lang/src/deploy/deploy_runtime_containerized.rs
+++ b/hydro_lang/src/deploy/deploy_runtime_containerized.rs
@@ -36,7 +36,7 @@ use crate::location::{LocationKey, MemberId, MembershipEvent};
 pub const CHANNEL_MUX_PORT: u16 = 10000;
 
 /// Magic constant embedded in every [`ChannelMagic`] header.
-pub const CHANNEL_MAGIC: u64 = 0x4859_4452_4f5f_4348;
+pub const CHANNEL_MAGIC: u64 = 0x4859_4452_4F5F_4348;
 
 /// Magic header sent as the very first frame of every channel handshake.
 ///

--- a/hydro_lang/src/location/mod.rs
+++ b/hydro_lang/src/location/mod.rs
@@ -132,11 +132,11 @@ impl LocationKey {
 
     /// A key for testing with index 1.
     #[cfg(test)]
-    pub const TEST_KEY_1: Self = Self(slotmap::KeyData::from_ffi(0x000000ff00000001)); // `1v255`
+    pub const TEST_KEY_1: Self = Self(slotmap::KeyData::from_ffi(0x000000FF00000001)); // `1v255`
 
     /// A key for testing with index 2.
     #[cfg(test)]
-    pub const TEST_KEY_2: Self = Self(slotmap::KeyData::from_ffi(0x000000ff00000002)); // `2v255`
+    pub const TEST_KEY_2: Self = Self(slotmap::KeyData::from_ffi(0x000000FF00000002)); // `2v255`
 }
 
 /// This is used within `q!` code in docker and ECS.

--- a/hydro_lang/src/viz/render.rs
+++ b/hydro_lang/src/viz/render.rs
@@ -549,11 +549,11 @@ impl std::str::FromStr for VizNodeKey {
 impl VizNodeKey {
     /// A key for testing with index 1.
     #[cfg(test)]
-    pub const TEST_KEY_1: Self = Self(slotmap::KeyData::from_ffi(0x0000008f00000001)); // `1v143`
+    pub const TEST_KEY_1: Self = Self(slotmap::KeyData::from_ffi(0x0000008F00000001)); // `1v143`
 
     /// A key for testing with index 2.
     #[cfg(test)]
-    pub const TEST_KEY_2: Self = Self(slotmap::KeyData::from_ffi(0x0000008f00000002)); // `2v143`
+    pub const TEST_KEY_2: Self = Self(slotmap::KeyData::from_ffi(0x0000008F00000002)); // `2v143`
 }
 
 /// Edge information in the Hydro graph.

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,7 +1,7 @@
 format_code_in_doc_comments = true
 format_macro_matchers = true
 group_imports = "StdExternalCrate"
-hex_literal_case = "Lower"
+hex_literal_case = "Upper"
 imports_granularity = "Module"
 newline_style = "Native"
 normalize_comments = true


### PR DESCRIPTION
## Summary

Switched `hex_literal_case` from `"Lower"` to `"Upper"` in `rustfmt.toml` and ran `cargo +nightly fmt` to reformat the codebase, since agents tend to prefer uppercase hex literals.

## Changed files

- **rustfmt.toml** — `hex_literal_case = "Lower"` → `"Upper"`
- **benches/benches/cross_join_multiset.rs** — hex bitmasks uppercased
- **dfir_lang/src/graph/meta_graph.rs** — slotmap key mask uppercased
- **hydro_lang/src/deploy/deploy_runtime_containerized.rs** — `CHANNEL_MAGIC` constant uppercased
- **hydro_lang/src/location/mod.rs** — test key constants uppercased
- **hydro_lang/src/viz/render.rs** — test key constants uppercased