### PR TITLE
feat(hydro_lang): add entries_partially_ordered to KeyedStream

### DIFF
--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -493,6 +493,31 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
         )
     }
 
+    /// Flattens the keyed stream into a totally ordered stream of key-value pairs,
+    /// preserving the order of values within each key group but non-deterministically
+    /// interleaving across keys.
+    ///
+    /// Requires the keyed stream to be totally ordered within each group (`O: IsOrdered`).
+    ///
+    /// # Non-Determinism
+    /// The interleaving of entries across different keys is non-deterministic.
+    /// Within each key, the original order is preserved.
+    pub fn entries_partially_ordered(self, _nondet: NonDet) -> Stream<(K, V), L, B, TotalOrder, R>
+    where
+        O: IsOrdered,
+    {
+        Stream::new(
+            self.location.clone(),
+            HydroNode::ObserveNonDet {
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                trusted: false,
+                metadata: self
+                    .location
+                    .new_node_metadata(Stream::<(K, V), L, B, TotalOrder, R>::collection_kind()),
+            },
+        )
+    }
+
     /// Flattens the keyed stream into an unordered stream of only the values.
     ///
     /// # Example
@@ -3301,5 +3326,104 @@ mod tests {
             "did not see an instance with key 1 having [0, 1] in order"
         );
         assert_eq!(instance_count, 58);
+    }
+
+    #[cfg(feature = "sim")]
+    #[test]
+    fn sim_entries_partially_ordered_bounded() {
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<()>();
+
+        let (port, input) = node.sim_input::<_, TotalOrder, _>();
+
+        let tick = node.tick();
+        let batch = input.into_keyed().batch(&tick, nondet!(/** test */));
+        let out_recv = batch
+            .entries_partially_ordered(nondet!(/** test */))
+            .all_ticks()
+            .sim_output();
+
+        let instance_count = flow.sim().exhaustive(async || {
+            port.send((1, 'a'));
+            port.send((1, 'b'));
+            port.send((2, 'c'));
+            let _: Vec<(i32, char)> = out_recv.collect().await;
+        });
+
+        assert_eq!(instance_count, 12);
+    }
+
+    #[cfg(feature = "sim")]
+    #[test]
+    fn sim_entries_partially_ordered_top_level() {
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<()>();
+
+        let (in_send, input) = node.sim_input::<_, TotalOrder, _>();
+
+        let out_recv = input
+            .into_keyed()
+            .entries_partially_ordered(nondet!(/** test */))
+            .sim_output();
+
+        let instance_count = flow.sim().exhaustive(async || {
+            in_send.send((1, 'a'));
+            in_send.send((1, 'b'));
+            in_send.send((2, 'c'));
+            let _: Vec<(i32, char)> = out_recv.collect().await;
+        });
+
+        assert_eq!(instance_count, 3);
+    }
+
+    #[cfg(feature = "sim")]
+    #[test]
+    fn sim_entries_partially_ordered_cycle_back() {
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<()>();
+        let node2 = flow.process::<()>();
+
+        let (in_send, input) = node.sim_input::<_, NoOrder, _>();
+
+        let (complete_cycle_back, cycle_back) =
+            node.forward_ref::<super::KeyedStream<_, _, _, _, NoOrder>>();
+        let ordered = input
+            .into_keyed()
+            .merge_unordered(cycle_back)
+            .assume_ordering::<TotalOrder>(nondet!(/** test */));
+
+        let flat = ordered
+            .clone()
+            .entries_partially_ordered(nondet!(/** test */));
+
+        complete_cycle_back.complete(
+            flat.clone()
+                .map(q!(|(k, v): (i32, i32)| (k, v + 1)))
+                .filter(q!(|(_, v)| *v % 2 == 1))
+                .send(&node2, TCP.fail_stop().bincode())
+                .send(&node, TCP.fail_stop().bincode())
+                .into_keyed(),
+        );
+
+        let out_recv = flat.sim_output();
+
+        let mut saw = false;
+        let instance_count = flow.sim().exhaustive(async || {
+            // Send (1, 0) and (1, 2). 0+1=1 is odd so cycles back as (1, 1).
+            // We want to see (1, 1) before (1, 2) - the cycled back value beats the pending one
+            in_send.send_many_unordered([(1, 0), (1, 2)]);
+            let results: Vec<(i32, i32)> = out_recv.collect().await;
+
+            let pos_1 = results.iter().position(|v| *v == (1, 1));
+            let pos_2 = results.iter().position(|v| *v == (1, 2));
+            if let (Some(p1), Some(p2)) = (pos_1, pos_2)
+                && p1 < p2
+            {
+                saw = true;
+            }
+        });
+
+        assert!(saw, "did not see an instance with (1, 1) before (1, 2)");
+        assert_eq!(instance_count, 78);
     }
 }

