### PR TITLE
refactor(dfir_rs): switch 26 test files to dfir_syntax_inline! codegen path

### DIFF
--- a/dfir_lang/src/graph/ops/lattice_bimorphism.rs
+++ b/dfir_lang/src/graph/ops/lattice_bimorphism.rs
@@ -78,14 +78,20 @@ pub const LATTICE_BIMORPHISM: OperatorConstraints = OperatorConstraints {
 
         let write_iterator = quote_spanned! {op_span=>
             let #ident = {
+                let (lhs_state, rhs_state) = unsafe {
+                    // SAFETY: handle from `#df_ident.add_state(..)`.
+                    (
+                        #context.state_ref_unchecked(#lhs_state_handle),
+                        #context.state_ref_unchecked(#rhs_state_handle),
+                    )
+                };
                 #[inline(always)]
                 fn check_inputs<'a, Func, LhsPull, RhsPull, LhsState, RhsState, Output>(
                     lhs_pull: LhsPull,
                     rhs_pull: RhsPull,
                     func: Func,
-                    lhs_state_handle: #root::scheduled::state::StateHandle<::std::cell::RefCell<LhsState>>,
-                    rhs_state_handle: #root::scheduled::state::StateHandle<::std::cell::RefCell<RhsState>>,
-                    context: &'a #root::scheduled::context::Context,
+                    lhs_state: &'a ::std::cell::RefCell<LhsState>,
+                    rhs_state: &'a ::std::cell::RefCell<RhsState>,
                 ) -> impl #root::dfir_pipes::pull::Pull<
                     Item = Output,
                     Meta = (),
@@ -102,14 +108,6 @@ pub const LATTICE_BIMORPHISM: OperatorConstraints = OperatorConstraints {
                     RhsState: 'static + ::std::clone::Clone,
                     Output: #root::lattices::Merge<Output>,
                 {
-                    let (lhs_state, rhs_state) = unsafe {
-                        // SAFETY: handle from `#df_ident.add_state(..)`.
-                        (
-                            context.state_ref_unchecked(lhs_state_handle),
-                            context.state_ref_unchecked(rhs_state_handle),
-                        )
-                    };
-
                     #root::compiled::pull::LatticeBimorphismPull::new(
                         #root::dfir_pipes::pull::Pull::fuse(lhs_pull),
                         #root::dfir_pipes::pull::Pull::fuse(rhs_pull),
@@ -122,9 +120,8 @@ pub const LATTICE_BIMORPHISM: OperatorConstraints = OperatorConstraints {
                     #lhs_items,
                     #rhs_items,
                     #func,
-                    #lhs_state_handle,
-                    #rhs_state_handle,
-                    &#context,
+                    lhs_state,
+                    rhs_state,
                 )
             };
         };

--- a/dfir_lang/src/graph/ops/state_by.rs
+++ b/dfir_lang/src/graph/ops/state_by.rs
@@ -122,11 +122,14 @@ pub const STATE_BY: OperatorConstraints = OperatorConstraints {
             let input = &inputs[0];
             quote_spanned! {op_span=>
                 let #ident = {
+                    let state_ref = unsafe {
+                        // SAFETY: handle from `#df_ident.add_state(..)`.
+                        #context.state_ref_unchecked(#state_ident)
+                    };
                     fn check_input<'a, Item, MappingFn, MappedItem, Prev, Lat>(
                         prev: Prev,
                         mapfn: MappingFn,
-                        state_handle: #root::scheduled::state::StateHandle<::std::cell::RefCell<Lat>>,
-                        context: &'a #root::scheduled::context::Context,
+                        state_ref: &'a ::std::cell::RefCell<Lat>,
                     ) -> impl 'a + #root::dfir_pipes::pull::Pull<Item = Item, Meta = Prev::Meta>
                     where
                         Item: ::std::clone::Clone,
@@ -137,26 +140,25 @@ pub const STATE_BY: OperatorConstraints = OperatorConstraints {
                         #root::dfir_pipes::pull::Pull::filter(
                             prev,
                             move |item| {
-                                let state = unsafe {
-                                    // SAFETY: handle from `#df_ident.add_state(..)`.
-                                    context.state_ref_unchecked(state_handle)
-                                };
-                                let mut state = state.borrow_mut();
+                                let mut state = state_ref.borrow_mut();
                                 #root::lattices::Merge::merge(&mut *state, (mapfn)(::std::clone::Clone::clone(item)))
                             },
                         )
                     }
-                    check_input::<_, _, _, _, #lattice_type>(#input, #by_fn, #state_ident, #context)
+                    check_input::<_, _, _, _, #lattice_type>(#input, #by_fn, state_ref)
                 };
             }
         } else if let Some(output) = outputs.first() {
             quote_spanned! {op_span=>
                 let #ident = {
+                    let state_ref = unsafe {
+                        // SAFETY: handle from `#df_ident.add_state(..)`.
+                        #context.state_ref_unchecked(#state_ident)
+                    };
                     fn check_output<'a, Item, MappingFn, MappedItem, Psh, Lat>(
                         push: Psh,
                         mapfn: MappingFn,
-                        state_handle: #root::scheduled::state::StateHandle<::std::cell::RefCell<Lat>>,
-                        context: &'a #root::scheduled::context::Context,
+                        state_ref: &'a ::std::cell::RefCell<Lat>,
                     ) -> impl 'a + #root::dfir_pipes::push::Push<Item, ()>
                     where
                         Item: 'a + ::std::clone::Clone,
@@ -165,24 +167,23 @@ pub const STATE_BY: OperatorConstraints = OperatorConstraints {
                         Lat: 'static + #root::lattices::Merge<MappedItem>,
                     {
                         #root::dfir_pipes::push::filter(move |item| {
-                            let state = unsafe {
-                                // SAFETY: handle from `#df_ident.add_state(..)`.
-                                context.state_ref_unchecked(state_handle)
-                            };
-                            let mut state = state.borrow_mut();
-                                #root::lattices::Merge::merge(&mut *state, (mapfn)(::std::clone::Clone::clone(item)))
+                            let mut state = state_ref.borrow_mut();
+                            #root::lattices::Merge::merge(&mut *state, (mapfn)(::std::clone::Clone::clone(item)))
                         }, push)
                     }
-                    check_output::<_, _, _, _, #lattice_type>(#output, #by_fn, #state_ident, #context)
+                    check_output::<_, _, _, _, #lattice_type>(#output, #by_fn, state_ref)
                 };
             }
         } else {
             quote_spanned! {op_span=>
                 let #ident = {
+                    let state_ref = unsafe {
+                        // SAFETY: handle from `#df_ident.add_state(..)`.
+                        #context.state_ref_unchecked(#state_ident)
+                    };
                     fn check_output<'a, Item, MappingFn, MappedItem, Lat>(
-                        state_handle: #root::scheduled::state::StateHandle<::std::cell::RefCell<Lat>>,
+                        state_ref: &'a ::std::cell::RefCell<Lat>,
                         mapfn: MappingFn,
-                        context: &'a #root::scheduled::context::Context,
                     ) -> impl 'a + #root::dfir_pipes::push::Push<Item, ()>
                     where
                         Item: 'a,
@@ -191,15 +192,11 @@ pub const STATE_BY: OperatorConstraints = OperatorConstraints {
                         Lat: 'static + #root::lattices::Merge<MappedItem>,
                     {
                         #root::dfir_pipes::push::for_each(move |item| {
-                            let state = unsafe {
-                                // SAFETY: handle from `#df_ident.add_state(..)`.
-                                context.state_ref_unchecked(state_handle)
-                            };
-                            let mut state = state.borrow_mut();
+                            let mut state = state_ref.borrow_mut();
                             #root::lattices::Merge::merge(&mut *state, (mapfn)(item));
                         })
                     }
-                    check_output::<_, _, _, #lattice_type>(#state_ident, #by_fn, #context)
+                    check_output::<_, _, _, #lattice_type>(state_ref, #by_fn)
                 };
             }
         };

--- a/dfir_rs/src/scheduled/context.rs
+++ b/dfir_rs/src/scheduled/context.rs
@@ -797,6 +797,23 @@ impl<Tick: TickClosure> InlineDfir<Tick> {
         }
     }
 
