### PR TITLE
fix: KeyedStream::get now handles Unbounded input and preserves Order

### DIFF
--- a/hydro_lang/src/compile/ir/snapshots/backtrace.snap
+++ b/hydro_lang/src/compile/ir/snapshots/backtrace.snap
@@ -1,10 +1,10 @@
 ---
 source: hydro_lang/src/compile/ir/backtrace.rs
-expression: elements
+expression: "elements.collect::<Vec<_>>()"
 ---
 [
     BacktraceElement {
-        fn_name: "hydro_lang::compile::ir::backtrace::tests::test_backtrace",
+        fn_name: "test_backtrace",
         lineno: Some(
             184,
         ),
@@ -13,7 +13,7 @@ expression: elements
         ),
     },
     BacktraceElement {
-        fn_name: "hydro_lang::compile::ir::backtrace::tests::test_backtrace::{{closure}}",
+        fn_name: "{closure#0}",
         lineno: Some(
             176,
         ),
@@ -22,7 +22,7 @@ expression: elements
         ),
     },
     BacktraceElement {
-        fn_name: "core::ops::function::FnOnce::call_once",
+        fn_name: "call_once<hydro_lang::compile::ir::backtrace::tests::test_backtrace",
         lineno: Some(
             250,
         ),

--- a/hydro_lang/src/live_collections/keyed_singleton.rs
+++ b/hydro_lang/src/live_collections/keyed_singleton.rs
@@ -625,7 +625,7 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound> KeyedSingleton<K, V, L, 
     pub fn get(self, key: impl Into<Optional<K, L, Bounded>>) -> Optional<V, L, Bounded>
     where
         B: IsBounded,
-        K: Hash + Eq,
+        K: Eq + Clone,
     {
         self.make_bounded()
             .into_keyed_stream()

--- a/hydro_lang/src/live_collections/keyed_singleton.rs
+++ b/hydro_lang/src/live_collections/keyed_singleton.rs
@@ -625,7 +625,7 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound> KeyedSingleton<K, V, L, 
     pub fn get(self, key: impl Into<Optional<K, L, Bounded>>) -> Optional<V, L, Bounded>
     where
         B: IsBounded,
-        K: Eq + Clone,
+        K: Eq,
     {
         self.make_bounded()
             .into_keyed_stream()

--- a/hydro_lang/src/live_collections/keyed_singleton.rs
+++ b/hydro_lang/src/live_collections/keyed_singleton.rs
@@ -625,7 +625,7 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound> KeyedSingleton<K, V, L, 
     pub fn get(self, key: impl Into<Optional<K, L, Bounded>>) -> Optional<V, L, Bounded>
     where
         B: IsBounded,
-        K: Eq,
+        K: Eq + Clone,
     {
         self.make_bounded()
             .into_keyed_stream()

--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -2199,6 +2199,9 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     /// Gets the values associated with a specific key from the keyed stream.
     /// Returns an empty stream if the key is `None` or there are no associated values.
     ///
+    /// If the keyed stream has [`TotalOrder`], the output stream will also have [`TotalOrder`].
+    /// This method also works on [`Unbounded`] keyed streams.
+    ///
     /// # Example
     /// ```rust
     /// # #[cfg(feature = "deploy")] {
@@ -2223,15 +2226,29 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     /// # }));
     /// # }
     /// ```
-    pub fn get(self, key: impl Into<Optional<K, L, Bounded>>) -> Stream<V, L, Bounded, NoOrder, R>
+    pub fn get(self, key: impl Into<Optional<K, L, Bounded>>) -> Stream<V, L, B, O, R>
     where
-        B: IsBounded,
-        K: Eq + Hash,
+        K: Eq + Clone,
     {
-        self.make_bounded()
-            .entries()
-            .join(key.into().into_stream().map(q!(|k| (k, ()))))
-            .map(q!(|(_, (v, _))| v))
+        let key: Optional<K, L, Bounded> = key.into();
+        // Preserve ordering by working at the Stream<(K, V)> level directly
+        // rather than going through entries() which drops to NoOrder.
+        let entries_preserving_order: Stream<(K, V), L, B, O, R> = Stream::new(
+            self.location.clone(),
+            HydroNode::Cast {
+                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                metadata: self
+                    .location
+                    .new_node_metadata(Stream::<(K, V), L, B, O, R>::collection_kind()),
+            },
+        );
+        entries_preserving_order
+            .cross_singleton(key)
+            .filter_map(q!(|((k, v), lookup_key)| if k == lookup_key {
+                Some(v)
+            } else {
+                None
+            }))
     }
 
     /// For each value in `self`, find the matching key in `lookup`.

--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -2228,7 +2228,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     /// ```
     pub fn get(self, key: impl Into<Optional<K, L, Bounded>>) -> Stream<V, L, B, O, R>
     where
-        K: Eq,
+        K: Eq + Clone,
     {
         let key: Optional<K, L, Bounded> = key.into();
         check_matching_location(&self.location, &key.location);

--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -2232,7 +2232,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     {
         let filtered = self
             .cross_singleton(key)
-            .filter_with_key(q!(|(k, (_v, lookup_key))| k == lookup_key))
+            .filter_with_key(q!(|&(ref k, (_, ref lookup_key))| k == lookup_key))
             .map(q!(|(v, _lookup_key)| v));
 
         // Cast KeyedStream<K, V> to Stream<(K, V)> preserving O (unlike

--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -2230,40 +2230,24 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     where
         K: Eq + Clone,
     {
-        let key: Optional<K, L, Bounded> = key.into();
-        check_matching_location(&self.location, &key.location);
+        let filtered = self
+            .cross_singleton(key)
+            .filter_map_with_key(q!(|(k, (v, lookup_key))| {
+                if k == lookup_key { Some(v) } else { None }
+            }));
 
-        // Build CrossSingleton IR node directly (rather than calling
-        // Stream::cross_singleton) so we avoid requiring K: Clone.
-        // The DFIR cross_singleton operator handles cloning internally.
-        let cross_node = HydroNode::CrossSingleton {
-            left: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
-            right: Box::new(key.ir_node.replace(HydroNode::Placeholder)),
-            metadata: self
-                .location
-                .new_node_metadata(Stream::<((K, V), K), L, B, O, R>::collection_kind()),
-        };
-
-        let filter_map_f = q!(|((k, v), lookup_key)| {
-            if k == lookup_key {
-                Some(v)
-            } else {
-                None
-            }
-        })
-        .splice_fn1_ctx::<((K, V), K), Option<V>>(&self.location)
-        .into();
-
-        Stream::new(
-            self.location.clone(),
-            HydroNode::FilterMap {
-                f: filter_map_f,
-                input: Box::new(cross_node),
-                metadata: self
+        // Cast KeyedStream<K, V> to Stream<(K, V)> preserving O (unlike
+        // entries() which drops to NoOrder), then map to just V.
+        Stream::<(K, V), L, B, O, R>::new(
+            filtered.location.clone(),
+            HydroNode::Cast {
+                inner: Box::new(filtered.ir_node.replace(HydroNode::Placeholder)),
+                metadata: filtered
                     .location
-                    .new_node_metadata(Stream::<V, L, B, O, R>::collection_kind()),
+                    .new_node_metadata(Stream::<(K, V), L, B, O, R>::collection_kind()),
             },
         )
+        .map(q!(|(_k, v)| v))
     }
 
     /// For each value in `self`, find the matching key in `lookup`.

--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -2232,9 +2232,8 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     {
         let filtered = self
             .cross_singleton(key)
-            .filter_map_with_key(q!(|(k, (v, lookup_key))| {
-                if k == lookup_key { Some(v) } else { None }
-            }));
+            .filter_with_key(q!(|(k, (_v, lookup_key))| k == lookup_key))
+            .map(q!(|(v, _lookup_key)| v));
 
         // Cast KeyedStream<K, V> to Stream<(K, V)> preserving O (unlike
         // entries() which drops to NoOrder), then map to just V.
@@ -3334,8 +3333,8 @@ mod tests {
             .assume_ordering::<TotalOrder>(nondet!(/** test */));
 
         let key = tick.singleton(q!(1));
-        // get returns TotalOrder, so first() (which requires IsOrdered) compiles,
-        // and sim_output yields a TotalOrder receiver with assert_yields_only.
+        // get preserves TotalOrder here, so all_ticks().sim_output() produces
+        // an ordered receiver that supports assert_yields_only.
         let out = keyed.get(key).all_ticks().sim_output();
 
         flow.sim().exhaustive(async || {

--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -2228,27 +2228,42 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     /// ```
     pub fn get(self, key: impl Into<Optional<K, L, Bounded>>) -> Stream<V, L, B, O, R>
     where
-        K: Eq + Clone,
+        K: Eq,
     {
         let key: Optional<K, L, Bounded> = key.into();
-        // Preserve ordering by working at the Stream<(K, V)> level directly
-        // rather than going through entries() which drops to NoOrder.
-        let entries_preserving_order: Stream<(K, V), L, B, O, R> = Stream::new(
-            self.location.clone(),
-            HydroNode::Cast {
-                inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
-                metadata: self
-                    .location
-                    .new_node_metadata(Stream::<(K, V), L, B, O, R>::collection_kind()),
-            },
-        );
-        entries_preserving_order
-            .cross_singleton(key)
-            .filter_map(q!(|((k, v), lookup_key)| if k == lookup_key {
+        check_matching_location(&self.location, &key.location);
+
+        // Build CrossSingleton IR node directly (rather than calling
+        // Stream::cross_singleton) so we avoid requiring K: Clone.
+        // The DFIR cross_singleton operator handles cloning internally.
+        let cross_node = HydroNode::CrossSingleton {
+            left: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+            right: Box::new(key.ir_node.replace(HydroNode::Placeholder)),
+            metadata: self
+                .location
+                .new_node_metadata(Stream::<((K, V), K), L, B, O, R>::collection_kind()),
+        };
+
+        let filter_map_f = q!(|((k, v), lookup_key)| {
+            if k == lookup_key {
                 Some(v)
             } else {
                 None
-            }))
+            }
+        })
+        .splice_fn1_ctx::<((K, V), K), Option<V>>(&self.location)
+        .into();
+
+        Stream::new(
+            self.location.clone(),
+            HydroNode::FilterMap {
+                f: filter_map_f,
+                input: Box::new(cross_node),
+                metadata: self
+                    .location
+                    .new_node_metadata(Stream::<V, L, B, O, R>::collection_kind()),
+            },
+        )
     }
 
     /// For each value in `self`, find the matching key in `lookup`.
@@ -3318,5 +3333,47 @@ mod tests {
             "did not see an instance with key 1 having [0, 1] in order"
         );
         assert_eq!(instance_count, 58);
+    }
+
+    /// Regression: `get` on a `TotalOrder` keyed stream must produce a `TotalOrder` stream.
+    #[cfg(feature = "sim")]
+    #[test]
+    fn sim_get_preserves_total_order() {
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<()>();
+        let tick = node.tick();
+
+        let keyed = node
+            .source_iter(q!(vec![(1, 10), (1, 11), (2, 20)]))
+            .into_keyed()
+            .batch(&tick, nondet!(/** test */))
+            .assume_ordering::<TotalOrder>(nondet!(/** test */));
+
+        let key = tick.singleton(q!(1));
+        // get returns TotalOrder, so first() (which requires IsOrdered) compiles,
+        // and sim_output yields a TotalOrder receiver with assert_yields_only.
+        let out = keyed.get(key).all_ticks().sim_output();
+
+        flow.sim().exhaustive(async || {
+            out.assert_yields_only([10, 11]).await;
+        });
+    }
+
+    /// Regression: `get` must work on `Unbounded` keyed streams.
+    #[cfg(feature = "sim")]
+    #[test]
+    fn sim_get_on_unbounded() {
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<()>();
+
+        let (in_send, input) = node.sim_input::<_, TotalOrder, _>();
+        // keyed is Unbounded here — get must compile without IsBounded.
+        let key = node.singleton(q!(1));
+        let out = input.into_keyed().get(key).sim_output();
+
+        flow.sim().exhaustive(async || {
+            in_send.send_many([(1, 10), (1, 11), (2, 20)]);
+            out.assert_yields([10, 11]).await;
+        });
     }
 }

--- a/hydro_lang/src/live_collections/stream/tests/snapshots/backtrace_chained_ops-2.snap
+++ b/hydro_lang/src/live_collections/stream/tests/snapshots/backtrace_chained_ops-2.snap
@@ -1,10 +1,10 @@
 ---
 source: hydro_lang/src/live_collections/stream/tests/backtrace_chained_ops.rs
-expression: for_each_meta.backtrace.elements()
+expression: "for_each_meta.backtrace.elements().collect::<Vec<_>>()"
 ---
 [
     BacktraceElement {
-        fn_name: "hydro_lang::live_collections::stream::tests::backtrace_chained_ops::backtrace_chained_ops",
+        fn_name: "backtrace_chained_ops",
         lineno: Some(
             20,
         ),
@@ -13,7 +13,7 @@ expression: for_each_meta.backtrace.elements()
         ),
     },
     BacktraceElement {
-        fn_name: "hydro_lang::live_collections::stream::tests::backtrace_chained_ops::backtrace_chained_ops::{{closure}}",
+        fn_name: "{closure#0}",
         lineno: Some(
             5,
         ),
@@ -22,7 +22,7 @@ expression: for_each_meta.backtrace.elements()
         ),
     },
     BacktraceElement {
-        fn_name: "core::ops::function::FnOnce::call_once",
+        fn_name: "call_once<hydro_lang::live_collections::stream::tests::backtrace_chained_ops::backtrace_chained_ops",
         lineno: Some(
             250,
         ),

--- a/hydro_lang/src/live_collections/stream/tests/snapshots/backtrace_chained_ops.snap
+++ b/hydro_lang/src/live_collections/stream/tests/snapshots/backtrace_chained_ops.snap
@@ -1,10 +1,10 @@
 ---
 source: hydro_lang/src/live_collections/stream/tests/backtrace_chained_ops.rs
-expression: source_meta.backtrace.elements()
+expression: "source_meta.backtrace.elements().collect::<Vec<_>>()"
 ---
 [
     BacktraceElement {
-        fn_name: "hydro_lang::live_collections::stream::tests::backtrace_chained_ops::backtrace_chained_ops",
+        fn_name: "backtrace_chained_ops",
         lineno: Some(
             20,
         ),
@@ -13,7 +13,7 @@ expression: source_meta.backtrace.elements()
         ),
     },
     BacktraceElement {
-        fn_name: "hydro_lang::live_collections::stream::tests::backtrace_chained_ops::backtrace_chained_ops::{{closure}}",
+        fn_name: "{closure#0}",
         lineno: Some(
             5,
         ),
@@ -22,7 +22,7 @@ expression: source_meta.backtrace.elements()
         ),
     },
     BacktraceElement {
-        fn_name: "core::ops::function::FnOnce::call_once",
+        fn_name: "call_once<hydro_lang::live_collections::stream::tests::backtrace_chained_ops::backtrace_chained_ops",
         lineno: Some(
             250,
         ),


### PR DESCRIPTION
There are many cases where the system imposes a KeyedStream with TotalOrder (e.g. cluster communication over TCP::fail_stop), and we want a Stream with TotalOrder out. 

This mod:
1. Allows `get` to work on `Unbounded` input/output
2. Preserves `TotalOrder` on the output `Stream` if the input `KeyedStream` is `TotalOrder`.