--- a/hydro_lang/src/sim/builder.rs
+++ b/hydro_lang/src/sim/builder.rs
@@ -685,6 +685,81 @@ impl DfirBuilder for SimBuilder {
                         None,
                     );
                 }
+                (
+                    CollectionKind::KeyedStream {
+                        value_order: StreamOrder::TotalOrder,
+                        value_retry: StreamRetry::ExactlyOnce,
+                        key_type,
+                        value_type,
+                        ..
+                    },
+                    CollectionKind::Stream {
+                        order: StreamOrder::TotalOrder,
+                        retry: StreamRetry::ExactlyOnce,
+                        ..
+                    },
+                ) => {
+                    let hoff_id = self.next_hoff_id;
+                    self.next_hoff_id += 1;
+
+                    let buffered_ident =
+                        syn::Ident::new(&format!("__buffered_{hoff_id}"), Span::call_site());
+                    let hoff_send_ident =
+                        syn::Ident::new(&format!("__hoff_send_{hoff_id}"), Span::call_site());
+                    let hoff_recv_ident =
+                        syn::Ident::new(&format!("__hoff_recv_{hoff_id}"), Span::call_site());
+
+                    self.add_extra_stmt_internal(location.root(), syn::parse_quote! {
+                        let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unbounded_channel();
+                    });
+
+                    self.add_extra_stmt_internal(location.root(), syn::parse_quote! {
+                        let #hoff_recv_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(#hoff_recv_ident.into_inner()));
+                    });
+
+                    self.add_extra_stmt_internal(location.root(), syn::parse_quote! {
+                        let #buffered_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(None));
+                    });
+
+                    self.add_inline_hook(
+                        location,
+                        syn::parse_quote!(
+                            Box::new(#root::sim::runtime::PartiallyOrderedStreamHook::<_, _>::new(
+                                #buffered_ident.clone(),
+                                #hoff_send_ident,
+                                (#assume_location, #line, #caret),
+                                #root::__maybe_debug__!(#key_type),
+                                #root::__maybe_debug__!(#value_type),
+                            ))
+                        ),
+                    );
+
+                    let builder = self.get_dfir_mut(location);
+                    builder.add_dfir(
+                        parse_quote! {
+                            #out_ident = #in_ident -> fold::<'tick>(
+                                || ::std::vec::Vec::new(),
+                                |acc, v| {
+                                    acc.push(v);
+                                }
+                            ) -> map(|v| {
+                                let #buffered_ident = #buffered_ident.clone();
+                                let #hoff_recv_ident = #hoff_recv_ident.clone();
+                                async move {
+                                    fn force_matching_type<T>(a: &mut Option<::std::vec::Vec<T>>, b: ::std::vec::Vec<T>) -> ::std::vec::Vec<T> {
+                                        b
+                                    }
+
+                                    let mut out_holder = Some(v);
+                                    *#buffered_ident.borrow_mut() = out_holder.take();
+                                    force_matching_type(&mut out_holder, #hoff_recv_ident.borrow_mut().recv().await.unwrap())
+                                }
+                            }) -> resolve_futures_blocking() -> flatten();
+                        },
+                        None,
+                        None,
+                    );
+                }
                 _ => {
                     todo!(
                         "non-trusted observe_nondet not yet supported for kinds {:?} -> {:?}",
@@ -792,6 +867,66 @@ impl DfirBuilder for SimBuilder {
                         location,
                         syn::parse_quote!(
                             Box::new(#root::sim::runtime::TopLevelKeyedStreamOrderHook::<_, _> {
+                                input: #buffered_ident.clone(),
+                                to_release: None,
+                                output: #hoff_send_ident,
+                                location: (#assume_location, #line, #caret),
+                                format_item_debug: #root::__maybe_debug__!((#key_type, #value_type)),
+                            })
+                        ),
+                    );
+
+                    self.get_dfir_mut(location).add_dfir(
+                        parse_quote! {
+                            #in_ident -> for_each(|(k, v)| #buffered_ident.borrow_mut().entry(k).or_insert_with(::std::collections::VecDeque::new).push_back(v));
+                        },
+                        None,
+                        None,
+                    );
+
+                    self.get_dfir_mut(location).add_dfir(
+                        parse_quote! {
+                            #out_ident = source_stream(#hoff_recv_ident);
+                        },
+                        None,
+                        None,
+                    );
+                }
+                (
+                    CollectionKind::KeyedStream {
+                        value_order: StreamOrder::TotalOrder,
+                        value_retry: StreamRetry::ExactlyOnce,
+                        key_type,
+                        value_type,
+                        ..
+                    },
+                    CollectionKind::Stream {
+                        order: StreamOrder::TotalOrder,
+                        retry: StreamRetry::ExactlyOnce,
+                        ..
+                    },
+                ) => {
+                    let hoff_id = self.next_hoff_id;
+                    self.next_hoff_id += 1;
+
+                    let buffered_ident =
+                        syn::Ident::new(&format!("__buffered_{hoff_id}"), Span::call_site());
+                    let hoff_send_ident =
+                        syn::Ident::new(&format!("__hoff_send_{hoff_id}"), Span::call_site());
+                    let hoff_recv_ident =
+                        syn::Ident::new(&format!("__hoff_recv_{hoff_id}"), Span::call_site());
+
+                    self.add_extra_stmt_internal(location, syn::parse_quote! {
+                        let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unbounded_channel();
+                    });
+                    self.add_extra_stmt_internal(location, syn::parse_quote! {
+                        let #buffered_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(__root_dfir_rs::rustc_hash::FxHashMap::default()));
+                    });
+                    self.add_hook(
+                        location,
+                        location,
+                        syn::parse_quote!(
+                            Box::new(#root::sim::runtime::TopLevelPartiallyOrderedStreamHook::<_, _> {
                                 input: #buffered_ident.clone(),
                                 to_release: None,
                                 output: #hoff_send_ident,

--- a/hydro_lang/src/sim/runtime.rs
+++ b/hydro_lang/src/sim/runtime.rs
@@ -961,6 +961,123 @@ impl<K: Hash + Eq + Clone, V> SimInlineHook for KeyedStreamOrderHook<K, V> {
     }
 }
 
+/// Inline hook for `entries_partially_ordered` on bounded/not-root keyed streams.
+/// Produces a random interleaving of key-value pairs that preserves within-key order.
+pub struct PartiallyOrderedStreamHook<K: Hash + Eq + Clone, V> {
+    input: KeyedStreamOrderHookInput<K, V>,
+    to_release: Option<Vec<(K, V)>>,
+    output: UnboundedSender<Vec<(K, V)>>,
+    batch_location: HookLocationMeta,
+    format_key_debug: fn(&K) -> Option<String>,
+    format_value_debug: fn(&V) -> Option<String>,
+}
+
+impl<K: Hash + Eq + Clone, V> PartiallyOrderedStreamHook<K, V> {
+    pub fn new(
+        input: KeyedStreamOrderHookInput<K, V>,
+        output: UnboundedSender<Vec<(K, V)>>,
+        batch_location: HookLocationMeta,
+        format_key_debug: fn(&K) -> Option<String>,
+        format_value_debug: fn(&V) -> Option<String>,
+    ) -> Self {
+        Self {
+            input,
+            to_release: None,
+            output,
+            batch_location,
+            format_key_debug,
+            format_value_debug,
+        }
+    }
+}
+
+impl<K: Hash + Eq + Clone, V> SimInlineHook for PartiallyOrderedStreamHook<K, V> {
+    fn pending_decision(&self) -> bool {
+        self.input.borrow().is_some()
+    }
+
+    fn has_decision(&self) -> bool {
+        self.to_release.is_some()
+    }
+
+    fn autonomous_decision<'a>(&mut self, driver: &mut Borrowed<'a>) {
+        let inputs = self.input.borrow_mut().take().unwrap();
+        // Group by key, preserving within-key order
+        let mut grouped: Vec<(K, VecDeque<V>)> = Vec::new();
+        let mut key_indices: FxHashMap<K, usize> = FxHashMap::default();
+        for (k, v) in inputs {
+            if let Some(&idx) = key_indices.get(&k) {
+                grouped[idx].1.push_back(v);
+            } else {
+                let idx = grouped.len();
+                key_indices.insert(k.clone(), idx);
+                grouped.push((k, VecDeque::from([v])));
+            }
+        }
+
+        // Interleave: repeatedly pick a random non-empty key and take its front element
+        let mut out = Vec::new();
+        loop {
+            let nonempty: Vec<usize> = grouped
+                .iter()
+                .enumerate()
+                .filter(|(_, (_, q))| !q.is_empty())
+                .map(|(i, _)| i)
+                .collect();
+            if nonempty.is_empty() {
+                break;
+            }
+            let pick = nonempty[(0..nonempty.len()).generate(driver).unwrap()];
+            let (k, q) = &mut grouped[pick];
+            out.push((k.clone(), q.pop_front().unwrap()));
+        }
+
+        self.to_release = Some(out);
+    }
+
+    fn release_decision(&mut self, log_writer: &mut dyn std::fmt::Write) {
+        if let Some(to_release) = self.to_release.take() {
+            if !to_release.is_empty() {
+                let (batch_location, line, caret_indent) = self.batch_location;
+                let mut note_str = String::new();
+                for (key, value) in &to_release {
+                    let entry_text = format!(
+                        "({:?}, {:?})",
+                        ManualDebug(key, self.format_key_debug),
+                        ManualDebug(value, self.format_value_debug)
+                    );
+                    if !note_str.is_empty() {
+                        note_str.push_str(", ");
+                    }
+                    note_str.push_str(&entry_text);
+                }
+                note_str = format!("^ observed partially-ordered interleaving: [{}]", note_str);
+
+                let _ = writeln!(
+                    log_writer,
+                    "{} {}",
+                    "-->".color(colored::Color::Blue),
+                    batch_location
+                );
+
+                let _ = writeln!(log_writer, " {}{}", "|".color(colored::Color::Blue), line);
+
+                let _ = writeln!(
+                    log_writer,
+                    " {}{}{}",
+                    "|".color(colored::Color::Blue),
+                    caret_indent,
+                    note_str.color(colored::Color::Cyan)
+                );
+            }
+
+            self.output.send(to_release).unwrap();
+        } else {
+            panic!("No decision to release");
+        }
+    }
+}
+
 /// Top-level (outside-tick) `assume_ordering` hooks release elements **one at a
 /// time** rather than shuffling the entire batch. This is the key mechanism for
 /// simulating causality in feedback cycles: when data flows through a network hop
@@ -1131,6 +1248,102 @@ impl<K: Hash + Eq + Clone, V> SimHook for TopLevelKeyedStreamOrderHook<K, V> {
                 let (batch_location, line, caret_indent) = self.location;
                 let note_str = format!(
                     "^ observed non-deterministic order: {:?}",
+                    TruncatedVecDebug(
+                        RefCell::new(Some(to_release.iter())),
+                        8,
+                        self.format_item_debug
+                    )
+                );
+
+                let _ = writeln!(
+                    log_writer,
+                    "\n{} {}",
+                    "-->".color(colored::Color::Blue),
+                    batch_location
+                );
+
+                let _ = writeln!(log_writer, " {}{}", "|".color(colored::Color::Blue), line);
+
+                let _ = writeln!(
+                    log_writer,
+                    " {}{}{}",
+                    "|".color(colored::Color::Blue),
+                    caret_indent,
+                    note_str.color(colored::Color::Green)
+                );
+            }
+
+            for item in to_release {
+                self.output.send(item).unwrap();
+            }
+        } else {
+            panic!("No decision to release");
+        }
+    }
+}
+
+/// Top-level variant of [`PartiallyOrderedStreamHook`]. Same one-at-a-time release
+/// strategy as [`TopLevelKeyedStreamOrderHook`], but always takes from the FRONT
+/// of the chosen key's queue to preserve within-key order.
+pub struct TopLevelPartiallyOrderedStreamHook<K: Hash + Eq + Clone, V> {
+    pub input: Rc<RefCell<FxHashMap<K, VecDeque<V>>>>,
+    pub to_release: Option<Vec<(K, V)>>,
+    pub output: UnboundedSender<(K, V)>,
+    pub location: HookLocationMeta,
+    pub format_item_debug: fn(&(K, V)) -> Option<String>,
+}
+
+impl<K: Hash + Eq + Clone, V> SimHook for TopLevelPartiallyOrderedStreamHook<K, V> {
+    fn current_decision(&self) -> Option<bool> {
+        self.to_release.as_ref().map(|v| !v.is_empty())
+    }
+
+    fn can_make_nontrivial_decision(&self) -> bool {
+        #[expect(clippy::disallowed_methods, reason = "FxHasher is deterministic")]
+        !self.input.borrow().values().all(|q| q.is_empty())
+    }
+
+    fn autonomous_decision<'a>(
+        &mut self,
+        driver: &mut Borrowed<'a>,
+        force_nontrivial: bool,
+    ) -> bool {
+        let mut current_input = self.input.borrow_mut();
+
+        #[expect(clippy::disallowed_methods, reason = "FxHasher is deterministic")]
+        let nonempty_keys: Vec<K> = current_input
+            .iter()
+            .filter(|(_, q)| !q.is_empty())
+            .map(|(k, _)| k.clone())
+            .collect();
+
+        if nonempty_keys.is_empty() {
+            self.to_release = Some(vec![]);
+            return false;
+        }
+
+        if !force_nontrivial && produce().generate(driver).unwrap() {
+            self.to_release = Some(vec![]);
+            return false;
+        }
+
+        // Pick which key to release from
+        let key_idx = (0..nonempty_keys.len()).generate(driver).unwrap();
+        let key = &nonempty_keys[key_idx];
+
+        // Always take from the front to preserve within-key order
+        let item = current_input.get_mut(key).unwrap().pop_front().unwrap();
+
+        self.to_release = Some(vec![(key.clone(), item)]);
+        true
+    }
+
+    fn release_decision(&mut self, log_writer: &mut dyn std::fmt::Write) {
+        if let Some(to_release) = self.to_release.take() {
+            if !to_release.is_empty() {
+                let (batch_location, line, caret_indent) = self.location;
+                let note_str = format!(
+                    "^ observed partially-ordered interleaving: {:?}",
                     TruncatedVecDebug(
                         RefCell::new(Some(to_release.iter())),
                         8,


### PR DESCRIPTION
New method on `KeyedStream` that requires `O: IsOrdered`, takes a `NonDet`, and returns a `TotalOrder` `Stream<(K, V)>`. Preserves within-key order while non-deterministically interleaving across keys via `ObserveNonDet` IR.

Two new sim hooks wired up in the sim builder for the `KeyedStream{TotalOrder} -> Stream{TotalOrder}` transition:
- `PartiallyOrderedStreamHook`: inline hook for bounded/not-root cases
- `TopLevelPartiallyOrderedStreamHook`: one-at-a-time release hook for unbounded top-level cases, always taking from queue front to preserve within-key order

Three sim tests covering bounded, unbounded, and cycle-back behavior.