### PR TITLE
feat(dfir_lang): support defer_tick() in dfir_syntax_inline! codegen

### DIFF
--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1499,10 +1499,7 @@ impl DfirGraph {
                 // Non-lazy tick-boundary: pred at extra_stratum, succ at lower stratum.
                 if succ_stratum < pred_stratum && !self.subgraph_laziness(pred_sg) {
                     let span = node.span();
-                    idents.push(Ident::new(
-                        &format!("hoff_{:?}_buf", hoff_id.data()),
-                        span,
-                    ));
+                    idents.push(Ident::new(&format!("hoff_{:?}_buf", hoff_id.data()), span));
                 }
             }
             idents

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1425,20 +1425,28 @@ impl DfirGraph {
         // 2. Collect subgraph handoffs (same as as_code).
         let subgraph_handoffs = self.helper_collect_subgraph_handoffs();
 
-        // 3. Sort subgraphs topologically (excluding `defer_tick_lazy()` edges). This bypasses
-        // existing stratum logic (except to detect `defer_tick_lazy()`). Without this, or if we
-        // only use strata, deferred data can arrive one tick late. See
+        // 3. Sort subgraphs topologically and collect non-lazy defer_tick buffer idents.
+        //
+        // The topo sort excludes `defer_tick`/`defer_tick_lazy` back-edges (where
+        // succ_stratum < pred_stratum). This bypasses existing stratum logic. Without this,
+        // or if we only use strata, deferred data can arrive one tick late. See
         // https://github.com/hydro-project/hydro/issues/2747
         //
-        // TODO(cleanup): Once scheduled Dfir is removed, move this topological ordering to replace
-        // the subgraph stratification pass directly, rather than doing it as a post-hoc sort in
-        // codegen.
+        // While iterating handoffs, we also collect buffer idents for non-lazy tick-boundary
+        // edges (defer_tick). When these buffers are non-empty at end of tick, we set
+        // can_start_tick so that run_available continues ticking.
+        //
+        // TODO(cleanup): Once scheduled Dfir is removed, move this topological ordering to
+        // replace the subgraph stratification pass directly, rather than doing it as a
+        // post-hoc sort in codegen. Also replace the `subgraph_laziness` flag with a more
+        // direct representation (e.g., a `DelayType` on the handoff edge itself) — currently
+        // we piggyback on the laziness bit of the intermediate identity subgraph that
+        // `flat_to_partitioned` injects for `defer_tick` vs `defer_tick_lazy`.
+        let mut defer_tick_buf_idents: Vec<Ident> = Vec::new();
         let all_subgraphs = {
-            // Build predecessor map for subgraphs.
             let mut sg_preds = SecondaryMap::<_, Vec<_>>::with_capacity(self.subgraph_nodes.len());
             for (hoff_id, node) in self.nodes() {
                 if !matches!(node, GraphNode::Handoff { .. }) {
-                    // Not between handoffs
                     continue;
                 }
                 assert_eq!(1, self.node_successors(hoff_id).len());
@@ -1459,6 +1467,14 @@ impl DfirGraph {
                     // order unconstrained and can collapse a tick delay to zero when inline
                     // handoff buffers persist across ticks.
                     sg_preds.entry(pred_sg).unwrap().or_default().push(succ_sg);
+
+                    // Non-lazy tick-boundary: defer_tick (not defer_tick_lazy).
+                    if !self.subgraph_laziness(pred_sg) {
+                        defer_tick_buf_idents.push(Ident::new(
+                            &format!("hoff_{:?}_buf", hoff_id.data()),
+                            node.span(),
+                        ));
+                    }
                 } else {
                     sg_preds.entry(succ_sg).unwrap().or_default().push(pred_sg);
                 }
@@ -1473,36 +1489,6 @@ impl DfirGraph {
                 .into_iter()
                 .map(|sg_id| (sg_id, self.subgraph(sg_id)))
                 .collect::<Vec<_>>()
-        };
-
-        // Collect handoff buffer idents for non-lazy tick-boundary edges (defer_tick).
-        // When these buffers are non-empty at end of tick, we must set can_start_tick
-        // so that run_available continues ticking.
-        //
-        // TODO(cleanup): Once scheduled Dfir is removed, replace the `subgraph_laziness`
-        // flag with a more direct representation (e.g., a `DelayType` on the handoff edge
-        // itself). Currently we piggyback on the laziness bit of the intermediate identity
-        // subgraph that `flat_to_partitioned` injects for `defer_tick` vs `defer_tick_lazy`,
-        // which is an indirect way to distinguish the two.
-        let defer_tick_buf_idents: Vec<Ident> = {
-            let mut idents = Vec::new();
-            for (hoff_id, node) in self.nodes() {
-                if !matches!(node, GraphNode::Handoff { .. }) {
-                    continue;
-                }
-                let (_edge_id, pred) = self.node_predecessors(hoff_id).next().unwrap();
-                let (_edge_id, succ) = self.node_successors(hoff_id).next().unwrap();
-                let pred_sg = self.node_subgraph(pred).unwrap();
-                let succ_sg = self.node_subgraph(succ).unwrap();
-                let pred_stratum = self.subgraph_stratum(pred_sg).unwrap();
-                let succ_stratum = self.subgraph_stratum(succ_sg).unwrap();
-                // Non-lazy tick-boundary: pred at extra_stratum, succ at lower stratum.
-                if succ_stratum < pred_stratum && !self.subgraph_laziness(pred_sg) {
-                    let span = node.span();
-                    idents.push(Ident::new(&format!("hoff_{:?}_buf", hoff_id.data()), span));
-                }
-            }
-            idents
         };
 
         let mut op_prologue_code = Vec::new();
@@ -2067,10 +2053,7 @@ impl DfirGraph {
                     // For non-lazy defer_tick: if any deferred buffer has data,
                     // signal that another tick should run (sets can_start_tick).
                     if false #( || !#defer_tick_buf_idents.is_empty() )* {
-                        #df.schedule_subgraph(
-                            #root::scheduled::SubgraphId::from_raw(0),
-                            true,
-                        );
+                        #df.request_next_tick();
                     }
 
                     #df.__end_tick();

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1444,9 +1444,11 @@ impl DfirGraph {
         // `flat_to_partitioned` injects for `defer_tick` vs `defer_tick_lazy`.
         let mut defer_tick_buf_idents: Vec<Ident> = Vec::new();
         let all_subgraphs = {
+            // Build predecessor map for subgraphs.
             let mut sg_preds = SecondaryMap::<_, Vec<_>>::with_capacity(self.subgraph_nodes.len());
             for (hoff_id, node) in self.nodes() {
                 if !matches!(node, GraphNode::Handoff { .. }) {
+                    // Not a handoff; skip.
                     continue;
                 }
                 assert_eq!(1, self.node_successors(hoff_id).len());
@@ -2052,8 +2054,14 @@ impl DfirGraph {
 
                     // For non-lazy defer_tick: if any deferred buffer has data,
                     // signal that another tick should run (sets can_start_tick).
+                    // Inline DFIR doesn't dynamically schedule subgraph IDs, so the
+                    // subgraph ID here is a meaningless placeholder.
+                    // TODO(cleanup): remove the subgraph ID parameter once scheduled DFIR is gone.
                     if false #( || !#defer_tick_buf_idents.is_empty() )* {
-                        #df.request_next_tick();
+                        #df.schedule_subgraph(
+                            #root::scheduled::SubgraphId::from_raw(0),
+                            true,
+                        );
                     }
 
                     #df.__end_tick();

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1475,6 +1475,39 @@ impl DfirGraph {
                 .collect::<Vec<_>>()
         };
 
+        // Collect handoff buffer idents for non-lazy tick-boundary edges (defer_tick).
+        // When these buffers are non-empty at end of tick, we must set can_start_tick
+        // so that run_available continues ticking.
+        //
+        // TODO(cleanup): Once scheduled Dfir is removed, replace the `subgraph_laziness`
+        // flag with a more direct representation (e.g., a `DelayType` on the handoff edge
+        // itself). Currently we piggyback on the laziness bit of the intermediate identity
+        // subgraph that `flat_to_partitioned` injects for `defer_tick` vs `defer_tick_lazy`,
+        // which is an indirect way to distinguish the two.
+        let defer_tick_buf_idents: Vec<Ident> = {
+            let mut idents = Vec::new();
+            for (hoff_id, node) in self.nodes() {
+                if !matches!(node, GraphNode::Handoff { .. }) {
+                    continue;
+                }
+                let (_edge_id, pred) = self.node_predecessors(hoff_id).next().unwrap();
+                let (_edge_id, succ) = self.node_successors(hoff_id).next().unwrap();
+                let pred_sg = self.node_subgraph(pred).unwrap();
+                let succ_sg = self.node_subgraph(succ).unwrap();
+                let pred_stratum = self.subgraph_stratum(pred_sg).unwrap();
+                let succ_stratum = self.subgraph_stratum(succ_sg).unwrap();
+                // Non-lazy tick-boundary: pred at extra_stratum, succ at lower stratum.
+                if succ_stratum < pred_stratum && !self.subgraph_laziness(pred_sg) {
+                    let span = node.span();
+                    idents.push(Ident::new(
+                        &format!("hoff_{:?}_buf", hoff_id.data()),
+                        span,
+                    ));
+                }
+            }
+            idents
+        };
+
         let mut op_prologue_code = Vec::new();
         let mut op_prologue_after_code = Vec::new();
         let mut subgraph_blocks = Vec::new();
@@ -2033,6 +2066,15 @@ impl DfirGraph {
                 #[allow(unused_qualifications, unused_mut, unused_variables, clippy::await_holding_refcell_ref)]
                 let __dfir_inline_tick = async move || {
                     #( #subgraph_blocks )*
+
+                    // For non-lazy defer_tick: if any deferred buffer has data,
+                    // signal that another tick should run (sets can_start_tick).
+                    if false #( || !#defer_tick_buf_idents.is_empty() )* {
+                        #df.schedule_subgraph(
+                            #root::scheduled::SubgraphId::from_raw(0),
+                            true,
+                        );
+                    }
 
                     #df.__end_tick();
                     ::std::mem::take(&mut __dfir_work_done)

--- a/dfir_lang/src/graph/mod.rs
+++ b/dfir_lang/src/graph/mod.rs
@@ -550,17 +550,14 @@ fn validate_inline(graph: &DfirGraph, diagnostics: &mut Diagnostics) {
         ));
     }
 
-    // 2. Reject intra-tick cycles (non-DAG dataflows excluding tick-boundary edges).
-    // Build a subgraph-level directed graph, excluding edges that cross tick boundaries
-    // (defer_tick_lazy subgraphs, and back-edges where succ_stratum < pred_stratum).
-    // Then check for cycles via topo sort.
+    // 2. Reject intra-tick cycles.
+    // Build a subgraph-level directed graph, excluding edges where succ_stratum < pred_stratum.
+    // Stratification (find_subgraph_strata) guarantees that strata are non-decreasing along
+    // all non-tick edges: regular edges get non-decreasing strata via topo sort, Stratum
+    // (negative) edges get an increment, and Tick/TickLazy edges are excluded from
+    // stratification entirely and re-introduced at extra_stratum. So succ_stratum < pred_stratum
+    // can only occur for defer_tick/defer_tick_lazy back-edges, which are cross-tick by design.
     {
-        use std::collections::BTreeSet;
-
-        let all_sgs: BTreeSet<GraphSubgraphId> = graph.subgraph_ids().collect();
-
-        // Build predecessor map: for each subgraph, find which subgraphs feed into it
-        // within the same tick (excluding lazy subgraphs and tick-boundary back-edges).
         let predecessors = |sg_id: GraphSubgraphId| -> Vec<GraphSubgraphId> {
             let mut recv_hoffs = Vec::new();
             for &node_id in graph.subgraph(sg_id) {
@@ -573,28 +570,25 @@ fn validate_inline(graph: &DfirGraph, diagnostics: &mut Diagnostics) {
             let mut preds = Vec::new();
             for hoff_id in recv_hoffs {
                 for (_edge, pred_id) in graph.node_predecessors(hoff_id) {
-                    if let Some(pred_sg) = graph.node_subgraph(pred_id)
-                        && all_sgs.contains(&pred_sg)
-                    {
-                        // Skip lazy subgraphs (defer_tick_lazy intermediates).
-                        if graph.subgraph_laziness(pred_sg) {
-                            continue;
-                        }
-                        // Skip tick-boundary back-edges (defer_tick intermediates at extra_stratum
-                        // feeding into lower-stratum successors).
-                        let pred_stratum = graph.subgraph_stratum(pred_sg).unwrap_or(0);
-                        let succ_stratum = graph.subgraph_stratum(sg_id).unwrap_or(0);
-                        if succ_stratum < pred_stratum {
-                            continue;
-                        }
-                        preds.push(pred_sg);
+                    let pred_sg = graph
+                        .node_subgraph(pred_id)
+                        .expect("bug: handoff predecessor must belong to a subgraph");
+                    let pred_stratum = graph
+                        .subgraph_stratum(pred_sg)
+                        .expect("bug: subgraph must have a stratum assigned");
+                    let succ_stratum = graph
+                        .subgraph_stratum(sg_id)
+                        .expect("bug: subgraph must have a stratum assigned");
+                    if succ_stratum < pred_stratum {
+                        continue;
                     }
+                    preds.push(pred_sg);
                 }
             }
             preds
         };
 
-        let topo_result = graph_algorithms::topo_sort(all_sgs.iter().copied(), predecessors);
+        let topo_result = graph_algorithms::topo_sort(graph.subgraph_ids(), predecessors);
         if let Err(cycle) = topo_result {
             // Find a representative span from the first subgraph in the cycle.
             let span = cycle

--- a/dfir_lang/src/graph/mod.rs
+++ b/dfir_lang/src/graph/mod.rs
@@ -536,7 +536,7 @@ pub fn build_dfir_code_inline(
 }
 
 /// Validates that a partitioned graph is compatible with the inline codegen path.
-/// Rejects: (1) `loop {}` blocks, (2) `defer_tick()` (non-lazy), (3) intra-tick cycles.
+/// Rejects: (1) `loop {}` blocks, (2) intra-tick cycles.
 fn validate_inline(graph: &DfirGraph, diagnostics: &mut Diagnostics) {
     // 1. Reject `loop { }` blocks.
     if let Some((_loop_id, nodes)) = graph.loops().next() {
@@ -550,33 +550,17 @@ fn validate_inline(graph: &DfirGraph, diagnostics: &mut Diagnostics) {
         ));
     }
 
-    // 2. Reject `defer_tick()` (non-lazy).
-    for (node_id, _node) in graph.nodes() {
-        if let Some(op_inst) = graph.node_op_inst(node_id)
-            && op_inst.op_constraints.name == "defer_tick"
-        {
-            diagnostics.push(Diagnostic::spanned(
-                graph.node(node_id).span(),
-                Level::Error,
-                "`defer_tick()` is not (yet) supported in `dfir_syntax_inline!`. Use `defer_tick_lazy()` instead.",
-            ));
-        }
-    }
-
-    // 3. Reject intra-tick cycles (non-DAG dataflows excluding defer_tick_lazy).
-    // Build a subgraph-level directed graph, excluding lazy subgraphs (defer_tick_lazy).
-    // Then check for cycles via topo sort. Also check for self-loops on subgraphs.
+    // 2. Reject intra-tick cycles (non-DAG dataflows excluding tick-boundary edges).
+    // Build a subgraph-level directed graph, excluding edges that cross tick boundaries
+    // (defer_tick_lazy subgraphs, and back-edges where succ_stratum < pred_stratum).
+    // Then check for cycles via topo sort.
     {
         use std::collections::BTreeSet;
 
-        // Collect non-lazy subgraph IDs.
-        let non_lazy_sgs: BTreeSet<GraphSubgraphId> = graph
-            .subgraph_ids()
-            .filter(|&sg_id| !graph.subgraph_laziness(sg_id))
-            .collect();
+        let all_sgs: BTreeSet<GraphSubgraphId> = graph.subgraph_ids().collect();
 
-        // Build predecessor map: for each non-lazy subgraph, find which non-lazy subgraphs feed into it
-        // (including self-loops). Edges go through handoff nodes: pred_sg -> handoff -> succ_sg.
+        // Build predecessor map: for each subgraph, find which subgraphs feed into it
+        // within the same tick (excluding lazy subgraphs and tick-boundary back-edges).
         let predecessors = |sg_id: GraphSubgraphId| -> Vec<GraphSubgraphId> {
             let mut recv_hoffs = Vec::new();
             for &node_id in graph.subgraph(sg_id) {
@@ -590,8 +574,19 @@ fn validate_inline(graph: &DfirGraph, diagnostics: &mut Diagnostics) {
             for hoff_id in recv_hoffs {
                 for (_edge, pred_id) in graph.node_predecessors(hoff_id) {
                     if let Some(pred_sg) = graph.node_subgraph(pred_id)
-                        && non_lazy_sgs.contains(&pred_sg)
+                        && all_sgs.contains(&pred_sg)
                     {
+                        // Skip lazy subgraphs (defer_tick_lazy intermediates).
+                        if graph.subgraph_laziness(pred_sg) {
+                            continue;
+                        }
+                        // Skip tick-boundary back-edges (defer_tick intermediates at extra_stratum
+                        // feeding into lower-stratum successors).
+                        let pred_stratum = graph.subgraph_stratum(pred_sg).unwrap_or(0);
+                        let succ_stratum = graph.subgraph_stratum(sg_id).unwrap_or(0);
+                        if succ_stratum < pred_stratum {
+                            continue;
+                        }
                         preds.push(pred_sg);
                     }
                 }
@@ -599,7 +594,7 @@ fn validate_inline(graph: &DfirGraph, diagnostics: &mut Diagnostics) {
             preds
         };
 
-        let topo_result = graph_algorithms::topo_sort(non_lazy_sgs.iter().copied(), predecessors);
+        let topo_result = graph_algorithms::topo_sort(all_sgs.iter().copied(), predecessors);
         if let Err(cycle) = topo_result {
             // Find a representative span from the first subgraph in the cycle.
             let span = cycle
@@ -610,7 +605,7 @@ fn validate_inline(graph: &DfirGraph, diagnostics: &mut Diagnostics) {
             diagnostics.push(Diagnostic::spanned(
                 span,
                 Level::Error,
-                "Cyclical dataflow within a tick is not supported in `dfir_syntax_inline!`. Use `defer_tick_lazy()` to break the cycle across ticks.",
+                "Cyclical dataflow within a tick is not supported in `dfir_syntax_inline!`. Use `defer_tick()` or `defer_tick_lazy()` to break the cycle across ticks.",
             ));
         }
     }

--- a/dfir_rs/src/scheduled/context.rs
+++ b/dfir_rs/src/scheduled/context.rs
@@ -569,6 +569,13 @@ impl InlineContext {
         }
     }
 
+    /// Signals that another tick should be started (sets `can_start_tick`).
+    /// Used by generated code for non-lazy `defer_tick` buffers.
+    #[doc(hidden)]
+    pub fn request_next_tick(&self) {
+        self.wake_state.wake_by_ref();
+    }
+
     /// Returns a waker that signals external data has arrived.
     pub fn waker(&self) -> std::task::Waker {
         std::task::Waker::from(self.wake_state.clone())

--- a/dfir_rs/src/scheduled/context.rs
+++ b/dfir_rs/src/scheduled/context.rs
@@ -569,13 +569,6 @@ impl InlineContext {
         }
     }
 
-    /// Signals that another tick should be started (sets `can_start_tick`).
-    /// Used by generated code for non-lazy `defer_tick` buffers.
-    #[doc(hidden)]
-    pub fn request_next_tick(&self) {
-        self.wake_state.wake_by_ref();
-    }
-
     /// Returns a waker that signals external data has arrived.
     pub fn waker(&self) -> std::task::Waker {
         std::task::Waker::from(self.wake_state.clone())

--- a/dfir_rs/tests/compile-fail-stable/surface_inline_cycle.stderr
+++ b/dfir_rs/tests/compile-fail-stable/surface_inline_cycle.stderr
@@ -1,4 +1,4 @@
-error: Cyclical dataflow within a tick is not supported in `dfir_syntax_inline!`. Use `defer_tick_lazy()` to break the cycle across ticks.
+error: Cyclical dataflow within a tick is not supported in `dfir_syntax_inline!`. Use `defer_tick()` or `defer_tick_lazy()` to break the cycle across ticks.
  --> tests/compile-fail-stable/surface_inline_cycle.rs:3:9
   |
 3 |         source_iter(0..5_i32) -> my_union;

--- a/dfir_rs/tests/compile-fail-stable/surface_inline_defer_tick.rs
+++ b/dfir_rs/tests/compile-fail-stable/surface_inline_defer_tick.rs
@@ -1,1 +1,0 @@
-../compile-fail/surface_inline_defer_tick.rs

--- a/dfir_rs/tests/compile-fail-stable/surface_inline_defer_tick.stderr
+++ b/dfir_rs/tests/compile-fail-stable/surface_inline_defer_tick.stderr
@@ -1,5 +1,0 @@
-error: `defer_tick()` is not (yet) supported in `dfir_syntax_inline!`. Use `defer_tick_lazy()` instead.
- --> tests/compile-fail-stable/surface_inline_defer_tick.rs:3:34
-  |
-3 |         source_iter(0..5_i32) -> defer_tick() -> for_each(|_x: i32| {});
-  |                                  ^^^^^^^^^^

--- a/dfir_rs/tests/compile-fail/surface_inline_cycle.stderr
+++ b/dfir_rs/tests/compile-fail/surface_inline_cycle.stderr
@@ -1,4 +1,4 @@
-error: Cyclical dataflow within a tick is not supported in `dfir_syntax_inline!`. Use `defer_tick_lazy()` to break the cycle across ticks.
+error: Cyclical dataflow within a tick is not supported in `dfir_syntax_inline!`. Use `defer_tick()` or `defer_tick_lazy()` to break the cycle across ticks.
  --> tests/compile-fail/surface_inline_cycle.rs:3:9
   |
 3 |         source_iter(0..5_i32) -> my_union;

--- a/dfir_rs/tests/compile-fail/surface_inline_defer_tick.rs
+++ b/dfir_rs/tests/compile-fail/surface_inline_defer_tick.rs
@@ -1,5 +1,0 @@
-fn main() {
-    let mut flow = dfir_rs::dfir_syntax_inline! {
-        source_iter(0..5_i32) -> defer_tick() -> for_each(|_x: i32| {});
-    };
-}

--- a/dfir_rs/tests/compile-fail/surface_inline_defer_tick.stderr
+++ b/dfir_rs/tests/compile-fail/surface_inline_defer_tick.stderr
@@ -1,5 +1,0 @@
-error: `defer_tick()` is not (yet) supported in `dfir_syntax_inline!`. Use `defer_tick_lazy()` instead.
- --> tests/compile-fail/surface_inline_defer_tick.rs:3:34
-  |
-3 |         source_iter(0..5_i32) -> defer_tick() -> for_each(|_x: i32| {});
-  |                                  ^^^^^^^^^^

--- a/dfir_rs/tests/surface_inline.rs
+++ b/dfir_rs/tests/surface_inline.rs
@@ -424,3 +424,97 @@ pub async fn test_inline_defer_tick_lazy_cycle() {
     flow.run_tick().await;
     assert_eq!(vec![4, 12], output.take());
 }
+
+/// Test: defer_tick (non-lazy) — data from tick N appears in tick N+1.
+#[dfir_rs::test]
+pub async fn test_inline_defer_tick() {
+    let (send, recv) = dfir_rs::util::unbounded_channel::<i32>();
+    let (out_send, mut out_recv) = dfir_rs::util::unbounded_channel::<i32>();
+    let mut flow = dfir_rs::dfir_syntax_inline! {
+        source_stream(recv) -> defer_tick() -> for_each(|v: i32| out_send.send(v).unwrap());
+    };
+
+    send.send(1).unwrap();
+    send.send(2).unwrap();
+    flow.run_tick().await;
+    // Tick 0: data is deferred, nothing comes out yet.
+    assert_eq!(
+        Vec::<i32>::new(),
+        dfir_rs::util::collect_ready_async::<Vec<_>, _>(&mut out_recv).await
+    );
+
+    send.send(3).unwrap();
+    flow.run_tick().await;
+    // Tick 1: data from tick 0 appears.
+    assert_eq!(
+        vec![1, 2],
+        dfir_rs::util::collect_ready_async::<Vec<_>, _>(&mut out_recv).await
+    );
+
+    flow.run_tick().await;
+    // Tick 2: data from tick 1 appears.
+    assert_eq!(
+        vec![3],
+        dfir_rs::util::collect_ready_async::<Vec<_>, _>(&mut out_recv).await
+    );
+}
+
+/// Test: defer_tick (non-lazy) flip-flop — a cycle through defer_tick toggles a boolean.
+#[dfir_rs::test]
+pub async fn test_inline_defer_tick_nonlazy_flipflop() {
+    let (out_send, mut out_recv) = dfir_rs::util::unbounded_channel::<bool>();
+    let mut flow = dfir_rs::dfir_syntax_inline! {
+        source_iter(vec![true])
+                -> state;
+        state = union()
+                -> inspect(|x: &bool| out_send.send(*x).unwrap())
+                -> map(|x: bool| !x)
+                -> defer_tick()
+                -> state;
+    };
+
+    flow.run_tick().await;
+    assert_eq!(
+        vec![true],
+        dfir_rs::util::collect_ready_async::<Vec<_>, _>(&mut out_recv).await
+    );
+
+    flow.run_tick().await;
+    assert_eq!(
+        vec![false],
+        dfir_rs::util::collect_ready_async::<Vec<_>, _>(&mut out_recv).await
+    );
+
+    flow.run_tick().await;
+    assert_eq!(
+        vec![true],
+        dfir_rs::util::collect_ready_async::<Vec<_>, _>(&mut out_recv).await
+    );
+}
+
+/// Test: defer_tick (non-lazy) with run_available — run_available should continue
+/// ticking as long as defer_tick buffers have data (the key difference from lazy).
+#[dfir_rs::test]
+pub async fn test_inline_defer_tick_run_available() {
+    let output = std::rc::Rc::new(std::cell::RefCell::new(Vec::<usize>::new()));
+    let output_inner = std::rc::Rc::clone(&output);
+
+    let mut flow = dfir_rs::dfir_syntax_inline! {
+        a = union() -> tee();
+        source_iter([1_usize, 3]) -> [0]a;
+        a[0] -> defer_tick() -> map(|x: usize| 2 * x) -> filter(|&x: &usize| x < 20) -> [1]a;
+        a[1] -> for_each(|x: usize| output_inner.borrow_mut().push(x));
+    };
+
+    // run_available should run multiple ticks until quiescence (defer buffers empty).
+    flow.run_available().await;
+
+    let result = output.take();
+    // Tick 0: [1, 3]
+    // Tick 1: [2, 6] (from defer of 1,3 -> *2)
+    // Tick 2: [4, 12] (from defer of 2,6 -> *2)
+    // Tick 3: [8] (from defer of 4,12 -> *2, 24 filtered out)
+    // Tick 4: [16] (from defer of 8 -> *2)
+    // Tick 5: [] (32 filtered out, no more data)
+    assert_eq!(vec![1, 3, 2, 6, 4, 12, 8, 16], result);
+}


### PR DESCRIPTION
Previously, `defer_tick()` (non-lazy) was explicitly rejected in the inline
codegen path with an error directing users to use `defer_tick_lazy()` instead.
This change adds full support for `defer_tick()` in inline mode.

Changes:

1. dfir_lang/src/graph/mod.rs - validate_inline():
   - Removed the explicit rejection of `defer_tick()` operators.
   - Updated cycle detection to exclude tick-boundary back-edges (where
     succ_stratum < pred_stratum) in addition to lazy subgraphs, so that
     `defer_tick` cycles are correctly recognized as cross-tick, not intra-tick.
   - Updated error message to suggest both `defer_tick()` and `defer_tick_lazy()`.

2. dfir_lang/src/graph/meta_graph.rs - as_code_inline():
   - Added collection of handoff buffer idents for non-lazy tick-boundary edges
     (defer_tick intermediates at extra_stratum feeding lower-stratum successors).
   - Generated end-of-tick code that checks if any non-lazy defer buffers are
     non-empty and calls `schedule_subgraph(_, true)` to set `can_start_tick`,
     ensuring `run_available()` continues ticking until quiescence.
   - Added TODO(cleanup) noting that `subgraph_laziness` is an indirect way to
     distinguish defer_tick from defer_tick_lazy and should be replaced with a
     more direct representation once the old scheduled Dfir is removed.

3. Removed compile-fail test files for surface_inline_defer_tick (now supported).

4. Updated compile-fail stderr for surface_inline_cycle to match new error message.

5. Added 3 new tests in dfir_rs/tests/surface_inline.rs:
   - test_inline_defer_tick: basic data deferral by one tick
   - test_inline_defer_tick_nonlazy_flipflop: cycle through defer_tick
   - test_inline_defer_tick_run_available: verifies run_available runs multiple
     ticks until quiescence (the key behavioral difference from defer_tick_lazy)

Co-authored-by: Infinity 🤖 <infinity@hydro.run>