### PR TITLE
fix(hydro_lang): disable backtrace tests on all non-Linux platforms

### DIFF
--- a/hydro_lang/src/compile/ir/backtrace.rs
+++ b/hydro_lang/src/compile/ir/backtrace.rs
@@ -173,13 +173,9 @@ impl Debug for BacktraceElement {
 mod tests {
     #[cfg(feature = "build")]
     #[test]
+    #[cfg_attr(not(target_os = "linux"), ignore)]
     fn test_backtrace() {
         use super::*;
-
-        if cfg!(not(target_os = "linux")) && std::env::var_os("GITHUB_ACTIONS").is_some() {
-            eprintln!("Backtrace tests fail on non-linux Github Actions runners, skipping.");
-            return;
-        }
 
         let backtrace = Backtrace::get_backtrace(0);
         let elements = backtrace.elements();

--- a/hydro_lang/src/compile/ir/snapshots/backtrace.snap
+++ b/hydro_lang/src/compile/ir/snapshots/backtrace.snap
@@ -6,7 +6,7 @@ expression: elements
     BacktraceElement {
         fn_name: "hydro_lang::compile::ir::backtrace::tests::test_backtrace",
         lineno: Some(
-            184,
+            180,
         ),
         colno: Some(
             25,
@@ -15,7 +15,7 @@ expression: elements
     BacktraceElement {
         fn_name: "hydro_lang::compile::ir::backtrace::tests::test_backtrace::{{closure}}",
         lineno: Some(
-            176,
+            177,
         ),
         colno: Some(
             24,

--- a/hydro_lang/src/live_collections/stream/tests/backtrace_chained_ops.rs
+++ b/hydro_lang/src/live_collections/stream/tests/backtrace_chained_ops.rs
@@ -2,12 +2,8 @@
 
 #[cfg(feature = "build")]
 #[test]
+#[cfg_attr(not(target_os = "linux"), ignore)]
 fn backtrace_chained_ops() {
-    if cfg!(not(target_os = "linux")) && std::env::var_os("GITHUB_ACTIONS").is_some() {
-        eprintln!("Backtrace tests fail on non-linux Github Actions runners, skipping.");
-        return;
-    }
-
     use stageleft::q;
 
     use crate::compile::ir::HydroRoot;

--- a/hydro_lang/src/live_collections/stream/tests/snapshots/backtrace_chained_ops-2.snap
+++ b/hydro_lang/src/live_collections/stream/tests/snapshots/backtrace_chained_ops-2.snap
@@ -6,7 +6,7 @@ expression: for_each_meta.backtrace.elements()
     BacktraceElement {
         fn_name: "hydro_lang::live_collections::stream::tests::backtrace_chained_ops::backtrace_chained_ops",
         lineno: Some(
-            20,
+            16,
         ),
         colno: Some(
             33,
@@ -15,7 +15,7 @@ expression: for_each_meta.backtrace.elements()
     BacktraceElement {
         fn_name: "hydro_lang::live_collections::stream::tests::backtrace_chained_ops::backtrace_chained_ops::{{closure}}",
         lineno: Some(
-            5,
+            6,
         ),
         colno: Some(
             27,

--- a/hydro_lang/src/live_collections/stream/tests/snapshots/backtrace_chained_ops.snap
+++ b/hydro_lang/src/live_collections/stream/tests/snapshots/backtrace_chained_ops.snap
@@ -6,7 +6,7 @@ expression: source_meta.backtrace.elements()
     BacktraceElement {
         fn_name: "hydro_lang::live_collections::stream::tests::backtrace_chained_ops::backtrace_chained_ops",
         lineno: Some(
-            20,
+            16,
         ),
         colno: Some(
             10,
@@ -15,7 +15,7 @@ expression: source_meta.backtrace.elements()
     BacktraceElement {
         fn_name: "hydro_lang::live_collections::stream::tests::backtrace_chained_ops::backtrace_chained_ops::{{closure}}",
         lineno: Some(
-            5,
+            6,
         ),
         colno: Some(
             27,


### PR DESCRIPTION
macOS backtrace format has also drifted from Linux