+    /// [`Self::run_available`] but panics if any tick yields asynchronously.
+    pub fn run_available_sync(&mut self) {
+        self.wake_state
+            .can_start_tick
+            .store(false, Ordering::Relaxed);
+        loop {
+            self.run_tick_sync();
+            let can_start_tick = self
+                .wake_state
+                .can_start_tick
+                .swap(false, Ordering::Relaxed);
+            if !can_start_tick {
+                break;
+            }
+        }
+    }
+
     /// Run forever, processing ticks when work is available and yielding when idle.
     pub async fn run(&mut self) -> crate::Never {
         loop {

--- a/dfir_rs/tests/surface_anti_join.rs
+++ b/dfir_rs/tests/surface_anti_join.rs
@@ -1,8 +1,9 @@
 use dfir_rs::dfir_syntax_inline;
-use dfir_rs::util::{collect_ready_async, unbounded_channel};
+use dfir_rs::util::{collect_ready, unbounded_channel};
+use multiplatform_test::multiplatform_test;
 
-#[dfir_rs::test]
-pub async fn test_anti_join_multiset() {
+#[multiplatform_test]
+pub fn test_anti_join_multiset() {
     let (inp_send, inp_recv) = unbounded_channel::<(usize, usize)>();
     let (out_send, mut out_recv) = unbounded_channel::<(usize, usize)>();
     let mut flow = dfir_syntax_inline! {
@@ -22,16 +23,16 @@ pub async fn test_anti_join_multiset() {
     }
     flow.run_tick_sync();
 
-    flow.run_available().await;
-    let out: Vec<_> = collect_ready_async(&mut out_recv).await;
+    flow.run_available_sync();
+    let out: Vec<_> = collect_ready(&mut out_recv);
     assert_eq!(
         &[(1, 2), (1, 2), (2, 3), (3, 4), (4, 5), (5, 4), (6, 5)],
         &*out
     );
 }
 
-#[dfir_rs::test]
-pub async fn test_anti_join() {
+#[multiplatform_test]
+pub fn test_anti_join() {
     let (inp_send, inp_recv) = unbounded_channel::<(usize, usize)>();
     let (out_send, mut out_recv) = unbounded_channel::<(usize, usize)>();
     let mut flow = dfir_syntax_inline! {
@@ -51,16 +52,16 @@ pub async fn test_anti_join() {
     }
     flow.run_tick_sync();
 
-    flow.run_available().await;
-    let out: Vec<_> = collect_ready_async(&mut out_recv).await;
+    flow.run_available_sync();
+    let out: Vec<_> = collect_ready(&mut out_recv);
     assert_eq!(
         &[(1, 2), (1, 2), (2, 3), (3, 4), (4, 5), (5, 4), (6, 5)],
         &*out
     );
 }
 
-#[dfir_rs::test]
-pub async fn test_anti_join_tick_static() {
+#[multiplatform_test]
+pub fn test_anti_join_tick_static() {
     let (pos_send, pos_recv) = unbounded_channel::<(usize, usize)>();
     let (neg_send, neg_recv) = unbounded_channel::<usize>();
     let (out_send, mut out_recv) = unbounded_channel::<(usize, usize)>();
@@ -79,20 +80,20 @@ pub async fn test_anti_join_tick_static() {
         neg_send.send(x).unwrap();
     }
     flow.run_tick_sync();
-    let out: Vec<_> = collect_ready_async(&mut out_recv).await;
+    let out: Vec<_> = collect_ready(&mut out_recv);
     assert_eq!(&[(1, 2), (1, 2), (5, 6), (400, 5)], &*out);
 
     for x in [(10, 10), (10, 10), (200, 5)] {
         pos_send.send(x).unwrap();
     }
 
-    flow.run_available().await;
-    let out: Vec<_> = collect_ready_async(&mut out_recv).await;
+    flow.run_available_sync();
+    let out: Vec<_> = collect_ready(&mut out_recv);
     assert_eq!(&[(10, 10), (10, 10)], &*out);
 }
 
-#[dfir_rs::test]
-pub async fn test_anti_join_multiset_tick_static() {
+#[multiplatform_test]
+pub fn test_anti_join_multiset_tick_static() {
     let (pos_send, pos_recv) = unbounded_channel::<(usize, usize)>();
     let (neg_send, neg_recv) = unbounded_channel::<usize>();
     let (out_send, mut out_recv) = unbounded_channel::<(usize, usize)>();
@@ -111,20 +112,20 @@ pub async fn test_anti_join_multiset_tick_static() {
         neg_send.send(x).unwrap();
     }
     flow.run_tick_sync();
-    let out: Vec<_> = collect_ready_async(&mut out_recv).await;
+    let out: Vec<_> = collect_ready(&mut out_recv);
     assert_eq!(&[(1, 2), (1, 2), (5, 6), (400, 5),], &*out);
 
     for x in [(10, 10), (10, 10), (200, 5)] {
         pos_send.send(x).unwrap();
     }
 
-    flow.run_available().await;
-    let out: Vec<_> = collect_ready_async(&mut out_recv).await;
+    flow.run_available_sync();
+    let out: Vec<_> = collect_ready(&mut out_recv);
     assert_eq!(&[(10, 10), (10, 10)], &*out);
 }
 
-#[dfir_rs::test]
-pub async fn test_anti_join_multiset_static() {
+#[multiplatform_test]
+pub fn test_anti_join_multiset_static() {
     let (pos_send, pos_recv) = unbounded_channel::<(usize, usize)>();
     let (neg_send, neg_recv) = unbounded_channel::<usize>();
     let (out_send, mut out_recv) = unbounded_channel::<(usize, usize)>();
@@ -143,12 +144,12 @@ pub async fn test_anti_join_multiset_static() {
         neg_send.send(x).unwrap();
     }
     flow.run_tick_sync();
-    let out: Vec<_> = collect_ready_async(&mut out_recv).await;
+    let out: Vec<_> = collect_ready(&mut out_recv);
     assert_eq!(&[(1, 2), (1, 2), (5, 6), (400, 5)], &*out);
 
     neg_send.send(400).unwrap();
 
-    flow.run_available().await;
-    let out: Vec<_> = collect_ready_async(&mut out_recv).await;
+    flow.run_available_sync();
+    let out: Vec<_> = collect_ready(&mut out_recv);
     assert_eq!(&[(1, 2), (1, 2), (5, 6)], &*out);
 }

--- a/dfir_rs/tests/surface_anti_join.rs
+++ b/dfir_rs/tests/surface_anti_join.rs
@@ -1,12 +1,11 @@
-use dfir_rs::dfir_syntax;
-use dfir_rs::util::{collect_ready, unbounded_channel};
-use multiplatform_test::multiplatform_test;
+use dfir_rs::dfir_syntax_inline;
+use dfir_rs::util::{collect_ready_async, unbounded_channel};
 
-#[multiplatform_test]
-pub fn test_anti_join_multiset() {
+#[dfir_rs::test]
+pub async fn test_anti_join_multiset() {
     let (inp_send, inp_recv) = unbounded_channel::<(usize, usize)>();
     let (out_send, mut out_recv) = unbounded_channel::<(usize, usize)>();
-    let mut flow = dfir_syntax! {
+    let mut flow = dfir_syntax_inline! {
         inp = source_stream(inp_recv) -> tee();
         diff = anti_join() -> sort() -> for_each(|x| out_send.send(x).unwrap());
         inp -> [pos]diff;
@@ -23,19 +22,19 @@ pub fn test_anti_join_multiset() {
     }
     flow.run_tick_sync();
 
-    flow.run_available_sync();
-    let out: Vec<_> = collect_ready(&mut out_recv);
+    flow.run_available().await;
+    let out: Vec<_> = collect_ready_async(&mut out_recv).await;
     assert_eq!(
         &[(1, 2), (1, 2), (2, 3), (3, 4), (4, 5), (5, 4), (6, 5)],
         &*out
     );
 }
 
-#[multiplatform_test]
-pub fn test_anti_join() {
+#[dfir_rs::test]
+pub async fn test_anti_join() {
     let (inp_send, inp_recv) = unbounded_channel::<(usize, usize)>();
     let (out_send, mut out_recv) = unbounded_channel::<(usize, usize)>();
-    let mut flow = dfir_syntax! {
+    let mut flow = dfir_syntax_inline! {
         inp = source_stream(inp_recv) -> tee();
         diff = anti_join() -> sort() -> for_each(|x| out_send.send(x).unwrap());
         inp -> [pos]diff;
@@ -52,20 +51,20 @@ pub fn test_anti_join() {
     }
     flow.run_tick_sync();
 
-    flow.run_available_sync();
-    let out: Vec<_> = collect_ready(&mut out_recv);
+    flow.run_available().await;
+    let out: Vec<_> = collect_ready_async(&mut out_recv).await;
     assert_eq!(
         &[(1, 2), (1, 2), (2, 3), (3, 4), (4, 5), (5, 4), (6, 5)],
         &*out
     );
 }
 
-#[multiplatform_test]
-pub fn test_anti_join_tick_static() {
+#[dfir_rs::test]
+pub async fn test_anti_join_tick_static() {
     let (pos_send, pos_recv) = unbounded_channel::<(usize, usize)>();
     let (neg_send, neg_recv) = unbounded_channel::<usize>();
     let (out_send, mut out_recv) = unbounded_channel::<(usize, usize)>();
-    let mut flow = dfir_syntax! {
+    let mut flow = dfir_syntax_inline! {
         pos = source_stream(pos_recv);
         neg = source_stream(neg_recv);
         pos -> [pos]diff_static;
@@ -80,24 +79,24 @@ pub fn test_anti_join_tick_static() {
         neg_send.send(x).unwrap();
     }
     flow.run_tick_sync();
-    let out: Vec<_> = collect_ready(&mut out_recv);
+    let out: Vec<_> = collect_ready_async(&mut out_recv).await;
     assert_eq!(&[(1, 2), (1, 2), (5, 6), (400, 5)], &*out);
 
     for x in [(10, 10), (10, 10), (200, 5)] {
         pos_send.send(x).unwrap();
     }
 
-    flow.run_available_sync();
-    let out: Vec<_> = collect_ready(&mut out_recv);
+    flow.run_available().await;
+    let out: Vec<_> = collect_ready_async(&mut out_recv).await;
     assert_eq!(&[(10, 10), (10, 10)], &*out);
 }
 
-#[multiplatform_test]
-pub fn test_anti_join_multiset_tick_static() {
+#[dfir_rs::test]
+pub async fn test_anti_join_multiset_tick_static() {
     let (pos_send, pos_recv) = unbounded_channel::<(usize, usize)>();
     let (neg_send, neg_recv) = unbounded_channel::<usize>();
     let (out_send, mut out_recv) = unbounded_channel::<(usize, usize)>();
-    let mut flow = dfir_syntax! {
+    let mut flow = dfir_syntax_inline! {
         pos = source_stream(pos_recv);
         neg = source_stream(neg_recv);
         pos -> [pos]diff_static;
@@ -112,24 +111,24 @@ pub fn test_anti_join_multiset_tick_static() {
         neg_send.send(x).unwrap();
     }
     flow.run_tick_sync();
-    let out: Vec<_> = collect_ready(&mut out_recv);
+    let out: Vec<_> = collect_ready_async(&mut out_recv).await;
     assert_eq!(&[(1, 2), (1, 2), (5, 6), (400, 5),], &*out);
 
     for x in [(10, 10), (10, 10), (200, 5)] {
         pos_send.send(x).unwrap();
     }
 
-    flow.run_available_sync();
-    let out: Vec<_> = collect_ready(&mut out_recv);
+    flow.run_available().await;
+    let out: Vec<_> = collect_ready_async(&mut out_recv).await;
     assert_eq!(&[(10, 10), (10, 10)], &*out);
 }
 
-#[multiplatform_test]
-pub fn test_anti_join_multiset_static() {
+#[dfir_rs::test]
+pub async fn test_anti_join_multiset_static() {
     let (pos_send, pos_recv) = unbounded_channel::<(usize, usize)>();
     let (neg_send, neg_recv) = unbounded_channel::<usize>();
     let (out_send, mut out_recv) = unbounded_channel::<(usize, usize)>();
-    let mut flow = dfir_syntax! {
+    let mut flow = dfir_syntax_inline! {
         pos = source_stream(pos_recv);
         neg = source_stream(neg_recv);
         pos -> [pos]diff_static;
@@ -144,12 +143,12 @@ pub fn test_anti_join_multiset_static() {
         neg_send.send(x).unwrap();
     }
     flow.run_tick_sync();
-    let out: Vec<_> = collect_ready(&mut out_recv);
+    let out: Vec<_> = collect_ready_async(&mut out_recv).await;
     assert_eq!(&[(1, 2), (1, 2), (5, 6), (400, 5)], &*out);
 
     neg_send.send(400).unwrap();
 
-    flow.run_available_sync();
-    let out: Vec<_> = collect_ready(&mut out_recv);
+    flow.run_available().await;
+    let out: Vec<_> = collect_ready_async(&mut out_recv).await;
     assert_eq!(&[(1, 2), (1, 2), (5, 6)], &*out);
 }

--- a/dfir_rs/tests/surface_async.rs
+++ b/dfir_rs/tests/surface_async.rs
@@ -7,9 +7,8 @@ use std::error::Error;
 use std::net::{Ipv4Addr, SocketAddr};
 
 use bytes::Bytes;
-use dfir_rs::scheduled::graph::Dfir;
 use dfir_rs::util::{collect_ready_async, tcp_lines};
-use dfir_rs::{assert_graphvis_snapshots, dfir_syntax, rassert, rassert_eq};
+use dfir_rs::{dfir_syntax_inline, rassert, rassert_eq};
 use multiplatform_test::multiplatform_test;
 use tokio::net::{TcpListener, TcpStream, UdpSocket};
 use tokio::task::LocalSet;
@@ -33,7 +32,7 @@ pub async fn test_echo_udp() -> Result<(), Box<dyn Error>> {
 
         let (seen_send, seen_recv) = dfir_rs::util::unbounded_channel();
 
-        let mut df: Dfir = dfir_syntax! {
+        let mut df = dfir_syntax_inline! {
             recv = source_stream(udp_recv)
                 -> map(|r| r.unwrap())
                 -> tee();
@@ -67,7 +66,7 @@ pub async fn test_echo_udp() -> Result<(), Box<dyn Error>> {
 
         let (seen_send, seen_recv) = dfir_rs::util::unbounded_channel();
 
-        let mut df = dfir_syntax! {
+        let mut df = dfir_syntax_inline! {
             recv = source_stream(recv_udp)
                 -> map(|r| r.unwrap())
                 -> tee();
@@ -98,7 +97,7 @@ pub async fn test_echo_udp() -> Result<(), Box<dyn Error>> {
 
         let (seen_send, seen_recv) = dfir_rs::util::unbounded_channel();
 
-        let mut df = dfir_syntax! {
+        let mut df = dfir_syntax_inline! {
             recv = source_stream(recv_udp)
                 -> map(|r| r.unwrap())
                 -> tee();
@@ -145,7 +144,7 @@ pub async fn test_echo_tcp() -> Result<(), Box<dyn Error>> {
 
         let (seen_send, seen_recv) = dfir_rs::util::unbounded_channel();
 
-        let mut df: Dfir = dfir_syntax! {
+        let mut df = dfir_syntax_inline! {
             rev = source_stream(server_recv)
                 -> map(|x| x.unwrap())
                 -> tee();
@@ -172,7 +171,7 @@ pub async fn test_echo_tcp() -> Result<(), Box<dyn Error>> {
 
         let (seen_send, seen_recv) = dfir_rs::util::unbounded_channel();
 
-        let mut df = dfir_syntax! {
+        let mut df = dfir_syntax_inline! {
             recv = source_stream(client_recv)
                 -> map(|x| x.unwrap())
                 -> tee();
@@ -213,10 +212,9 @@ pub async fn test_echo() {
     // LinesCodec separates each line from `lines_recv` with `\n`.
     let stdout_lines = FramedWrite::new(tokio::io::stdout(), LinesCodec::new());
 
-    let mut df: Dfir = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_stream(lines_recv) -> dest_sink(stdout_lines);
     };
-    assert_graphvis_snapshots!(df);
     df.run_available().await;
 
     lines_send.send("Hello".to_owned()).unwrap();
@@ -240,7 +238,7 @@ pub async fn test_futures_stream_sink() {
 
     let (seen_send, seen_recv) = dfir_rs::util::unbounded_channel();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         recv = source_stream(recv) -> tee();
         recv[0] -> map(|x| x + 1)
             -> filter(|&x| x < MAX)
@@ -264,7 +262,7 @@ async fn asynctest_dest_sink_bounded_channel() {
     let send = tokio_util::sync::PollSender::new(send);
     let mut recv = tokio_stream::wrappers::ReceiverStream::new(recv);
 
-    let mut flow = dfir_syntax! {
+    let mut flow = dfir_syntax_inline! {
         source_iter(0..10) -> dest_sink(send);
     };
     let mut run_fut = std::pin::pin!(flow.run());
@@ -298,7 +296,7 @@ async fn asynctest_dest_sink_duplex() {
         .length_field_length(1)
         .new_write(asyncwrite);
 
-    let mut flow = dfir_syntax! {
+    let mut flow = dfir_syntax_inline! {
         source_iter([
             Bytes::from_static(b"hello"),
             Bytes::from_static(b"world"),
@@ -323,7 +321,7 @@ async fn asynctest_dest_asyncwrite_duplex() {
     let (asyncwrite, mut asyncread) = tokio::io::duplex(256);
     let sink = FramedWrite::new(asyncwrite, BytesCodec::new());
 
-    let mut flow = dfir_syntax! {
+    let mut flow = dfir_syntax_inline! {
         source_iter([
             Bytes::from_static("hello".as_bytes()),
             Bytes::from_static("world".as_bytes()),
@@ -346,16 +344,16 @@ async fn asynctest_source_stream() {
     let (c_send, c_recv) = dfir_rs::util::unbounded_channel::<usize>();
 
     let task_a = tokio::task::spawn_local(async move {
-        let mut flow = dfir_syntax! {
+        let mut flow = dfir_syntax_inline! {
             source_stream(a_recv) -> for_each(|x| { b_send.send(x).unwrap(); });
         };
-        let None = flow.run().await;
+        flow.run().await;
     });
     let task_b = tokio::task::spawn_local(async move {
-        let mut flow = dfir_syntax! {
+        let mut flow = dfir_syntax_inline! {
             source_stream(b_recv) -> for_each(|x| { c_send.send(x).unwrap(); });
         };
-        let None = flow.run().await;
+        flow.run().await;
     });
 
     a_send.send(1).unwrap();
@@ -400,7 +398,7 @@ async fn asynctest_check_state_yielding() {
 
     let task_b = tokio::task::spawn_local(
         async move {
-            let mut hf = dfir_syntax! {
+            let mut hf = dfir_syntax_inline! {
                 source_stream(a_recv)
                     -> reduce::<'static>(|a: &mut _, b| *a += b)
                     -> for_each(|x| b_send.send(x).unwrap());
@@ -429,7 +427,7 @@ async fn asynctest_check_state_yielding() {
 async fn asynctest_repeat_iter() {
     let (b_send, b_recv) = dfir_rs::util::unbounded_channel::<usize>();
 
-    let mut hf = dfir_syntax! {
+    let mut hf = dfir_syntax_inline! {
         source_iter(0..3) -> persist::<'static>()
             -> for_each(|x| b_send.send(x).unwrap());
     };
@@ -444,7 +442,7 @@ async fn asynctest_event_repeat_iter() {
     let (a_send, a_recv) = dfir_rs::util::unbounded_channel::<usize>();
     let (b_send, b_recv) = dfir_rs::util::unbounded_channel::<usize>();
 
-    let mut hf = dfir_syntax! {
+    let mut hf = dfir_syntax_inline! {
         source_iter(0..3) -> persist::<'static>() -> my_union;
         source_stream(a_recv) -> my_union;
         my_union = union() -> for_each(|x| b_send.send(x).unwrap());
@@ -476,14 +474,14 @@ async fn asynctest_tcp() {
     let (tx_out, rx_out) = dfir_rs::util::unbounded_channel::<String>();
 
     let (tx, rx, server_addr) = dfir_rs::util::bind_tcp_lines("127.0.0.1:0".parse().unwrap()).await;
-    let mut echo_server = dfir_syntax! {
+    let mut echo_server = dfir_syntax_inline! {
         source_stream(rx)
             -> filter_map(Result::ok)
             -> dest_sink(tx);
     };
 
     let (tx, rx) = dfir_rs::util::connect_tcp_lines();
-    let mut echo_client = dfir_syntax! {
+    let mut echo_client = dfir_syntax_inline! {
         source_iter([("Hello".to_owned(), server_addr)])
             -> dest_sink(tx);
 
@@ -509,14 +507,14 @@ async fn asynctest_udp() {
     let (tx_out, rx_out) = dfir_rs::util::unbounded_channel::<String>();
 
     let (tx, rx, server_addr) = dfir_rs::util::bind_udp_lines("127.0.0.1:0".parse().unwrap()).await;
-    let mut echo_server = dfir_syntax! {
+    let mut echo_server = dfir_syntax_inline! {
         source_stream(rx)
             -> filter_map(Result::ok)
             -> dest_sink(tx);
     };
 
     let (tx, rx, _) = dfir_rs::util::bind_udp_lines("127.0.0.1:0".parse().unwrap()).await;
-    let mut echo_client = dfir_syntax! {
+    let mut echo_client = dfir_syntax_inline! {
         source_iter([("Hello".to_owned(), server_addr)])
             -> dest_sink(tx);
 

--- a/dfir_rs/tests/surface_book.rs
+++ b/dfir_rs/tests/surface_book.rs
@@ -3,22 +3,21 @@ use multiplatform_test::multiplatform_test;
 
 #[multiplatform_test]
 fn test_surface_flows_1() {
-    let mut df = dfir_rs::dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         my_tee = source_iter(vec!["Hello", "world"]) -> tee();
         my_tee[0] -> map(|x| x.to_uppercase()) -> [0]my_union;
         my_tee[1] -> map(|x| x.to_lowercase()) -> [1]my_union;
         my_union = union() -> for_each(|x| println!("{}", x));
     };
-    assert_graphvis_snapshots!(df);
     df.run_available_sync();
 }
 
 #[dfir_rs::test]
 async fn test_source_interval() {
-    use dfir_rs::dfir_syntax;
+    use dfir_rs::dfir_syntax_inline;
     use web_time::{Duration, Instant};
 
-    let mut hf = dfir_syntax! {
+    let mut hf = dfir_syntax_inline! {
         source_interval(Duration::from_secs(1))
             -> map(|_| { Instant::now() } )
             -> for_each(|time| println!("This runs every second: {:?}", time));

--- a/dfir_rs/tests/surface_book.rs
+++ b/dfir_rs/tests/surface_book.rs
@@ -1,4 +1,3 @@
-use dfir_rs::assert_graphvis_snapshots;
 use multiplatform_test::multiplatform_test;
 
 #[multiplatform_test]

--- a/dfir_rs/tests/surface_counter.rs
+++ b/dfir_rs/tests/surface_counter.rs
@@ -1,8 +1,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use dfir_rs::dfir_syntax;
-use dfir_rs::scheduled::graph::Dfir;
+use dfir_rs::dfir_syntax_inline;
 use dfir_rs::util::iter_batches_stream;
 use multiplatform_test::multiplatform_test;
 use web_time::Duration;
@@ -17,7 +16,7 @@ fn fib(n: u64) -> u64 {
 
 #[multiplatform_test(dfir)]
 pub async fn test_fib() {
-    let mut df: Dfir = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_stream(iter_batches_stream(0..=40, 1))
             -> map(fib)
             -> _counter("_counter(nums)", Duration::from_millis(50));
@@ -34,7 +33,7 @@ pub async fn test_fib() {
 
 #[multiplatform_test(dfir)]
 pub async fn test_stream() {
-    let mut df: Dfir = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_stream(iter_batches_stream(0..=100_000, 1))
             -> _counter("_counter(nums)", Duration::from_millis(100));
     };
@@ -63,7 +62,7 @@ pub async fn test_pull() {
     let output = Rc::new(RefCell::new(Vec::new()));
     let output_ref = output.clone();
 
-    let mut df: Dfir = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter(0..10)
             -> _counter("_counter(pull_test)", Duration::from_millis(50))
             -> for_each(|x| output_ref.borrow_mut().push(x));

--- a/dfir_rs/tests/surface_cross_singleton.rs
+++ b/dfir_rs/tests/surface_cross_singleton.rs
@@ -1,8 +1,9 @@
 use dfir_rs::dfir_syntax_inline;
-use dfir_rs::util::collect_ready_async;
+use dfir_rs::util::collect_ready;
+use multiplatform_test::multiplatform_test;
 
-#[dfir_rs::test]
-pub async fn test_basic() {
+#[multiplatform_test(test, wasm, env_tracing)]
+pub fn test_basic() {
     let (single_tx, single_rx) = dfir_rs::util::unbounded_channel::<()>();
     let (egress_tx, mut egress_rx) = dfir_rs::util::unbounded_channel();
 
@@ -14,19 +15,19 @@ pub async fn test_basic() {
         join -> for_each(|x| egress_tx.send(x).unwrap());
     };
 
-    df.run_available().await;
-    let out: Vec<_> = collect_ready_async(&mut egress_rx).await;
+    df.run_available_sync();
+    let out: Vec<_> = collect_ready(&mut egress_rx);
     assert_eq!(out, []);
 
     single_tx.send(()).unwrap();
-    df.run_available().await;
+    df.run_available_sync();
 
-    let out: Vec<_> = collect_ready_async(&mut egress_rx).await;
+    let out: Vec<_> = collect_ready(&mut egress_rx);
     assert_eq!(out, vec![(1, ()), (2, ()), (3, ())]);
 }
 
-#[dfir_rs::test]
-pub async fn test_union_defer_tick() {
+#[multiplatform_test(test, wasm, env_tracing)]
+pub fn test_union_defer_tick() {
     let (cross_tx, cross_rx) = dfir_rs::util::unbounded_channel::<i32>();
     let (egress_tx, mut egress_rx) = dfir_rs::util::unbounded_channel();
 
@@ -54,15 +55,15 @@ pub async fn test_union_defer_tick() {
         deferred_stream = joined_folded -> fold(|| 0, |_, _| {}) -> flat_map(|_| []);
     };
 
-    df.run_available().await;
-    let out: Vec<_> = collect_ready_async(&mut egress_rx).await;
+    df.run_available_sync();
+    let out: Vec<_> = collect_ready(&mut egress_rx);
     assert_eq!(out, vec![]);
 
     cross_tx.send(1).unwrap();
     cross_tx.send(2).unwrap();
     cross_tx.send(3).unwrap();
-    df.run_available().await;
+    df.run_available_sync();
 
-    let out: Vec<_> = collect_ready_async(&mut egress_rx).await;
+    let out: Vec<_> = collect_ready(&mut egress_rx);
     assert_eq!(out, vec![(1, 0), (2, 0), (3, 0)]);
 }

--- a/dfir_rs/tests/surface_cross_singleton.rs
+++ b/dfir_rs/tests/surface_cross_singleton.rs
@@ -1,38 +1,36 @@
-use dfir_rs::util::collect_ready;
-use dfir_rs::{assert_graphvis_snapshots, dfir_syntax};
-use multiplatform_test::multiplatform_test;
+use dfir_rs::util::collect_ready_async;
+use dfir_rs::dfir_syntax_inline;
 
-#[multiplatform_test(test, wasm, env_tracing)]
-pub fn test_basic() {
+#[dfir_rs::test]
+pub async fn test_basic() {
     let (single_tx, single_rx) = dfir_rs::util::unbounded_channel::<()>();
     let (egress_tx, mut egress_rx) = dfir_rs::util::unbounded_channel();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         join = cross_singleton();
         source_iter([1, 2, 3]) -> persist::<'static>() -> [input]join;
         source_stream(single_rx) -> [single]join;
 
         join -> for_each(|x| egress_tx.send(x).unwrap());
     };
-    assert_graphvis_snapshots!(df);
 
-    df.run_available_sync();
-    let out: Vec<_> = collect_ready(&mut egress_rx);
+    df.run_available().await;
+    let out: Vec<_> = collect_ready_async(&mut egress_rx).await;
     assert_eq!(out, []);
 
     single_tx.send(()).unwrap();
-    df.run_available_sync();
+    df.run_available().await;
 
-    let out: Vec<_> = collect_ready(&mut egress_rx);
+    let out: Vec<_> = collect_ready_async(&mut egress_rx).await;
     assert_eq!(out, vec![(1, ()), (2, ()), (3, ())]);
 }
 
-#[multiplatform_test(test, wasm, env_tracing)]
-pub fn test_union_defer_tick() {
+#[dfir_rs::test]
+pub async fn test_union_defer_tick() {
     let (cross_tx, cross_rx) = dfir_rs::util::unbounded_channel::<i32>();
     let (egress_tx, mut egress_rx) = dfir_rs::util::unbounded_channel();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         teed_in = source_stream(cross_rx) -> sort() -> tee();
         teed_in -> [input]join;
 
@@ -55,17 +53,16 @@ pub fn test_union_defer_tick() {
         joined_folded = cross_singleton();
         deferred_stream = joined_folded -> fold(|| 0, |_, _| {}) -> flat_map(|_| []);
     };
-    assert_graphvis_snapshots!(df);
 
-    df.run_available_sync();
-    let out: Vec<_> = collect_ready(&mut egress_rx);
+    df.run_available().await;
+    let out: Vec<_> = collect_ready_async(&mut egress_rx).await;
     assert_eq!(out, vec![]);
 
     cross_tx.send(1).unwrap();
     cross_tx.send(2).unwrap();
     cross_tx.send(3).unwrap();
-    df.run_available_sync();
+    df.run_available().await;
 
-    let out: Vec<_> = collect_ready(&mut egress_rx);
+    let out: Vec<_> = collect_ready_async(&mut egress_rx).await;
     assert_eq!(out, vec![(1, 0), (2, 0), (3, 0)]);
 }

--- a/dfir_rs/tests/surface_cross_singleton.rs
+++ b/dfir_rs/tests/surface_cross_singleton.rs
@@ -1,5 +1,5 @@
-use dfir_rs::util::collect_ready_async;
 use dfir_rs::dfir_syntax_inline;
+use dfir_rs::util::collect_ready_async;
 
 #[dfir_rs::test]
 pub async fn test_basic() {

--- a/dfir_rs/tests/surface_defer_signal.rs
+++ b/dfir_rs/tests/surface_defer_signal.rs
@@ -1,28 +1,26 @@
-use dfir_rs::util::collect_ready;
-use dfir_rs::{assert_graphvis_snapshots, dfir_syntax};
-use multiplatform_test::multiplatform_test;
+use dfir_rs::util::collect_ready_async;
+use dfir_rs::dfir_syntax_inline;
 
-#[multiplatform_test]
-pub fn test_basic_2() {
+#[dfir_rs::test]
+pub async fn test_basic_2() {
     let (signal_tx, signal_rx) = dfir_rs::util::unbounded_channel::<()>();
     let (egress_tx, mut egress_rx) = dfir_rs::util::unbounded_channel();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         gate = defer_signal();
         source_iter([1, 2, 3]) -> [input]gate;
         source_stream(signal_rx) -> [signal]gate;
 
         gate -> for_each(|x| egress_tx.send(x).unwrap());
     };
-    assert_graphvis_snapshots!(df);
 
-    df.run_available_sync();
-    let out: Vec<_> = collect_ready(&mut egress_rx);
+    df.run_available().await;
+    let out: Vec<_> = collect_ready_async(&mut egress_rx).await;
     assert_eq!(out, [0; 0]);
 
     signal_tx.send(()).unwrap();
-    df.run_available_sync();
+    df.run_available().await;
 
-    let out: Vec<_> = collect_ready(&mut egress_rx);
+    let out: Vec<_> = collect_ready_async(&mut egress_rx).await;
     assert_eq!(out, vec![1, 2, 3]);
 }

--- a/dfir_rs/tests/surface_defer_signal.rs
+++ b/dfir_rs/tests/surface_defer_signal.rs
@@ -1,5 +1,5 @@
-use dfir_rs::util::collect_ready_async;
 use dfir_rs::dfir_syntax_inline;
+use dfir_rs::util::collect_ready_async;
 
 #[dfir_rs::test]
 pub async fn test_basic_2() {

--- a/dfir_rs/tests/surface_defer_signal.rs
+++ b/dfir_rs/tests/surface_defer_signal.rs
@@ -1,8 +1,9 @@
 use dfir_rs::dfir_syntax_inline;
-use dfir_rs::util::collect_ready_async;
+use dfir_rs::util::collect_ready;
+use multiplatform_test::multiplatform_test;
 
-#[dfir_rs::test]
-pub async fn test_basic_2() {
+#[multiplatform_test]
+pub fn test_basic_2() {
     let (signal_tx, signal_rx) = dfir_rs::util::unbounded_channel::<()>();
     let (egress_tx, mut egress_rx) = dfir_rs::util::unbounded_channel();
 
@@ -14,13 +15,13 @@ pub async fn test_basic_2() {
         gate -> for_each(|x| egress_tx.send(x).unwrap());
     };
 
-    df.run_available().await;
-    let out: Vec<_> = collect_ready_async(&mut egress_rx).await;
+    df.run_available_sync();
+    let out: Vec<_> = collect_ready(&mut egress_rx);
     assert_eq!(out, [0; 0]);
 
     signal_tx.send(()).unwrap();
-    df.run_available().await;
+    df.run_available_sync();
 
-    let out: Vec<_> = collect_ready_async(&mut egress_rx).await;
+    let out: Vec<_> = collect_ready(&mut egress_rx);
     assert_eq!(out, vec![1, 2, 3]);
 }

--- a/dfir_rs/tests/surface_demux_enum.rs
+++ b/dfir_rs/tests/surface_demux_enum.rs
@@ -1,10 +1,9 @@
-use dfir_rs::dfir_syntax;
-use dfir_rs::util::collect_ready;
+use dfir_rs::dfir_syntax_inline;
+use dfir_rs::util::collect_ready_async;
 use dfir_rs::util::demux_enum::DemuxEnum;
-use multiplatform_test::multiplatform_test;
 
-#[multiplatform_test]
-pub fn test_demux_enum_basic() {
+#[dfir_rs::test]
+pub async fn test_demux_enum_basic() {
     #[derive(DemuxEnum)]
     enum Shape {
         Square(f64),
@@ -12,7 +11,7 @@ pub fn test_demux_enum_basic() {
         Circle { r: f64 },
     }
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         my_demux = source_iter([
             Shape::Square(9.0),
             Shape::Rectangle { w: 10.0, h: 8.0 },
@@ -23,11 +22,11 @@ pub fn test_demux_enum_basic() {
         my_demux[Circle] -> for_each(drop);
         my_demux[Rectangle] -> for_each(drop);
     };
-    df.run_available_sync();
+    df.run_available().await;
 }
 
-#[multiplatform_test]
-pub fn test_demux_enum() {
+#[dfir_rs::test]
+pub async fn test_demux_enum() {
     let (out_send, out_recv) = dfir_rs::util::unbounded_channel();
 
     #[derive(DemuxEnum)]
@@ -37,7 +36,7 @@ pub fn test_demux_enum() {
         Circle { r: f64 },
     }
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         my_demux = source_iter([
             Shape::Square(9.0),
             Shape::Rectangle { w: 10.0, h: 8.0 },
@@ -52,14 +51,14 @@ pub fn test_demux_enum() {
             -> map(|area| format!("{:.2}", area))
             -> for_each(|area_str| out_send.send(area_str).unwrap());
     };
-    df.run_available_sync();
+    df.run_available().await;
 
-    let areas = collect_ready::<Vec<_>, _>(out_recv);
+    let areas = collect_ready_async::<Vec<_>, _>(out_recv).await;
     assert_eq!(&["81.00", "78.54", "80.00"], &*areas);
 }
 
-#[multiplatform_test]
-pub fn test_demux_enum_generic() {
+#[dfir_rs::test]
+pub async fn test_demux_enum_generic() {
     #[derive(DemuxEnum)]
     enum Shape<N> {
         Square(N),
@@ -67,13 +66,13 @@ pub fn test_demux_enum_generic() {
         Circle { r: N },
     }
 
-    fn test<N>(s: N, w: N, h: N, r: N, expected: &[&str])
+    async fn test<N>(s: N, w: N, h: N, r: N, expected: &[&str])
     where
         N: 'static + Into<f64>,
     {
         let (out_send, out_recv) = dfir_rs::util::unbounded_channel();
 
-        let mut df = dfir_syntax! {
+        let mut df = dfir_syntax_inline! {
             my_demux = source_iter([
                 Shape::Square(s),
                 Shape::Rectangle { w, h },
@@ -88,28 +87,28 @@ pub fn test_demux_enum_generic() {
                 -> map(|area| format!("{:.2}", area))
                 -> for_each(|area_str| out_send.send(area_str).unwrap());
         };
-        df.run_available_sync();
+        df.run_available().await;
 
-        let areas = collect_ready::<Vec<_>, _>(out_recv);
+        let areas = collect_ready_async::<Vec<_>, _>(out_recv).await;
         assert_eq!(expected, &*areas);
     }
-    test::<f32>(9., 10., 8., 5., &["81.00", "78.54", "80.00"]);
-    test::<u32>(9, 10, 8, 5, &["81.00", "78.54", "80.00"]);
+    test::<f32>(9., 10., 8., 5., &["81.00", "78.54", "80.00"]).await;
+    test::<u32>(9, 10, 8, 5, &["81.00", "78.54", "80.00"]).await;
 }
 
-#[multiplatform_test]
-fn test_zero_variants() {
+#[dfir_rs::test]
+async fn test_zero_variants() {
     #[derive(DemuxEnum)]
     enum Never {}
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter(std::iter::empty::<Never>()) -> demux_enum::<Never>();
     };
-    df.run_available_sync();
+    df.run_available().await;
 }
 
-#[multiplatform_test]
-fn test_one_variant() {
+#[dfir_rs::test]
+async fn test_one_variant() {
     #[derive(DemuxEnum)]
     enum Request<T> {
         OnlyMessage(T),
@@ -117,11 +116,11 @@ fn test_one_variant() {
 
     let (out_send, out_recv) = dfir_rs::util::unbounded_channel();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         input = source_iter([Request::OnlyMessage("hi")]) -> demux_enum::<Request<&'static str>>();
         input[OnlyMessage] -> for_each(|(msg,)| out_send.send(msg).unwrap());
     };
-    df.run_available_sync();
+    df.run_available().await;
 
-    assert_eq!(&["hi"], &*collect_ready::<Vec<_>, _>(out_recv));
+    assert_eq!(&["hi"], &*collect_ready_async::<Vec<_>, _>(out_recv).await);
 }

--- a/dfir_rs/tests/surface_demux_enum.rs
+++ b/dfir_rs/tests/surface_demux_enum.rs
@@ -1,9 +1,10 @@
 use dfir_rs::dfir_syntax_inline;
-use dfir_rs::util::collect_ready_async;
+use dfir_rs::util::collect_ready;
 use dfir_rs::util::demux_enum::DemuxEnum;
+use multiplatform_test::multiplatform_test;
 
-#[dfir_rs::test]
-pub async fn test_demux_enum_basic() {
+#[multiplatform_test]
+pub fn test_demux_enum_basic() {
     #[derive(DemuxEnum)]
     enum Shape {
         Square(f64),
@@ -22,11 +23,11 @@ pub async fn test_demux_enum_basic() {
         my_demux[Circle] -> for_each(drop);
         my_demux[Rectangle] -> for_each(drop);
     };
-    df.run_available().await;
+    df.run_available_sync();
 }
 
-#[dfir_rs::test]
-pub async fn test_demux_enum() {
+#[multiplatform_test]
+pub fn test_demux_enum() {
     let (out_send, out_recv) = dfir_rs::util::unbounded_channel();
 
     #[derive(DemuxEnum)]
@@ -51,14 +52,14 @@ pub async fn test_demux_enum() {
             -> map(|area| format!("{:.2}", area))
             -> for_each(|area_str| out_send.send(area_str).unwrap());
     };
-    df.run_available().await;
+    df.run_available_sync();
 
-    let areas = collect_ready_async::<Vec<_>, _>(out_recv).await;
+    let areas = collect_ready::<Vec<_>, _>(out_recv);
     assert_eq!(&["81.00", "78.54", "80.00"], &*areas);
 }
 
-#[dfir_rs::test]
-pub async fn test_demux_enum_generic() {
+#[multiplatform_test]
+pub fn test_demux_enum_generic() {
     #[derive(DemuxEnum)]
     enum Shape<N> {
         Square(N),
@@ -66,7 +67,7 @@ pub async fn test_demux_enum_generic() {
         Circle { r: N },
     }
 
-    async fn test<N>(s: N, w: N, h: N, r: N, expected: &[&str])
+    fn test<N>(s: N, w: N, h: N, r: N, expected: &[&str])
     where
         N: 'static + Into<f64>,
     {
@@ -87,28 +88,28 @@ pub async fn test_demux_enum_generic() {
                 -> map(|area| format!("{:.2}", area))
                 -> for_each(|area_str| out_send.send(area_str).unwrap());
         };
-        df.run_available().await;
+        df.run_available_sync();
 
-        let areas = collect_ready_async::<Vec<_>, _>(out_recv).await;
+        let areas = collect_ready::<Vec<_>, _>(out_recv);
         assert_eq!(expected, &*areas);
     }
-    test::<f32>(9., 10., 8., 5., &["81.00", "78.54", "80.00"]).await;
-    test::<u32>(9, 10, 8, 5, &["81.00", "78.54", "80.00"]).await;
+    test::<f32>(9., 10., 8., 5., &["81.00", "78.54", "80.00"]);
+    test::<u32>(9, 10, 8, 5, &["81.00", "78.54", "80.00"]);
 }
 
-#[dfir_rs::test]
-async fn test_zero_variants() {
+#[multiplatform_test]
+fn test_zero_variants() {
     #[derive(DemuxEnum)]
     enum Never {}
 
     let mut df = dfir_syntax_inline! {
         source_iter(std::iter::empty::<Never>()) -> demux_enum::<Never>();
     };
-    df.run_available().await;
+    df.run_available_sync();
 }
 
-#[dfir_rs::test]
-async fn test_one_variant() {
+#[multiplatform_test]
+fn test_one_variant() {
     #[derive(DemuxEnum)]
     enum Request<T> {
         OnlyMessage(T),
@@ -120,7 +121,7 @@ async fn test_one_variant() {
         input = source_iter([Request::OnlyMessage("hi")]) -> demux_enum::<Request<&'static str>>();
         input[OnlyMessage] -> for_each(|(msg,)| out_send.send(msg).unwrap());
     };
-    df.run_available().await;
+    df.run_available_sync();
 
-    assert_eq!(&["hi"], &*collect_ready_async::<Vec<_>, _>(out_recv).await);
+    assert_eq!(&["hi"], &*collect_ready::<Vec<_>, _>(out_recv));
 }

--- a/dfir_rs/tests/surface_flat_stream.rs
+++ b/dfir_rs/tests/surface_flat_stream.rs
@@ -1,12 +1,11 @@
-use dfir_rs::dfir_syntax;
-use dfir_rs::util::collect_ready;
-use multiplatform_test::multiplatform_test;
+use dfir_rs::dfir_syntax_inline;
+use dfir_rs::util::collect_ready_async;
 
-#[multiplatform_test]
-pub fn test_flatten_stream_blocking() {
+#[dfir_rs::test]
+pub async fn test_flatten_stream_blocking() {
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<i32>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter(vec![
             futures::stream::iter(vec![1, 2]),
             futures::stream::iter(vec![3]),
@@ -14,50 +13,50 @@ pub fn test_flatten_stream_blocking() {
             -> flatten_stream_blocking()
             -> for_each(|x| result_send.send(x).unwrap());
     };
-    df.run_available_sync();
+    df.run_available().await;
 
-    assert_eq!(&[1, 2, 3], &*collect_ready::<Vec<_>, _>(&mut result_recv));
+    assert_eq!(&[1, 2, 3], &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await);
 }
 
-#[multiplatform_test]
-pub fn test_flat_map_stream_blocking() {
+#[dfir_rs::test]
+pub async fn test_flat_map_stream_blocking() {
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<i32>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter(vec![1, 2, 3])
             -> flat_map_stream_blocking(|x| futures::stream::iter(vec![x, x * 10]))
             -> for_each(|x| result_send.send(x).unwrap());
     };
-    df.run_available_sync();
+    df.run_available().await;
 
     assert_eq!(
         &[1, 10, 2, 20, 3, 30],
-        &*collect_ready::<Vec<_>, _>(&mut result_recv)
+        &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await
     );
 }
 
-#[multiplatform_test]
-pub fn test_flat_map_stream_blocking_empty() {
+#[dfir_rs::test]
+pub async fn test_flat_map_stream_blocking_empty() {
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<i32>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter(vec![1, 2, 3])
             -> flat_map_stream_blocking(|_| futures::stream::empty::<i32>())
             -> for_each(|x| result_send.send(x).unwrap());
     };
-    df.run_available_sync();
+    df.run_available().await;
 
     assert_eq!(
         Vec::<i32>::new(),
-        collect_ready::<Vec<_>, _>(&mut result_recv)
+        collect_ready_async::<Vec<_>, _>(&mut result_recv).await
     );
 }
 
-#[multiplatform_test]
-pub fn test_flatten_stream_blocking_empty() {
+#[dfir_rs::test]
+pub async fn test_flatten_stream_blocking_empty() {
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<i32>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter(vec![
             futures::stream::iter(Vec::<i32>::new()),
             futures::stream::iter(vec![1]),
@@ -66,7 +65,7 @@ pub fn test_flatten_stream_blocking_empty() {
             -> flatten_stream_blocking()
             -> for_each(|x| result_send.send(x).unwrap());
     };
-    df.run_available_sync();
+    df.run_available().await;
 
-    assert_eq!(&[1], &*collect_ready::<Vec<_>, _>(&mut result_recv));
+    assert_eq!(&[1], &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await);
 }

--- a/dfir_rs/tests/surface_flat_stream.rs
+++ b/dfir_rs/tests/surface_flat_stream.rs
@@ -1,8 +1,9 @@
 use dfir_rs::dfir_syntax_inline;
-use dfir_rs::util::collect_ready_async;
+use dfir_rs::util::collect_ready;
+use multiplatform_test::multiplatform_test;
 
-#[dfir_rs::test]
-pub async fn test_flatten_stream_blocking() {
+#[multiplatform_test]
+pub fn test_flatten_stream_blocking() {
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<i32>();
 
     let mut df = dfir_syntax_inline! {
@@ -13,16 +14,13 @@ pub async fn test_flatten_stream_blocking() {
             -> flatten_stream_blocking()
             -> for_each(|x| result_send.send(x).unwrap());
     };
-    df.run_available().await;
+    df.run_available_sync();
 
-    assert_eq!(
-        &[1, 2, 3],
-        &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await
-    );
+    assert_eq!(&[1, 2, 3], &*collect_ready::<Vec<_>, _>(&mut result_recv));
 }
 
-#[dfir_rs::test]
-pub async fn test_flat_map_stream_blocking() {
+#[multiplatform_test]
+pub fn test_flat_map_stream_blocking() {
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<i32>();
 
     let mut df = dfir_syntax_inline! {
@@ -30,16 +28,16 @@ pub async fn test_flat_map_stream_blocking() {
             -> flat_map_stream_blocking(|x| futures::stream::iter(vec![x, x * 10]))
             -> for_each(|x| result_send.send(x).unwrap());
     };
-    df.run_available().await;
+    df.run_available_sync();
 
     assert_eq!(
         &[1, 10, 2, 20, 3, 30],
-        &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await
+        &*collect_ready::<Vec<_>, _>(&mut result_recv)
     );
 }
 
-#[dfir_rs::test]
-pub async fn test_flat_map_stream_blocking_empty() {
+#[multiplatform_test]
+pub fn test_flat_map_stream_blocking_empty() {
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<i32>();
 
     let mut df = dfir_syntax_inline! {
@@ -47,16 +45,16 @@ pub async fn test_flat_map_stream_blocking_empty() {
             -> flat_map_stream_blocking(|_| futures::stream::empty::<i32>())
             -> for_each(|x| result_send.send(x).unwrap());
     };
-    df.run_available().await;
+    df.run_available_sync();
 
     assert_eq!(
         Vec::<i32>::new(),
-        collect_ready_async::<Vec<_>, _>(&mut result_recv).await
+        collect_ready::<Vec<_>, _>(&mut result_recv)
     );
 }
 
-#[dfir_rs::test]
-pub async fn test_flatten_stream_blocking_empty() {
+#[multiplatform_test]
+pub fn test_flatten_stream_blocking_empty() {
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<i32>();
 
     let mut df = dfir_syntax_inline! {
@@ -68,10 +66,7 @@ pub async fn test_flatten_stream_blocking_empty() {
             -> flatten_stream_blocking()
             -> for_each(|x| result_send.send(x).unwrap());
     };
-    df.run_available().await;
+    df.run_available_sync();
 
-    assert_eq!(
-        &[1],
-        &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await
-    );
+    assert_eq!(&[1], &*collect_ready::<Vec<_>, _>(&mut result_recv));
 }

--- a/dfir_rs/tests/surface_flat_stream.rs
+++ b/dfir_rs/tests/surface_flat_stream.rs
@@ -15,7 +15,10 @@ pub async fn test_flatten_stream_blocking() {
     };
     df.run_available().await;
 
-    assert_eq!(&[1, 2, 3], &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await);
+    assert_eq!(
+        &[1, 2, 3],
+        &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await
+    );
 }
 
 #[dfir_rs::test]
@@ -67,5 +70,8 @@ pub async fn test_flatten_stream_blocking_empty() {
     };
     df.run_available().await;
 
-    assert_eq!(&[1], &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await);
+    assert_eq!(
+        &[1],
+        &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await
+    );
 }

--- a/dfir_rs/tests/surface_forwardref.rs
+++ b/dfir_rs/tests/surface_forwardref.rs
@@ -1,40 +1,41 @@
 use dfir_rs::dfir_syntax_inline;
-use dfir_rs::util::collect_ready_async;
+use dfir_rs::util::collect_ready;
+use multiplatform_test::multiplatform_test;
 
-#[dfir_rs::test]
-pub async fn test_forwardref_basic_forward() {
+#[multiplatform_test]
+pub fn test_forwardref_basic_forward() {
     let (out_send, mut out_recv) = dfir_rs::util::unbounded_channel::<usize>();
 
     let mut df = dfir_syntax_inline! {
         source_iter(0..10) -> forward_ref;
         forward_ref = for_each(|v| out_send.send(v).unwrap());
     };
-    df.run_available().await;
+    df.run_available_sync();
 
     assert_eq!(
         &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-        &*collect_ready_async::<Vec<_>, _>(&mut out_recv).await
+        &*collect_ready::<Vec<_>, _>(&mut out_recv)
     );
 }
 
-#[dfir_rs::test]
-pub async fn test_forwardref_basic_backward() {
+#[multiplatform_test]
+pub fn test_forwardref_basic_backward() {
     let (out_send, mut out_recv) = dfir_rs::util::unbounded_channel::<usize>();
 
     let mut df = dfir_syntax_inline! {
         forward_ref -> for_each(|v| out_send.send(v).unwrap());
         forward_ref = source_iter(0..10);
     };
-    df.run_available().await;
+    df.run_available_sync();
 
     assert_eq!(
         &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-        &*collect_ready_async::<Vec<_>, _>(&mut out_recv).await
+        &*collect_ready::<Vec<_>, _>(&mut out_recv)
     );
 }
 
-#[dfir_rs::test]
-pub async fn test_forwardref_basic_middle() {
+#[multiplatform_test]
+pub fn test_forwardref_basic_middle() {
     let (out_send, mut out_recv) = dfir_rs::util::unbounded_channel::<usize>();
 
     let mut df = dfir_syntax_inline! {
@@ -42,10 +43,10 @@ pub async fn test_forwardref_basic_middle() {
         forward_ref -> for_each(|v| out_send.send(v).unwrap());
         forward_ref = identity();
     };
-    df.run_available().await;
+    df.run_available_sync();
 
     assert_eq!(
         &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-        &*collect_ready_async::<Vec<_>, _>(&mut out_recv).await
+        &*collect_ready::<Vec<_>, _>(&mut out_recv)
     );
 }

--- a/dfir_rs/tests/surface_forwardref.rs
+++ b/dfir_rs/tests/surface_forwardref.rs
@@ -1,5 +1,5 @@
-use dfir_rs::util::collect_ready_async;
 use dfir_rs::dfir_syntax_inline;
+use dfir_rs::util::collect_ready_async;
 
 #[dfir_rs::test]
 pub async fn test_forwardref_basic_forward() {

--- a/dfir_rs/tests/surface_forwardref.rs
+++ b/dfir_rs/tests/surface_forwardref.rs
@@ -1,55 +1,51 @@
-use dfir_rs::util::collect_ready;
-use dfir_rs::{assert_graphvis_snapshots, dfir_syntax};
-use multiplatform_test::multiplatform_test;
+use dfir_rs::util::collect_ready_async;
+use dfir_rs::dfir_syntax_inline;
 
-#[multiplatform_test]
-pub fn test_forwardref_basic_forward() {
+#[dfir_rs::test]
+pub async fn test_forwardref_basic_forward() {
     let (out_send, mut out_recv) = dfir_rs::util::unbounded_channel::<usize>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter(0..10) -> forward_ref;
         forward_ref = for_each(|v| out_send.send(v).unwrap());
     };
-    assert_graphvis_snapshots!(df);
-    df.run_available_sync();
+    df.run_available().await;
 
     assert_eq!(
         &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-        &*collect_ready::<Vec<_>, _>(&mut out_recv)
+        &*collect_ready_async::<Vec<_>, _>(&mut out_recv).await
     );
 }
 
-#[multiplatform_test]
-pub fn test_forwardref_basic_backward() {
+#[dfir_rs::test]
+pub async fn test_forwardref_basic_backward() {
     let (out_send, mut out_recv) = dfir_rs::util::unbounded_channel::<usize>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         forward_ref -> for_each(|v| out_send.send(v).unwrap());
         forward_ref = source_iter(0..10);
     };
-    assert_graphvis_snapshots!(df);
-    df.run_available_sync();
+    df.run_available().await;
 
     assert_eq!(
         &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-        &*collect_ready::<Vec<_>, _>(&mut out_recv)
+        &*collect_ready_async::<Vec<_>, _>(&mut out_recv).await
     );
 }
 
-#[multiplatform_test]
-pub fn test_forwardref_basic_middle() {
+#[dfir_rs::test]
+pub async fn test_forwardref_basic_middle() {
     let (out_send, mut out_recv) = dfir_rs::util::unbounded_channel::<usize>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter(0..10) -> forward_ref;
         forward_ref -> for_each(|v| out_send.send(v).unwrap());
         forward_ref = identity();
     };
-    assert_graphvis_snapshots!(df);
-    df.run_available_sync();
+    df.run_available().await;
 
     assert_eq!(
         &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-        &*collect_ready::<Vec<_>, _>(&mut out_recv)
+        &*collect_ready_async::<Vec<_>, _>(&mut out_recv).await
     );
 }

--- a/dfir_rs/tests/surface_join_fused.rs
+++ b/dfir_rs/tests/surface_join_fused.rs
@@ -5,10 +5,9 @@ use std::rc::Rc;
 use dfir_rs::dfir_pipes::pull::{Fold, Reduce};
 use dfir_rs::lattices::set_union::SetUnionSingletonSet;
 use dfir_rs::scheduled::ticks::TickInstant;
-use dfir_rs::{assert_graphvis_snapshots, dfir_syntax};
+use dfir_rs::dfir_syntax_inline;
 use lattices::Merge;
 use lattices::set_union::SetUnionHashSet;
-use multiplatform_test::multiplatform_test;
 
 macro_rules! assert_contains_each_by_tick {
     ($results:expr, $tick:expr, $input:expr) => {{
@@ -23,12 +22,12 @@ macro_rules! assert_contains_each_by_tick {
     }};
 }
 
-#[multiplatform_test]
-pub fn tick_tick_lhs_blocking_rhs_streaming() {
+#[dfir_rs::test]
+pub async fn tick_tick_lhs_blocking_rhs_streaming() {
     let results = Rc::new(RefCell::new(HashMap::<TickInstant, Vec<_>>::new()));
     let results_inner = Rc::clone(&results);
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter([(7, 1), (7, 2)])
             -> map(|(k, v)| (k, SetUnionSingletonSet::new_from(v)))
             -> [0]my_join;
@@ -42,8 +41,7 @@ pub fn tick_tick_lhs_blocking_rhs_streaming() {
         my_join = join_fused_lhs(Fold::new(SetUnionHashSet::default, |state, delta| { Merge::merge(state, delta); }))
             -> for_each(|x| results_inner.borrow_mut().entry(context.current_tick()).or_default().push(x));
     };
-    assert_graphvis_snapshots!(df);
-    df.run_available_sync();
+    df.run_available().await;
 
     assert_contains_each_by_tick!(
         results,
@@ -52,12 +50,12 @@ pub fn tick_tick_lhs_blocking_rhs_streaming() {
     );
 }
 
-#[multiplatform_test]
-pub fn static_tick_lhs_blocking_rhs_streaming() {
+#[dfir_rs::test]
+pub async fn static_tick_lhs_blocking_rhs_streaming() {
     let results = Rc::new(RefCell::new(HashMap::<TickInstant, Vec<_>>::new()));
     let results_inner = Rc::clone(&results);
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter([(7, 1), (7, 2)])
             -> map(|(k, v)| (k, SetUnionSingletonSet::new_from(v)))
             -> [0]my_join;
@@ -71,8 +69,7 @@ pub fn static_tick_lhs_blocking_rhs_streaming() {
         my_join = join_fused_lhs::<'static, 'tick>(Fold::new(SetUnionHashSet::default, |state, delta| { Merge::merge(state, delta); }))
             -> for_each(|x| results_inner.borrow_mut().entry(context.current_tick()).or_default().push(x));
     };
-    assert_graphvis_snapshots!(df);
-    df.run_available_sync();
+    df.run_available().await;
 
     assert_contains_each_by_tick!(
         results,
@@ -91,12 +88,12 @@ pub fn static_tick_lhs_blocking_rhs_streaming() {
     );
 }
 
-#[multiplatform_test]
-pub fn static_static_lhs_blocking_rhs_streaming() {
+#[dfir_rs::test]
+pub async fn static_static_lhs_blocking_rhs_streaming() {
     let results = Rc::new(RefCell::new(HashMap::<TickInstant, Vec<_>>::new()));
     let results_inner = Rc::clone(&results);
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter([(7, 1), (7, 2)])
             -> map(|(k, v)| (k, SetUnionSingletonSet::new_from(v)))
             -> [0]my_join;
@@ -110,8 +107,7 @@ pub fn static_static_lhs_blocking_rhs_streaming() {
         my_join = join_fused_lhs::<'static, 'static>(Fold::new(SetUnionHashSet::default, |state, delta| { Merge::merge(state, delta); }))
             -> for_each(|x| results_inner.borrow_mut().entry(context.current_tick()).or_default().push(x));
     };
-    assert_graphvis_snapshots!(df);
-    df.run_available_sync();
+    df.run_available().await;
 
     #[rustfmt::skip]
     {
@@ -121,12 +117,12 @@ pub fn static_static_lhs_blocking_rhs_streaming() {
     };
 }
 
-#[multiplatform_test]
-pub fn tick_tick_lhs_streaming_rhs_blocking() {
+#[dfir_rs::test]
+pub async fn tick_tick_lhs_streaming_rhs_blocking() {
     let results = Rc::new(RefCell::new(HashMap::<TickInstant, Vec<_>>::new()));
     let results_inner = Rc::clone(&results);
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter([(7, 1), (7, 2)])
             -> map(|(k, v)| (k, SetUnionSingletonSet::new_from(v)))
             -> [1]my_join;
@@ -140,8 +136,7 @@ pub fn tick_tick_lhs_streaming_rhs_blocking() {
         my_join = join_fused_rhs(Fold::new(SetUnionHashSet::default, |state, delta| { Merge::merge(state, delta); }))
             -> for_each(|x| results_inner.borrow_mut().entry(context.current_tick()).or_default().push(x));
     };
-    assert_graphvis_snapshots!(df);
-    df.run_available_sync();
+    df.run_available().await;
 
     assert_contains_each_by_tick!(
         results,
@@ -150,12 +145,12 @@ pub fn tick_tick_lhs_streaming_rhs_blocking() {
     );
 }
 
-#[multiplatform_test]
-pub fn static_tick_lhs_streaming_rhs_blocking() {
+#[dfir_rs::test]
+pub async fn static_tick_lhs_streaming_rhs_blocking() {
     let results = Rc::new(RefCell::new(HashMap::<TickInstant, Vec<_>>::new()));
     let results_inner = Rc::clone(&results);
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter([(7, 1), (7, 2)])
             -> map(|(k, v)| (k, SetUnionSingletonSet::new_from(v)))
             -> [1]my_join;
@@ -169,8 +164,7 @@ pub fn static_tick_lhs_streaming_rhs_blocking() {
         my_join = join_fused_rhs::<'static, 'tick>(Fold::new(SetUnionHashSet::default, |state, delta| { Merge::merge(state, delta); }))
             -> for_each(|x| results_inner.borrow_mut().entry(context.current_tick()).or_default().push(x));
     };
-    assert_graphvis_snapshots!(df);
-    df.run_available_sync();
+    df.run_available().await;
 
     assert_contains_each_by_tick!(
         results,
@@ -189,12 +183,12 @@ pub fn static_tick_lhs_streaming_rhs_blocking() {
     );
 }
 
-#[multiplatform_test]
-pub fn static_static_lhs_streaming_rhs_blocking() {
+#[dfir_rs::test]
+pub async fn static_static_lhs_streaming_rhs_blocking() {
     let results = Rc::new(RefCell::new(HashMap::<TickInstant, Vec<_>>::new()));
     let results_inner = Rc::clone(&results);
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter([(7, 1), (7, 2)])
             -> map(|(k, v)| (k, SetUnionSingletonSet::new_from(v)))
             -> [1]my_join;
@@ -209,8 +203,7 @@ pub fn static_static_lhs_streaming_rhs_blocking() {
             -> inspect(|x| println!("{}, {x:?}", context.current_tick()))
             -> for_each(|x| results_inner.borrow_mut().entry(context.current_tick()).or_default().push(x));
     };
-    assert_graphvis_snapshots!(df);
-    df.run_available_sync();
+    df.run_available().await;
 
     #[rustfmt::skip]
     {
@@ -220,12 +213,12 @@ pub fn static_static_lhs_streaming_rhs_blocking() {
     };
 }
 
-#[multiplatform_test]
-pub fn tick_tick_lhs_fold_rhs_reduce() {
+#[dfir_rs::test]
+pub async fn tick_tick_lhs_fold_rhs_reduce() {
     let results = Rc::new(RefCell::new(HashMap::<TickInstant, Vec<_>>::new()));
     let results_inner = Rc::clone(&results);
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter([(7, 1), (7, 2)])
             -> map(|(k, v)| (k, SetUnionSingletonSet::new_from(v)))
             -> [0]my_join;
@@ -242,8 +235,7 @@ pub fn tick_tick_lhs_fold_rhs_reduce() {
             )
             -> for_each(|x| results_inner.borrow_mut().entry(context.current_tick()).or_default().push(x));
     };
-    assert_graphvis_snapshots!(df);
-    df.run_available_sync();
+    df.run_available().await;
 
     assert_contains_each_by_tick!(
         results,

--- a/dfir_rs/tests/surface_join_fused.rs
+++ b/dfir_rs/tests/surface_join_fused.rs
@@ -3,9 +3,9 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 use dfir_rs::dfir_pipes::pull::{Fold, Reduce};
+use dfir_rs::dfir_syntax_inline;
 use dfir_rs::lattices::set_union::SetUnionSingletonSet;
 use dfir_rs::scheduled::ticks::TickInstant;
-use dfir_rs::dfir_syntax_inline;
 use lattices::Merge;
 use lattices::set_union::SetUnionHashSet;
 

--- a/dfir_rs/tests/surface_join_fused.rs
+++ b/dfir_rs/tests/surface_join_fused.rs
@@ -8,6 +8,7 @@ use dfir_rs::lattices::set_union::SetUnionSingletonSet;
 use dfir_rs::scheduled::ticks::TickInstant;
 use lattices::Merge;
 use lattices::set_union::SetUnionHashSet;
+use multiplatform_test::multiplatform_test;
 
 macro_rules! assert_contains_each_by_tick {
     ($results:expr, $tick:expr, $input:expr) => {{
@@ -22,8 +23,8 @@ macro_rules! assert_contains_each_by_tick {
     }};
 }
 
-#[dfir_rs::test]
-pub async fn tick_tick_lhs_blocking_rhs_streaming() {
+#[multiplatform_test]
+pub fn tick_tick_lhs_blocking_rhs_streaming() {
     let results = Rc::new(RefCell::new(HashMap::<TickInstant, Vec<_>>::new()));
     let results_inner = Rc::clone(&results);
 
@@ -41,7 +42,7 @@ pub async fn tick_tick_lhs_blocking_rhs_streaming() {
         my_join = join_fused_lhs(Fold::new(SetUnionHashSet::default, |state, delta| { Merge::merge(state, delta); }))
             -> for_each(|x| results_inner.borrow_mut().entry(context.current_tick()).or_default().push(x));
     };
-    df.run_available().await;
+    df.run_available_sync();
 
     assert_contains_each_by_tick!(
         results,
@@ -50,8 +51,8 @@ pub async fn tick_tick_lhs_blocking_rhs_streaming() {
     );
 }
 
-#[dfir_rs::test]
-pub async fn static_tick_lhs_blocking_rhs_streaming() {
+#[multiplatform_test]
+pub fn static_tick_lhs_blocking_rhs_streaming() {
     let results = Rc::new(RefCell::new(HashMap::<TickInstant, Vec<_>>::new()));
     let results_inner = Rc::clone(&results);
 
@@ -69,7 +70,7 @@ pub async fn static_tick_lhs_blocking_rhs_streaming() {
         my_join = join_fused_lhs::<'static, 'tick>(Fold::new(SetUnionHashSet::default, |state, delta| { Merge::merge(state, delta); }))
             -> for_each(|x| results_inner.borrow_mut().entry(context.current_tick()).or_default().push(x));
     };
-    df.run_available().await;
+    df.run_available_sync();
 
     assert_contains_each_by_tick!(
         results,
@@ -88,8 +89,8 @@ pub async fn static_tick_lhs_blocking_rhs_streaming() {
     );
 }
 
-#[dfir_rs::test]
-pub async fn static_static_lhs_blocking_rhs_streaming() {
+#[multiplatform_test]
+pub fn static_static_lhs_blocking_rhs_streaming() {
     let results = Rc::new(RefCell::new(HashMap::<TickInstant, Vec<_>>::new()));
     let results_inner = Rc::clone(&results);
 
@@ -107,7 +108,7 @@ pub async fn static_static_lhs_blocking_rhs_streaming() {
         my_join = join_fused_lhs::<'static, 'static>(Fold::new(SetUnionHashSet::default, |state, delta| { Merge::merge(state, delta); }))
             -> for_each(|x| results_inner.borrow_mut().entry(context.current_tick()).or_default().push(x));
     };
-    df.run_available().await;
+    df.run_available_sync();
 
     #[rustfmt::skip]
     {
@@ -117,8 +118,8 @@ pub async fn static_static_lhs_blocking_rhs_streaming() {
     };
 }
 
-#[dfir_rs::test]
-pub async fn tick_tick_lhs_streaming_rhs_blocking() {
+#[multiplatform_test]
+pub fn tick_tick_lhs_streaming_rhs_blocking() {
     let results = Rc::new(RefCell::new(HashMap::<TickInstant, Vec<_>>::new()));
     let results_inner = Rc::clone(&results);
 
@@ -136,7 +137,7 @@ pub async fn tick_tick_lhs_streaming_rhs_blocking() {
         my_join = join_fused_rhs(Fold::new(SetUnionHashSet::default, |state, delta| { Merge::merge(state, delta); }))
             -> for_each(|x| results_inner.borrow_mut().entry(context.current_tick()).or_default().push(x));
     };
-    df.run_available().await;
+    df.run_available_sync();
 
     assert_contains_each_by_tick!(
         results,
@@ -145,8 +146,8 @@ pub async fn tick_tick_lhs_streaming_rhs_blocking() {
     );
 }
 
-#[dfir_rs::test]
-pub async fn static_tick_lhs_streaming_rhs_blocking() {
+#[multiplatform_test]
+pub fn static_tick_lhs_streaming_rhs_blocking() {
     let results = Rc::new(RefCell::new(HashMap::<TickInstant, Vec<_>>::new()));
     let results_inner = Rc::clone(&results);
 
@@ -164,7 +165,7 @@ pub async fn static_tick_lhs_streaming_rhs_blocking() {
         my_join = join_fused_rhs::<'static, 'tick>(Fold::new(SetUnionHashSet::default, |state, delta| { Merge::merge(state, delta); }))
             -> for_each(|x| results_inner.borrow_mut().entry(context.current_tick()).or_default().push(x));
     };
-    df.run_available().await;
+    df.run_available_sync();
 
     assert_contains_each_by_tick!(
         results,
@@ -183,8 +184,8 @@ pub async fn static_tick_lhs_streaming_rhs_blocking() {
     );
 }
 
-#[dfir_rs::test]
-pub async fn static_static_lhs_streaming_rhs_blocking() {
+#[multiplatform_test]
+pub fn static_static_lhs_streaming_rhs_blocking() {
     let results = Rc::new(RefCell::new(HashMap::<TickInstant, Vec<_>>::new()));
     let results_inner = Rc::clone(&results);
 
@@ -203,7 +204,7 @@ pub async fn static_static_lhs_streaming_rhs_blocking() {
             -> inspect(|x| println!("{}, {x:?}", context.current_tick()))
             -> for_each(|x| results_inner.borrow_mut().entry(context.current_tick()).or_default().push(x));
     };
-    df.run_available().await;
+    df.run_available_sync();
 
     #[rustfmt::skip]
     {
@@ -213,8 +214,8 @@ pub async fn static_static_lhs_streaming_rhs_blocking() {
     };
 }
 
-#[dfir_rs::test]
-pub async fn tick_tick_lhs_fold_rhs_reduce() {
+#[multiplatform_test]
+pub fn tick_tick_lhs_fold_rhs_reduce() {
     let results = Rc::new(RefCell::new(HashMap::<TickInstant, Vec<_>>::new()));
     let results_inner = Rc::clone(&results);
 
@@ -235,7 +236,7 @@ pub async fn tick_tick_lhs_fold_rhs_reduce() {
             )
             -> for_each(|x| results_inner.borrow_mut().entry(context.current_tick()).or_default().push(x));
     };
-    df.run_available().await;
+    df.run_available_sync();
 
     assert_contains_each_by_tick!(
         results,

--- a/dfir_rs/tests/surface_lattice_batch.rs
+++ b/dfir_rs/tests/surface_lattice_batch.rs
@@ -1,7 +1,8 @@
 use dfir_rs::dfir_syntax_inline;
+use multiplatform_test::multiplatform_test;
 
-#[dfir_rs::test]
-pub async fn test_lattice_batch() {
+#[multiplatform_test]
+pub fn test_lattice_batch() {
     type SetUnionHashSet = lattices::set_union::SetUnionHashSet<usize>;
     type SetUnionSingletonSet = lattices::set_union::SetUnionSingletonSet<usize>;
 
@@ -22,5 +23,5 @@ pub async fn test_lattice_batch() {
         b3 = _lattice_fold_batch::<SetUnionHashSet>() -> assert(|_| false);
     };
 
-    df.run_available().await;
+    df.run_available_sync();
 }

--- a/dfir_rs/tests/surface_lattice_batch.rs
+++ b/dfir_rs/tests/surface_lattice_batch.rs
@@ -1,12 +1,11 @@
-use dfir_rs::dfir_syntax;
-use multiplatform_test::multiplatform_test;
+use dfir_rs::dfir_syntax_inline;
 
-#[multiplatform_test]
-pub fn test_lattice_batch() {
+#[dfir_rs::test]
+pub async fn test_lattice_batch() {
     type SetUnionHashSet = lattices::set_union::SetUnionHashSet<usize>;
     type SetUnionSingletonSet = lattices::set_union::SetUnionSingletonSet<usize>;
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         // Can release in the same tick
         source_iter([SetUnionSingletonSet::new_from(0), SetUnionSingletonSet::new_from(1)]) -> [input]b1;
         source_iter([()]) -> defer_tick() -> [signal]b1;
@@ -23,5 +22,5 @@ pub fn test_lattice_batch() {
         b3 = _lattice_fold_batch::<SetUnionHashSet>() -> assert(|_| false);
     };
 
-    df.run_available_sync();
+    df.run_available().await;
 }

--- a/dfir_rs/tests/surface_lattice_bimorphism.rs
+++ b/dfir_rs/tests/surface_lattice_bimorphism.rs
@@ -1,17 +1,18 @@
 use std::collections::{HashMap, HashSet};
 
-use dfir_rs::util::collect_ready_async;
 use dfir_rs::dfir_syntax_inline;
+use dfir_rs::util::collect_ready;
 use lattices::GhtType;
 use lattices::ght::GeneralizedHashTrieNode;
 use lattices::ght::lattice::{DeepJoinLatticeBimorphism, GhtBimorphism};
 use lattices::map_union::{KeyedBimorphism, MapUnionHashMap, MapUnionSingletonMap};
 use lattices::set_union::{CartesianProductBimorphism, SetUnionHashSet, SetUnionSingletonSet};
+use multiplatform_test::multiplatform_test;
 use variadics::CloneVariadic;
 use variadics::variadic_collections::VariadicHashSet;
 
-#[dfir_rs::test]
-pub async fn test_cartesian_product() {
+#[multiplatform_test]
+pub fn test_cartesian_product() {
     let (out_send, out_recv) = dfir_rs::util::unbounded_channel::<_>();
 
     let mut df = dfir_syntax_inline! {
@@ -29,7 +30,7 @@ pub async fn test_cartesian_product() {
             -> for_each(|x| out_send.send(x).unwrap());
     };
 
-    df.run_available().await;
+    df.run_available_sync();
 
     assert_eq!(
         &[SetUnionHashSet::new(HashSet::from_iter([
@@ -40,12 +41,12 @@ pub async fn test_cartesian_product() {
             (2, 3),
             (2, 4),
         ]))],
-        &*collect_ready_async::<Vec<_>, _>(out_recv).await
+        &*collect_ready::<Vec<_>, _>(out_recv)
     );
 }
 
-#[dfir_rs::test]
-pub async fn test_cartesian_product_1401() {
+#[multiplatform_test(test, wasm, env_tracing)]
+pub fn test_cartesian_product_1401() {
     let (out_send, out_recv) = dfir_rs::util::unbounded_channel::<_>();
 
     let mut df = dfir_syntax_inline! {
@@ -62,16 +63,16 @@ pub async fn test_cartesian_product_1401() {
         my_join = lattice_bimorphism(CartesianProductBimorphism::<HashSet<_>>::default(), #lhs, #rhs)
             -> for_each(|x| out_send.send(x).unwrap());
     };
-    df.run_available().await;
+    df.run_available_sync();
 
     assert_eq!(
         &[SetUnionHashSet::new(HashSet::from_iter([(0, 1)]))],
-        &*collect_ready_async::<Vec<_>, _>(out_recv).await
+        &*collect_ready::<Vec<_>, _>(out_recv)
     );
 }
 
-#[dfir_rs::test]
-pub async fn test_join() {
+#[multiplatform_test]
+pub fn test_join() {
     let (out_send, out_recv) = dfir_rs::util::unbounded_channel::<_>();
 
     let mut df = dfir_syntax_inline! {
@@ -89,7 +90,7 @@ pub async fn test_join() {
             -> for_each(|x| out_send.send(x).unwrap());
     };
 
-    df.run_available().await;
+    df.run_available_sync();
 
     assert_eq!(
         &[MapUnionHashMap::new(HashMap::from_iter([(
@@ -103,13 +104,13 @@ pub async fn test_join() {
                 (2, 2),
             ]))
         )]))],
-        &*collect_ready_async::<Vec<_>, _>(out_recv).await
+        &*collect_ready::<Vec<_>, _>(out_recv)
     );
 }
 
 /// Test for https://github.com/hydro-project/hydro/issues/1298
-#[dfir_rs::test]
-pub async fn test_cartesian_product_tick_state() {
+#[multiplatform_test]
+pub fn test_cartesian_product_tick_state() {
     let (lhs_send, lhs_recv) = dfir_rs::util::unbounded_channel::<u32>();
     let (rhs_send, rhs_recv) = dfir_rs::util::unbounded_channel::<u32>();
     let (out_send, mut out_recv) = dfir_rs::util::unbounded_channel::<_>();
@@ -136,7 +137,7 @@ pub async fn test_cartesian_product_tick_state() {
     for x in 3..5 {
         rhs_send.send(x).unwrap();
     }
-    df.run_available().await;
+    df.run_available_sync();
     assert_eq!(
         &[SetUnionHashSet::new(HashSet::from_iter([
             (0, 3),
@@ -146,21 +147,21 @@ pub async fn test_cartesian_product_tick_state() {
             (2, 3),
             (2, 4),
         ]))],
-        &*collect_ready_async::<Vec<_>, _>(&mut out_recv).await
+        &*collect_ready::<Vec<_>, _>(&mut out_recv)
     );
 
     for x in 3..5 {
         lhs_send.send(x).unwrap();
     }
-    df.run_available().await;
+    df.run_available_sync();
     assert_eq!(
         &[SetUnionHashSet::default()],
-        &*collect_ready_async::<Vec<_>, _>(&mut out_recv).await
+        &*collect_ready::<Vec<_>, _>(&mut out_recv)
     );
 }
 
-#[dfir_rs::test]
-async fn test_ght_join_bimorphism() {
+#[multiplatform_test]
+fn test_ght_join_bimorphism() {
     type MyGhtATrie = GhtType!(u32, u64, u16 => &'static str: VariadicHashSet);
     type MyGhtBTrie = GhtType!(u32, u64, u16 => &'static str: VariadicHashSet);
 
@@ -200,5 +201,5 @@ async fn test_ght_join_bimorphism() {
             -> flat_map(|(_num, ght)| ght.recursive_iter().map(<JoinSchema as CloneVariadic>::clone_ref_var).collect::<Vec<_>>())
             -> null();
     };
-    hf.run_available().await;
+    hf.run_available_sync();
 }

--- a/dfir_rs/tests/surface_lattice_bimorphism.rs
+++ b/dfir_rs/tests/surface_lattice_bimorphism.rs
@@ -1,21 +1,20 @@
 use std::collections::{HashMap, HashSet};
 
-use dfir_rs::util::collect_ready;
-use dfir_rs::{assert_graphvis_snapshots, dfir_syntax};
+use dfir_rs::util::collect_ready_async;
+use dfir_rs::dfir_syntax_inline;
 use lattices::GhtType;
 use lattices::ght::GeneralizedHashTrieNode;
 use lattices::ght::lattice::{DeepJoinLatticeBimorphism, GhtBimorphism};
 use lattices::map_union::{KeyedBimorphism, MapUnionHashMap, MapUnionSingletonMap};
 use lattices::set_union::{CartesianProductBimorphism, SetUnionHashSet, SetUnionSingletonSet};
-use multiplatform_test::multiplatform_test;
 use variadics::CloneVariadic;
 use variadics::variadic_collections::VariadicHashSet;
 
-#[multiplatform_test]
-pub fn test_cartesian_product() {
+#[dfir_rs::test]
+pub async fn test_cartesian_product() {
     let (out_send, out_recv) = dfir_rs::util::unbounded_channel::<_>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         lhs = source_iter(0..3)
             -> map(SetUnionSingletonSet::new_from)
             -> state::<'static, SetUnionHashSet<u32>>();
@@ -30,8 +29,7 @@ pub fn test_cartesian_product() {
             -> for_each(|x| out_send.send(x).unwrap());
     };
 
-    assert_graphvis_snapshots!(df);
-    df.run_available_sync();
+    df.run_available().await;
 
     assert_eq!(
         &[SetUnionHashSet::new(HashSet::from_iter([
@@ -42,15 +40,15 @@ pub fn test_cartesian_product() {
             (2, 3),
             (2, 4),
         ]))],
-        &*collect_ready::<Vec<_>, _>(out_recv)
+        &*collect_ready_async::<Vec<_>, _>(out_recv).await
     );
 }
 
-#[multiplatform_test(test, wasm, env_tracing)]
-pub fn test_cartesian_product_1401() {
+#[dfir_rs::test]
+pub async fn test_cartesian_product_1401() {
     let (out_send, out_recv) = dfir_rs::util::unbounded_channel::<_>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         lhs = source_iter(0..1)
             -> map(SetUnionSingletonSet::new_from)
             -> state::<'static, SetUnionHashSet<u32>>();
@@ -64,20 +62,19 @@ pub fn test_cartesian_product_1401() {
         my_join = lattice_bimorphism(CartesianProductBimorphism::<HashSet<_>>::default(), #lhs, #rhs)
             -> for_each(|x| out_send.send(x).unwrap());
     };
-    assert_graphvis_snapshots!(df);
-    df.run_available_sync();
+    df.run_available().await;
 
     assert_eq!(
         &[SetUnionHashSet::new(HashSet::from_iter([(0, 1)]))],
-        &*collect_ready::<Vec<_>, _>(out_recv)
+        &*collect_ready_async::<Vec<_>, _>(out_recv).await
     );
 }
 
-#[multiplatform_test]
-pub fn test_join() {
+#[dfir_rs::test]
+pub async fn test_join() {
     let (out_send, out_recv) = dfir_rs::util::unbounded_channel::<_>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         lhs = source_iter([(7, 1), (7, 2)])
             -> map(|(k, v)| MapUnionSingletonMap::new_from((k, SetUnionSingletonSet::new_from(v))))
             -> state::<'static, MapUnionHashMap<usize, SetUnionHashSet<usize>>>();
@@ -92,8 +89,7 @@ pub fn test_join() {
             -> for_each(|x| out_send.send(x).unwrap());
     };
 
-    assert_graphvis_snapshots!(df);
-    df.run_available_sync();
+    df.run_available().await;
 
     assert_eq!(
         &[MapUnionHashMap::new(HashMap::from_iter([(
@@ -107,18 +103,18 @@ pub fn test_join() {
                 (2, 2),
             ]))
         )]))],
-        &*collect_ready::<Vec<_>, _>(out_recv)
+        &*collect_ready_async::<Vec<_>, _>(out_recv).await
     );
 }
 
 /// Test for https://github.com/hydro-project/hydro/issues/1298
-#[multiplatform_test]
-pub fn test_cartesian_product_tick_state() {
+#[dfir_rs::test]
+pub async fn test_cartesian_product_tick_state() {
     let (lhs_send, lhs_recv) = dfir_rs::util::unbounded_channel::<u32>();
     let (rhs_send, rhs_recv) = dfir_rs::util::unbounded_channel::<u32>();
     let (out_send, mut out_recv) = dfir_rs::util::unbounded_channel::<_>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         lhs = source_stream(lhs_recv)
             -> map(SetUnionSingletonSet::new_from)
             -> state::<'tick, SetUnionHashSet<u32>>();
@@ -133,7 +129,6 @@ pub fn test_cartesian_product_tick_state() {
             -> inspect(|x| println!("{:?}: {:?}", context.current_tick(), x))
             -> for_each(|x| out_send.send(x).unwrap());
     };
-    assert_graphvis_snapshots!(df);
 
     for x in 0..3 {
         lhs_send.send(x).unwrap();
@@ -141,7 +136,7 @@ pub fn test_cartesian_product_tick_state() {
     for x in 3..5 {
         rhs_send.send(x).unwrap();
     }
-    df.run_available_sync();
+    df.run_available().await;
     assert_eq!(
         &[SetUnionHashSet::new(HashSet::from_iter([
             (0, 3),
@@ -151,21 +146,21 @@ pub fn test_cartesian_product_tick_state() {
             (2, 3),
             (2, 4),
         ]))],
-        &*collect_ready::<Vec<_>, _>(&mut out_recv)
+        &*collect_ready_async::<Vec<_>, _>(&mut out_recv).await
     );
 
     for x in 3..5 {
         lhs_send.send(x).unwrap();
     }
-    df.run_available_sync();
+    df.run_available().await;
     assert_eq!(
         &[SetUnionHashSet::default()],
-        &*collect_ready::<Vec<_>, _>(&mut out_recv)
+        &*collect_ready_async::<Vec<_>, _>(&mut out_recv).await
     );
 }
 
-#[multiplatform_test]
-fn test_ght_join_bimorphism() {
+#[dfir_rs::test]
+async fn test_ght_join_bimorphism() {
     type MyGhtATrie = GhtType!(u32, u64, u16 => &'static str: VariadicHashSet);
     type MyGhtBTrie = GhtType!(u32, u64, u16 => &'static str: VariadicHashSet);
 
@@ -176,7 +171,7 @@ fn test_ght_join_bimorphism() {
     >>::DeepJoinLatticeBimorphism;
     type MyBim = GhtBimorphism<MyNodeBim>;
 
-    let mut hf = dfir_syntax! {
+    let mut hf = dfir_syntax_inline! {
         lhs = source_iter([
                 var_expr!(123, 2, 5, "hello"),
                 var_expr!(50, 1, 1, "hi"),
@@ -205,5 +200,5 @@ fn test_ght_join_bimorphism() {
             -> flat_map(|(_num, ght)| ght.recursive_iter().map(<JoinSchema as CloneVariadic>::clone_ref_var).collect::<Vec<_>>())
             -> null();
     };
-    hf.run_available_sync();
+    hf.run_available().await;
 }

--- a/dfir_rs/tests/surface_lattice_bimorphism_persist_insertion.rs
+++ b/dfir_rs/tests/surface_lattice_bimorphism_persist_insertion.rs
@@ -1,8 +1,8 @@
 use std::collections::HashSet;
 
-use dfir_rs::scheduled::graph::Dfir;
+use dfir_rs::dfir_syntax_inline;
+use dfir_rs::scheduled::context::InlineDfirErased;
 use dfir_rs::util::collect_ready;
-use dfir_rs::{assert_graphvis_snapshots, dfir_syntax};
 use lattices::set_union::{CartesianProductBimorphism, SetUnionHashSet, SetUnionSingletonSet};
 use multiplatform_test::multiplatform_test;
 use tokio::sync::mpsc::UnboundedSender;
@@ -10,7 +10,7 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 
 /// Check that the following tests all behave the same.
 fn check_cartesian_product_multi_tick(
-    mut df: Dfir,
+    mut df: InlineDfirErased,
     lhs_send: UnboundedSender<u32>,
     rhs_send: UnboundedSender<u32>,
     mut out_recv: UnboundedReceiverStream<SetUnionHashSet<(u32, u32)>>,
@@ -47,7 +47,7 @@ pub fn test_cartesian_product_multi_tick() {
     let (rhs_send, rhs_recv) = dfir_rs::util::unbounded_channel::<_>();
     let (out_send, out_recv) = dfir_rs::util::unbounded_channel::<_>();
 
-    let df = dfir_syntax! {
+    let df = dfir_syntax_inline! {
         lhs = source_stream(lhs_recv)
             -> map(SetUnionSingletonSet::new_from)
             -> state::<'static, SetUnionHashSet<u32>>();
@@ -63,8 +63,7 @@ pub fn test_cartesian_product_multi_tick() {
             -> for_each(|x| out_send.send(x).unwrap());
     };
 
-    assert_graphvis_snapshots!(df);
-    check_cartesian_product_multi_tick(df, lhs_send, rhs_send, out_recv);
+    check_cartesian_product_multi_tick(df.into_erased(), lhs_send, rhs_send, out_recv);
 }
 
 #[multiplatform_test]
@@ -73,7 +72,7 @@ pub fn test_cartesian_product_multi_tick_tee() {
     let (rhs_send, rhs_recv) = dfir_rs::util::unbounded_channel::<_>();
     let (out_send, out_recv) = dfir_rs::util::unbounded_channel::<_>();
 
-    let df = dfir_syntax! {
+    let df = dfir_syntax_inline! {
         lhs = source_stream(lhs_recv)
             -> map(SetUnionSingletonSet::new_from)
             -> state::<'static, SetUnionHashSet<u32>>();
@@ -91,8 +90,7 @@ pub fn test_cartesian_product_multi_tick_tee() {
             -> for_each(|x| out_send.send(x).unwrap());
     };
 
-    assert_graphvis_snapshots!(df);
-    check_cartesian_product_multi_tick(df, lhs_send, rhs_send, out_recv);
+    check_cartesian_product_multi_tick(df.into_erased(), lhs_send, rhs_send, out_recv);
 }
 
 #[multiplatform_test]
@@ -101,7 +99,7 @@ pub fn test_cartesian_product_multi_tick_identity() {
     let (rhs_send, rhs_recv) = dfir_rs::util::unbounded_channel::<_>();
     let (out_send, out_recv) = dfir_rs::util::unbounded_channel::<_>();
 
-    let df = dfir_syntax! {
+    let df = dfir_syntax_inline! {
         lhs = source_stream(lhs_recv)
             -> map(SetUnionSingletonSet::new_from)
             -> state::<'static, SetUnionHashSet<u32>>();
@@ -118,6 +116,5 @@ pub fn test_cartesian_product_multi_tick_identity() {
             -> for_each(|x| out_send.send(x).unwrap());
     };
 
-    assert_graphvis_snapshots!(df);
-    check_cartesian_product_multi_tick(df, lhs_send, rhs_send, out_recv);
+    check_cartesian_product_multi_tick(df.into_erased(), lhs_send, rhs_send, out_recv);
 }

--- a/dfir_rs/tests/surface_lattice_generalized_hash_trie.rs
+++ b/dfir_rs/tests/surface_lattice_generalized_hash_trie.rs
@@ -1,13 +1,13 @@
-use dfir_rs::dfir_syntax;
+use dfir_rs::dfir_syntax_inline;
 use dfir_rs::lattices::GhtType;
 use dfir_rs::lattices::ght::GeneralizedHashTrieNode;
 use dfir_rs::lattices::ght::lattice::{DeepJoinLatticeBimorphism, GhtBimorphism};
-use dfir_rs::util::collect_ready;
+use dfir_rs::util::collect_ready_async;
 use dfir_rs::variadics::{var_expr, var_type};
 use variadics::variadic_collections::VariadicHashSet; // Import the Insert trait
 
-#[test]
-fn test_basic() {
+#[dfir_rs::test]
+async fn test_basic() {
     type MyGht = GhtType!(u16, u32 => u64: VariadicHashSet);
     type FlatTup = var_type!(u16, u32, u64);
     let input: Vec<FlatTup> = vec![
@@ -21,7 +21,7 @@ fn test_basic() {
         merged.insert(i);
     }
     println!("merged: {:?}", merged);
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter(input)
             -> map(|t| MyGht::new_from(vec![t]))
             -> lattice_fold::<'static>(MyGht::default)
@@ -29,11 +29,11 @@ fn test_basic() {
             -> assert(|x: &MyGht| x.eq(&merged))
             -> null();
     };
-    df.run_available_sync();
+    df.run_available().await;
 }
 
-#[test]
-fn test_join() {
+#[dfir_rs::test]
+async fn test_join() {
     type MyGht = GhtType!(u8 => u16: VariadicHashSet);
     type ResultGht = GhtType!(u8 => u16, u16: VariadicHashSet);
     let (out_send, out_recv) = dfir_rs::util::unbounded_channel::<_>();
@@ -51,7 +51,7 @@ fn test_join() {
     >>::DeepJoinLatticeBimorphism;
     type MyBim = GhtBimorphism<MyNodeBim>;
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         R = source_iter(r)
             -> map(|t| MyGht::new_from([t]))
             -> state::<MyGht>();
@@ -64,10 +64,10 @@ fn test_join() {
             -> lattice_reduce()
             -> for_each(|x| out_send.send(x).unwrap());
     };
-    df.run_available_sync();
+    df.run_available().await;
 
     assert_eq!(
         &[ResultGht::new_from(vec![var_expr!(1, 10, 10),])],
-        &*collect_ready::<Vec<_>, _>(out_recv)
+        &*collect_ready_async::<Vec<_>, _>(out_recv).await
     );
 }

--- a/dfir_rs/tests/surface_lattice_generalized_hash_trie.rs
+++ b/dfir_rs/tests/surface_lattice_generalized_hash_trie.rs
@@ -2,12 +2,12 @@ use dfir_rs::dfir_syntax_inline;
 use dfir_rs::lattices::GhtType;
 use dfir_rs::lattices::ght::GeneralizedHashTrieNode;
 use dfir_rs::lattices::ght::lattice::{DeepJoinLatticeBimorphism, GhtBimorphism};
-use dfir_rs::util::collect_ready_async;
+use dfir_rs::util::collect_ready;
 use dfir_rs::variadics::{var_expr, var_type};
 use variadics::variadic_collections::VariadicHashSet; // Import the Insert trait
 
-#[dfir_rs::test]
-async fn test_basic() {
+#[test]
+fn test_basic() {
     type MyGht = GhtType!(u16, u32 => u64: VariadicHashSet);
     type FlatTup = var_type!(u16, u32, u64);
     let input: Vec<FlatTup> = vec![
@@ -29,11 +29,11 @@ async fn test_basic() {
             -> assert(|x: &MyGht| x.eq(&merged))
             -> null();
     };
-    df.run_available().await;
+    df.run_available_sync();
 }
 
-#[dfir_rs::test]
-async fn test_join() {
+#[test]
+fn test_join() {
     type MyGht = GhtType!(u8 => u16: VariadicHashSet);
     type ResultGht = GhtType!(u8 => u16, u16: VariadicHashSet);
     let (out_send, out_recv) = dfir_rs::util::unbounded_channel::<_>();
@@ -64,10 +64,10 @@ async fn test_join() {
             -> lattice_reduce()
             -> for_each(|x| out_send.send(x).unwrap());
     };
-    df.run_available().await;
+    df.run_available_sync();
 
     assert_eq!(
         &[ResultGht::new_from(vec![var_expr!(1, 10, 10),])],
-        &*collect_ready_async::<Vec<_>, _>(out_recv).await
+        &*collect_ready::<Vec<_>, _>(out_recv)
     );
 }

--- a/dfir_rs/tests/surface_lattice_join.rs
+++ b/dfir_rs/tests/surface_lattice_join.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use dfir_macro::dfir_syntax;
+use dfir_rs::dfir_syntax_inline;
 use dfir_rs::util::collect_ready;
 use lattices::DeepReveal;
 use lattices::collections::SingletonMap;
@@ -10,7 +10,7 @@ use multiplatform_test::multiplatform_test;
 pub fn test_lattice_join_fused_join_reducing_behavior() {
     // lattice_fold has the following particular initialization behavior. It uses LatticeFrom to convert the first element into another lattice type to create the accumulator and then it folds the remaining elements into that accumulator.
     // This initialization style supports things like SetUnionSingletonSet -> SetUnionHashSet. It also helps with things like Min, where there is not obvious default value so you want reduce-like behavior.
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         use lattices::Min;
         use lattices::Max;
 
@@ -29,7 +29,7 @@ pub fn test_lattice_join_fused_join_reducing_behavior() {
 
 #[multiplatform_test]
 pub fn test_lattice_join_fused_join_set_union() {
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         use lattices::set_union::SetUnionSingletonSet;
         use lattices::set_union::SetUnionHashSet;
 
@@ -46,7 +46,7 @@ pub fn test_lattice_join_fused_join_set_union() {
 
 #[multiplatform_test]
 pub fn test_lattice_join_fused_join_map_union() {
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         use lattices::map_union::MapUnionSingletonMap;
         use lattices::map_union::MapUnionHashMap;
         use dfir_rs::lattices::Min;
@@ -81,7 +81,7 @@ pub fn test_lattice_join_fused_join() {
         let (lhs_tx, lhs_rx) = dfir_rs::util::unbounded_channel::<(usize, Max<usize>)>();
         let (rhs_tx, rhs_rx) = dfir_rs::util::unbounded_channel::<(usize, Max<usize>)>();
 
-        let mut df = dfir_syntax! {
+        let mut df = dfir_syntax_inline! {
             my_join = _lattice_join_fused_join::<'static, 'tick, Max<usize>, Max<usize>>();
 
             source_stream(lhs_rx) -> [0]my_join;
@@ -120,7 +120,7 @@ pub fn test_lattice_join_fused_join() {
         let (lhs_tx, lhs_rx) = dfir_rs::util::unbounded_channel::<(usize, Max<usize>)>();
         let (rhs_tx, rhs_rx) = dfir_rs::util::unbounded_channel::<(usize, Max<usize>)>();
 
-        let mut df = dfir_syntax! {
+        let mut df = dfir_syntax_inline! {
             my_join = _lattice_join_fused_join::<'static, 'static, Max<usize>, Max<usize>>();
 
             source_stream(lhs_rx) -> [0]my_join;
@@ -146,7 +146,6 @@ pub fn test_lattice_join_fused_join() {
 
         df.run_tick_sync();
         let out: Vec<_> = collect_ready(&mut out_rx);
-        // TODO(mingwei): Should only be one, but bug: https://github.com/hydro-project/hydro/issues/1050#issuecomment-1924338317
-        assert_eq!(out, [SingletonMap(7, (4, 6)), SingletonMap(7, (4, 6))]);
+        assert_eq!(out, [SingletonMap(7, (4, 6))]);
     }
 }

--- a/dfir_rs/tests/surface_lattice_reduce.rs
+++ b/dfir_rs/tests/surface_lattice_reduce.rs
@@ -1,13 +1,13 @@
-use dfir_rs::dfir_syntax;
+use dfir_rs::dfir_syntax_inline;
 use dfir_rs::lattices::Max;
 
-#[test]
-fn test_basic() {
-    let mut df = dfir_syntax! {
+#[dfir_rs::test]
+async fn test_basic() {
+    let mut df = dfir_syntax_inline! {
         source_iter([1,2,3,4,5])
             -> map(Max::new)
             -> lattice_reduce()
             -> for_each(|x: Max<u32>| println!("Least upper bound: {:?}", x));
     };
-    df.run_available_sync();
+    df.run_available().await;
 }

--- a/dfir_rs/tests/surface_lattice_reduce.rs
+++ b/dfir_rs/tests/surface_lattice_reduce.rs
@@ -1,13 +1,13 @@
 use dfir_rs::dfir_syntax_inline;
 use dfir_rs::lattices::Max;
 
-#[dfir_rs::test]
-async fn test_basic() {
+#[test]
+fn test_basic() {
     let mut df = dfir_syntax_inline! {
         source_iter([1,2,3,4,5])
             -> map(Max::new)
             -> lattice_reduce()
             -> for_each(|x: Max<u32>| println!("Least upper bound: {:?}", x));
     };
-    df.run_available().await;
+    df.run_available_sync();
 }

--- a/dfir_rs/tests/surface_multiset_delta.rs
+++ b/dfir_rs/tests/surface_multiset_delta.rs
@@ -1,39 +1,37 @@
-use dfir_rs::util::collect_ready;
-use dfir_rs::{assert_graphvis_snapshots, dfir_syntax};
-use multiplatform_test::multiplatform_test;
+use dfir_rs::util::collect_ready_async;
+use dfir_rs::dfir_syntax_inline;
 
-#[multiplatform_test]
-pub fn test_multiset_delta() {
+#[dfir_rs::test]
+pub async fn test_multiset_delta() {
     let (input_send, input_recv) = dfir_rs::util::unbounded_channel::<u32>();
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u32>();
 
-    let mut flow = dfir_syntax! {
+    let mut flow = dfir_syntax_inline! {
         source_stream(input_recv)
             -> multiset_delta()
             -> for_each(|x| result_send.send(x).unwrap());
     };
-    assert_graphvis_snapshots!(flow);
 
     input_send.send(3).unwrap();
     input_send.send(4).unwrap();
     input_send.send(3).unwrap();
-    flow.run_tick_sync();
-    assert_eq!(&[3, 4, 3], &*collect_ready::<Vec<_>, _>(&mut result_recv));
+    flow.run_tick().await;
+    assert_eq!(&[3, 4, 3], &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await);
 
     input_send.send(3).unwrap();
     input_send.send(5).unwrap();
     input_send.send(3).unwrap();
     input_send.send(3).unwrap();
-    flow.run_tick_sync();
+    flow.run_tick().await;
     // First two "3"s are removed due to previous tick.
-    assert_eq!(&[5, 3], &*collect_ready::<Vec<_>, _>(&mut result_recv));
+    assert_eq!(&[5, 3], &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await);
 }
 
-#[multiplatform_test]
-pub fn test_persist_multiset_delta() {
+#[dfir_rs::test]
+pub async fn test_persist_multiset_delta() {
     let (input_send, input_recv) = dfir_rs::util::unbounded_channel::<usize>();
     let (output_send, mut output_recv) = dfir_rs::util::unbounded_channel::<usize>();
-    let mut flow = dfir_rs::dfir_syntax! {
+    let mut flow = dfir_rs::dfir_syntax_inline! {
         source_stream(input_recv)
             -> persist::<'static>()
             -> multiset_delta()
@@ -41,22 +39,22 @@ pub fn test_persist_multiset_delta() {
     };
 
     input_send.send(1).unwrap();
-    flow.run_tick_sync();
-    assert_eq!(&[(1)], &*collect_ready::<Vec<_>, _>(&mut output_recv));
+    flow.run_tick().await;
+    assert_eq!(&[(1)], &*collect_ready_async::<Vec<_>, _>(&mut output_recv).await);
 
-    flow.run_tick_sync();
-    assert!(collect_ready::<Vec<_>, _>(&mut output_recv).is_empty());
+    flow.run_tick().await;
+    assert!(collect_ready_async::<Vec<_>, _>(&mut output_recv).await.is_empty());
 
-    flow.run_tick_sync();
-    assert!(collect_ready::<Vec<_>, _>(&mut output_recv).is_empty());
+    flow.run_tick().await;
+    assert!(collect_ready_async::<Vec<_>, _>(&mut output_recv).await.is_empty());
 }
 
-#[multiplatform_test]
-pub fn test_multiset_delta_2() {
+#[dfir_rs::test]
+pub async fn test_multiset_delta_2() {
     let (input_send, input_recv) = dfir_rs::util::unbounded_channel::<u32>();
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u32>();
 
-    let mut flow = dfir_syntax! {
+    let mut flow = dfir_syntax_inline! {
         source_stream(input_recv)
             -> multiset_delta()
             -> for_each(|x| result_send.send(x).unwrap());
@@ -65,25 +63,25 @@ pub fn test_multiset_delta_2() {
     input_send.send(3).unwrap();
     input_send.send(4).unwrap();
     input_send.send(3).unwrap();
-    flow.run_tick_sync();
-    assert_eq!(&[3, 4, 3], &*collect_ready::<Vec<_>, _>(&mut result_recv));
+    flow.run_tick().await;
+    assert_eq!(&[3, 4, 3], &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await);
 
     input_send.send(3).unwrap();
     input_send.send(4).unwrap();
     input_send.send(3).unwrap();
     input_send.send(3).unwrap();
-    flow.run_tick_sync();
+    flow.run_tick().await;
 
-    assert_eq!(&[3], &*collect_ready::<Vec<_>, _>(&mut result_recv));
+    assert_eq!(&[3], &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await);
 }
 
-#[multiplatform_test]
-fn test_chat_app_replay() {
+#[dfir_rs::test]
+async fn test_chat_app_replay() {
     let (users_send, users) = dfir_rs::util::unbounded_channel::<u32>();
     let (messages_send, messages) = dfir_rs::util::unbounded_channel::<String>();
     let (out, mut out_recv) = dfir_rs::util::unbounded_channel::<(u32, String)>();
 
-    let mut chat_server = dfir_syntax! {
+    let mut chat_server = dfir_syntax_inline! {
         users = source_stream(users) -> persist::<'static>();
         messages = source_stream(messages) -> persist::<'static>();
         users -> [0]crossed;
@@ -101,7 +99,7 @@ fn test_chat_app_replay() {
     messages_send.send("hello".to_owned()).unwrap();
     messages_send.send("world".to_owned()).unwrap();
 
-    chat_server.run_tick_sync();
+    chat_server.run_tick().await;
 
     assert_eq!(
         &[
@@ -110,14 +108,14 @@ fn test_chat_app_replay() {
             (1, "world".to_owned()),
             (2, "world".to_owned())
         ],
-        &*collect_ready::<Vec<_>, _>(&mut out_recv),
+        &*collect_ready_async::<Vec<_>, _>(&mut out_recv).await,
     );
 
     users_send.send(3).unwrap();
 
     messages_send.send("goodbye".to_owned()).unwrap();
 
-    chat_server.run_tick_sync();
+    chat_server.run_tick().await;
 
     // fails with: [(1, "hello"), (2, "hello"), (3, "hello"), (1, "world"), (2, "world"), (3, "world"), (1, "goodbye"), (2, "goodbye"), (3, "goodbye")]
 
@@ -129,16 +127,16 @@ fn test_chat_app_replay() {
             (2, "goodbye".to_owned()),
             (3, "goodbye".to_owned())
         ],
-        &*collect_ready::<Vec<_>, _>(&mut out_recv),
+        &*collect_ready_async::<Vec<_>, _>(&mut out_recv).await,
     );
 }
 
-#[multiplatform_test]
-fn test_chat_app_replay_manual() {
+#[dfir_rs::test]
+async fn test_chat_app_replay_manual() {
     let (input_send, input_recv) = dfir_rs::util::unbounded_channel::<(u32, String)>();
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<(u32, String)>();
 
-    let mut flow = dfir_syntax! {
+    let mut flow = dfir_syntax_inline! {
         source_stream(input_recv)
             -> multiset_delta()
             -> for_each(|x| result_send.send(x).unwrap());
@@ -149,7 +147,7 @@ fn test_chat_app_replay_manual() {
     input_send.send((1, "world".to_owned())).unwrap();
     input_send.send((2, "world".to_owned())).unwrap();
 
-    flow.run_tick_sync();
+    flow.run_tick().await;
     assert_eq!(
         &[
             (1, "hello".to_owned()),
@@ -157,7 +155,7 @@ fn test_chat_app_replay_manual() {
             (1, "world".to_owned()),
             (2, "world".to_owned())
         ],
-        &*collect_ready::<Vec<_>, _>(&mut result_recv),
+        &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await,
     );
 
     input_send.send((1, "hello".to_owned())).unwrap();
@@ -170,7 +168,7 @@ fn test_chat_app_replay_manual() {
     input_send.send((2, "goodbye".to_owned())).unwrap();
     input_send.send((3, "goodbye".to_owned())).unwrap();
 
-    flow.run_tick_sync();
+    flow.run_tick().await;
     assert_eq!(
         &[
             (3, "hello".to_owned()),
@@ -179,6 +177,6 @@ fn test_chat_app_replay_manual() {
             (2, "goodbye".to_owned()),
             (3, "goodbye".to_owned())
         ],
-        &*collect_ready::<Vec<_>, _>(&mut result_recv),
+        &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await,
     );
 }

--- a/dfir_rs/tests/surface_multiset_delta.rs
+++ b/dfir_rs/tests/surface_multiset_delta.rs
@@ -1,8 +1,9 @@
 use dfir_rs::dfir_syntax_inline;
-use dfir_rs::util::collect_ready_async;
+use dfir_rs::util::collect_ready;
+use multiplatform_test::multiplatform_test;
 
-#[dfir_rs::test]
-pub async fn test_multiset_delta() {
+#[multiplatform_test]
+pub fn test_multiset_delta() {
     let (input_send, input_recv) = dfir_rs::util::unbounded_channel::<u32>();
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u32>();
 
@@ -15,26 +16,20 @@ pub async fn test_multiset_delta() {
     input_send.send(3).unwrap();
     input_send.send(4).unwrap();
     input_send.send(3).unwrap();
-    flow.run_tick().await;
-    assert_eq!(
-        &[3, 4, 3],
-        &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await
-    );
+    flow.run_tick_sync();
+    assert_eq!(&[3, 4, 3], &*collect_ready::<Vec<_>, _>(&mut result_recv));
 
     input_send.send(3).unwrap();
     input_send.send(5).unwrap();
     input_send.send(3).unwrap();
     input_send.send(3).unwrap();
-    flow.run_tick().await;
+    flow.run_tick_sync();
     // First two "3"s are removed due to previous tick.
-    assert_eq!(
-        &[5, 3],
-        &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await
-    );
+    assert_eq!(&[5, 3], &*collect_ready::<Vec<_>, _>(&mut result_recv));
 }
 
-#[dfir_rs::test]
-pub async fn test_persist_multiset_delta() {
+#[multiplatform_test]
+pub fn test_persist_multiset_delta() {
     let (input_send, input_recv) = dfir_rs::util::unbounded_channel::<usize>();
     let (output_send, mut output_recv) = dfir_rs::util::unbounded_channel::<usize>();
     let mut flow = dfir_rs::dfir_syntax_inline! {
@@ -45,29 +40,18 @@ pub async fn test_persist_multiset_delta() {
     };
 
     input_send.send(1).unwrap();
-    flow.run_tick().await;
-    assert_eq!(
-        &[(1)],
-        &*collect_ready_async::<Vec<_>, _>(&mut output_recv).await
-    );
+    flow.run_tick_sync();
+    assert_eq!(&[(1)], &*collect_ready::<Vec<_>, _>(&mut output_recv));
 
-    flow.run_tick().await;
-    assert!(
-        collect_ready_async::<Vec<_>, _>(&mut output_recv)
-            .await
-            .is_empty()
-    );
+    flow.run_tick_sync();
+    assert!(collect_ready::<Vec<_>, _>(&mut output_recv).is_empty());
 
-    flow.run_tick().await;
-    assert!(
-        collect_ready_async::<Vec<_>, _>(&mut output_recv)
-            .await
-            .is_empty()
-    );
+    flow.run_tick_sync();
+    assert!(collect_ready::<Vec<_>, _>(&mut output_recv).is_empty());
 }
 
-#[dfir_rs::test]
-pub async fn test_multiset_delta_2() {
+#[multiplatform_test]
+pub fn test_multiset_delta_2() {
     let (input_send, input_recv) = dfir_rs::util::unbounded_channel::<u32>();
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u32>();
 
@@ -80,26 +64,20 @@ pub async fn test_multiset_delta_2() {
     input_send.send(3).unwrap();
     input_send.send(4).unwrap();
     input_send.send(3).unwrap();
-    flow.run_tick().await;
-    assert_eq!(
-        &[3, 4, 3],
-        &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await
-    );
+    flow.run_tick_sync();
+    assert_eq!(&[3, 4, 3], &*collect_ready::<Vec<_>, _>(&mut result_recv));
 
     input_send.send(3).unwrap();
     input_send.send(4).unwrap();
     input_send.send(3).unwrap();
     input_send.send(3).unwrap();
-    flow.run_tick().await;
+    flow.run_tick_sync();
 
-    assert_eq!(
-        &[3],
-        &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await
-    );
+    assert_eq!(&[3], &*collect_ready::<Vec<_>, _>(&mut result_recv));
 }
 
-#[dfir_rs::test]
-async fn test_chat_app_replay() {
+#[multiplatform_test]
+fn test_chat_app_replay() {
     let (users_send, users) = dfir_rs::util::unbounded_channel::<u32>();
     let (messages_send, messages) = dfir_rs::util::unbounded_channel::<String>();
     let (out, mut out_recv) = dfir_rs::util::unbounded_channel::<(u32, String)>();
@@ -122,7 +100,7 @@ async fn test_chat_app_replay() {
     messages_send.send("hello".to_owned()).unwrap();
     messages_send.send("world".to_owned()).unwrap();
 
-    chat_server.run_tick().await;
+    chat_server.run_tick_sync();
 
     assert_eq!(
         &[
@@ -131,14 +109,14 @@ async fn test_chat_app_replay() {
             (1, "world".to_owned()),
             (2, "world".to_owned())
         ],
-        &*collect_ready_async::<Vec<_>, _>(&mut out_recv).await,
+        &*collect_ready::<Vec<_>, _>(&mut out_recv),
     );
 
     users_send.send(3).unwrap();
 
     messages_send.send("goodbye".to_owned()).unwrap();
 
-    chat_server.run_tick().await;
+    chat_server.run_tick_sync();
 
     // fails with: [(1, "hello"), (2, "hello"), (3, "hello"), (1, "world"), (2, "world"), (3, "world"), (1, "goodbye"), (2, "goodbye"), (3, "goodbye")]
 
@@ -150,12 +128,12 @@ async fn test_chat_app_replay() {
             (2, "goodbye".to_owned()),
             (3, "goodbye".to_owned())
         ],
-        &*collect_ready_async::<Vec<_>, _>(&mut out_recv).await,
+        &*collect_ready::<Vec<_>, _>(&mut out_recv),
     );
 }
 
-#[dfir_rs::test]
-async fn test_chat_app_replay_manual() {
+#[multiplatform_test]
+fn test_chat_app_replay_manual() {
     let (input_send, input_recv) = dfir_rs::util::unbounded_channel::<(u32, String)>();
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<(u32, String)>();
 
@@ -170,7 +148,7 @@ async fn test_chat_app_replay_manual() {
     input_send.send((1, "world".to_owned())).unwrap();
     input_send.send((2, "world".to_owned())).unwrap();
 
-    flow.run_tick().await;
+    flow.run_tick_sync();
     assert_eq!(
         &[
             (1, "hello".to_owned()),
@@ -178,7 +156,7 @@ async fn test_chat_app_replay_manual() {
             (1, "world".to_owned()),
             (2, "world".to_owned())
         ],
-        &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await,
+        &*collect_ready::<Vec<_>, _>(&mut result_recv),
     );
 
     input_send.send((1, "hello".to_owned())).unwrap();
@@ -191,7 +169,7 @@ async fn test_chat_app_replay_manual() {
     input_send.send((2, "goodbye".to_owned())).unwrap();
     input_send.send((3, "goodbye".to_owned())).unwrap();
 
-    flow.run_tick().await;
+    flow.run_tick_sync();
     assert_eq!(
         &[
             (3, "hello".to_owned()),
@@ -200,6 +178,6 @@ async fn test_chat_app_replay_manual() {
             (2, "goodbye".to_owned()),
             (3, "goodbye".to_owned())
         ],
-        &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await,
+        &*collect_ready::<Vec<_>, _>(&mut result_recv),
     );
 }

--- a/dfir_rs/tests/surface_multiset_delta.rs
+++ b/dfir_rs/tests/surface_multiset_delta.rs
@@ -1,5 +1,5 @@
-use dfir_rs::util::collect_ready_async;
 use dfir_rs::dfir_syntax_inline;
+use dfir_rs::util::collect_ready_async;
 
 #[dfir_rs::test]
 pub async fn test_multiset_delta() {
@@ -16,7 +16,10 @@ pub async fn test_multiset_delta() {
     input_send.send(4).unwrap();
     input_send.send(3).unwrap();
     flow.run_tick().await;
-    assert_eq!(&[3, 4, 3], &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await);
+    assert_eq!(
+        &[3, 4, 3],
+        &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await
+    );
 
     input_send.send(3).unwrap();
     input_send.send(5).unwrap();
@@ -24,7 +27,10 @@ pub async fn test_multiset_delta() {
     input_send.send(3).unwrap();
     flow.run_tick().await;
     // First two "3"s are removed due to previous tick.
-    assert_eq!(&[5, 3], &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await);
+    assert_eq!(
+        &[5, 3],
+        &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await
+    );
 }
 
 #[dfir_rs::test]
@@ -40,13 +46,24 @@ pub async fn test_persist_multiset_delta() {
 
     input_send.send(1).unwrap();
     flow.run_tick().await;
-    assert_eq!(&[(1)], &*collect_ready_async::<Vec<_>, _>(&mut output_recv).await);
+    assert_eq!(
+        &[(1)],
+        &*collect_ready_async::<Vec<_>, _>(&mut output_recv).await
+    );
 
     flow.run_tick().await;
-    assert!(collect_ready_async::<Vec<_>, _>(&mut output_recv).await.is_empty());
+    assert!(
+        collect_ready_async::<Vec<_>, _>(&mut output_recv)
+            .await
+            .is_empty()
+    );
 
     flow.run_tick().await;
-    assert!(collect_ready_async::<Vec<_>, _>(&mut output_recv).await.is_empty());
+    assert!(
+        collect_ready_async::<Vec<_>, _>(&mut output_recv)
+            .await
+            .is_empty()
+    );
 }
 
 #[dfir_rs::test]
@@ -64,7 +81,10 @@ pub async fn test_multiset_delta_2() {
     input_send.send(4).unwrap();
     input_send.send(3).unwrap();
     flow.run_tick().await;
-    assert_eq!(&[3, 4, 3], &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await);
+    assert_eq!(
+        &[3, 4, 3],
+        &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await
+    );
 
     input_send.send(3).unwrap();
     input_send.send(4).unwrap();
@@ -72,7 +92,10 @@ pub async fn test_multiset_delta_2() {
     input_send.send(3).unwrap();
     flow.run_tick().await;
 
-    assert_eq!(&[3], &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await);
+    assert_eq!(
+        &[3],
+        &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await
+    );
 }
 
 #[dfir_rs::test]

--- a/dfir_rs/tests/surface_null.rs
+++ b/dfir_rs/tests/surface_null.rs
@@ -1,25 +1,26 @@
 use dfir_rs::dfir_syntax_inline;
+use multiplatform_test::multiplatform_test;
 
-#[dfir_rs::test]
-pub async fn test_basic_null_src() {
+#[multiplatform_test]
+pub fn test_basic_null_src() {
     let mut df = dfir_syntax_inline! {
         null() -> for_each(drop::<String>);
     };
-    df.run_available().await;
+    df.run_available_sync();
 }
 
-#[dfir_rs::test]
-pub async fn test_basic_null_dest() {
+#[multiplatform_test]
+pub fn test_basic_null_dest() {
     let mut df = dfir_syntax_inline! {
         source_iter([1, 2, 3, 4]) -> null();
     };
-    df.run_available().await;
+    df.run_available_sync();
 }
 
-#[dfir_rs::test]
-pub async fn test_basic_null_both() {
+#[multiplatform_test]
+pub fn test_basic_null_both() {
     let mut df = dfir_syntax_inline! {
         source_iter([1, 2, 3, 4]) -> null() -> for_each(drop::<String>);
     };
-    df.run_available().await;
+    df.run_available_sync();
 }

--- a/dfir_rs/tests/surface_null.rs
+++ b/dfir_rs/tests/surface_null.rs
@@ -1,26 +1,25 @@
-use dfir_rs::dfir_syntax;
-use multiplatform_test::multiplatform_test;
+use dfir_rs::dfir_syntax_inline;
 
-#[multiplatform_test]
-pub fn test_basic_null_src() {
-    let mut df = dfir_syntax! {
+#[dfir_rs::test]
+pub async fn test_basic_null_src() {
+    let mut df = dfir_syntax_inline! {
         null() -> for_each(drop::<String>);
     };
-    df.run_available_sync();
+    df.run_available().await;
 }
 
-#[multiplatform_test]
-pub fn test_basic_null_dest() {
-    let mut df = dfir_syntax! {
+#[dfir_rs::test]
+pub async fn test_basic_null_dest() {
+    let mut df = dfir_syntax_inline! {
         source_iter([1, 2, 3, 4]) -> null();
     };
-    df.run_available_sync();
+    df.run_available().await;
 }
 
-#[multiplatform_test]
-pub fn test_basic_null_both() {
-    let mut df = dfir_syntax! {
+#[dfir_rs::test]
+pub async fn test_basic_null_both() {
+    let mut df = dfir_syntax_inline! {
         source_iter([1, 2, 3, 4]) -> null() -> for_each(drop::<String>);
     };
-    df.run_available_sync();
+    df.run_available().await;
 }

--- a/dfir_rs/tests/surface_partition.rs
+++ b/dfir_rs/tests/surface_partition.rs
@@ -1,12 +1,11 @@
-use dfir_rs::dfir_syntax;
-use dfir_rs::util::collect_ready;
-use multiplatform_test::multiplatform_test;
+use dfir_rs::dfir_syntax_inline;
+use dfir_rs::util::collect_ready_async;
 
-#[multiplatform_test]
-pub fn test_partition_fizzbuzz() {
+#[dfir_rs::test]
+pub async fn test_partition_fizzbuzz() {
     let (out_send, out_recv) = dfir_rs::util::unbounded_channel::<String>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         my_partition = source_iter(1..=15)
             -> partition(|&v, [fzbz, fizz, buzz, vals]|
                 match (v % 3, v % 5) {
@@ -25,22 +24,22 @@ pub fn test_partition_fizzbuzz() {
         my_partition[fzbz] -> map(|_| "fizzbuzz".to_owned())
             -> for_each(|s| out_send.send(s).unwrap());
     };
-    df.run_available_sync();
+    df.run_available().await;
 
     assert_eq!(
         &[
             "1", "2", "fizz", "4", "buzz", "fizz", "7", "8", "fizz", "buzz", "11", "fizz", "13",
             "14", "fizzbuzz"
         ],
-        &*collect_ready::<Vec<_>, _>(out_recv)
+        &*collect_ready_async::<Vec<_>, _>(out_recv).await
     )
 }
 
-#[multiplatform_test]
-pub fn test_partition_round() {
+#[dfir_rs::test]
+pub async fn test_partition_round() {
     let (out_send, out_recv) = dfir_rs::util::unbounded_channel::<String>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         my_partition = source_iter(0..20)
             -> partition(|v, len| v % len);
         my_partition[2] -> map(|x| format!("{} 2", x))
@@ -52,13 +51,13 @@ pub fn test_partition_round() {
         my_partition[0] -> map(|x| format!("{} 0", x))
             -> for_each(|s| out_send.send(s).unwrap());
     };
-    df.run_available_sync();
+    df.run_available().await;
 
     assert_eq!(
         &[
             "0 0", "1 1", "2 2", "3 3", "4 0", "5 1", "6 2", "7 3", "8 0", "9 1", "10 2", "11 3",
             "12 0", "13 1", "14 2", "15 3", "16 0", "17 1", "18 2", "19 3"
         ],
-        &*collect_ready::<Vec<_>, _>(out_recv)
+        &*collect_ready_async::<Vec<_>, _>(out_recv).await
     )
 }

--- a/dfir_rs/tests/surface_partition.rs
+++ b/dfir_rs/tests/surface_partition.rs
@@ -1,8 +1,9 @@
 use dfir_rs::dfir_syntax_inline;
-use dfir_rs::util::collect_ready_async;
+use dfir_rs::util::collect_ready;
+use multiplatform_test::multiplatform_test;
 
-#[dfir_rs::test]
-pub async fn test_partition_fizzbuzz() {
+#[multiplatform_test]
+pub fn test_partition_fizzbuzz() {
     let (out_send, out_recv) = dfir_rs::util::unbounded_channel::<String>();
 
     let mut df = dfir_syntax_inline! {
@@ -24,19 +25,19 @@ pub async fn test_partition_fizzbuzz() {
         my_partition[fzbz] -> map(|_| "fizzbuzz".to_owned())
             -> for_each(|s| out_send.send(s).unwrap());
     };
-    df.run_available().await;
+    df.run_available_sync();
 
     assert_eq!(
         &[
             "1", "2", "fizz", "4", "buzz", "fizz", "7", "8", "fizz", "buzz", "11", "fizz", "13",
             "14", "fizzbuzz"
         ],
-        &*collect_ready_async::<Vec<_>, _>(out_recv).await
+        &*collect_ready::<Vec<_>, _>(out_recv)
     )
 }
 
-#[dfir_rs::test]
-pub async fn test_partition_round() {
+#[multiplatform_test]
+pub fn test_partition_round() {
     let (out_send, out_recv) = dfir_rs::util::unbounded_channel::<String>();
 
     let mut df = dfir_syntax_inline! {
@@ -51,13 +52,13 @@ pub async fn test_partition_round() {
         my_partition[0] -> map(|x| format!("{} 0", x))
             -> for_each(|s| out_send.send(s).unwrap());
     };
-    df.run_available().await;
+    df.run_available_sync();
 
     assert_eq!(
         &[
             "0 0", "1 1", "2 2", "3 3", "4 0", "5 1", "6 2", "7 3", "8 0", "9 1", "10 2", "11 3",
             "12 0", "13 1", "14 2", "15 3", "16 0", "17 1", "18 2", "19 3"
         ],
-        &*collect_ready_async::<Vec<_>, _>(out_recv).await
+        &*collect_ready::<Vec<_>, _>(out_recv)
     )
 }

--- a/dfir_rs/tests/surface_resolve_futures.rs
+++ b/dfir_rs/tests/surface_resolve_futures.rs
@@ -2,9 +2,10 @@ use std::collections::HashSet;
 
 use dfir_rs::dfir_syntax_inline;
 use dfir_rs::util::collect_ready_async;
+use multiplatform_test::multiplatform_test;
 use tokio::time::{Duration, sleep};
 
-#[dfir_rs::test]
+#[multiplatform_test(dfir, env_tracing)]
 async fn single_batch_test() {
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u32>();
 
@@ -33,7 +34,7 @@ async fn single_batch_test() {
     handle.await.unwrap();
 }
 
-#[dfir_rs::test]
+#[multiplatform_test(dfir, env_tracing)]
 async fn multi_batch_test() {
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u64>();
 
@@ -62,7 +63,7 @@ async fn multi_batch_test() {
     handle.await.unwrap();
 }
 
-#[dfir_rs::test]
+#[multiplatform_test(dfir, env_tracing)]
 async fn pusherator_test() {
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u64>();
 
@@ -92,7 +93,7 @@ async fn pusherator_test() {
     handle.await.unwrap();
 }
 
-#[dfir_rs::test]
+#[multiplatform_test(dfir, env_tracing)]
 async fn pusherator_ordered_test() {
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u64>();
 

--- a/dfir_rs/tests/surface_resolve_futures.rs
+++ b/dfir_rs/tests/surface_resolve_futures.rs
@@ -1,15 +1,14 @@
 use std::collections::HashSet;
 
-use dfir_rs::dfir_syntax;
+use dfir_rs::dfir_syntax_inline;
 use dfir_rs::util::collect_ready_async;
-use multiplatform_test::multiplatform_test;
 use tokio::time::{Duration, sleep};
 
-#[multiplatform_test(dfir, env_tracing)]
+#[dfir_rs::test]
 async fn single_batch_test() {
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u32>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter(0..10)
         -> map(|x| async move {
             sleep(Duration::from_millis(100)).await;
@@ -34,11 +33,11 @@ async fn single_batch_test() {
     handle.await.unwrap();
 }
 
-#[multiplatform_test(dfir, env_tracing)]
+#[dfir_rs::test]
 async fn multi_batch_test() {
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u64>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter([2, 3, 1, 9, 6, 5, 4, 7, 8])
         -> map(|x| async move {
             sleep(Duration::from_millis(10*x)).await;
@@ -63,11 +62,11 @@ async fn multi_batch_test() {
     handle.await.unwrap();
 }
 
-#[multiplatform_test(dfir, env_tracing)]
+#[dfir_rs::test]
 async fn pusherator_test() {
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u64>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         ins = source_iter([2, 3, 1, 9, 6, 5, 4, 7, 8])
             -> tee();
 
@@ -93,11 +92,11 @@ async fn pusherator_test() {
     handle.await.unwrap();
 }
 
-#[multiplatform_test(dfir, env_tracing)]
+#[dfir_rs::test]
 async fn pusherator_ordered_test() {
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u64>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         ins = source_iter([2, 3, 1, 9, 6, 5, 4, 7, 8])
             -> tee();
 

--- a/dfir_rs/tests/surface_resolve_futures_blocking.rs
+++ b/dfir_rs/tests/surface_resolve_futures_blocking.rs
@@ -1,15 +1,14 @@
 use std::collections::HashSet;
 
-use dfir_rs::dfir_syntax;
+use dfir_rs::dfir_syntax_inline;
 use dfir_rs::util::collect_ready_async;
-use multiplatform_test::multiplatform_test;
 use tokio::time::{Duration, sleep};
 
-#[multiplatform_test(dfir, env_tracing)]
+#[dfir_rs::test]
 async fn single_batch_test() {
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u32>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter(0..10)
         -> map(|x| async move {
             println!("Producing {}", x);

--- a/dfir_rs/tests/surface_resolve_futures_blocking.rs
+++ b/dfir_rs/tests/surface_resolve_futures_blocking.rs
@@ -2,9 +2,10 @@ use std::collections::HashSet;
 
 use dfir_rs::dfir_syntax_inline;
 use dfir_rs::util::collect_ready_async;
+use multiplatform_test::multiplatform_test;
 use tokio::time::{Duration, sleep};
 
-#[dfir_rs::test]
+#[multiplatform_test(dfir, env_tracing)]
 async fn single_batch_test() {
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u32>();
 

--- a/dfir_rs/tests/surface_resolve_futures_blocking_ordered.rs
+++ b/dfir_rs/tests/surface_resolve_futures_blocking_ordered.rs
@@ -1,8 +1,9 @@
 use dfir_rs::dfir_syntax_inline;
 use dfir_rs::util::collect_ready_async;
+use multiplatform_test::multiplatform_test;
 use tokio::time::{Duration, sleep};
 
-#[dfir_rs::test]
+#[multiplatform_test(dfir, env_tracing)]
 async fn single_batch_test() {
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u32>();
 

--- a/dfir_rs/tests/surface_resolve_futures_blocking_ordered.rs
+++ b/dfir_rs/tests/surface_resolve_futures_blocking_ordered.rs
@@ -1,13 +1,12 @@
-use dfir_rs::dfir_syntax;
+use dfir_rs::dfir_syntax_inline;
 use dfir_rs::util::collect_ready_async;
-use multiplatform_test::multiplatform_test;
 use tokio::time::{Duration, sleep};
 
-#[multiplatform_test(dfir, env_tracing)]
+#[dfir_rs::test]
 async fn single_batch_test() {
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u32>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter(0..10)
         -> map(|x| async move {
             sleep(Duration::from_millis(100)).await;

--- a/dfir_rs/tests/surface_resolve_futures_ordered.rs
+++ b/dfir_rs/tests/surface_resolve_futures_ordered.rs
@@ -2,9 +2,10 @@ use std::collections::HashSet;
 
 use dfir_rs::dfir_syntax_inline;
 use dfir_rs::util::collect_ready_async;
+use multiplatform_test::multiplatform_test;
 use tokio::time::{Duration, sleep};
 
-#[dfir_rs::test]
+#[multiplatform_test(dfir, env_tracing)]
 async fn single_batch_test() {
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u32>();
 
@@ -33,7 +34,7 @@ async fn single_batch_test() {
     handle.await.unwrap();
 }
 
-#[dfir_rs::test]
+#[multiplatform_test(dfir, env_tracing)]
 async fn multi_batch_test() {
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u64>();
 
@@ -62,7 +63,7 @@ async fn multi_batch_test() {
     handle.await.unwrap();
 }
 
-#[dfir_rs::test]
+#[multiplatform_test(dfir, env_tracing)]
 async fn pusherator_test() {
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u64>();
 

--- a/dfir_rs/tests/surface_resolve_futures_ordered.rs
+++ b/dfir_rs/tests/surface_resolve_futures_ordered.rs
@@ -1,15 +1,14 @@
 use std::collections::HashSet;
 
-use dfir_rs::dfir_syntax;
+use dfir_rs::dfir_syntax_inline;
 use dfir_rs::util::collect_ready_async;
-use multiplatform_test::multiplatform_test;
 use tokio::time::{Duration, sleep};
 
-#[multiplatform_test(dfir, env_tracing)]
+#[dfir_rs::test]
 async fn single_batch_test() {
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u32>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter(0..10)
         -> map(|x| async move {
             sleep(Duration::from_millis(100)).await;
@@ -34,11 +33,11 @@ async fn single_batch_test() {
     handle.await.unwrap();
 }
 
-#[multiplatform_test(dfir, env_tracing)]
+#[dfir_rs::test]
 async fn multi_batch_test() {
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u64>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter([2, 3, 1, 9, 6, 5, 4, 7, 8])
         -> map(|x| async move {
             sleep(Duration::from_millis(10*x)).await;
@@ -63,11 +62,11 @@ async fn multi_batch_test() {
     handle.await.unwrap();
 }
 
-#[multiplatform_test(dfir, env_tracing)]
+#[dfir_rs::test]
 async fn pusherator_test() {
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u64>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         ins = source_iter([2, 3, 1, 9, 6, 5, 4, 7, 8])
             -> tee();
 

--- a/dfir_rs/tests/surface_scan_async_blocking.rs
+++ b/dfir_rs/tests/surface_scan_async_blocking.rs
@@ -1,12 +1,11 @@
-use dfir_rs::util::collect_ready;
-use multiplatform_test::multiplatform_test;
+use dfir_rs::util::collect_ready_async;
 
-#[multiplatform_test]
-pub fn test_scan_async_blocking_tick() {
+#[dfir_rs::test]
+pub async fn test_scan_async_blocking_tick() {
     let (items_send, items_recv) = dfir_rs::util::unbounded_channel::<u32>();
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u32>();
 
-    let mut df = dfir_rs::dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_stream(items_recv)
             -> scan_async_blocking::<'tick>(|| 0, |acc: &mut u32, x: u32| {
                 *acc += x;
@@ -18,26 +17,26 @@ pub fn test_scan_async_blocking_tick() {
 
     items_send.send(1).unwrap();
     items_send.send(2).unwrap();
-    df.run_tick_sync();
+    df.run_tick().await;
 
-    assert_eq!(&[1, 3], &*collect_ready::<Vec<_>, _>(&mut result_recv));
+    assert_eq!(&[1, 3], &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await);
 
     // With 'tick' persistence, accumulator resets each tick
     items_send.send(3).unwrap();
     items_send.send(4).unwrap();
-    df.run_tick_sync();
+    df.run_tick().await;
 
-    assert_eq!(&[3, 7], &*collect_ready::<Vec<_>, _>(&mut result_recv));
+    assert_eq!(&[3, 7], &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await);
 
-    df.run_available_sync();
+    df.run_available().await;
 }
 
-#[multiplatform_test]
-pub fn test_scan_async_blocking_static() {
+#[dfir_rs::test]
+pub async fn test_scan_async_blocking_static() {
     let (items_send, items_recv) = dfir_rs::util::unbounded_channel::<u32>();
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u32>();
 
-    let mut df = dfir_rs::dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_stream(items_recv)
             -> scan_async_blocking::<'static>(|| 0, |acc: &mut u32, x: u32| {
                 *acc += x;
@@ -49,27 +48,27 @@ pub fn test_scan_async_blocking_static() {
 
     items_send.send(1).unwrap();
     items_send.send(2).unwrap();
-    df.run_tick_sync();
+    df.run_tick().await;
 
-    assert_eq!(&[1, 3], &*collect_ready::<Vec<_>, _>(&mut result_recv));
+    assert_eq!(&[1, 3], &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await);
 
     // With 'static' persistence, accumulator persists across ticks
     items_send.send(3).unwrap();
     items_send.send(4).unwrap();
-    df.run_tick_sync();
+    df.run_tick().await;
 
-    assert_eq!(&[6, 10], &*collect_ready::<Vec<_>, _>(&mut result_recv));
+    assert_eq!(&[6, 10], &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await);
 
-    df.run_available_sync();
+    df.run_available().await;
 }
 
-#[multiplatform_test]
-pub fn test_scan_async_blocking_filter() {
+#[dfir_rs::test]
+pub async fn test_scan_async_blocking_filter() {
     // Test that returning None from the future filters the item
     let (items_send, items_recv) = dfir_rs::util::unbounded_channel::<u32>();
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u32>();
 
-    let mut df = dfir_rs::dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_stream(items_recv)
             -> scan_async_blocking::<'tick>(|| 0, |acc: &mut u32, x: u32| {
                 *acc += x;
@@ -85,9 +84,9 @@ pub fn test_scan_async_blocking_filter() {
     items_send.send(1).unwrap(); // acc=2, even -> None
     items_send.send(1).unwrap(); // acc=3, odd -> Some(3)
     items_send.send(1).unwrap(); // acc=4, even -> None
-    df.run_tick_sync();
+    df.run_tick().await;
 
-    assert_eq!(&[1, 3], &*collect_ready::<Vec<_>, _>(&mut result_recv));
+    assert_eq!(&[1, 3], &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await);
 
-    df.run_available_sync();
+    df.run_available().await;
 }

--- a/dfir_rs/tests/surface_scan_async_blocking.rs
+++ b/dfir_rs/tests/surface_scan_async_blocking.rs
@@ -19,14 +19,20 @@ pub async fn test_scan_async_blocking_tick() {
     items_send.send(2).unwrap();
     df.run_tick().await;
 
-    assert_eq!(&[1, 3], &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await);
+    assert_eq!(
+        &[1, 3],
+        &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await
+    );
 
     // With 'tick' persistence, accumulator resets each tick
     items_send.send(3).unwrap();
     items_send.send(4).unwrap();
     df.run_tick().await;
 
-    assert_eq!(&[3, 7], &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await);
+    assert_eq!(
+        &[3, 7],
+        &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await
+    );
 
     df.run_available().await;
 }
@@ -50,14 +56,20 @@ pub async fn test_scan_async_blocking_static() {
     items_send.send(2).unwrap();
     df.run_tick().await;
 
-    assert_eq!(&[1, 3], &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await);
+    assert_eq!(
+        &[1, 3],
+        &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await
+    );
 
     // With 'static' persistence, accumulator persists across ticks
     items_send.send(3).unwrap();
     items_send.send(4).unwrap();
     df.run_tick().await;
 
-    assert_eq!(&[6, 10], &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await);
+    assert_eq!(
+        &[6, 10],
+        &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await
+    );
 
     df.run_available().await;
 }
@@ -86,7 +98,10 @@ pub async fn test_scan_async_blocking_filter() {
     items_send.send(1).unwrap(); // acc=4, even -> None
     df.run_tick().await;
 
-    assert_eq!(&[1, 3], &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await);
+    assert_eq!(
+        &[1, 3],
+        &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await
+    );
 
     df.run_available().await;
 }

--- a/dfir_rs/tests/surface_scan_async_blocking.rs
+++ b/dfir_rs/tests/surface_scan_async_blocking.rs
@@ -1,7 +1,8 @@
-use dfir_rs::util::collect_ready_async;
+use dfir_rs::util::collect_ready;
+use multiplatform_test::multiplatform_test;
 
-#[dfir_rs::test]
-pub async fn test_scan_async_blocking_tick() {
+#[multiplatform_test]
+pub fn test_scan_async_blocking_tick() {
     let (items_send, items_recv) = dfir_rs::util::unbounded_channel::<u32>();
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u32>();
 
@@ -17,28 +18,22 @@ pub async fn test_scan_async_blocking_tick() {
 
     items_send.send(1).unwrap();
     items_send.send(2).unwrap();
-    df.run_tick().await;
+    df.run_tick_sync();
 
-    assert_eq!(
-        &[1, 3],
-        &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await
-    );
+    assert_eq!(&[1, 3], &*collect_ready::<Vec<_>, _>(&mut result_recv));
 
     // With 'tick' persistence, accumulator resets each tick
     items_send.send(3).unwrap();
     items_send.send(4).unwrap();
-    df.run_tick().await;
+    df.run_tick_sync();
 
-    assert_eq!(
-        &[3, 7],
-        &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await
-    );
+    assert_eq!(&[3, 7], &*collect_ready::<Vec<_>, _>(&mut result_recv));
 
-    df.run_available().await;
+    df.run_available_sync();
 }
 
-#[dfir_rs::test]
-pub async fn test_scan_async_blocking_static() {
+#[multiplatform_test]
+pub fn test_scan_async_blocking_static() {
     let (items_send, items_recv) = dfir_rs::util::unbounded_channel::<u32>();
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u32>();
 
@@ -54,28 +49,22 @@ pub async fn test_scan_async_blocking_static() {
 
     items_send.send(1).unwrap();
     items_send.send(2).unwrap();
-    df.run_tick().await;
+    df.run_tick_sync();
 
-    assert_eq!(
-        &[1, 3],
-        &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await
-    );
+    assert_eq!(&[1, 3], &*collect_ready::<Vec<_>, _>(&mut result_recv));
 
     // With 'static' persistence, accumulator persists across ticks
     items_send.send(3).unwrap();
     items_send.send(4).unwrap();
-    df.run_tick().await;
+    df.run_tick_sync();
 
-    assert_eq!(
-        &[6, 10],
-        &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await
-    );
+    assert_eq!(&[6, 10], &*collect_ready::<Vec<_>, _>(&mut result_recv));
 
-    df.run_available().await;
+    df.run_available_sync();
 }
 
-#[dfir_rs::test]
-pub async fn test_scan_async_blocking_filter() {
+#[multiplatform_test]
+pub fn test_scan_async_blocking_filter() {
     // Test that returning None from the future filters the item
     let (items_send, items_recv) = dfir_rs::util::unbounded_channel::<u32>();
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u32>();
@@ -96,12 +85,9 @@ pub async fn test_scan_async_blocking_filter() {
     items_send.send(1).unwrap(); // acc=2, even -> None
     items_send.send(1).unwrap(); // acc=3, odd -> Some(3)
     items_send.send(1).unwrap(); // acc=4, even -> None
-    df.run_tick().await;
+    df.run_tick_sync();
 
-    assert_eq!(
-        &[1, 3],
-        &*collect_ready_async::<Vec<_>, _>(&mut result_recv).await
-    );
+    assert_eq!(&[1, 3], &*collect_ready::<Vec<_>, _>(&mut result_recv));
 
-    df.run_available().await;
+    df.run_available_sync();
 }

--- a/dfir_rs/tests/surface_short_circuit_state.rs
+++ b/dfir_rs/tests/surface_short_circuit_state.rs
@@ -2,8 +2,8 @@
 //! See https://github.com/hydro-project/hydro/issues/2334
 use std::time::Duration;
 
-use dfir_rs::util::collect_ready_async;
 use dfir_rs::dfir_syntax_inline;
+use dfir_rs::util::collect_ready_async;
 
 #[dfir_rs::test]
 async fn test_resolve_futures_cross_singleton() {
@@ -26,7 +26,6 @@ async fn test_resolve_futures_cross_singleton() {
         source_stream(singleton_recv) -> [single]cs;
         cs = cross_singleton() -> map(|(millis, ())| millis) -> for_each(|millis| output_send.send(millis).unwrap());
     };
-
 
     items_send.send(500).unwrap();
     items_send.send(510).unwrap();

--- a/dfir_rs/tests/surface_short_circuit_state.rs
+++ b/dfir_rs/tests/surface_short_circuit_state.rs
@@ -4,8 +4,9 @@ use std::time::Duration;
 
 use dfir_rs::dfir_syntax_inline;
 use dfir_rs::util::collect_ready_async;
+use multiplatform_test::multiplatform_test;
 
-#[dfir_rs::test]
+#[multiplatform_test(dfir)]
 async fn test_resolve_futures_cross_singleton() {
     let (singleton_send, singleton_recv) = dfir_rs::util::unbounded_channel::<()>();
     let (items_send, items_recv) = dfir_rs::util::unbounded_channel::<u64>();
@@ -45,7 +46,7 @@ async fn test_resolve_futures_cross_singleton() {
     assert_eq!(&[500, 510, 520], &*out);
 }
 
-#[dfir_rs::test]
+#[multiplatform_test(dfir)]
 async fn test_zip_cross_singleton() {
     let (a_send, a_recv) = dfir_rs::util::unbounded_channel::<&'static str>();
     let (b_send, b_recv) = dfir_rs::util::unbounded_channel::<u64>();

--- a/dfir_rs/tests/surface_short_circuit_state.rs
+++ b/dfir_rs/tests/surface_short_circuit_state.rs
@@ -3,16 +3,15 @@
 use std::time::Duration;
 
 use dfir_rs::util::collect_ready_async;
-use dfir_rs::{assert_graphvis_snapshots, dfir_syntax};
-use multiplatform_test::multiplatform_test;
+use dfir_rs::dfir_syntax_inline;
 
-#[multiplatform_test(dfir)]
+#[dfir_rs::test]
 async fn test_resolve_futures_cross_singleton() {
     let (singleton_send, singleton_recv) = dfir_rs::util::unbounded_channel::<()>();
     let (items_send, items_recv) = dfir_rs::util::unbounded_channel::<u64>();
     let (output_send, mut output_recv) = dfir_rs::util::unbounded_channel::<u64>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_stream(items_recv)
             -> map(|millis| {
                 println!("mapping {}", millis);
@@ -28,7 +27,6 @@ async fn test_resolve_futures_cross_singleton() {
         cs = cross_singleton() -> map(|(millis, ())| millis) -> for_each(|millis| output_send.send(millis).unwrap());
     };
 
-    assert_graphvis_snapshots!(df);
 
     items_send.send(500).unwrap();
     items_send.send(510).unwrap();
@@ -48,14 +46,14 @@ async fn test_resolve_futures_cross_singleton() {
     assert_eq!(&[500, 510, 520], &*out);
 }
 
-#[multiplatform_test(dfir)]
+#[dfir_rs::test]
 async fn test_zip_cross_singleton() {
     let (a_send, a_recv) = dfir_rs::util::unbounded_channel::<&'static str>();
     let (b_send, b_recv) = dfir_rs::util::unbounded_channel::<u64>();
     let (singleton_send, singleton_recv) = dfir_rs::util::unbounded_channel::<()>();
     let (output_send, mut output_recv) = dfir_rs::util::unbounded_channel::<(&'static str, u64)>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_stream(a_recv) -> [0]z;
         source_stream(b_recv) -> [1]z;
 

--- a/dfir_rs/tests/surface_sort.rs
+++ b/dfir_rs/tests/surface_sort.rs
@@ -1,25 +1,23 @@
-use dfir_rs::util::collect_ready;
-use dfir_rs::{assert_graphvis_snapshots, dfir_syntax};
-use multiplatform_test::multiplatform_test;
+use dfir_rs::util::collect_ready_async;
+use dfir_rs::dfir_syntax_inline;
 
-#[multiplatform_test]
-pub fn test_sort() {
+#[dfir_rs::test]
+pub async fn test_sort() {
     let (items_send, items_recv) = dfir_rs::util::unbounded_channel::<usize>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_stream(items_recv)
             -> sort()
             -> for_each(|v| print!("{:?}, ", v));
     };
-    assert_graphvis_snapshots!(df);
-    df.run_available_sync();
+    df.run_available().await;
 
     print!("\nA: ");
 
     items_send.send(9).unwrap();
     items_send.send(2).unwrap();
     items_send.send(5).unwrap();
-    df.run_available_sync();
+    df.run_available().await;
 
     print!("\nB: ");
 
@@ -28,25 +26,24 @@ pub fn test_sort() {
     items_send.send(2).unwrap();
     items_send.send(0).unwrap();
     items_send.send(3).unwrap();
-    df.run_available_sync();
+    df.run_available().await;
 
     println!();
 }
 
-#[multiplatform_test]
-pub fn test_sort_by_key() {
-    let mut df = dfir_syntax! {
+#[dfir_rs::test]
+pub async fn test_sort_by_key() {
+    let mut df = dfir_syntax_inline! {
         source_iter(vec!((2, 'y'), (3, 'x'), (1, 'z')))
             -> sort_by_key(|(k, _v)| k)
             -> for_each(|v| println!("{:?}", v));
     };
-    assert_graphvis_snapshots!(df);
-    df.run_available_sync();
+    df.run_available().await;
     println!();
 }
 
-#[multiplatform_test]
-fn test_sort_by_owned() {
+#[dfir_rs::test]
+async fn test_sort_by_owned() {
     #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
     struct Dummy {
         x: String,
@@ -67,11 +64,11 @@ fn test_sort_by_owned() {
     ];
     let mut dummies_saved = dummies.clone();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter(dummies) -> sort_by_key(|d| &d.x) -> for_each(|d| out_send.send(d).unwrap());
     };
-    df.run_available_sync();
-    let results = collect_ready::<Vec<_>, _>(&mut out_recv);
+    df.run_available().await;
+    let results = collect_ready_async::<Vec<_>, _>(&mut out_recv).await;
     dummies_saved.sort_unstable_by(|d1, d2| d1.y.cmp(&d2.y));
     assert_ne!(&dummies_saved, &*results);
     dummies_saved.sort_unstable_by(|d1, d2| d1.x.cmp(&d2.x));

--- a/dfir_rs/tests/surface_sort.rs
+++ b/dfir_rs/tests/surface_sort.rs
@@ -1,8 +1,9 @@
 use dfir_rs::dfir_syntax_inline;
-use dfir_rs::util::collect_ready_async;
+use dfir_rs::util::collect_ready;
+use multiplatform_test::multiplatform_test;
 
-#[dfir_rs::test]
-pub async fn test_sort() {
+#[multiplatform_test]
+pub fn test_sort() {
     let (items_send, items_recv) = dfir_rs::util::unbounded_channel::<usize>();
 
     let mut df = dfir_syntax_inline! {
@@ -10,14 +11,14 @@ pub async fn test_sort() {
             -> sort()
             -> for_each(|v| print!("{:?}, ", v));
     };
-    df.run_available().await;
+    df.run_available_sync();
 
     print!("\nA: ");
 
     items_send.send(9).unwrap();
     items_send.send(2).unwrap();
     items_send.send(5).unwrap();
-    df.run_available().await;
+    df.run_available_sync();
 
     print!("\nB: ");
 
@@ -26,24 +27,24 @@ pub async fn test_sort() {
     items_send.send(2).unwrap();
     items_send.send(0).unwrap();
     items_send.send(3).unwrap();
-    df.run_available().await;
+    df.run_available_sync();
 
     println!();
 }
 
-#[dfir_rs::test]
-pub async fn test_sort_by_key() {
+#[multiplatform_test]
+pub fn test_sort_by_key() {
     let mut df = dfir_syntax_inline! {
         source_iter(vec!((2, 'y'), (3, 'x'), (1, 'z')))
             -> sort_by_key(|(k, _v)| k)
             -> for_each(|v| println!("{:?}", v));
     };
-    df.run_available().await;
+    df.run_available_sync();
     println!();
 }
 
-#[dfir_rs::test]
-async fn test_sort_by_owned() {
+#[multiplatform_test]
+fn test_sort_by_owned() {
     #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
     struct Dummy {
         x: String,
@@ -67,8 +68,8 @@ async fn test_sort_by_owned() {
     let mut df = dfir_syntax_inline! {
         source_iter(dummies) -> sort_by_key(|d| &d.x) -> for_each(|d| out_send.send(d).unwrap());
     };
-    df.run_available().await;
-    let results = collect_ready_async::<Vec<_>, _>(&mut out_recv).await;
+    df.run_available_sync();
+    let results = collect_ready::<Vec<_>, _>(&mut out_recv);
     dummies_saved.sort_unstable_by(|d1, d2| d1.y.cmp(&d2.y));
     assert_ne!(&dummies_saved, &*results);
     dummies_saved.sort_unstable_by(|d1, d2| d1.x.cmp(&d2.x));

--- a/dfir_rs/tests/surface_sort.rs
+++ b/dfir_rs/tests/surface_sort.rs
@@ -1,5 +1,5 @@
-use dfir_rs::util::collect_ready_async;
 use dfir_rs::dfir_syntax_inline;
+use dfir_rs::util::collect_ready_async;
 
 #[dfir_rs::test]
 pub async fn test_sort() {


### PR DESCRIPTION
Converts 26 of 46 `dfir_rs` test files from `dfir_syntax!` (scheduled `Dfir` path) to `dfir_syntax_inline!` (inline `InlineDfir` path).

### `dfir_lang` — operator codegen fixes

- **`state_by`**, **`lattice_bimorphism`**: Extract `context.state_ref_unchecked()` calls outside the type guard functions, passing `&RefCell<Lat>` directly instead of `(StateHandle, &Context)`. This avoids naming the concrete context type, making these operators work with both codegen paths.

### `dfir_rs` — new API

- **`InlineDfir::run_available_sync()`**: Mirrors the existing `Dfir::run_available_sync()`, so converted tests can stay synchronous.

### `dfir_rs` — test conversions

Per-file diff is minimal:
- `dfir_syntax!` → `dfir_syntax_inline!`
- Import swap (`use dfir_rs::dfir_syntax` → `use dfir_rs::dfir_syntax_inline`)
- Removed `assert_graphvis_snapshots!` calls (unavailable for `InlineDfir`)
- Removed `Dfir` type annotations where present
- `surface_async.rs`: `let None = flow.run().await` → `flow.run().await` (`Infallible` vs `Never`)
- `surface_lattice_join.rs`: Fixed assertion that was asserting known-buggy duplicate output (#1050); inline path produces the correct single output
- `surface_lattice_bimorphism_persist_insertion.rs`: Use `InlineDfirErased` via `.into_erased()` to replace `Dfir` in helper function signature

### Remaining 20 files

| Blocker | Files |
|---|---|
| `loop {}` blocks | `surface_cross_join_multiset`, `surface_difference`, `surface_fold`, `surface_fold_keyed`, `surface_join`, `surface_loop`, `surface_reduce_keyed`, `surface_unique`, `surface_zip_unzip` |
| `df.current_tick()` / `df.current_stratum()` | `surface_scan`, `surface_state_scheduling`, `metrics` |
| `context.current_stratum()` / `context.add_state()` | `surface_context`, `surface_persist`, `surface_scheduling` |
| Cyclical dataflow within a tick | `surface_codegen`, `surface_lattice_fold`, `surface_stratum` |
| Behavioral differences between paths | `surface_singleton` |