### PR TITLE
fix(dfir_lang): topologically sort subgraphs for inline codegen, fix #2747

### DIFF
--- a/dfir_lang/src/graph/flat_to_partitioned.rs
+++ b/dfir_lang/src/graph/flat_to_partitioned.rs
@@ -335,7 +335,7 @@ fn find_subgraph_strata(
     // Iterate handoffs between subgraphs, to build a subgraph meta-graph.
     for (node_id, node) in partitioned_graph.nodes() {
         if matches!(node, GraphNode::Handoff { .. }) {
-            assert_eq!(1, partitioned_graph.node_successors(node_id).count());
+            assert_eq!(1, partitioned_graph.node_successors(node_id).len());
             let (succ_edge, succ) = partitioned_graph.node_successors(node_id).next().unwrap();
 
             // TODO(mingwei): Should we look at the singleton references too?
@@ -348,7 +348,7 @@ fn find_subgraph_strata(
                 continue;
             }
 
-            assert_eq!(1, partitioned_graph.node_predecessors(node_id).count());
+            assert_eq!(1, partitioned_graph.node_predecessors(node_id).len());
             let (_edge_id, pred) = partitioned_graph.node_predecessors(node_id).next().unwrap();
 
             let pred_sg = partitioned_graph.node_subgraph(pred).unwrap();
@@ -426,7 +426,7 @@ fn find_subgraph_strata(
         }
         let (_hoff_port, dst_port) = partitioned_graph.edge_ports(edge_id);
 
-        assert_eq!(1, partitioned_graph.node_predecessors(hoff).count());
+        assert_eq!(1, partitioned_graph.node_predecessors(hoff).len());
         let src = partitioned_graph
             .node_predecessor_nodes(hoff)
             .next()

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1453,10 +1453,15 @@ impl DfirGraph {
                 let pred_stratum = self.subgraph_stratum(pred_sg).unwrap();
                 let succ_stratum = self.subgraph_stratum(succ_sg).unwrap();
                 if succ_stratum < pred_stratum {
-                    // `defer_tick_lazy()` back-edge.
-                    continue;
+                    // Tick/back-edge handoff: preserve the required same-tick ordering by
+                    // forcing the higher-stratum producer subgraph to run after the
+                    // lower-stratum consumer subgraph. Dropping this edge entirely leaves the
+                    // order unconstrained and can collapse a tick delay to zero when inline
+                    // handoff buffers persist across ticks.
+                    sg_preds.entry(pred_sg).unwrap().or_default().push(succ_sg);
+                } else {
+                    sg_preds.entry(succ_sg).unwrap().or_default().push(pred_sg);
                 }
-                sg_preds.entry(succ_sg).unwrap().or_default().push(pred_sg);
             }
 
             let topo_sort = super::graph_algorithms::topo_sort(self.subgraph_ids(), |sg_id| {

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -464,9 +464,9 @@ impl DfirGraph {
         }
 
         // In-degree, excluding ref-edges.
-        let inn_degree = self.node_predecessor_nodes(node_id).count();
+        let inn_degree = self.node_predecessor_nodes(node_id).len();
         // Out-degree excluding ref-edges.
-        let out_degree = self.node_successor_nodes(node_id).count();
+        let out_degree = self.node_successor_nodes(node_id).len();
 
         match (inn_degree, out_degree) {
             (0, 0) => None, // Generally should not happen, "Degenerate subgraph detected".
@@ -1425,15 +1425,50 @@ impl DfirGraph {
         // 2. Collect subgraph handoffs (same as as_code).
         let subgraph_handoffs = self.helper_collect_subgraph_handoffs();
 
-        // 3. Sort subgraphs by stratum, then sources (no-preds) first (for type inference).
-        let mut all_subgraphs: Vec<_> = self.subgraph_nodes.iter().collect();
-        all_subgraphs.sort_by_key(|&(sg_id, nodes)| {
-            let stratum = self.subgraph_stratum.get(sg_id).copied().unwrap_or(0);
-            let is_source = nodes
-                .iter()
-                .any(|&node_id| self.node_degree_in(node_id) == 0);
-            (stratum, !is_source)
-        });
+        // 3. Sort subgraphs topologically (excluding `defer_tick_lazy()` edges). This bypasses
+        // existing stratum logic (except to detect `defer_tick_lazy()`). Without this, or if we
+        // only use strata, deferred data can arrive one tick late. See
+        // https://github.com/hydro-project/hydro/issues/2747
+        //
+        // TODO(cleanup): Once scheduled Dfir is removed, move this topological ordering to replace
+        // the subgraph stratification pass directly, rather than doing it as a post-hoc sort in
+        // codegen.
+        let all_subgraphs = {
+            // Build predecessor map for subgraphs.
+            let mut sg_preds = SecondaryMap::<_, Vec<_>>::with_capacity(self.subgraph_nodes.len());
+            for (hoff_id, node) in self.nodes() {
+                if !matches!(node, GraphNode::Handoff { .. }) {
+                    // Not between handoffs
+                    continue;
+                }
+                assert_eq!(1, self.node_successors(hoff_id).len());
+                assert_eq!(1, self.node_predecessors(hoff_id).len());
+                let (_edge_id, pred) = self.node_predecessors(hoff_id).next().unwrap();
+                let (_edge_id, succ) = self.node_successors(hoff_id).next().unwrap();
+                let pred_sg = self.node_subgraph(pred).unwrap();
+                let succ_sg = self.node_subgraph(succ).unwrap();
+                if pred_sg == succ_sg {
+                    panic!("bug: unexpected subgraph self-handoff cycle");
+                }
+                let pred_stratum = self.subgraph_stratum(pred_sg).unwrap();
+                let succ_stratum = self.subgraph_stratum(succ_sg).unwrap();
+                if succ_stratum < pred_stratum {
+                    // `defer_tick_lazy()` back-edge.
+                    continue;
+                }
+                sg_preds.entry(succ_sg).unwrap().or_default().push(pred_sg);
+            }
+
+            let topo_sort = super::graph_algorithms::topo_sort(self.subgraph_ids(), |sg_id| {
+                sg_preds.get(sg_id).into_iter().flatten().copied()
+            })
+            .expect("bug: unexpected cycle between subgraphs within the tick");
+
+            topo_sort
+                .into_iter()
+                .map(|sg_id| (sg_id, self.subgraph(sg_id)))
+                .collect::<Vec<_>>()
+        };
 
         let mut op_prologue_code = Vec::new();
         let mut op_prologue_after_code = Vec::new();

--- a/dfir_rs/tests/surface_inline.rs
+++ b/dfir_rs/tests/surface_inline.rs
@@ -399,3 +399,28 @@ pub async fn test_inline_hydro_pattern_multi_tick() {
     result.sort();
     assert_eq!(vec![(200, 8), (300, 8)], result);
 }
+
+/// Regression test for https://github.com/hydro-project/hydro/issues/2747
+/// defer_tick_lazy in a cycle must deliver data on the next tick, not two ticks later.
+/// This was caused by missing topological sort of subgraphs within a stratum.
+#[dfir_rs::test]
+pub async fn test_inline_defer_tick_lazy_cycle() {
+    let output = std::rc::Rc::new(std::cell::RefCell::new(Vec::<usize>::new()));
+    let output_inner = std::rc::Rc::clone(&output);
+
+    let mut flow = dfir_rs::dfir_syntax_inline! {
+        a = union() -> tee();
+        source_iter([1_usize, 3]) -> [0]a;
+        a[0] -> defer_tick_lazy() -> map(|x: usize| 2 * x) -> [1]a;
+        a[1] -> for_each(|x: usize| output_inner.borrow_mut().push(x));
+    };
+
+    flow.run_tick().await;
+    assert_eq!(vec![1, 3], output.take());
+
+    flow.run_tick().await;
+    assert_eq!(vec![2, 6], output.take());
+
+    flow.run_tick().await;
+    assert_eq!(vec![4, 12], output.take());
+}


### PR DESCRIPTION
Fixes https://github.com/hydro-project/hydro/issues/2747

The inline codegen path (`as_code_inline`) previously sorted subgraphs by stratum number, with no ordering within a stratum. This caused `defer_tick_lazy` in cycles to (possibly but consistently) delay data by two ticks instead of one: the deferred data's consumer subgraph could run before the producer subgraph within the same stratum. (This worked in scheduled code since subgraphs would run multiple times within the stratum, but now they do not).

This swaps out the strata for a full topological sort of all subgraphs.

Also added a regression test (`test_inline_defer_tick_lazy_cycle`) that verifies deferred data in a cycle arrives on the next tick.