### PR TITLE
feat(dfir_rs): advance dfir_syntax_inline! migration — expose current_tick, fix singleton ordering, convert ~77 tests

### DIFF
--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1491,12 +1491,10 @@ impl DfirGraph {
                     .copied()
                     .flatten()
                 {
-                    let Some(src_sg) = self.node_subgraph(src_ref_id) else {
-                        continue;
-                    };
-                    let Some(dst_sg) = self.node_subgraph(dst_id) else {
-                        continue;
-                    };
+                    let src_sg = self.node_subgraph(src_ref_id)
+                        .expect("bug: singleton ref node must belong to a subgraph");
+                    let dst_sg = self.node_subgraph(dst_id)
+                        .expect("bug: singleton ref consumer must belong to a subgraph");
                     if src_sg != dst_sg {
                         sg_preds.entry(dst_sg).unwrap().or_default().push(src_sg);
                     }

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1491,9 +1491,11 @@ impl DfirGraph {
                     .copied()
                     .flatten()
                 {
-                    let src_sg = self.node_subgraph(src_ref_id)
+                    let src_sg = self
+                        .node_subgraph(src_ref_id)
                         .expect("bug: singleton ref node must belong to a subgraph");
-                    let dst_sg = self.node_subgraph(dst_id)
+                    let dst_sg = self
+                        .node_subgraph(dst_id)
                         .expect("bug: singleton ref consumer must belong to a subgraph");
                     if src_sg != dst_sg {
                         sg_preds.entry(dst_sg).unwrap().or_default().push(src_sg);
@@ -2046,20 +2048,19 @@ impl DfirGraph {
                     #root::scheduled::context::InlineWakeState::default()
                 );
 
-                let __dfir_current_tick = ::std::rc::Rc::new(
-                    ::std::cell::Cell::new(#root::scheduled::ticks::TickInstant::default())
-                );
-
-                let __dfir_metrics = {
+                let __dfir_shared = {
                     let mut dfir_metrics = #root::scheduled::metrics::DfirMetrics::default();
                     #( #metrics_init_code )*
-                    ::std::rc::Rc::new(dfir_metrics)
+                    ::std::rc::Rc::new(#root::scheduled::context::InlineSharedState {
+                        current_tick: ::std::cell::Cell::new(#root::scheduled::ticks::TickInstant::default()),
+                        metrics: ::std::rc::Rc::new(dfir_metrics),
+                    })
                 };
 
                 #[allow(unused_mut)]
                 let mut #df = #root::scheduled::context::InlineContext::new(
                     ::std::clone::Clone::clone(&__dfir_wake_state),
-                    ::std::clone::Clone::clone(&__dfir_current_tick),
+                    ::std::clone::Clone::clone(&__dfir_shared),
                 );
 
                 #( #buffer_code )*
@@ -2071,7 +2072,7 @@ impl DfirGraph {
                 // start false (from take()) and are set true by recv port code
                 // if any handoff buffer has data.
                 let mut __dfir_work_done = true;
-                let __dfir_metrics_outer = ::std::clone::Clone::clone(&__dfir_metrics);
+                let __dfir_metrics = ::std::clone::Clone::clone(&__dfir_shared.metrics);
                 #[allow(unused_qualifications, unused_mut, unused_variables, clippy::await_holding_refcell_ref)]
                 let __dfir_inline_tick = async move || {
                     #( #subgraph_blocks )*
@@ -2094,8 +2095,7 @@ impl DfirGraph {
                 #root::scheduled::context::InlineDfir::new(
                     __dfir_inline_tick,
                     __dfir_wake_state,
-                    __dfir_current_tick,
-                    __dfir_metrics_outer,
+                    __dfir_shared,
                     Some(#meta_graph_json),
                     Some(#diagnostics_json),
                 )

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -2027,6 +2027,10 @@ impl DfirGraph {
                     #root::scheduled::context::InlineWakeState::default()
                 );
 
+                let __dfir_current_tick = ::std::rc::Rc::new(
+                    ::std::cell::Cell::new(#root::scheduled::ticks::TickInstant::default())
+                );
+
                 let __dfir_metrics = {
                     let mut dfir_metrics = #root::scheduled::metrics::DfirMetrics::default();
                     #( #metrics_init_code )*
@@ -2036,6 +2040,7 @@ impl DfirGraph {
                 #[allow(unused_mut)]
                 let mut #df = #root::scheduled::context::InlineContext::new(
                     ::std::clone::Clone::clone(&__dfir_wake_state),
+                    ::std::clone::Clone::clone(&__dfir_current_tick),
                 );
 
                 #( #buffer_code )*
@@ -2070,6 +2075,7 @@ impl DfirGraph {
                 #root::scheduled::context::InlineDfir::new(
                     __dfir_inline_tick,
                     __dfir_wake_state,
+                    __dfir_current_tick,
                     __dfir_metrics_outer,
                     Some(#meta_graph_json),
                     Some(#diagnostics_json),

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -2048,19 +2048,20 @@ impl DfirGraph {
                     #root::scheduled::context::InlineWakeState::default()
                 );
 
-                let __dfir_shared = {
+                let __dfir_current_tick = ::std::rc::Rc::new(
+                    ::std::cell::Cell::new(#root::scheduled::ticks::TickInstant::default())
+                );
+
+                let __dfir_metrics = {
                     let mut dfir_metrics = #root::scheduled::metrics::DfirMetrics::default();
                     #( #metrics_init_code )*
-                    ::std::rc::Rc::new(#root::scheduled::context::InlineSharedState {
-                        current_tick: ::std::cell::Cell::new(#root::scheduled::ticks::TickInstant::default()),
-                        metrics: ::std::rc::Rc::new(dfir_metrics),
-                    })
+                    ::std::rc::Rc::new(dfir_metrics)
                 };
 
                 #[allow(unused_mut)]
                 let mut #df = #root::scheduled::context::InlineContext::new(
                     ::std::clone::Clone::clone(&__dfir_wake_state),
-                    ::std::clone::Clone::clone(&__dfir_shared),
+                    ::std::clone::Clone::clone(&__dfir_current_tick),
                 );
 
                 #( #buffer_code )*
@@ -2072,7 +2073,7 @@ impl DfirGraph {
                 // start false (from take()) and are set true by recv port code
                 // if any handoff buffer has data.
                 let mut __dfir_work_done = true;
-                let __dfir_metrics = ::std::clone::Clone::clone(&__dfir_shared.metrics);
+                let __dfir_metrics_outer = ::std::clone::Clone::clone(&__dfir_metrics);
                 #[allow(unused_qualifications, unused_mut, unused_variables, clippy::await_holding_refcell_ref)]
                 let __dfir_inline_tick = async move || {
                     #( #subgraph_blocks )*
@@ -2095,7 +2096,8 @@ impl DfirGraph {
                 #root::scheduled::context::InlineDfir::new(
                     __dfir_inline_tick,
                     __dfir_wake_state,
-                    __dfir_shared,
+                    __dfir_current_tick,
+                    __dfir_metrics_outer,
                     Some(#meta_graph_json),
                     Some(#diagnostics_json),
                 )

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1482,6 +1482,27 @@ impl DfirGraph {
                 }
             }
 
+            // Include singleton reference edges: if node A references the
+            // singleton output of node B, then A's subgraph must run after B's.
+            for dst_id in self.node_ids() {
+                for src_ref_id in self
+                    .node_singleton_references(dst_id)
+                    .iter()
+                    .copied()
+                    .flatten()
+                {
+                    let Some(src_sg) = self.node_subgraph(src_ref_id) else {
+                        continue;
+                    };
+                    let Some(dst_sg) = self.node_subgraph(dst_id) else {
+                        continue;
+                    };
+                    if src_sg != dst_sg {
+                        sg_preds.entry(dst_sg).unwrap().or_default().push(src_sg);
+                    }
+                }
+            }
+
             let topo_sort = super::graph_algorithms::topo_sort(self.subgraph_ids(), |sg_id| {
                 sg_preds.get(sg_id).into_iter().flatten().copied()
             })

--- a/dfir_macro/src/lib.rs
+++ b/dfir_macro/src/lib.rs
@@ -128,6 +128,7 @@ fn dfir_syntax_inline_internal(
                 #root::scheduled::context::InlineDfir::new(
                     async move || { false },
                     ::std::sync::Arc::new(#root::scheduled::context::InlineWakeState::default()),
+                    ::std::rc::Rc::new(::std::cell::Cell::new(#root::scheduled::ticks::TickInstant::default())),
                     ::std::rc::Rc::new(#root::scheduled::metrics::DfirMetrics::default()),
                     None,
                     None,

--- a/dfir_macro/src/lib.rs
+++ b/dfir_macro/src/lib.rs
@@ -128,8 +128,10 @@ fn dfir_syntax_inline_internal(
                 #root::scheduled::context::InlineDfir::new(
                     async move || { false },
                     ::std::sync::Arc::new(#root::scheduled::context::InlineWakeState::default()),
-                    ::std::rc::Rc::new(::std::cell::Cell::new(#root::scheduled::ticks::TickInstant::default())),
-                    ::std::rc::Rc::new(#root::scheduled::metrics::DfirMetrics::default()),
+                    ::std::rc::Rc::new(#root::scheduled::context::InlineSharedState {
+                        current_tick: ::std::cell::Cell::new(#root::scheduled::ticks::TickInstant::default()),
+                        metrics: ::std::rc::Rc::new(#root::scheduled::metrics::DfirMetrics::default()),
+                    }),
                     None,
                     None,
                 )

--- a/dfir_macro/src/lib.rs
+++ b/dfir_macro/src/lib.rs
@@ -128,10 +128,8 @@ fn dfir_syntax_inline_internal(
                 #root::scheduled::context::InlineDfir::new(
                     async move || { false },
                     ::std::sync::Arc::new(#root::scheduled::context::InlineWakeState::default()),
-                    ::std::rc::Rc::new(#root::scheduled::context::InlineSharedState {
-                        current_tick: ::std::cell::Cell::new(#root::scheduled::ticks::TickInstant::default()),
-                        metrics: ::std::rc::Rc::new(#root::scheduled::metrics::DfirMetrics::default()),
-                    }),
+                    ::std::rc::Rc::new(::std::cell::Cell::new(#root::scheduled::ticks::TickInstant::default())),
+                    ::std::rc::Rc::new(#root::scheduled::metrics::DfirMetrics::default()),
                     None,
                     None,
                 )

--- a/dfir_rs/src/scheduled/context.rs
+++ b/dfir_rs/src/scheduled/context.rs
@@ -472,15 +472,21 @@ impl Wake for InlineWakeState {
 pub struct InlineContext {
     states: SlotVec<StateTag, StateData>,
     current_tick: TickInstant,
+    /// Shared tick counter readable from `InlineDfir` outside the closure.
+    current_tick_shared: Rc<Cell<TickInstant>>,
     wake_state: std::sync::Arc<InlineWakeState>,
 }
 
 impl InlineContext {
-    /// Create a new inline context with shared wake state.
-    pub fn new(wake_state: std::sync::Arc<InlineWakeState>) -> Self {
+    /// Create a new inline context with shared wake state and tick counter.
+    pub fn new(
+        wake_state: std::sync::Arc<InlineWakeState>,
+        current_tick_shared: Rc<Cell<TickInstant>>,
+    ) -> Self {
         Self {
             states: SlotVec::new(),
             current_tick: TickInstant::default(),
+            current_tick_shared,
             wake_state,
         }
     }
@@ -597,6 +603,7 @@ impl InlineContext {
             (lifespan_hook_fn)(Box::deref_mut(state));
         }
         self.current_tick += crate::scheduled::ticks::TickDuration::SINGLE_TICK;
+        self.current_tick_shared.set(self.current_tick);
     }
 }
 
@@ -624,6 +631,9 @@ impl InlineContext {
 pub struct InlineDfir<Tick> {
     tick_closure: Tick,
     wake_state: std::sync::Arc<InlineWakeState>,
+
+    /// Shared tick counter, updated by `InlineContext::__end_tick()` inside the closure.
+    current_tick: Rc<Cell<TickInstant>>,
 
     #[cfg(feature = "meta")]
     /// See [`Self::meta_graph()`].
@@ -680,11 +690,12 @@ pub type InlineDfirErased = InlineDfir<TickClosureErased>;
 
 impl<Tick: TickClosure> InlineDfir<Tick> {
     /// Create a new `InlineDfir` from a tick closure, shared wake state,
-    /// meta graph / diagnostics JSON strings, and metrics.
+    /// shared tick counter, meta graph / diagnostics JSON strings, and metrics.
     #[doc(hidden)]
     pub fn new(
         tick_closure: Tick,
         wake_state: std::sync::Arc<InlineWakeState>,
+        current_tick: Rc<Cell<TickInstant>>,
         metrics: Rc<DfirMetrics>,
         meta_graph_json: Option<&str>,
         diagnostics_json: Option<&str>,
@@ -694,6 +705,7 @@ impl<Tick: TickClosure> InlineDfir<Tick> {
         Self {
             tick_closure,
             wake_state,
+            current_tick,
             #[cfg(feature = "meta")]
             meta_graph: meta_graph_json.map(|json| {
                 let mut meta_graph: DfirGraph =
@@ -732,6 +744,11 @@ impl<Tick: TickClosure> InlineDfir<Tick> {
     /// Returns a reference-counted handle to the continually-updated runtime metrics for this DFIR instance.
     pub fn metrics(&self) -> Rc<DfirMetrics> {
         Rc::clone(&self.metrics)
+    }
+
+    /// Gets the current tick (local time) count.
+    pub fn current_tick(&self) -> TickInstant {
+        self.current_tick.get()
     }
 
     /// Returns a [`DfirMetricsIntervals`] handle where each call to
@@ -847,6 +864,7 @@ impl<Tick: AsyncFnMut() -> bool + 'static> InlineDfir<Tick> {
         InlineDfir {
             tick_closure: TickClosureErased(Box::new(self.tick_closure)),
             wake_state: self.wake_state,
+            current_tick: self.current_tick,
             #[cfg(feature = "meta")]
             meta_graph: self.meta_graph,
             #[cfg(feature = "meta")]

--- a/dfir_rs/src/scheduled/context.rs
+++ b/dfir_rs/src/scheduled/context.rs
@@ -427,6 +427,20 @@ struct StateData {
 }
 type LifespanResetFn = Box<dyn FnMut(&mut dyn Any)>;
 
+/// Runtime state shared between [`InlineContext`] (inside the tick closure) and [`InlineDfir`]
+/// (the external handle). Wrapped in `Rc` so both sides can read/write without ownership issues.
+///
+/// This consolidates non-wake shared state into a single allocation. Wake-related state
+/// lives separately in [`InlineWakeState`] (which requires `Arc` for the [`Wake`] trait).
+#[doc(hidden)]
+pub struct InlineSharedState {
+    /// Current tick counter, incremented by [`InlineContext::__end_tick`].
+    pub current_tick: Cell<TickInstant>,
+    /// Live-updating DFIR runtime metrics (subgraph run counts, handoff item counts, etc.).
+    /// Wrapped in its own `Rc` for compatibility with [`DfirMetricsIntervals`].
+    pub metrics: Rc<DfirMetrics>,
+}
+
 /// Coordinates waking between [`InlineContext`] (inside the tick closure) and [`InlineDfir`]
 /// (the external runner). Shared via `Arc` between both.
 ///
@@ -471,20 +485,17 @@ impl Wake for InlineWakeState {
 #[doc(hidden)]
 pub struct InlineContext {
     states: SlotVec<StateTag, StateData>,
-    /// Shared tick counter, also readable from `InlineDfir` outside the closure.
-    current_tick: Rc<Cell<TickInstant>>,
+    /// Shared state readable from both inside the closure and from [`InlineDfir`].
+    shared: Rc<InlineSharedState>,
     wake_state: std::sync::Arc<InlineWakeState>,
 }
 
 impl InlineContext {
-    /// Create a new inline context with shared wake state and tick counter.
-    pub fn new(
-        wake_state: std::sync::Arc<InlineWakeState>,
-        current_tick: Rc<Cell<TickInstant>>,
-    ) -> Self {
+    /// Create a new inline context with shared wake state and shared state.
+    pub fn new(wake_state: std::sync::Arc<InlineWakeState>, shared: Rc<InlineSharedState>) -> Self {
         Self {
             states: SlotVec::new(),
-            current_tick,
+            shared,
             wake_state,
         }
     }
@@ -556,7 +567,7 @@ impl InlineContext {
 
     /// Gets the current tick count.
     pub fn current_tick(&self) -> TickInstant {
-        self.current_tick.get()
+        self.shared.current_tick.get()
     }
 
     /// No-op: inline mode has no subgraph scheduling.
@@ -600,7 +611,9 @@ impl InlineContext {
             };
             (lifespan_hook_fn)(Box::deref_mut(state));
         }
-        self.current_tick.set(self.current_tick.get() + crate::scheduled::ticks::TickDuration::SINGLE_TICK);
+        self.shared.current_tick.set(
+            self.shared.current_tick.get() + crate::scheduled::ticks::TickDuration::SINGLE_TICK,
+        );
     }
 }
 
@@ -629,8 +642,8 @@ pub struct InlineDfir<Tick> {
     tick_closure: Tick,
     wake_state: std::sync::Arc<InlineWakeState>,
 
-    /// Shared tick counter, updated by `InlineContext::__end_tick()` inside the closure.
-    current_tick: Rc<Cell<TickInstant>>,
+    /// Shared state, also held by [`InlineContext`] inside the tick closure.
+    shared: Rc<InlineSharedState>,
 
     #[cfg(feature = "meta")]
     /// See [`Self::meta_graph()`].
@@ -639,9 +652,6 @@ pub struct InlineDfir<Tick> {
     #[cfg(feature = "meta")]
     /// See [`Self::diagnostics()`].
     diagnostics: Option<Vec<Diagnostic<SerdeSpan>>>,
-
-    /// Live-updating DFIR runtime metrics via interior mutability.
-    metrics: Rc<DfirMetrics>,
 }
 
 /// Trait for tick closures — abstracts over both concrete async closures
@@ -687,13 +697,12 @@ pub type InlineDfirErased = InlineDfir<TickClosureErased>;
 
 impl<Tick: TickClosure> InlineDfir<Tick> {
     /// Create a new `InlineDfir` from a tick closure, shared wake state,
-    /// shared tick counter, meta graph / diagnostics JSON strings, and metrics.
+    /// shared state, and meta graph / diagnostics JSON strings.
     #[doc(hidden)]
     pub fn new(
         tick_closure: Tick,
         wake_state: std::sync::Arc<InlineWakeState>,
-        current_tick: Rc<Cell<TickInstant>>,
-        metrics: Rc<DfirMetrics>,
+        shared: Rc<InlineSharedState>,
         meta_graph_json: Option<&str>,
         diagnostics_json: Option<&str>,
     ) -> Self {
@@ -702,7 +711,7 @@ impl<Tick: TickClosure> InlineDfir<Tick> {
         Self {
             tick_closure,
             wake_state,
-            current_tick,
+            shared,
             #[cfg(feature = "meta")]
             meta_graph: meta_graph_json.map(|json| {
                 let mut meta_graph: DfirGraph =
@@ -720,7 +729,6 @@ impl<Tick: TickClosure> InlineDfir<Tick> {
             diagnostics: diagnostics_json.map(|json| {
                 serde_json::from_str(json).expect("Failed to deserialize diagnostics.")
             }),
-            metrics,
         }
     }
 
@@ -740,12 +748,12 @@ impl<Tick: TickClosure> InlineDfir<Tick> {
 
     /// Returns a reference-counted handle to the continually-updated runtime metrics for this DFIR instance.
     pub fn metrics(&self) -> Rc<DfirMetrics> {
-        Rc::clone(&self.metrics)
+        Rc::clone(&self.shared.metrics)
     }
 
     /// Gets the current tick (local time) count.
     pub fn current_tick(&self) -> TickInstant {
-        self.current_tick.get()
+        self.shared.current_tick.get()
     }
 
     /// Returns a [`DfirMetricsIntervals`] handle where each call to
@@ -861,12 +869,11 @@ impl<Tick: AsyncFnMut() -> bool + 'static> InlineDfir<Tick> {
         InlineDfir {
             tick_closure: TickClosureErased(Box::new(self.tick_closure)),
             wake_state: self.wake_state,
-            current_tick: self.current_tick,
+            shared: self.shared,
             #[cfg(feature = "meta")]
             meta_graph: self.meta_graph,
             #[cfg(feature = "meta")]
             diagnostics: self.diagnostics,
-            metrics: self.metrics,
         }
     }
 }

--- a/dfir_rs/src/scheduled/context.rs
+++ b/dfir_rs/src/scheduled/context.rs
@@ -427,20 +427,6 @@ struct StateData {
 }
 type LifespanResetFn = Box<dyn FnMut(&mut dyn Any)>;
 
-/// Runtime state shared between [`InlineContext`] (inside the tick closure) and [`InlineDfir`]
-/// (the external handle). Wrapped in `Rc` so both sides can read/write without ownership issues.
-///
-/// This consolidates non-wake shared state into a single allocation. Wake-related state
-/// lives separately in [`InlineWakeState`] (which requires `Arc` for the [`Wake`] trait).
-#[doc(hidden)]
-pub struct InlineSharedState {
-    /// Current tick counter, incremented by [`InlineContext::__end_tick`].
-    pub current_tick: Cell<TickInstant>,
-    /// Live-updating DFIR runtime metrics (subgraph run counts, handoff item counts, etc.).
-    /// Wrapped in its own `Rc` for compatibility with [`DfirMetricsIntervals`].
-    pub metrics: Rc<DfirMetrics>,
-}
-
 /// Coordinates waking between [`InlineContext`] (inside the tick closure) and [`InlineDfir`]
 /// (the external runner). Shared via `Arc` between both.
 ///
@@ -485,17 +471,20 @@ impl Wake for InlineWakeState {
 #[doc(hidden)]
 pub struct InlineContext {
     states: SlotVec<StateTag, StateData>,
-    /// Shared state readable from both inside the closure and from [`InlineDfir`].
-    shared: Rc<InlineSharedState>,
+    /// Shared tick counter, also readable from [`InlineDfir`] outside the closure.
+    current_tick: Rc<Cell<TickInstant>>,
     wake_state: std::sync::Arc<InlineWakeState>,
 }
 
 impl InlineContext {
-    /// Create a new inline context with shared wake state and shared state.
-    pub fn new(wake_state: std::sync::Arc<InlineWakeState>, shared: Rc<InlineSharedState>) -> Self {
+    /// Create a new inline context with shared wake state and tick counter.
+    pub fn new(
+        wake_state: std::sync::Arc<InlineWakeState>,
+        current_tick: Rc<Cell<TickInstant>>,
+    ) -> Self {
         Self {
             states: SlotVec::new(),
-            shared,
+            current_tick,
             wake_state,
         }
     }
@@ -567,7 +556,7 @@ impl InlineContext {
 
     /// Gets the current tick count.
     pub fn current_tick(&self) -> TickInstant {
-        self.shared.current_tick.get()
+        self.current_tick.get()
     }
 
     /// No-op: inline mode has no subgraph scheduling.
@@ -611,8 +600,8 @@ impl InlineContext {
             };
             (lifespan_hook_fn)(Box::deref_mut(state));
         }
-        self.shared.current_tick.set(
-            self.shared.current_tick.get() + crate::scheduled::ticks::TickDuration::SINGLE_TICK,
+        self.current_tick.set(
+            self.current_tick.get() + crate::scheduled::ticks::TickDuration::SINGLE_TICK,
         );
     }
 }
@@ -642,8 +631,11 @@ pub struct InlineDfir<Tick> {
     tick_closure: Tick,
     wake_state: std::sync::Arc<InlineWakeState>,
 
-    /// Shared state, also held by [`InlineContext`] inside the tick closure.
-    shared: Rc<InlineSharedState>,
+    /// Shared tick counter, updated by [`InlineContext::__end_tick`] inside the closure.
+    current_tick: Rc<Cell<TickInstant>>,
+
+    /// Live-updating DFIR runtime metrics via interior mutability.
+    metrics: Rc<DfirMetrics>,
 
     #[cfg(feature = "meta")]
     /// See [`Self::meta_graph()`].
@@ -697,12 +689,13 @@ pub type InlineDfirErased = InlineDfir<TickClosureErased>;
 
 impl<Tick: TickClosure> InlineDfir<Tick> {
     /// Create a new `InlineDfir` from a tick closure, shared wake state,
-    /// shared state, and meta graph / diagnostics JSON strings.
+    /// shared tick counter, metrics, and meta graph / diagnostics JSON strings.
     #[doc(hidden)]
     pub fn new(
         tick_closure: Tick,
         wake_state: std::sync::Arc<InlineWakeState>,
-        shared: Rc<InlineSharedState>,
+        current_tick: Rc<Cell<TickInstant>>,
+        metrics: Rc<DfirMetrics>,
         meta_graph_json: Option<&str>,
         diagnostics_json: Option<&str>,
     ) -> Self {
@@ -711,7 +704,8 @@ impl<Tick: TickClosure> InlineDfir<Tick> {
         Self {
             tick_closure,
             wake_state,
-            shared,
+            current_tick,
+            metrics,
             #[cfg(feature = "meta")]
             meta_graph: meta_graph_json.map(|json| {
                 let mut meta_graph: DfirGraph =
@@ -748,12 +742,12 @@ impl<Tick: TickClosure> InlineDfir<Tick> {
 
     /// Returns a reference-counted handle to the continually-updated runtime metrics for this DFIR instance.
     pub fn metrics(&self) -> Rc<DfirMetrics> {
-        Rc::clone(&self.shared.metrics)
+        Rc::clone(&self.metrics)
     }
 
     /// Gets the current tick (local time) count.
     pub fn current_tick(&self) -> TickInstant {
-        self.shared.current_tick.get()
+        self.current_tick.get()
     }
 
     /// Returns a [`DfirMetricsIntervals`] handle where each call to
@@ -869,7 +863,8 @@ impl<Tick: AsyncFnMut() -> bool + 'static> InlineDfir<Tick> {
         InlineDfir {
             tick_closure: TickClosureErased(Box::new(self.tick_closure)),
             wake_state: self.wake_state,
-            shared: self.shared,
+            current_tick: self.current_tick,
+            metrics: self.metrics,
             #[cfg(feature = "meta")]
             meta_graph: self.meta_graph,
             #[cfg(feature = "meta")]

--- a/dfir_rs/src/scheduled/context.rs
+++ b/dfir_rs/src/scheduled/context.rs
@@ -600,9 +600,8 @@ impl InlineContext {
             };
             (lifespan_hook_fn)(Box::deref_mut(state));
         }
-        self.current_tick.set(
-            self.current_tick.get() + crate::scheduled::ticks::TickDuration::SINGLE_TICK,
-        );
+        self.current_tick
+            .set(self.current_tick.get() + crate::scheduled::ticks::TickDuration::SINGLE_TICK);
     }
 }
 

--- a/dfir_rs/src/scheduled/context.rs
+++ b/dfir_rs/src/scheduled/context.rs
@@ -471,9 +471,8 @@ impl Wake for InlineWakeState {
 #[doc(hidden)]
 pub struct InlineContext {
     states: SlotVec<StateTag, StateData>,
-    current_tick: TickInstant,
-    /// Shared tick counter readable from `InlineDfir` outside the closure.
-    current_tick_shared: Rc<Cell<TickInstant>>,
+    /// Shared tick counter, also readable from `InlineDfir` outside the closure.
+    current_tick: Rc<Cell<TickInstant>>,
     wake_state: std::sync::Arc<InlineWakeState>,
 }
 
@@ -481,12 +480,11 @@ impl InlineContext {
     /// Create a new inline context with shared wake state and tick counter.
     pub fn new(
         wake_state: std::sync::Arc<InlineWakeState>,
-        current_tick_shared: Rc<Cell<TickInstant>>,
+        current_tick: Rc<Cell<TickInstant>>,
     ) -> Self {
         Self {
             states: SlotVec::new(),
-            current_tick: TickInstant::default(),
-            current_tick_shared,
+            current_tick,
             wake_state,
         }
     }
@@ -558,7 +556,7 @@ impl InlineContext {
 
     /// Gets the current tick count.
     pub fn current_tick(&self) -> TickInstant {
-        self.current_tick
+        self.current_tick.get()
     }
 
     /// No-op: inline mode has no subgraph scheduling.
@@ -602,8 +600,7 @@ impl InlineContext {
             };
             (lifespan_hook_fn)(Box::deref_mut(state));
         }
-        self.current_tick += crate::scheduled::ticks::TickDuration::SINGLE_TICK;
-        self.current_tick_shared.set(self.current_tick);
+        self.current_tick.set(self.current_tick.get() + crate::scheduled::ticks::TickDuration::SINGLE_TICK);
     }
 }
 

--- a/dfir_rs/tests/metrics_inline.rs
+++ b/dfir_rs/tests/metrics_inline.rs
@@ -103,8 +103,7 @@ async fn test_multiple_ticks() {
     assert_eq!(1, metrics.subgraphs.len());
     let sg_id = metrics.subgraphs.keys().next().unwrap();
     assert_eq!(1, metrics.subgraphs[sg_id].total_run_count());
-    // TODO(https://github.com/hydro-project/hydro/issues/2741): assert current_tick once
-    // InlineDfir exposes it.
+    assert_eq!(1, flow.current_tick().0);
 
     input_send.send(3).unwrap();
     input_send.send(4).unwrap();
@@ -112,7 +111,7 @@ async fn test_multiple_ticks() {
 
     let metrics = flow.metrics();
     assert_eq!(2, metrics.subgraphs[sg_id].total_run_count());
-    // TODO(https://github.com/hydro-project/hydro/issues/2741): assert current_tick == 2.
+    assert_eq!(2, flow.current_tick().0);
 
     let output: Vec<_> = collect_ready_async(&mut output_recv).await;
     assert_eq!(output, vec![2, 3, 4, 5]);

--- a/dfir_rs/tests/snapshots/surface_context__context_ref@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_context__context_ref@graphvis_dot.snap
@@ -6,7 +6,7 @@ digraph {
     node [fontname="Monaco,Menlo,Consolas,&quot;Droid Sans Mono&quot;,Inconsolata,&quot;Courier New&quot;,monospace", style=filled];
     edge [fontname="Monaco,Menlo,Consolas,&quot;Droid Sans Mono&quot;,Inconsolata,&quot;Courier New&quot;,monospace"];
     n1v1 [label="(n1v1) source_iter([()])", shape=invhouse, fillcolor="#88aaff"]
-    n2v1 [label="(n2v1) for_each(|()| {\l    println!(\l        \"Current tick: {}, stratum: {}\",\l        context.current_tick(),\l        context.current_stratum(),\l    )\l})\l", shape=house, fillcolor="#ffff88"]
+    n2v1 [label="(n2v1) for_each(|()| println!(\"Current tick: {}\", context.current_tick()))", shape=house, fillcolor="#ffff88"]
     n1v1 -> n2v1
     subgraph sg_1v1 {
         cluster=true

--- a/dfir_rs/tests/snapshots/surface_context__context_ref@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_context__context_ref@graphvis_mermaid.snap
@@ -9,7 +9,7 @@ classDef pushClass fill:#ff8,stroke:#000,text-align:left,white-space:pre
 classDef otherClass fill:#fdc,stroke:#000,text-align:left,white-space:pre
 linkStyle default stroke:#aaa
 1v1[\"(1v1) <code>source_iter([()])</code>"/]:::pullClass
-2v1[/"<div style=text-align:center>(2v1)</div> <code>for_each(|()| {<br>    println!(<br>        &quot;Current tick: {}, stratum: {}&quot;,<br>        context.current_tick(),<br>        context.current_stratum(),<br>    )<br>})</code>"\]:::pushClass
+2v1[/"(2v1) <code>for_each(|()| println!(&quot;Current tick: {}&quot;, context.current_tick()))</code>"\]:::pushClass
 1v1-->2v1
 subgraph sg_1v1 ["sg_1v1 stratum 0"]
     1v1

--- a/dfir_rs/tests/surface_codegen.rs
+++ b/dfir_rs/tests/surface_codegen.rs
@@ -4,7 +4,7 @@ use dfir_rs::scheduled::graph::Dfir;
 use dfir_rs::scheduled::ticks::TickInstant;
 use dfir_rs::util::collect_ready;
 use dfir_rs::util::multiset::HashMultiSet;
-use dfir_rs::{assert_graphvis_snapshots, dfir_syntax};
+use dfir_rs::{assert_graphvis_snapshots, dfir_syntax, dfir_syntax_inline};
 use multiplatform_test::multiplatform_test;
 
 // TODO(mingwei): custom operators? How to handle in syntax? How to handle state?
@@ -28,10 +28,9 @@ use multiplatform_test::multiplatform_test;
 pub fn test_basic_2() {
     let (out_send, mut out_recv) = dfir_rs::util::unbounded_channel::<usize>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter([1]) -> for_each(|v| out_send.send(v).unwrap());
     };
-    assert_graphvis_snapshots!(df);
     df.run_available_sync();
 
     assert_eq!(&[1], &*collect_ready::<Vec<_>, _>(&mut out_recv));
@@ -41,10 +40,9 @@ pub fn test_basic_2() {
 pub fn test_basic_3() {
     let (out_send, mut out_recv) = dfir_rs::util::unbounded_channel::<usize>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter([1]) -> map(|v| v + 1) -> for_each(|v| out_send.send(v).unwrap());
     };
-    assert_graphvis_snapshots!(df);
     df.run_available_sync();
 
     assert_eq!(&[2], &*collect_ready::<Vec<_>, _>(&mut out_recv));
@@ -54,12 +52,11 @@ pub fn test_basic_3() {
 pub fn test_basic_union() {
     let (out_send, mut out_recv) = dfir_rs::util::unbounded_channel::<usize>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         m = union() -> for_each(|v| out_send.send(v).unwrap());
         source_iter([1]) -> [0]m;
         source_iter([2]) -> [1]m;
     };
-    assert_graphvis_snapshots!(df);
     df.run_available_sync();
 
     assert_eq!(&[1, 2], &*collect_ready::<Vec<_>, _>(&mut out_recv));
@@ -70,7 +67,7 @@ pub fn test_basic_tee() {
     let (out_send_a, mut out_recv) = dfir_rs::util::unbounded_channel::<String>();
     let out_send_b = out_send_a.clone();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         t = source_iter([1]) -> tee();
         t[0] -> for_each(|v| out_send_a.send(format!("A {}", v)).unwrap());
         t[1] -> for_each(|v| out_send_b.send(format!("B {}", v)).unwrap());
@@ -91,7 +88,7 @@ pub fn test_basic_inspect_null() {
     let seen = Rc::new(RefCell::new(Vec::new()));
     let seen_inner = Rc::clone(&seen);
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter([1, 2, 3, 4]) -> inspect(|&x| seen_inner.borrow_mut().push(x)) -> null();
     };
     df.run_available_sync();
@@ -107,7 +104,7 @@ pub fn test_basic_inspect_no_null() {
     let seen = Rc::new(RefCell::new(Vec::new()));
     let seen_inner = Rc::clone(&seen);
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter([1, 2, 3, 4]) -> inspect(|&x| seen_inner.borrow_mut().push(x));
     };
     df.run_available_sync();
@@ -118,7 +115,7 @@ pub fn test_basic_inspect_no_null() {
 // Mainly checking subgraph partitioning pull-push handling.
 #[multiplatform_test]
 pub fn test_large_diamond() {
-    let mut df: Dfir = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         t = source_iter([1]) -> tee();
         j = union() -> for_each(|x| println!("{}", x));
         t[0] -> map(std::convert::identity) -> map(std::convert::identity) -> [0]j;
@@ -132,11 +129,10 @@ pub fn test_large_diamond() {
 pub fn test_recv_expr() {
     let send_recv = dfir_rs::util::unbounded_channel::<usize>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_stream(send_recv.1)
             -> for_each(|v| print!("{:?}", v));
     };
-    assert_graphvis_snapshots!(df);
     df.run_available_sync();
 
     let items_send = send_recv.0;
@@ -148,12 +144,12 @@ pub fn test_recv_expr() {
 
 #[multiplatform_test]
 pub fn test_join_order() {
-    let _df_good = dfir_syntax! {
+    let _df_good = dfir_syntax_inline! {
         yikes = join() -> for_each(|m: ((), (u32, String))| println!("{:?}", m));
         source_iter([0,1,2]) -> map(|i| ((), i)) -> [0]yikes;
         source_iter(["a".to_owned(),"b".to_owned(),"c".to_owned()]) -> map(|s| ((), s)) -> [1]yikes;
     };
-    let _df_bad = dfir_syntax! {
+    let _df_bad = dfir_syntax_inline! {
         yikes = join() -> for_each(|m: ((), (u32, String))| println!("{:?}", m));
         source_iter(["a".to_owned(),"b".to_owned(),"c".to_owned()]) -> map(|s| ((), s)) -> [1]yikes;
         source_iter([0,1,2]) -> map(|i| ((), i)) -> [0]yikes;
@@ -168,7 +164,7 @@ pub fn test_multiset_join() {
 
         let (out_tx, mut out_rx) = dfir_rs::util::unbounded_channel::<(usize, (usize, usize))>();
 
-        let mut df = dfir_syntax! {
+        let mut df = dfir_syntax_inline! {
             my_join = join::<HalfSetJoinState>() -> for_each(|m| out_tx.send(m).unwrap());
             source_iter([(0, 1), (0, 1)]) -> [0]my_join;
             source_iter([(0, 2)]) -> [1]my_join;
@@ -185,7 +181,7 @@ pub fn test_multiset_join() {
         use dfir_pipes::pull::HalfMultisetJoinState;
         let (out_tx, mut out_rx) = dfir_rs::util::unbounded_channel::<(usize, (usize, usize))>();
 
-        let mut df = dfir_syntax! {
+        let mut df = dfir_syntax_inline! {
             my_join = join::<HalfMultisetJoinState>() -> for_each(|m| out_tx.send(m).unwrap());
             source_iter([(1, 1), (1, 1), (1, 1)]) -> [0]my_join;
             source_iter([(1, 2), (1, 2), (1, 2), (1, 2)]) -> [1]my_join;
@@ -202,7 +198,7 @@ pub fn test_multiset_join() {
         use dfir_pipes::pull::HalfMultisetJoinState;
         let (out_tx, mut out_rx) = dfir_rs::util::unbounded_channel::<(usize, (usize, usize))>();
 
-        let mut df = dfir_syntax! {
+        let mut df = dfir_syntax_inline! {
             my_join = join::<HalfMultisetJoinState>() -> for_each(|m| out_tx.send(m).unwrap());
             source_iter([(1, 1), (1, 1), (1, 1), (1, 1)]) -> [0]my_join;
             source_iter([(1, 2), (1, 2), (1, 2)]) -> [1]my_join;
@@ -219,7 +215,7 @@ pub fn test_multiset_join() {
 pub fn test_cross_join() {
     let (out_send, mut out_recv) = dfir_rs::util::unbounded_channel::<(usize, &str)>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         cj = cross_join() -> for_each(|v| out_send.send(v).unwrap());
         source_iter([1, 2, 2, 3]) -> [0]cj;
         source_iter(["a", "b", "c", "c"]) -> [1]cj;
@@ -248,7 +244,7 @@ pub fn test_cross_join() {
 pub fn test_cross_join_multiset() {
     let (out_send, mut out_recv) = dfir_rs::util::unbounded_channel::<(usize, &str)>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         cj = cross_join_multiset() -> for_each(|v| out_send.send(v).unwrap());
         source_iter([1, 2, 2, 3]) -> [0]cj;
         source_iter(["a", "b", "c", "c"]) -> [1]cj;
@@ -284,7 +280,7 @@ pub fn test_cross_join_multiset() {
 pub fn test_defer_tick() {
     let (inp_send, inp_recv) = dfir_rs::util::unbounded_channel::<usize>();
     let (out_send, mut out_recv) = dfir_rs::util::unbounded_channel::<usize>();
-    let mut flow = dfir_syntax! {
+    let mut flow = dfir_syntax_inline! {
         inp = source_stream(inp_recv) -> tee();
         diff = difference() -> for_each(|x| out_send.send(x).unwrap());
         inp -> [pos]diff;
@@ -314,11 +310,11 @@ pub fn test_channel_minimal() {
 
     let (out_send, mut out_recv) = dfir_rs::util::unbounded_channel::<usize>();
 
-    let mut df1 = dfir_syntax! {
+    let mut df1 = dfir_syntax_inline! {
         source_iter([1, 2, 3]) -> for_each(|x| { send.send(x).unwrap(); });
     };
 
-    let mut df2 = dfir_syntax! {
+    let mut df2 = dfir_syntax_inline! {
         source_stream(recv) -> for_each(|x| out_send.send(x).unwrap());
     };
 
@@ -563,7 +559,7 @@ pub fn test_covid_tracing() {
 
 #[multiplatform_test]
 pub fn test_assert_eq() {
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter([1, 2, 3]) -> assert_eq([1, 2, 3]) -> assert_eq([1, 2, 3]); // one in pull, one in push
         source_iter([1, 2, 3]) -> assert_eq([1, 2, 3]) -> assert_eq(vec![1, 2, 3]);
         source_iter([1, 2, 3]) -> assert_eq(vec![1, 2, 3]) -> assert_eq([1, 2, 3]);
@@ -576,7 +572,7 @@ pub fn test_assert_eq() {
 pub fn test_assert_failures() {
     assert!(
         std::panic::catch_unwind(|| {
-            let mut df = dfir_syntax! {
+            let mut df = dfir_syntax_inline! {
                 source_iter([0]) -> assert_eq([1]);
             };
 
@@ -587,7 +583,7 @@ pub fn test_assert_failures() {
 
     assert!(
         std::panic::catch_unwind(|| {
-            let mut df = dfir_syntax! {
+            let mut df = dfir_syntax_inline! {
                 source_iter([0]) -> assert_eq([1]) -> null();
             };
 
@@ -608,7 +604,7 @@ pub fn test_iter_stream_batches() {
         .map(|n| (TickInstant::new((n / BATCH).try_into().unwrap()), n))
         .collect();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_stream(stream)
             -> map(|x| (context.current_tick(), x))
             -> assert_eq(expected);

--- a/dfir_rs/tests/surface_codegen.rs
+++ b/dfir_rs/tests/surface_codegen.rs
@@ -31,6 +31,7 @@ pub fn test_basic_2() {
     let mut df = dfir_syntax_inline! {
         source_iter([1]) -> for_each(|v| out_send.send(v).unwrap());
     };
+    assert_graphvis_snapshots!(df);
     df.run_available_sync();
 
     assert_eq!(&[1], &*collect_ready::<Vec<_>, _>(&mut out_recv));
@@ -43,6 +44,7 @@ pub fn test_basic_3() {
     let mut df = dfir_syntax_inline! {
         source_iter([1]) -> map(|v| v + 1) -> for_each(|v| out_send.send(v).unwrap());
     };
+    assert_graphvis_snapshots!(df);
     df.run_available_sync();
 
     assert_eq!(&[2], &*collect_ready::<Vec<_>, _>(&mut out_recv));
@@ -57,6 +59,7 @@ pub fn test_basic_union() {
         source_iter([1]) -> [0]m;
         source_iter([2]) -> [1]m;
     };
+    assert_graphvis_snapshots!(df);
     df.run_available_sync();
 
     assert_eq!(&[1, 2], &*collect_ready::<Vec<_>, _>(&mut out_recv));
@@ -133,6 +136,7 @@ pub fn test_recv_expr() {
         source_stream(send_recv.1)
             -> for_each(|v| print!("{:?}", v));
     };
+    assert_graphvis_snapshots!(df);
     df.run_available_sync();
 
     let items_send = send_recv.0;

--- a/dfir_rs/tests/surface_context.rs
+++ b/dfir_rs/tests/surface_context.rs
@@ -12,6 +12,7 @@ pub fn test_context_ref() {
         source_iter([()])
             -> for_each(|()| println!("Current tick: {}", context.current_tick()));
     };
+    assert_graphvis_snapshots!(df);
     df.run_available_sync();
 }
 

--- a/dfir_rs/tests/surface_context.rs
+++ b/dfir_rs/tests/surface_context.rs
@@ -8,11 +8,10 @@ use web_time::Duration;
 
 #[multiplatform_test]
 pub fn test_context_ref() {
-    let mut df = dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_iter([()])
-            -> for_each(|()| println!("Current tick: {}, stratum: {}", context.current_tick(), context.current_stratum()));
+            -> for_each(|()| println!("Current tick: {}", context.current_tick()));
     };
-    assert_graphvis_snapshots!(df);
     df.run_available_sync();
 }
 
@@ -56,7 +55,7 @@ pub async fn test_context_current_tick_start_does_not_count_time_between_ticks_a
 pub async fn test_defered_tick_and_no_io_with_run_async() {
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_iter([()])
             -> defer_tick()
             -> for_each(|_| tx.send(()).unwrap());

--- a/dfir_rs/tests/surface_cross_join_multiset.rs
+++ b/dfir_rs/tests/surface_cross_join_multiset.rs
@@ -28,7 +28,7 @@ pub fn tick_tick() {
     let results = Rc::new(RefCell::new(HashMap::<TickInstant, Vec<_>>::new()));
     let results_inner = Rc::clone(&results);
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_iter([1, 2])
             -> [0]my_cross_join_multiset;
 
@@ -53,7 +53,7 @@ pub fn tick_static() {
     let results = Rc::new(RefCell::new(HashMap::<TickInstant, Vec<_>>::new()));
     let results_inner = Rc::clone(&results);
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_iter([1, 2])
             -> [0]my_cross_join_multiset;
 
@@ -78,7 +78,7 @@ pub fn static_tick() {
     let results = Rc::new(RefCell::new(HashMap::<TickInstant, Vec<_>>::new()));
     let results_inner = Rc::clone(&results);
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_iter([1, 2])
             -> [0]my_cross_join_multiset;
 
@@ -105,7 +105,7 @@ pub fn static_static() {
     let results = Rc::new(RefCell::new(HashMap::<TickInstant, Vec<_>>::new()));
     let results_inner = Rc::clone(&results);
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_iter([1, 2])
             -> [0]my_cross_join_multiset;
 
@@ -143,7 +143,7 @@ pub fn replay_static() {
     let results = Rc::new(RefCell::new(HashMap::<TickInstant, Vec<_>>::new()));
     let results_inner = Rc::clone(&results);
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_iter([1, 2]) -> [0]my_cross_join_multiset;
         source_iter([3, 4]) -> [1]my_cross_join_multiset;
         my_cross_join_multiset = cross_join_multiset::<'static, 'static>()

--- a/dfir_rs/tests/surface_difference.rs
+++ b/dfir_rs/tests/surface_difference.rs
@@ -1,12 +1,12 @@
 use dfir_rs::util::{collect_ready, iter_batches_stream, unbounded_channel};
-use dfir_rs::{assert_graphvis_snapshots, dfir_syntax};
+use dfir_rs::dfir_syntax;
 use multiplatform_test::multiplatform_test;
 
 #[multiplatform_test]
 pub fn test_difference() {
     let (result_send, mut result_recv) = unbounded_channel::<usize>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_iter([1, 2, 3, 4, 5]) -> [pos]diff;
         source_iter([2, 3, 4]) -> [neg]diff;
         diff = difference() -> for_each(|x| result_send.send(x).unwrap());
@@ -20,7 +20,7 @@ pub fn test_difference() {
 pub fn test_difference_multiset() {
     let (result_send, mut result_recv) = unbounded_channel::<usize>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_iter([1, 2, 2, 3, 3, 4, 4, 5, 5]) -> [pos]diff;
         source_iter([2, 3, 4]) -> [neg]diff;
         diff = difference() -> for_each(|x| result_send.send(x).unwrap());
@@ -38,15 +38,13 @@ pub fn test_diff_timing() {
 
     let (output_send, mut output_recv) = unbounded_channel::<_>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_stream(pos_recv) -> [pos]diff;
         source_stream(neg_recv) -> [neg]diff;
         diff = difference() -> for_each(|x| output_send.send((context.current_tick().0, x)).unwrap());
     };
-    assert_graphvis_snapshots!(df);
 
     df.run_tick_sync();
-    println!("{}x{}", df.current_tick(), df.current_stratum());
 
     println!("A");
 
@@ -82,12 +80,11 @@ pub fn test_diff_static() {
 
     let (output_send, mut output_recv) = unbounded_channel::<usize>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_stream(pos_recv) -> [pos]diff;
         source_stream(neg_recv) -> [neg]diff;
         diff = difference::<'tick, 'static>() -> sort() -> for_each(|v| output_send.send(v).unwrap());
     };
-    assert_graphvis_snapshots!(df);
 
     pos_send.send(1).unwrap();
     pos_send.send(1).unwrap();
@@ -117,15 +114,13 @@ pub fn test_diff_multiset_timing() {
 
     let (output_send, mut output_recv) = unbounded_channel::<_>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_stream(pos_recv) -> [pos]diff;
         source_stream(neg_recv) -> [neg]diff;
         diff = difference() -> for_each(|x| output_send.send((context.current_tick().0, x)).unwrap());
     };
-    assert_graphvis_snapshots!(df);
 
     df.run_tick_sync();
-    println!("{}x{}", df.current_tick(), df.current_stratum());
 
     println!("A");
 
@@ -161,7 +156,7 @@ pub fn test_diff_multiset_static() {
 
     let (output_send, mut output_recv) = unbounded_channel::<usize>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         diff = difference::<'static>() -> sort() -> for_each(|v| output_send.send(v).unwrap());
 
         poss = source_stream(pos_recv); //-> tee();
@@ -174,7 +169,6 @@ pub fn test_diff_multiset_static() {
         negs -> for_each(|x| println!("neg: {:?}", x));
 
     };
-    assert_graphvis_snapshots!(df);
 
     pos_send.send(1).unwrap();
     pos_send.send(1).unwrap();
@@ -207,7 +201,7 @@ pub fn test_diff_multiset_tick_static() {
 
     let (output_send, mut output_recv) = unbounded_channel::<usize>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         diff = difference::<'tick, 'static>() -> sort() -> for_each(|v| output_send.send(v).unwrap());
 
         poss = source_stream(pos_recv); //-> tee();
@@ -220,7 +214,6 @@ pub fn test_diff_multiset_tick_static() {
         negs -> for_each(|x| println!("neg: {:?}", x));
 
     };
-    assert_graphvis_snapshots!(df);
 
     pos_send.send(1).unwrap();
     pos_send.send(1).unwrap();
@@ -250,7 +243,7 @@ pub fn test_diff_multiset_static_tick() {
 
     let (output_send, mut output_recv) = unbounded_channel::<usize>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         diff = difference::<'static, 'tick>() -> sort() -> for_each(|v| output_send.send(v).unwrap());
 
         poss = source_stream(pos_recv); //-> tee();
@@ -263,7 +256,6 @@ pub fn test_diff_multiset_static_tick() {
         negs -> for_each(|x| println!("neg: {:?}", x));
 
     };
-    assert_graphvis_snapshots!(df);
 
     pos_send.send(1).unwrap();
     pos_send.send(1).unwrap();

--- a/dfir_rs/tests/surface_difference.rs
+++ b/dfir_rs/tests/surface_difference.rs
@@ -1,6 +1,5 @@
-use dfir_rs::assert_graphvis_snapshots;
-use dfir_rs::dfir_syntax;
 use dfir_rs::util::{collect_ready, iter_batches_stream, unbounded_channel};
+use dfir_rs::{assert_graphvis_snapshots, dfir_syntax};
 use multiplatform_test::multiplatform_test;
 
 #[multiplatform_test]
@@ -46,7 +45,6 @@ pub fn test_diff_timing() {
     };
     assert_graphvis_snapshots!(df);
 
-
     df.run_tick_sync();
 
     println!("A");
@@ -90,7 +88,6 @@ pub fn test_diff_static() {
     };
     assert_graphvis_snapshots!(df);
 
-
     pos_send.send(1).unwrap();
     pos_send.send(1).unwrap();
     pos_send.send(2).unwrap();
@@ -125,7 +122,6 @@ pub fn test_diff_multiset_timing() {
         diff = difference() -> for_each(|x| output_send.send((context.current_tick().0, x)).unwrap());
     };
     assert_graphvis_snapshots!(df);
-
 
     df.run_tick_sync();
 
@@ -178,7 +174,6 @@ pub fn test_diff_multiset_static() {
     };
     assert_graphvis_snapshots!(df);
 
-
     pos_send.send(1).unwrap();
     pos_send.send(1).unwrap();
     pos_send.send(2).unwrap();
@@ -225,7 +220,6 @@ pub fn test_diff_multiset_tick_static() {
     };
     assert_graphvis_snapshots!(df);
 
-
     pos_send.send(1).unwrap();
     pos_send.send(1).unwrap();
     pos_send.send(2).unwrap();
@@ -268,7 +262,6 @@ pub fn test_diff_multiset_static_tick() {
 
     };
     assert_graphvis_snapshots!(df);
-
 
     pos_send.send(1).unwrap();
     pos_send.send(1).unwrap();

--- a/dfir_rs/tests/surface_difference.rs
+++ b/dfir_rs/tests/surface_difference.rs
@@ -1,5 +1,5 @@
-use dfir_rs::util::{collect_ready, iter_batches_stream, unbounded_channel};
 use dfir_rs::dfir_syntax;
+use dfir_rs::util::{collect_ready, iter_batches_stream, unbounded_channel};
 use multiplatform_test::multiplatform_test;
 
 #[multiplatform_test]

--- a/dfir_rs/tests/surface_difference.rs
+++ b/dfir_rs/tests/surface_difference.rs
@@ -1,3 +1,4 @@
+use dfir_rs::assert_graphvis_snapshots;
 use dfir_rs::dfir_syntax;
 use dfir_rs::util::{collect_ready, iter_batches_stream, unbounded_channel};
 use multiplatform_test::multiplatform_test;
@@ -43,6 +44,8 @@ pub fn test_diff_timing() {
         source_stream(neg_recv) -> [neg]diff;
         diff = difference() -> for_each(|x| output_send.send((context.current_tick().0, x)).unwrap());
     };
+    assert_graphvis_snapshots!(df);
+
 
     df.run_tick_sync();
 
@@ -85,6 +88,8 @@ pub fn test_diff_static() {
         source_stream(neg_recv) -> [neg]diff;
         diff = difference::<'tick, 'static>() -> sort() -> for_each(|v| output_send.send(v).unwrap());
     };
+    assert_graphvis_snapshots!(df);
+
 
     pos_send.send(1).unwrap();
     pos_send.send(1).unwrap();
@@ -119,6 +124,8 @@ pub fn test_diff_multiset_timing() {
         source_stream(neg_recv) -> [neg]diff;
         diff = difference() -> for_each(|x| output_send.send((context.current_tick().0, x)).unwrap());
     };
+    assert_graphvis_snapshots!(df);
+
 
     df.run_tick_sync();
 
@@ -169,6 +176,8 @@ pub fn test_diff_multiset_static() {
         negs -> for_each(|x| println!("neg: {:?}", x));
 
     };
+    assert_graphvis_snapshots!(df);
+
 
     pos_send.send(1).unwrap();
     pos_send.send(1).unwrap();
@@ -214,6 +223,8 @@ pub fn test_diff_multiset_tick_static() {
         negs -> for_each(|x| println!("neg: {:?}", x));
 
     };
+    assert_graphvis_snapshots!(df);
+
 
     pos_send.send(1).unwrap();
     pos_send.send(1).unwrap();
@@ -256,6 +267,8 @@ pub fn test_diff_multiset_static_tick() {
         negs -> for_each(|x| println!("neg: {:?}", x));
 
     };
+    assert_graphvis_snapshots!(df);
+
 
     pos_send.send(1).unwrap();
     pos_send.send(1).unwrap();

--- a/dfir_rs/tests/surface_fold.rs
+++ b/dfir_rs/tests/surface_fold.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
+use dfir_rs::assert_graphvis_snapshots;
 use dfir_rs::scheduled::ticks::TickInstant;
 use dfir_rs::util::collect_ready;
 use dfir_rs::{dfir_syntax, dfir_syntax_inline};
@@ -15,6 +16,8 @@ pub fn test_fold_tick() {
             -> fold::<'tick>(Vec::new, |old: &mut Vec<u32>, mut x: Vec<u32>| { old.append(&mut x); })
             -> for_each(|v| result_send.send(v).unwrap());
     };
+    assert_graphvis_snapshots!(df);
+
 
     assert_eq!(TickInstant::new(0), df.current_tick());
 
@@ -51,6 +54,8 @@ pub fn test_fold_static() {
             -> fold::<'static>(Vec::new, |old: &mut Vec<u32>, mut x: Vec<u32>| { old.append(&mut x); })
             -> for_each(|v| result_send.send(v).unwrap());
     };
+    assert_graphvis_snapshots!(df);
+
 
     assert_eq!(TickInstant::new(0), df.current_tick());
 
@@ -94,6 +99,8 @@ pub fn test_fold_static_join() {
         join_node = cross_join_multiset();
         join_node -> for_each(|v| result_send.send(v).unwrap());
     };
+    assert_graphvis_snapshots!(df);
+
 
     assert_eq!(TickInstant::new(0), df.current_tick());
 

--- a/dfir_rs/tests/surface_fold.rs
+++ b/dfir_rs/tests/surface_fold.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use dfir_rs::scheduled::ticks::TickInstant;
 use dfir_rs::util::collect_ready;
-use dfir_rs::{assert_graphvis_snapshots, dfir_syntax};
+use dfir_rs::{dfir_syntax, dfir_syntax_inline};
 use multiplatform_test::multiplatform_test;
 
 #[multiplatform_test]
@@ -10,26 +10,19 @@ pub fn test_fold_tick() {
     let (items_send, items_recv) = dfir_rs::util::unbounded_channel::<Vec<u32>>();
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<Vec<u32>>();
 
-    let mut df = dfir_rs::dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_stream(items_recv)
             -> fold::<'tick>(Vec::new, |old: &mut Vec<u32>, mut x: Vec<u32>| { old.append(&mut x); })
             -> for_each(|v| result_send.send(v).unwrap());
     };
-    assert_graphvis_snapshots!(df);
 
-    assert_eq!(
-        (TickInstant::new(0), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(0), df.current_tick());
 
     items_send.send(vec![1, 2]).unwrap();
     items_send.send(vec![3, 4]).unwrap();
     df.run_tick_sync();
 
-    assert_eq!(
-        (TickInstant::new(1), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(1), df.current_tick());
     assert_eq!(
         &[vec![1, 2, 3, 4]],
         &*collect_ready::<Vec<_>, _>(&mut result_recv)
@@ -39,10 +32,7 @@ pub fn test_fold_tick() {
     items_send.send(vec![7, 8]).unwrap();
     df.run_tick_sync();
 
-    assert_eq!(
-        (TickInstant::new(2), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(2), df.current_tick());
     assert_eq!(
         &[vec![5, 6, 7, 8]],
         &*collect_ready::<Vec<_>, _>(&mut result_recv)
@@ -56,26 +46,19 @@ pub fn test_fold_static() {
     let (items_send, items_recv) = dfir_rs::util::unbounded_channel::<Vec<u32>>();
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<Vec<u32>>();
 
-    let mut df = dfir_rs::dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_stream(items_recv)
             -> fold::<'static>(Vec::new, |old: &mut Vec<u32>, mut x: Vec<u32>| { old.append(&mut x); })
             -> for_each(|v| result_send.send(v).unwrap());
     };
-    assert_graphvis_snapshots!(df);
 
-    assert_eq!(
-        (TickInstant::new(0), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(0), df.current_tick());
 
     items_send.send(vec![1, 2]).unwrap();
     items_send.send(vec![3, 4]).unwrap();
     df.run_tick_sync();
 
-    assert_eq!(
-        (TickInstant::new(1), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(1), df.current_tick());
     assert_eq!(
         &[vec![1, 2, 3, 4]],
         &*collect_ready::<Vec<_>, _>(&mut result_recv)
@@ -85,10 +68,7 @@ pub fn test_fold_static() {
     items_send.send(vec![7, 8]).unwrap();
     df.run_tick_sync();
 
-    assert_eq!(
-        (TickInstant::new(2), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(2), df.current_tick());
     assert_eq!(
         &[vec![1, 2, 3, 4, 5, 6, 7, 8]],
         &*collect_ready::<Vec<_>, _>(&mut result_recv)
@@ -102,7 +82,7 @@ pub fn test_fold_static_join() {
     let (items_send, items_recv) = dfir_rs::util::unbounded_channel::<usize>();
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<(usize, usize)>();
 
-    let mut df = dfir_rs::dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         teed_fold = source_iter([])
             -> fold::<'tick>(|| 0, |old: &mut usize, _: usize| { *old += 1; })
             -> tee();
@@ -114,29 +94,19 @@ pub fn test_fold_static_join() {
         join_node = cross_join_multiset();
         join_node -> for_each(|v| result_send.send(v).unwrap());
     };
-    assert_graphvis_snapshots!(df);
 
-    assert_eq!(
-        (TickInstant::new(0), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(0), df.current_tick());
 
     items_send.send(0).unwrap();
     df.run_available_sync();
 
-    assert_eq!(
-        (TickInstant::new(1), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(1), df.current_tick());
     assert_eq!(&[(0, 0)], &*collect_ready::<Vec<_>, _>(&mut result_recv));
 
     items_send.send(1).unwrap();
     df.run_available_sync();
 
-    assert_eq!(
-        (TickInstant::new(2), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(2), df.current_tick());
     assert_eq!(&[(1, 0)], &*collect_ready::<Vec<_>, _>(&mut result_recv));
 }
 
@@ -144,7 +114,7 @@ pub fn test_fold_static_join() {
 pub fn test_fold_flatten() {
     // test pull
     let (out_send, mut out_recv) = dfir_rs::util::unbounded_channel::<(u8, u8)>();
-    let mut df_pull = dfir_syntax! {
+    let mut df_pull = dfir_syntax_inline! {
         source_iter([(1,1), (1,2), (2,3), (2,4)])
             -> fold::<'tick>(HashMap::<u8, u8>::new, |ht: &mut HashMap<u8, u8>, t: (u8,u8)| {
                     let e = ht.entry(t.0).or_insert(0);
@@ -154,15 +124,9 @@ pub fn test_fold_flatten() {
             -> for_each(|(k,v)| out_send.send((k,v)).unwrap());
     };
 
-    assert_eq!(
-        (TickInstant::new(0), 0),
-        (df_pull.current_tick(), df_pull.current_stratum())
-    );
+    assert_eq!(TickInstant::new(0), df_pull.current_tick());
     df_pull.run_tick_sync();
-    assert_eq!(
-        (TickInstant::new(1), 0),
-        (df_pull.current_tick(), df_pull.current_stratum())
-    );
+    assert_eq!(TickInstant::new(1), df_pull.current_tick());
 
     let out: HashSet<_> = collect_ready(&mut out_recv);
     for pair in [(1, 3), (2, 7)] {
@@ -171,7 +135,7 @@ pub fn test_fold_flatten() {
 
     // test push
     let (out_send, mut out_recv) = dfir_rs::util::unbounded_channel::<(u8, u8)>();
-    let mut df_push = dfir_syntax! {
+    let mut df_push = dfir_syntax_inline! {
         datagen = source_iter([(1,2), (1,2), (2,4), (2,4)]) -> tee();
         datagen[0] -> fold::<'tick>(HashMap::<u8, u8>::new, |ht: &mut HashMap<u8, u8>, t:(u8,u8)| {
                 let e = ht.entry(t.0).or_insert(0);
@@ -181,15 +145,9 @@ pub fn test_fold_flatten() {
             -> for_each(|(k,v)| out_send.send((k,v)).unwrap());
         datagen[1] -> null();
     };
-    assert_eq!(
-        (TickInstant::new(0), 0),
-        (df_push.current_tick(), df_push.current_stratum())
-    );
+    assert_eq!(TickInstant::new(0), df_push.current_tick());
     df_push.run_tick_sync();
-    assert_eq!(
-        (TickInstant::new(1), 0),
-        (df_push.current_tick(), df_push.current_stratum())
-    );
+    assert_eq!(TickInstant::new(1), df_push.current_tick());
 
     let out: HashSet<_> = collect_ready(&mut out_recv);
     for pair in [(1, 4), (2, 8)] {
@@ -204,22 +162,15 @@ pub fn test_fold_flatten() {
 pub fn test_fold_sort() {
     let (items_send, items_recv) = dfir_rs::util::unbounded_channel::<usize>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_stream(items_recv)
             -> fold::<'tick>(Vec::new, Vec::push)
             -> flat_map(|mut vec| { vec.sort(); vec })
             -> for_each(|v| print!("{:?}, ", v));
     };
-    assert_graphvis_snapshots!(df);
-    assert_eq!(
-        (TickInstant::new(0), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(0), df.current_tick());
     df.run_tick_sync();
-    assert_eq!(
-        (TickInstant::new(1), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(1), df.current_tick());
 
     print!("\nA: ");
 
@@ -227,10 +178,7 @@ pub fn test_fold_sort() {
     items_send.send(2).unwrap();
     items_send.send(5).unwrap();
     df.run_tick_sync();
-    assert_eq!(
-        (TickInstant::new(2), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(2), df.current_tick());
 
     print!("\nB: ");
 
@@ -240,10 +188,7 @@ pub fn test_fold_sort() {
     items_send.send(0).unwrap();
     items_send.send(3).unwrap();
     df.run_tick_sync();
-    assert_eq!(
-        (TickInstant::new(3), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(3), df.current_tick());
 
     println!();
 
@@ -254,7 +199,7 @@ pub fn test_fold_sort() {
 pub fn test_fold_inference() {
     let (_items_send, items_recv) = dfir_rs::util::unbounded_channel::<String>();
 
-    let _ = dfir_rs::dfir_syntax! {
+    let _ = dfir_rs::dfir_syntax_inline! {
         source_stream(items_recv)
             -> fold::<'tick>(|| 0, |old, s| { *old += s.len() })
             -> for_each(|_| {});

--- a/dfir_rs/tests/surface_fold.rs
+++ b/dfir_rs/tests/surface_fold.rs
@@ -1,9 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
-use dfir_rs::assert_graphvis_snapshots;
 use dfir_rs::scheduled::ticks::TickInstant;
 use dfir_rs::util::collect_ready;
-use dfir_rs::{dfir_syntax, dfir_syntax_inline};
+use dfir_rs::{assert_graphvis_snapshots, dfir_syntax, dfir_syntax_inline};
 use multiplatform_test::multiplatform_test;
 
 #[multiplatform_test]
@@ -17,7 +16,6 @@ pub fn test_fold_tick() {
             -> for_each(|v| result_send.send(v).unwrap());
     };
     assert_graphvis_snapshots!(df);
-
 
     assert_eq!(TickInstant::new(0), df.current_tick());
 
@@ -55,7 +53,6 @@ pub fn test_fold_static() {
             -> for_each(|v| result_send.send(v).unwrap());
     };
     assert_graphvis_snapshots!(df);
-
 
     assert_eq!(TickInstant::new(0), df.current_tick());
 
@@ -100,7 +97,6 @@ pub fn test_fold_static_join() {
         join_node -> for_each(|v| result_send.send(v).unwrap());
     };
     assert_graphvis_snapshots!(df);
-
 
     assert_eq!(TickInstant::new(0), df.current_tick());
 
@@ -175,6 +171,7 @@ pub fn test_fold_sort() {
             -> flat_map(|mut vec| { vec.sort(); vec })
             -> for_each(|v| print!("{:?}, ", v));
     };
+    assert_graphvis_snapshots!(df);
     assert_eq!(TickInstant::new(0), df.current_tick());
     df.run_tick_sync();
     assert_eq!(TickInstant::new(1), df.current_tick());

--- a/dfir_rs/tests/surface_fold_keyed.rs
+++ b/dfir_rs/tests/surface_fold_keyed.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeSet;
 
+use dfir_rs::assert_graphvis_snapshots;
 use dfir_rs::scheduled::ticks::TickInstant;
 use dfir_rs::util::collect_ready;
 use multiplatform_test::multiplatform_test;
@@ -24,6 +25,8 @@ pub fn test_fold_keyed_infer_basic() {
             -> fold_keyed::<'static>(|| 0, |old: &mut u32, val: u32| *old += val)
             -> for_each(|kv| result_send.send(kv).unwrap());
     };
+    assert_graphvis_snapshots!(df);
+
     assert_eq!(TickInstant::new(0), df.current_tick());
     df.run_tick_sync();
     assert_eq!(TickInstant::new(1), df.current_tick());
@@ -56,6 +59,8 @@ pub fn test_fold_keyed_typed_basic() {
             -> fold_keyed::<'static, &'static str, u32>(|| 0, |old: &mut u32, val: u32| *old += val)
             -> for_each(|kv| result_send.send(kv).unwrap());
     };
+    assert_graphvis_snapshots!(df);
+
     assert_eq!(TickInstant::new(0), df.current_tick());
     df.run_tick_sync();
     assert_eq!(TickInstant::new(1), df.current_tick());
@@ -78,6 +83,8 @@ pub fn test_fold_keyed_tick() {
             -> fold_keyed::<'tick>(Vec::new, |old: &mut Vec<u32>, mut x: Vec<u32>| old.append(&mut x))
             -> for_each(|v| result_send.send(v).unwrap());
     };
+    assert_graphvis_snapshots!(df);
+
     assert_eq!(TickInstant::new(0), df.current_tick());
     df.run_tick_sync();
     assert_eq!(TickInstant::new(1), df.current_tick());
@@ -123,6 +130,8 @@ pub fn test_fold_keyed_static() {
             -> fold_keyed::<'static>(Vec::new, |old: &mut Vec<u32>, mut x: Vec<u32>| old.append(&mut x))
             -> for_each(|v| result_send.send(v).unwrap());
     };
+    assert_graphvis_snapshots!(df);
+
     assert_eq!(TickInstant::new(0), df.current_tick());
     df.run_tick_sync();
     assert_eq!(TickInstant::new(1), df.current_tick());

--- a/dfir_rs/tests/surface_fold_keyed.rs
+++ b/dfir_rs/tests/surface_fold_keyed.rs
@@ -1,6 +1,5 @@
 use std::collections::BTreeSet;
 
-use dfir_rs::assert_graphvis_snapshots;
 use dfir_rs::scheduled::ticks::TickInstant;
 use dfir_rs::util::collect_ready;
 use multiplatform_test::multiplatform_test;
@@ -13,7 +12,7 @@ pub fn test_fold_keyed_infer_basic() {
     }
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<(&'static str, u32)>();
 
-    let mut df = dfir_rs::dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_iter([
                 SubordResponse { xid: "123", mtype: 33 },
                 SubordResponse { xid: "123", mtype: 52 },
@@ -25,16 +24,9 @@ pub fn test_fold_keyed_infer_basic() {
             -> fold_keyed::<'static>(|| 0, |old: &mut u32, val: u32| *old += val)
             -> for_each(|kv| result_send.send(kv).unwrap());
     };
-    assert_graphvis_snapshots!(df);
-    assert_eq!(
-        (TickInstant::new(0), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(0), df.current_tick());
     df.run_tick_sync();
-    assert_eq!(
-        (TickInstant::new(1), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(1), df.current_tick());
 
     df.run_available_sync(); // Should return quickly and not hang
 
@@ -52,7 +44,7 @@ pub fn test_fold_keyed_typed_basic() {
     }
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<(&'static str, u32)>();
 
-    let mut df = dfir_rs::dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_iter([
                 SubordResponse { xid: "123", mtype: 33 },
                 SubordResponse { xid: "123", mtype: 52 },
@@ -64,16 +56,9 @@ pub fn test_fold_keyed_typed_basic() {
             -> fold_keyed::<'static, &'static str, u32>(|| 0, |old: &mut u32, val: u32| *old += val)
             -> for_each(|kv| result_send.send(kv).unwrap());
     };
-    assert_graphvis_snapshots!(df);
-    assert_eq!(
-        (TickInstant::new(0), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(0), df.current_tick());
     df.run_tick_sync();
-    assert_eq!(
-        (TickInstant::new(1), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(1), df.current_tick());
 
     df.run_available_sync(); // Should return quickly and not hang
 
@@ -88,21 +73,14 @@ pub fn test_fold_keyed_tick() {
     let (items_send, items_recv) = dfir_rs::util::unbounded_channel::<(u32, Vec<u32>)>();
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<(u32, Vec<u32>)>();
 
-    let mut df = dfir_rs::dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_stream(items_recv)
             -> fold_keyed::<'tick>(Vec::new, |old: &mut Vec<u32>, mut x: Vec<u32>| old.append(&mut x))
             -> for_each(|v| result_send.send(v).unwrap());
     };
-    assert_graphvis_snapshots!(df);
-    assert_eq!(
-        (TickInstant::new(0), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(0), df.current_tick());
     df.run_tick_sync();
-    assert_eq!(
-        (TickInstant::new(1), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(1), df.current_tick());
 
     items_send.send((0, vec![1, 2])).unwrap();
     items_send.send((0, vec![3, 4])).unwrap();
@@ -110,10 +88,7 @@ pub fn test_fold_keyed_tick() {
     items_send.send((1, vec![1, 2])).unwrap();
     df.run_tick_sync();
 
-    assert_eq!(
-        (TickInstant::new(2), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(2), df.current_tick());
     assert_eq!(
         [(0, vec![1, 2, 3, 4]), (1, vec![1, 1, 2])]
             .into_iter()
@@ -127,10 +102,7 @@ pub fn test_fold_keyed_tick() {
     items_send.send((1, vec![11, 12])).unwrap();
     df.run_tick_sync();
 
-    assert_eq!(
-        (TickInstant::new(3), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(3), df.current_tick());
     assert_eq!(
         [(0, vec![5, 6, 7, 8]), (1, vec![10, 11, 12])]
             .into_iter()
@@ -146,21 +118,14 @@ pub fn test_fold_keyed_static() {
     let (items_send, items_recv) = dfir_rs::util::unbounded_channel::<(u32, Vec<u32>)>();
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<(u32, Vec<u32>)>();
 
-    let mut df = dfir_rs::dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_stream(items_recv)
             -> fold_keyed::<'static>(Vec::new, |old: &mut Vec<u32>, mut x: Vec<u32>| old.append(&mut x))
             -> for_each(|v| result_send.send(v).unwrap());
     };
-    assert_graphvis_snapshots!(df);
-    assert_eq!(
-        (TickInstant::new(0), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(0), df.current_tick());
     df.run_tick_sync();
-    assert_eq!(
-        (TickInstant::new(1), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(1), df.current_tick());
 
     items_send.send((0, vec![1, 2])).unwrap();
     items_send.send((0, vec![3, 4])).unwrap();
@@ -168,10 +133,7 @@ pub fn test_fold_keyed_static() {
     items_send.send((1, vec![1, 2])).unwrap();
     df.run_tick_sync();
 
-    assert_eq!(
-        (TickInstant::new(2), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(2), df.current_tick());
     assert_eq!(
         [(0, vec![1, 2, 3, 4]), (1, vec![1, 1, 2])]
             .into_iter()
@@ -185,10 +147,7 @@ pub fn test_fold_keyed_static() {
     items_send.send((1, vec![11, 12])).unwrap();
     df.run_tick_sync();
 
-    assert_eq!(
-        (TickInstant::new(3), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(3), df.current_tick());
     assert_eq!(
         [
             (0, vec![1, 2, 3, 4, 5, 6, 7, 8]),

--- a/dfir_rs/tests/surface_join.rs
+++ b/dfir_rs/tests/surface_join.rs
@@ -41,6 +41,8 @@ pub fn tick_tick() {
         my_join = join::<'tick, 'tick>()
             -> for_each(|x| results_inner.borrow_mut().entry(context.current_tick()).or_default().push(x));
     };
+    assert_graphvis_snapshots!(df);
+
     df.run_available_sync();
 
     assert_contains_each_by_tick!(results, TickInstant::new(0), &[(7, (1, 0)), (7, (2, 0))]);
@@ -65,6 +67,8 @@ pub fn tick_static() {
         my_join = join::<'tick, 'static>()
             -> for_each(|x| results_inner.borrow_mut().entry(context.current_tick()).or_default().push(x));
     };
+    assert_graphvis_snapshots!(df);
+
     df.run_available_sync();
 
     assert_contains_each_by_tick!(results, TickInstant::new(0), &[(7, (1, 0)), (7, (2, 0))]);
@@ -89,6 +93,8 @@ pub fn static_tick() {
         my_join = join::<'static, 'tick>()
             -> for_each(|x| results_inner.borrow_mut().entry(context.current_tick()).or_default().push(x));
     };
+    assert_graphvis_snapshots!(df);
+
     df.run_available_sync();
 
     assert_contains_each_by_tick!(results, TickInstant::new(0), &[(7, (1, 0)), (7, (2, 0))]);
@@ -115,6 +121,8 @@ pub fn static_static() {
         my_join = join::<'static, 'static>()
             -> for_each(|x| results_inner.borrow_mut().entry(context.current_tick()).or_default().push(x));
     };
+    assert_graphvis_snapshots!(df);
+
     df.run_available_sync();
 
     #[rustfmt::skip]

--- a/dfir_rs/tests/surface_join.rs
+++ b/dfir_rs/tests/surface_join.rs
@@ -28,7 +28,7 @@ pub fn tick_tick() {
     let results = Rc::new(RefCell::new(HashMap::<TickInstant, Vec<_>>::new()));
     let results_inner = Rc::clone(&results);
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_iter([(7, 1), (7, 2)])
             -> [0]my_join;
 
@@ -41,7 +41,6 @@ pub fn tick_tick() {
         my_join = join::<'tick, 'tick>()
             -> for_each(|x| results_inner.borrow_mut().entry(context.current_tick()).or_default().push(x));
     };
-    assert_graphvis_snapshots!(df);
     df.run_available_sync();
 
     assert_contains_each_by_tick!(results, TickInstant::new(0), &[(7, (1, 0)), (7, (2, 0))]);
@@ -53,7 +52,7 @@ pub fn tick_static() {
     let results = Rc::new(RefCell::new(HashMap::<TickInstant, Vec<_>>::new()));
     let results_inner = Rc::clone(&results);
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_iter([(7, 1), (7, 2)])
             -> [0]my_join;
 
@@ -66,7 +65,6 @@ pub fn tick_static() {
         my_join = join::<'tick, 'static>()
             -> for_each(|x| results_inner.borrow_mut().entry(context.current_tick()).or_default().push(x));
     };
-    assert_graphvis_snapshots!(df);
     df.run_available_sync();
 
     assert_contains_each_by_tick!(results, TickInstant::new(0), &[(7, (1, 0)), (7, (2, 0))]);
@@ -78,7 +76,7 @@ pub fn static_tick() {
     let results = Rc::new(RefCell::new(HashMap::<TickInstant, Vec<_>>::new()));
     let results_inner = Rc::clone(&results);
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_iter([(7, 1), (7, 2)])
             -> [0]my_join;
 
@@ -91,7 +89,6 @@ pub fn static_tick() {
         my_join = join::<'static, 'tick>()
             -> for_each(|x| results_inner.borrow_mut().entry(context.current_tick()).or_default().push(x));
     };
-    assert_graphvis_snapshots!(df);
     df.run_available_sync();
 
     assert_contains_each_by_tick!(results, TickInstant::new(0), &[(7, (1, 0)), (7, (2, 0))]);
@@ -105,7 +102,7 @@ pub fn static_static() {
     let results = Rc::new(RefCell::new(HashMap::<TickInstant, Vec<_>>::new()));
     let results_inner = Rc::clone(&results);
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_iter([(7, 1), (7, 2)])
             -> [0]my_join;
 
@@ -118,7 +115,6 @@ pub fn static_static() {
         my_join = join::<'static, 'static>()
             -> for_each(|x| results_inner.borrow_mut().entry(context.current_tick()).or_default().push(x));
     };
-    assert_graphvis_snapshots!(df);
     df.run_available_sync();
 
     #[rustfmt::skip]
@@ -135,7 +131,7 @@ pub fn replay_static() {
     let results = Rc::new(RefCell::new(HashMap::<TickInstant, Vec<_>>::new()));
     let results_inner = Rc::clone(&results);
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_iter([(7, 1), (7, 2)]) -> [0]my_join;
         source_iter([(7, 3), (7, 4)]) -> [1]my_join;
         my_join = join::<'static, 'static>()

--- a/dfir_rs/tests/surface_lattice_fold.rs
+++ b/dfir_rs/tests/surface_lattice_fold.rs
@@ -4,7 +4,7 @@ use dfir_rs::util::collect_ready;
 
 #[test]
 fn test_basic() {
-    let mut df = dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_iter([1,2,3,4,5])
             -> map(Max::new)
             -> lattice_fold::<'static>(|| Max::<u32>::new(0))

--- a/dfir_rs/tests/surface_persist.rs
+++ b/dfir_rs/tests/surface_persist.rs
@@ -3,21 +3,20 @@ use std::collections::HashSet;
 use dfir_pipes::pull::HalfMultisetJoinState;
 use dfir_rs::scheduled::ticks::TickInstant;
 use dfir_rs::util::collect_ready;
-use dfir_rs::{assert_graphvis_snapshots, dfir_syntax};
+use dfir_rs::dfir_syntax;
 use multiplatform_test::multiplatform_test;
 
 #[multiplatform_test]
 pub fn test_persist_basic() {
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u32>();
 
-    let mut hf = dfir_syntax! {
+    let mut hf = dfir_rs::dfir_syntax_inline! {
         source_iter([1])
             -> persist::<'static>()
             -> persist::<'static>()
             -> fold(|| 0, |a: &mut _, b| *a += b)
             -> for_each(|x| result_send.send(x).unwrap());
     };
-    assert_graphvis_snapshots!(hf);
 
     for tick in 0..10 {
         assert_eq!(TickInstant::new(tick), hf.current_tick());
@@ -33,7 +32,7 @@ pub fn test_persist_basic() {
 pub fn test_persist_pull() {
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u32>();
 
-    let mut hf = dfir_syntax! {
+    let mut hf = dfir_rs::dfir_syntax_inline! {
         // Structured to ensure `persist::<'static>()` is pull-based.
         source_iter([1]) -> persist::<'static>() -> m0;
         null() -> m0;
@@ -43,7 +42,6 @@ pub fn test_persist_pull() {
             -> fold(|| 0, |a: &mut _, b| *a += b)
             -> for_each(|x| result_send.send(x).unwrap());
     };
-    assert_graphvis_snapshots!(hf);
 
     for tick in 0..10 {
         assert_eq!(TickInstant::new(tick), hf.current_tick());
@@ -59,14 +57,13 @@ pub fn test_persist_pull() {
 pub fn test_persist_push() {
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u32>();
 
-    let mut hf = dfir_syntax! {
+    let mut hf = dfir_rs::dfir_syntax_inline! {
         t0 = source_iter([1]) -> persist::<'static>() -> tee();
         t0 -> null();
         t1 = t0 -> persist::<'static>() -> tee();
         t1 -> null();
         t1 -> fold(|| 0, |a: &mut _, b| *a += b) -> for_each(|x| result_send.send(x).unwrap());
     };
-    assert_graphvis_snapshots!(hf);
 
     for tick in 0..10 {
         assert_eq!(TickInstant::new(tick), hf.current_tick());
@@ -81,7 +78,7 @@ pub fn test_persist_push() {
 #[multiplatform_test]
 pub fn test_persist_join() {
     let (input_send, input_recv) = dfir_rs::util::unbounded_channel::<(&str, &str)>();
-    let mut flow = dfir_rs::dfir_syntax! {
+    let mut flow = dfir_rs::dfir_syntax_inline! {
         source_iter([("hello", "world")]) -> persist::<'static>() -> [0]my_join;
         source_stream(input_recv) -> persist::<'static>() -> [1]my_join;
         my_join = join::<'tick>() -> for_each(|(k, (v1, v2))| println!("({}, ({}, {}))", k, v1, v2));
@@ -109,7 +106,6 @@ pub fn test_persist_replay_join() {
 
         product_node = cross_join::<'tick, 'tick>() -> for_each(|x| result_send.send(x).unwrap());
     };
-    assert_graphvis_snapshots!(hf);
 
     persist_input_send.send(1).unwrap();
     other_input_send.send(2).unwrap();
@@ -131,27 +127,27 @@ pub fn test_persist_double_handoff() {
     let (input_send, input_recv) = dfir_rs::util::unbounded_channel::<usize>();
     let (input_2_send, input_2_recv) = dfir_rs::util::unbounded_channel::<usize>();
     let (output_send, mut output_recv) = dfir_rs::util::unbounded_channel::<(usize, usize)>();
-    let mut flow = dfir_rs::dfir_syntax! {
+    let mut flow = dfir_rs::dfir_syntax_inline! {
         teed_first_sg = source_stream(input_2_recv) -> tee();
         teed_first_sg -> [0] joined_second_sg;
         teed_first_sg -> [1] joined_second_sg;
 
         source_stream(input_recv) -> persist::<'static>()
-            -> inspect(|x| println!("LHS {} {}:{}", x, context.current_tick(), context.current_stratum())) -> [0] cross;
+            -> inspect(|x| println!("LHS {} {}", x, context.current_tick())) -> [0] cross;
         joined_second_sg = cross_join::<'tick, 'tick>() -> map(|t| t.0)
-            -> inspect(|x| println!("RHS {} {}:{}", x, context.current_tick(), context.current_stratum())) -> [1] cross;
+            -> inspect(|x| println!("RHS {} {}", x, context.current_tick())) -> [1] cross;
         cross = cross_join::<'tick, 'tick, HalfMultisetJoinState>() -> for_each(|x| output_send.send(x).unwrap());
     };
-    println!("A {}:{}", flow.current_tick(), flow.current_stratum());
+    println!("A {}", flow.current_tick());
 
     input_send.send(0).unwrap();
     flow.run_tick_sync();
-    println!("B {}:{}", flow.current_tick(), flow.current_stratum());
+    println!("B {}", flow.current_tick());
     assert!(collect_ready::<Vec<_>, _>(&mut output_recv).is_empty());
 
     input_2_send.send(1).unwrap();
     flow.run_tick_sync();
-    println!("C {}:{}", flow.current_tick(), flow.current_stratum());
+    println!("C {}", flow.current_tick());
     assert_eq!(&[(0, 1)], &*collect_ready::<Vec<_>, _>(&mut output_recv));
 }
 
@@ -160,28 +156,28 @@ pub fn test_persist_single_handoff() {
     let (input_send, input_recv) = dfir_rs::util::unbounded_channel::<usize>();
     let (input_2_send, input_2_recv) = dfir_rs::util::unbounded_channel::<usize>();
     let (output_send, mut output_recv) = dfir_rs::util::unbounded_channel::<(usize, usize)>();
-    let mut flow = dfir_rs::dfir_syntax! {
+    let mut flow = dfir_rs::dfir_syntax_inline! {
         teed_first_sg = source_stream(input_2_recv) -> tee();
         teed_first_sg [0] -> null();
         teed_first_sg [1] -> joined_second_sg;
         null() -> joined_second_sg;
 
         source_stream(input_recv) -> persist::<'static>()
-            -> inspect(|x| println!("LHS {} {}:{}", x, context.current_tick(), context.current_stratum())) -> [0] cross;
+            -> inspect(|x| println!("LHS {} {}", x, context.current_tick())) -> [0] cross;
         joined_second_sg = union()
-            -> inspect(|x| println!("RHS {} {}:{}", x, context.current_tick(), context.current_stratum())) -> [1] cross;
+            -> inspect(|x| println!("RHS {} {}", x, context.current_tick())) -> [1] cross;
         cross = cross_join::<'tick, 'tick, HalfMultisetJoinState>() -> for_each(|x| output_send.send(x).unwrap());
     };
-    println!("A {}:{}", flow.current_tick(), flow.current_stratum());
+    println!("A {}", flow.current_tick());
 
     input_send.send(0).unwrap();
     flow.run_tick_sync();
-    println!("B {}:{}", flow.current_tick(), flow.current_stratum());
+    println!("B {}", flow.current_tick());
     assert!(collect_ready::<Vec<_>, _>(&mut output_recv).is_empty());
 
     input_2_send.send(1).unwrap();
     flow.run_tick_sync();
-    println!("C {}:{}", flow.current_tick(), flow.current_stratum());
+    println!("C {}", flow.current_tick());
     assert_eq!(&[(0, 1)], &*collect_ready::<Vec<_>, _>(&mut output_recv));
 }
 
@@ -190,24 +186,24 @@ pub fn test_persist_single_subgraph() {
     let (input_send, input_recv) = dfir_rs::util::unbounded_channel::<usize>();
     let (input_2_send, input_2_recv) = dfir_rs::util::unbounded_channel::<usize>();
     let (output_send, mut output_recv) = dfir_rs::util::unbounded_channel::<(usize, usize)>();
-    let mut flow = dfir_rs::dfir_syntax! {
+    let mut flow = dfir_rs::dfir_syntax_inline! {
         source_stream(input_2_recv) -> joined_second_sg;
 
         source_stream(input_recv) -> persist::<'static>()
-            -> inspect(|x| println!("LHS {} {}:{}", x, context.current_tick(), context.current_stratum())) -> [0] cross;
-        joined_second_sg = inspect(|x| println!("RHS {} {}:{}", x, context.current_tick(), context.current_stratum())) -> [1] cross;
+            -> inspect(|x| println!("LHS {} {}", x, context.current_tick())) -> [0] cross;
+        joined_second_sg = inspect(|x| println!("RHS {} {}", x, context.current_tick())) -> [1] cross;
         cross = cross_join::<'tick, 'tick, HalfMultisetJoinState>() -> for_each(|x| output_send.send(x).unwrap());
     };
-    println!("A {}:{}", flow.current_tick(), flow.current_stratum());
+    println!("A {}", flow.current_tick());
 
     input_send.send(0).unwrap();
     flow.run_tick_sync();
-    println!("B {}:{}", flow.current_tick(), flow.current_stratum());
+    println!("B {}", flow.current_tick());
     assert!(collect_ready::<Vec<_>, _>(&mut output_recv).is_empty());
 
     input_2_send.send(1).unwrap();
     flow.run_tick_sync();
-    println!("C {}:{}", flow.current_tick(), flow.current_stratum());
+    println!("C {}", flow.current_tick());
     assert_eq!(&[(0, 1)], &*collect_ready::<Vec<_>, _>(&mut output_recv));
 }
 
@@ -216,7 +212,7 @@ pub fn test_persist() {
     let (pull_tx, mut pull_rx) = dfir_rs::util::unbounded_channel::<usize>();
     let (push_tx, mut push_rx) = dfir_rs::util::unbounded_channel::<usize>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
 
         my_tee = source_iter([1, 2, 3])
             -> persist::<'static>() // pull
@@ -229,7 +225,6 @@ pub fn test_persist() {
             -> persist::<'static>() // push
             -> for_each(|v| push_tx.send(v).unwrap());
     };
-    assert_graphvis_snapshots!(df);
     df.run_available_sync();
 
     assert_eq!(&[1, 2, 3], &*collect_ready::<Vec<_>, _>(&mut pull_rx));
@@ -243,7 +238,7 @@ pub fn test_persist_mut() {
     let (pull_tx, mut pull_rx) = dfir_rs::util::unbounded_channel::<usize>();
     let (push_tx, mut push_rx) = dfir_rs::util::unbounded_channel::<usize>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
 
         my_tee = source_iter([Persist(1), Persist(2), Persist(3), Persist(4), Delete(2)])
             -> persist_mut::<'mutable>() // pull
@@ -257,7 +252,6 @@ pub fn test_persist_mut() {
             -> persist_mut::<'mutable>() // push
             -> for_each(|v| push_tx.send(v).unwrap());
     };
-    assert_graphvis_snapshots!(df);
     df.run_available_sync();
 
     assert_eq!(&[1, 3, 4], &*collect_ready::<Vec<_>, _>(&mut pull_rx));
@@ -271,7 +265,7 @@ pub fn test_persist_mut_keyed() {
     let (pull_tx, mut pull_rx) = dfir_rs::util::unbounded_channel::<usize>();
     let (push_tx, mut push_rx) = dfir_rs::util::unbounded_channel::<usize>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
 
         my_tee = source_iter([Persist(1, 1), Persist(2, 2), Persist(3, 3), Persist(4, 4), Delete(2)])
             -> persist_mut_keyed::<'mutable>() // pull
@@ -285,7 +279,6 @@ pub fn test_persist_mut_keyed() {
             -> persist_mut_keyed::<'mutable>() // push
             -> for_each(|(_k, v)| push_tx.send(v).unwrap());
     };
-    assert_graphvis_snapshots!(df);
     df.run_available_sync();
 
     assert_eq!(

--- a/dfir_rs/tests/surface_persist.rs
+++ b/dfir_rs/tests/surface_persist.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
 use dfir_pipes::pull::HalfMultisetJoinState;
+use dfir_rs::assert_graphvis_snapshots;
 use dfir_rs::scheduled::ticks::TickInstant;
 use dfir_rs::util::collect_ready;
 use dfir_rs::dfir_syntax;
@@ -17,6 +18,8 @@ pub fn test_persist_basic() {
             -> fold(|| 0, |a: &mut _, b| *a += b)
             -> for_each(|x| result_send.send(x).unwrap());
     };
+    assert_graphvis_snapshots!(hf);
+
 
     for tick in 0..10 {
         assert_eq!(TickInstant::new(tick), hf.current_tick());
@@ -42,6 +45,8 @@ pub fn test_persist_pull() {
             -> fold(|| 0, |a: &mut _, b| *a += b)
             -> for_each(|x| result_send.send(x).unwrap());
     };
+    assert_graphvis_snapshots!(hf);
+
 
     for tick in 0..10 {
         assert_eq!(TickInstant::new(tick), hf.current_tick());
@@ -64,6 +69,8 @@ pub fn test_persist_push() {
         t1 -> null();
         t1 -> fold(|| 0, |a: &mut _, b| *a += b) -> for_each(|x| result_send.send(x).unwrap());
     };
+    assert_graphvis_snapshots!(hf);
+
 
     for tick in 0..10 {
         assert_eq!(TickInstant::new(tick), hf.current_tick());
@@ -225,6 +232,8 @@ pub fn test_persist() {
             -> persist::<'static>() // push
             -> for_each(|v| push_tx.send(v).unwrap());
     };
+    assert_graphvis_snapshots!(df);
+
     df.run_available_sync();
 
     assert_eq!(&[1, 2, 3], &*collect_ready::<Vec<_>, _>(&mut pull_rx));
@@ -252,6 +261,8 @@ pub fn test_persist_mut() {
             -> persist_mut::<'mutable>() // push
             -> for_each(|v| push_tx.send(v).unwrap());
     };
+    assert_graphvis_snapshots!(df);
+
     df.run_available_sync();
 
     assert_eq!(&[1, 3, 4], &*collect_ready::<Vec<_>, _>(&mut pull_rx));
@@ -279,6 +290,8 @@ pub fn test_persist_mut_keyed() {
             -> persist_mut_keyed::<'mutable>() // push
             -> for_each(|(_k, v)| push_tx.send(v).unwrap());
     };
+    assert_graphvis_snapshots!(df);
+
     df.run_available_sync();
 
     assert_eq!(

--- a/dfir_rs/tests/surface_persist.rs
+++ b/dfir_rs/tests/surface_persist.rs
@@ -1,10 +1,9 @@
 use std::collections::HashSet;
 
 use dfir_pipes::pull::HalfMultisetJoinState;
-use dfir_rs::assert_graphvis_snapshots;
 use dfir_rs::scheduled::ticks::TickInstant;
 use dfir_rs::util::collect_ready;
-use dfir_rs::dfir_syntax;
+use dfir_rs::{assert_graphvis_snapshots, dfir_syntax};
 use multiplatform_test::multiplatform_test;
 
 #[multiplatform_test]
@@ -19,7 +18,6 @@ pub fn test_persist_basic() {
             -> for_each(|x| result_send.send(x).unwrap());
     };
     assert_graphvis_snapshots!(hf);
-
 
     for tick in 0..10 {
         assert_eq!(TickInstant::new(tick), hf.current_tick());
@@ -47,7 +45,6 @@ pub fn test_persist_pull() {
     };
     assert_graphvis_snapshots!(hf);
 
-
     for tick in 0..10 {
         assert_eq!(TickInstant::new(tick), hf.current_tick());
         hf.run_tick_sync();
@@ -70,7 +67,6 @@ pub fn test_persist_push() {
         t1 -> fold(|| 0, |a: &mut _, b| *a += b) -> for_each(|x| result_send.send(x).unwrap());
     };
     assert_graphvis_snapshots!(hf);
-
 
     for tick in 0..10 {
         assert_eq!(TickInstant::new(tick), hf.current_tick());
@@ -113,6 +109,7 @@ pub fn test_persist_replay_join() {
 
         product_node = cross_join::<'tick, 'tick>() -> for_each(|x| result_send.send(x).unwrap());
     };
+    assert_graphvis_snapshots!(hf);
 
     persist_input_send.send(1).unwrap();
     other_input_send.send(2).unwrap();

--- a/dfir_rs/tests/surface_reduce_keyed.rs
+++ b/dfir_rs/tests/surface_reduce_keyed.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeSet;
 
+use dfir_rs::assert_graphvis_snapshots;
 use dfir_rs::scheduled::ticks::TickInstant;
 use dfir_rs::util::collect_ready;
 use multiplatform_test::multiplatform_test;
@@ -24,6 +25,8 @@ pub fn test_reduce_keyed_infer_basic() {
             -> reduce_keyed::<'static>(|old: &mut u32, val: u32| *old += val)
             -> for_each(|kv| result_send.send(kv).unwrap());
     };
+    assert_graphvis_snapshots!(df);
+
     assert_eq!(TickInstant::new(0), df.current_tick());
     df.run_tick_sync();
     assert_eq!(TickInstant::new(1), df.current_tick());
@@ -46,6 +49,8 @@ pub fn test_reduce_keyed_tick() {
             -> reduce_keyed::<'tick>(|old: &mut Vec<u32>, mut x: Vec<u32>| old.append(&mut x))
             -> for_each(|v| result_send.send(v).unwrap());
     };
+    assert_graphvis_snapshots!(df);
+
     assert_eq!(TickInstant::new(0), df.current_tick());
     df.run_tick_sync();
     assert_eq!(TickInstant::new(1), df.current_tick());
@@ -91,6 +96,8 @@ pub fn test_reduce_keyed_static() {
             -> reduce_keyed::<'static>(|old: &mut Vec<u32>, mut x: Vec<u32>| old.append(&mut x))
             -> for_each(|v| result_send.send(v).unwrap());
     };
+    assert_graphvis_snapshots!(df);
+
     assert_eq!(TickInstant::new(0), df.current_tick());
     df.run_tick_sync();
     assert_eq!(TickInstant::new(1), df.current_tick());

--- a/dfir_rs/tests/surface_reduce_keyed.rs
+++ b/dfir_rs/tests/surface_reduce_keyed.rs
@@ -1,6 +1,5 @@
 use std::collections::BTreeSet;
 
-use dfir_rs::assert_graphvis_snapshots;
 use dfir_rs::scheduled::ticks::TickInstant;
 use dfir_rs::util::collect_ready;
 use multiplatform_test::multiplatform_test;
@@ -13,7 +12,7 @@ pub fn test_reduce_keyed_infer_basic() {
     }
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<(&'static str, u32)>();
 
-    let mut df = dfir_rs::dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_iter([
                 SubordResponse { xid: "123", mtype: 33 },
                 SubordResponse { xid: "123", mtype: 52 },
@@ -25,16 +24,9 @@ pub fn test_reduce_keyed_infer_basic() {
             -> reduce_keyed::<'static>(|old: &mut u32, val: u32| *old += val)
             -> for_each(|kv| result_send.send(kv).unwrap());
     };
-    assert_graphvis_snapshots!(df);
-    assert_eq!(
-        (TickInstant::new(0), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(0), df.current_tick());
     df.run_tick_sync();
-    assert_eq!(
-        (TickInstant::new(1), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(1), df.current_tick());
 
     df.run_available_sync(); // Should return quickly and not hang
 
@@ -49,21 +41,14 @@ pub fn test_reduce_keyed_tick() {
     let (items_send, items_recv) = dfir_rs::util::unbounded_channel::<(u32, Vec<u32>)>();
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<(u32, Vec<u32>)>();
 
-    let mut df = dfir_rs::dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_stream(items_recv)
             -> reduce_keyed::<'tick>(|old: &mut Vec<u32>, mut x: Vec<u32>| old.append(&mut x))
             -> for_each(|v| result_send.send(v).unwrap());
     };
-    assert_graphvis_snapshots!(df);
-    assert_eq!(
-        (TickInstant::new(0), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(0), df.current_tick());
     df.run_tick_sync();
-    assert_eq!(
-        (TickInstant::new(1), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(1), df.current_tick());
 
     items_send.send((0, vec![1, 2])).unwrap();
     items_send.send((0, vec![3, 4])).unwrap();
@@ -71,10 +56,7 @@ pub fn test_reduce_keyed_tick() {
     items_send.send((1, vec![1, 2])).unwrap();
     df.run_tick_sync();
 
-    assert_eq!(
-        (TickInstant::new(2), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(2), df.current_tick());
     assert_eq!(
         [(0, vec![1, 2, 3, 4]), (1, vec![1, 1, 2])]
             .into_iter()
@@ -88,10 +70,7 @@ pub fn test_reduce_keyed_tick() {
     items_send.send((1, vec![11, 12])).unwrap();
     df.run_tick_sync();
 
-    assert_eq!(
-        (TickInstant::new(3), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(3), df.current_tick());
     assert_eq!(
         [(0, vec![5, 6, 7, 8]), (1, vec![10, 11, 12])]
             .into_iter()
@@ -107,21 +86,14 @@ pub fn test_reduce_keyed_static() {
     let (items_send, items_recv) = dfir_rs::util::unbounded_channel::<(u32, Vec<u32>)>();
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<(u32, Vec<u32>)>();
 
-    let mut df = dfir_rs::dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_stream(items_recv)
             -> reduce_keyed::<'static>(|old: &mut Vec<u32>, mut x: Vec<u32>| old.append(&mut x))
             -> for_each(|v| result_send.send(v).unwrap());
     };
-    assert_graphvis_snapshots!(df);
-    assert_eq!(
-        (TickInstant::new(0), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(0), df.current_tick());
     df.run_tick_sync();
-    assert_eq!(
-        (TickInstant::new(1), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(1), df.current_tick());
 
     items_send.send((0, vec![1, 2])).unwrap();
     items_send.send((0, vec![3, 4])).unwrap();
@@ -129,10 +101,7 @@ pub fn test_reduce_keyed_static() {
     items_send.send((1, vec![1, 2])).unwrap();
     df.run_tick_sync();
 
-    assert_eq!(
-        (TickInstant::new(2), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(2), df.current_tick());
     assert_eq!(
         [(0, vec![1, 2, 3, 4]), (1, vec![1, 1, 2])]
             .into_iter()
@@ -146,10 +115,7 @@ pub fn test_reduce_keyed_static() {
     items_send.send((1, vec![11, 12])).unwrap();
     df.run_tick_sync();
 
-    assert_eq!(
-        (TickInstant::new(3), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(3), df.current_tick());
     assert_eq!(
         [
             (0, vec![1, 2, 3, 4, 5, 6, 7, 8]),

--- a/dfir_rs/tests/surface_scan.rs
+++ b/dfir_rs/tests/surface_scan.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use dfir_rs::assert_graphvis_snapshots;
 use dfir_rs::scheduled::ticks::TickInstant;
 use dfir_rs::util::collect_ready;
 use multiplatform_test::multiplatform_test;
@@ -13,7 +12,7 @@ pub fn test_scan_tick() {
     let (items_send, items_recv) = dfir_rs::util::unbounded_channel::<u32>();
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u32>();
 
-    let mut df = dfir_rs::dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_stream(items_recv)
             -> scan::<'tick>(|| 0, |acc: &mut u32, x: u32| {
                 *acc += x;
@@ -21,22 +20,15 @@ pub fn test_scan_tick() {
             })
             -> for_each(|v| result_send.send(v).unwrap());
     };
-    assert_graphvis_snapshots!(df);
 
-    assert_eq!(
-        (TickInstant::new(0), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(0), df.current_tick());
 
     // First tick with values 1, 2
     items_send.send(1).unwrap();
     items_send.send(2).unwrap();
     df.run_tick_sync();
 
-    assert_eq!(
-        (TickInstant::new(1), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(1), df.current_tick());
 
     // Should receive running sums: 1, 3
     assert_eq!(&[1, 3], &*collect_ready::<Vec<_>, _>(&mut result_recv));
@@ -46,10 +38,7 @@ pub fn test_scan_tick() {
     items_send.send(4).unwrap();
     df.run_tick_sync();
 
-    assert_eq!(
-        (TickInstant::new(2), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(2), df.current_tick());
 
     // With 'tick' persistence, accumulator resets each tick
     // So we should get: 3, 7 (not 6, 10)
@@ -64,7 +53,7 @@ pub fn test_scan_static() {
     let (items_send, items_recv) = dfir_rs::util::unbounded_channel::<u32>();
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u32>();
 
-    let mut df = dfir_rs::dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_stream(items_recv)
             -> scan::<'static>(|| 0, |acc: &mut u32, x: u32| {
                 *acc += x;
@@ -72,22 +61,15 @@ pub fn test_scan_static() {
             })
             -> for_each(|v| result_send.send(v).unwrap());
     };
-    assert_graphvis_snapshots!(df);
 
-    assert_eq!(
-        (TickInstant::new(0), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(0), df.current_tick());
 
     // First tick with values 1, 2
     items_send.send(1).unwrap();
     items_send.send(2).unwrap();
     df.run_tick_sync();
 
-    assert_eq!(
-        (TickInstant::new(1), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(1), df.current_tick());
 
     // Should receive running sums: 1, 3
     assert_eq!(&[1, 3], &*collect_ready::<Vec<_>, _>(&mut result_recv));
@@ -97,10 +79,7 @@ pub fn test_scan_static() {
     items_send.send(4).unwrap();
     df.run_tick_sync();
 
-    assert_eq!(
-        (TickInstant::new(2), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(2), df.current_tick());
 
     // With 'static' persistence, accumulator persists across ticks
     // So we should get: 6, 10 (continuing from previous sum of 3)
@@ -117,7 +96,7 @@ pub fn test_scan_empty_input() {
     let (_items_send, items_recv) = dfir_rs::util::unbounded_channel::<u32>();
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u32>();
 
-    let mut df = dfir_rs::dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_stream(items_recv)
             -> scan::<'tick>(|| 0, |acc: &mut u32, x: u32| {
                 *acc += x;
@@ -144,7 +123,7 @@ pub fn test_scan_different_types() {
     let (items_send, items_recv) = dfir_rs::util::unbounded_channel::<String>();
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<(usize, String)>();
 
-    let mut df = dfir_rs::dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_stream(items_recv)
             -> scan::<'tick>(|| (0, String::new()), |acc: &mut (usize, String), x: String| {
                 // Accumulator is a tuple of (count, concatenated_string)
@@ -179,7 +158,7 @@ pub fn test_scan_early_termination() {
     let (items_send, items_recv) = dfir_rs::util::unbounded_channel::<u32>();
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u32>();
 
-    let mut df = dfir_rs::dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_stream(items_recv)
             -> scan::<'tick>(|| 0, |acc: &mut u32, x: u32| {
                 *acc += x;
@@ -221,7 +200,7 @@ pub fn test_scan_static_early_termination() {
     let (items_send, items_recv) = dfir_rs::util::unbounded_channel::<u32>();
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u32>();
 
-    let mut df = dfir_rs::dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_stream(items_recv)
             -> scan::<'static>(|| 0, |acc: &mut u32, x: u32| {
                 *acc += x;
@@ -266,7 +245,7 @@ pub fn test_scan_complex_accumulator() {
     let (items_send, items_recv) = dfir_rs::util::unbounded_channel::<(String, u32)>();
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<HashMap<String, u32>>();
 
-    let mut df = dfir_rs::dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_stream(items_recv)
             -> scan::<'tick>(HashMap::<String, u32>::new, |acc: &mut HashMap<String, u32>, item: (String, u32)| {
                 // Update frequency count for each key
@@ -314,7 +293,7 @@ pub fn test_scan_push() {
     let (items_send, items_recv) = dfir_rs::util::unbounded_channel::<u32>();
     let (result_send, mut result_recv) = dfir_rs::util::unbounded_channel::<u32>();
 
-    let mut df = dfir_rs::dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         teed = source_stream(items_recv) -> tee();
         teed -> for_each(|_| {}); // Dummy consumer to force push
         teed
@@ -324,22 +303,15 @@ pub fn test_scan_push() {
             })
             -> for_each(|v| result_send.send(v).unwrap());
     };
-    assert_graphvis_snapshots!(df);
 
-    assert_eq!(
-        (TickInstant::new(0), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(0), df.current_tick());
 
     // First tick with values 1, 2
     items_send.send(1).unwrap();
     items_send.send(2).unwrap();
     df.run_tick_sync();
 
-    assert_eq!(
-        (TickInstant::new(1), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(1), df.current_tick());
 
     // Should receive running sums: 1, 3
     assert_eq!(&[1, 3], &*collect_ready::<Vec<_>, _>(&mut result_recv));
@@ -349,10 +321,7 @@ pub fn test_scan_push() {
     items_send.send(4).unwrap();
     df.run_tick_sync();
 
-    assert_eq!(
-        (TickInstant::new(2), 0),
-        (df.current_tick(), df.current_stratum())
-    );
+    assert_eq!(TickInstant::new(2), df.current_tick());
 
     // With 'tick' persistence, accumulator resets each tick
     // So we should get: 3, 7 (not 6, 10)

--- a/dfir_rs/tests/surface_scan.rs
+++ b/dfir_rs/tests/surface_scan.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use dfir_rs::assert_graphvis_snapshots;
 use dfir_rs::scheduled::ticks::TickInstant;
 use dfir_rs::util::collect_ready;
 use multiplatform_test::multiplatform_test;
@@ -20,6 +21,8 @@ pub fn test_scan_tick() {
             })
             -> for_each(|v| result_send.send(v).unwrap());
     };
+    assert_graphvis_snapshots!(df);
+
 
     assert_eq!(TickInstant::new(0), df.current_tick());
 
@@ -61,6 +64,8 @@ pub fn test_scan_static() {
             })
             -> for_each(|v| result_send.send(v).unwrap());
     };
+    assert_graphvis_snapshots!(df);
+
 
     assert_eq!(TickInstant::new(0), df.current_tick());
 
@@ -303,6 +308,8 @@ pub fn test_scan_push() {
             })
             -> for_each(|v| result_send.send(v).unwrap());
     };
+    assert_graphvis_snapshots!(df);
+
 
     assert_eq!(TickInstant::new(0), df.current_tick());
 

--- a/dfir_rs/tests/surface_scan.rs
+++ b/dfir_rs/tests/surface_scan.rs
@@ -23,7 +23,6 @@ pub fn test_scan_tick() {
     };
     assert_graphvis_snapshots!(df);
 
-
     assert_eq!(TickInstant::new(0), df.current_tick());
 
     // First tick with values 1, 2
@@ -65,7 +64,6 @@ pub fn test_scan_static() {
             -> for_each(|v| result_send.send(v).unwrap());
     };
     assert_graphvis_snapshots!(df);
-
 
     assert_eq!(TickInstant::new(0), df.current_tick());
 
@@ -309,7 +307,6 @@ pub fn test_scan_push() {
             -> for_each(|v| result_send.send(v).unwrap());
     };
     assert_graphvis_snapshots!(df);
-
 
     assert_eq!(TickInstant::new(0), df.current_tick());
 

--- a/dfir_rs/tests/surface_singleton.rs
+++ b/dfir_rs/tests/surface_singleton.rs
@@ -1,4 +1,3 @@
-
 use dfir_rs::scheduled::ticks::TickInstant;
 use dfir_rs::util::collect_ready;
 use lattices::Max;
@@ -28,7 +27,6 @@ pub fn test_state() {
             -> map(|x| (context.current_tick(), x.into_reveal()))
             -> for_each(|x| max_send.send(x).unwrap());
     };
-
 
     df.run_available_sync();
 
@@ -73,7 +71,6 @@ pub fn test_state_unused() {
         stream2 = source_iter(15..=25) -> map(Max::new);
         max_of_stream2 = stream2 -> state::<'static, Max<_>>();
     };
-
 
     df.run_available_sync();
 }
@@ -140,7 +137,6 @@ pub fn test_fold_cross() {
             -> for_each(|x| max_send.send(x).unwrap());
     };
 
-
     df.run_available_sync();
 
     assert_eq!(
@@ -182,7 +178,6 @@ pub fn test_fold_singleton() {
             -> for_each(|x| max_send.send(x).unwrap());
     };
 
-
     df.run_available_sync();
 
     assert_eq!(
@@ -219,7 +214,6 @@ pub fn test_fold_singleton_push() {
             -> map(|x| (context.current_tick(), x))
             -> for_each(|x| filter_send.send(x).unwrap());
     };
-
 
     df.run_available_sync();
 
@@ -259,7 +253,6 @@ pub fn test_reduce_singleton() {
             -> for_each(|x| max_send.send(x).unwrap());
     };
 
-
     df.run_available_sync();
 
     assert_eq!(
@@ -296,7 +289,6 @@ pub fn test_reduce_singleton_push() {
             -> map(|x| (context.current_tick(), x))
             -> for_each(|x| filter_send.send(x).unwrap());
     };
-
 
     df.run_available_sync();
 
@@ -380,7 +372,6 @@ pub fn test_multi_tick() {
             -> map(|x| (context.current_tick(), x.into_reveal()))
             -> for_each(|x| max_send.send(x).unwrap());
     };
-
 
     df.run_available_sync();
     assert_eq!(

--- a/dfir_rs/tests/surface_singleton.rs
+++ b/dfir_rs/tests/surface_singleton.rs
@@ -1,4 +1,4 @@
-use dfir_rs::assert_graphvis_snapshots;
+
 use dfir_rs::scheduled::ticks::TickInstant;
 use dfir_rs::util::collect_ready;
 use lattices::Max;
@@ -9,7 +9,7 @@ pub fn test_state() {
     let (filter_send, mut filter_recv) = dfir_rs::util::unbounded_channel::<(TickInstant, usize)>();
     let (max_send, mut max_recv) = dfir_rs::util::unbounded_channel::<(TickInstant, usize)>();
 
-    let mut df = dfir_rs::dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         stream1 = source_iter(1..=10);
         stream2 = source_iter(3..=5) -> map(Max::new);
         max_of_stream2 = stream2 -> state::<'static, Max<_>>();
@@ -29,7 +29,6 @@ pub fn test_state() {
             -> for_each(|x| max_send.send(x).unwrap());
     };
 
-    assert_graphvis_snapshots!(df);
 
     df.run_available_sync();
 
@@ -70,12 +69,11 @@ pub fn test_state() {
 /// Just tests that the codegen is valid.
 #[multiplatform_test]
 pub fn test_state_unused() {
-    let mut df = dfir_rs::dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         stream2 = source_iter(15..=25) -> map(Max::new);
         max_of_stream2 = stream2 -> state::<'static, Max<_>>();
     };
 
-    assert_graphvis_snapshots!(df);
 
     df.run_available_sync();
 }
@@ -85,7 +83,7 @@ pub fn test_state_unused() {
 pub fn test_state_tick() {
     let (input_send, input_recv) = dfir_rs::util::unbounded_channel::<usize>();
     let (max_send, mut max_recv) = dfir_rs::util::unbounded_channel::<(TickInstant, usize)>();
-    let mut df = dfir_rs::dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         stream2 = source_stream(input_recv) -> map(Max::new);
         max_of_stream2 = stream2 -> state::<'tick, Max<_>>();
 
@@ -119,7 +117,7 @@ pub fn test_fold_cross() {
     let (filter_send, mut filter_recv) = dfir_rs::util::unbounded_channel::<(TickInstant, usize)>();
     let (max_send, mut max_recv) = dfir_rs::util::unbounded_channel::<(TickInstant, usize)>();
 
-    let mut df = dfir_rs::dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         stream1 = source_iter(1..=10);
         stream2 = source_iter(3..=5) -> map(Max::new);
         max_of_stream2 = stream2 -> lattice_reduce() -> tee();
@@ -142,7 +140,6 @@ pub fn test_fold_cross() {
             -> for_each(|x| max_send.send(x).unwrap());
     };
 
-    assert_graphvis_snapshots!(df);
 
     df.run_available_sync();
 
@@ -167,7 +164,7 @@ pub fn test_fold_singleton() {
     let (filter_send, mut filter_recv) = dfir_rs::util::unbounded_channel::<(TickInstant, usize)>();
     let (max_send, mut max_recv) = dfir_rs::util::unbounded_channel::<(TickInstant, usize)>();
 
-    let mut df = dfir_rs::dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         stream1 = source_iter(1..=10);
         stream2 = source_iter(3..=5);
         max_of_stream2 = stream2 -> fold(|| 0, |a, b| *a = std::cmp::max(*a, b));
@@ -185,7 +182,6 @@ pub fn test_fold_singleton() {
             -> for_each(|x| max_send.send(x).unwrap());
     };
 
-    assert_graphvis_snapshots!(df);
 
     df.run_available_sync();
 
@@ -209,7 +205,7 @@ pub fn test_fold_singleton() {
 pub fn test_fold_singleton_push() {
     let (filter_send, mut filter_recv) = dfir_rs::util::unbounded_channel::<(TickInstant, usize)>();
 
-    let mut df = dfir_rs::dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         stream1 = source_iter(1..=10);
         stream2 = source_iter(3..=5);
         max_of_stream2 = stream2 -> fold(|| 0, |a, b| *a = std::cmp::max(*a, b));
@@ -224,7 +220,6 @@ pub fn test_fold_singleton_push() {
             -> for_each(|x| filter_send.send(x).unwrap());
     };
 
-    assert_graphvis_snapshots!(df);
 
     df.run_available_sync();
 
@@ -245,7 +240,7 @@ pub fn test_reduce_singleton() {
     let (filter_send, mut filter_recv) = dfir_rs::util::unbounded_channel::<(TickInstant, usize)>();
     let (max_send, mut max_recv) = dfir_rs::util::unbounded_channel::<(TickInstant, usize)>();
 
-    let mut df = dfir_rs::dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         stream1 = source_iter(1..=10);
         stream2 = source_iter(3..=5);
         max_of_stream2 = stream2 -> reduce(|a, b| *a = std::cmp::max(*a, b));
@@ -264,7 +259,6 @@ pub fn test_reduce_singleton() {
             -> for_each(|x| max_send.send(x).unwrap());
     };
 
-    assert_graphvis_snapshots!(df);
 
     df.run_available_sync();
 
@@ -288,7 +282,7 @@ pub fn test_reduce_singleton() {
 pub fn test_reduce_singleton_push() {
     let (filter_send, mut filter_recv) = dfir_rs::util::unbounded_channel::<(TickInstant, usize)>();
 
-    let mut df = dfir_rs::dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         stream1 = source_iter(1..=10);
         stream2 = source_iter(3..=5);
         max_of_stream2 = stream2 -> reduce(|a, b| *a = std::cmp::max(*a, b));
@@ -303,7 +297,6 @@ pub fn test_reduce_singleton_push() {
             -> for_each(|x| filter_send.send(x).unwrap());
     };
 
-    assert_graphvis_snapshots!(df);
 
     df.run_available_sync();
 
@@ -324,7 +317,7 @@ pub fn test_scheduling() {
     let (inn_send, inn_recv) = dfir_rs::util::unbounded_channel::<usize>();
     let (out_send, mut out_recv) = dfir_rs::util::unbounded_channel::<(TickInstant, usize)>();
 
-    let mut df = dfir_rs::dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         stream1 = source_iter(1..=10);
         stream2 = source_stream(inn_recv);
         max_of_stream2 = stream2 -> fold(|| 0, |a, b| *a = std::cmp::max(*a, b));
@@ -369,7 +362,7 @@ pub fn test_multi_tick() {
     let (filter_send, mut filter_recv) = dfir_rs::util::unbounded_channel::<(TickInstant, usize)>();
     let (max_send, mut max_recv) = dfir_rs::util::unbounded_channel::<(TickInstant, usize)>();
 
-    let mut df = dfir_rs::dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         stream1 = source_iter(1..=10);
         stream2 = source_iter(3..=5) -> map(Max::new);
         max_of_stream2 = stream2 -> state::<'static, Max<_>>();
@@ -388,7 +381,6 @@ pub fn test_multi_tick() {
             -> for_each(|x| max_send.send(x).unwrap());
     };
 
-    assert_graphvis_snapshots!(df);
 
     df.run_available_sync();
     assert_eq!(

--- a/dfir_rs/tests/surface_singleton.rs
+++ b/dfir_rs/tests/surface_singleton.rs
@@ -1,3 +1,4 @@
+use dfir_rs::assert_graphvis_snapshots;
 use dfir_rs::scheduled::ticks::TickInstant;
 use dfir_rs::util::collect_ready;
 use lattices::Max;
@@ -27,6 +28,8 @@ pub fn test_state() {
             -> map(|x| (context.current_tick(), x.into_reveal()))
             -> for_each(|x| max_send.send(x).unwrap());
     };
+    assert_graphvis_snapshots!(df);
+
 
     df.run_available_sync();
 
@@ -71,6 +74,8 @@ pub fn test_state_unused() {
         stream2 = source_iter(15..=25) -> map(Max::new);
         max_of_stream2 = stream2 -> state::<'static, Max<_>>();
     };
+    assert_graphvis_snapshots!(df);
+
 
     df.run_available_sync();
 }
@@ -136,6 +141,8 @@ pub fn test_fold_cross() {
             -> map(|x: Max<_>| (context.current_tick(), x.into_reveal()))
             -> for_each(|x| max_send.send(x).unwrap());
     };
+    assert_graphvis_snapshots!(df);
+
 
     df.run_available_sync();
 
@@ -177,6 +184,8 @@ pub fn test_fold_singleton() {
             -> map(|x| (context.current_tick(), x))
             -> for_each(|x| max_send.send(x).unwrap());
     };
+    assert_graphvis_snapshots!(df);
+
 
     df.run_available_sync();
 
@@ -214,6 +223,8 @@ pub fn test_fold_singleton_push() {
             -> map(|x| (context.current_tick(), x))
             -> for_each(|x| filter_send.send(x).unwrap());
     };
+    assert_graphvis_snapshots!(df);
+
 
     df.run_available_sync();
 
@@ -252,6 +263,8 @@ pub fn test_reduce_singleton() {
             -> map(|x| (context.current_tick(), x))
             -> for_each(|x| max_send.send(x).unwrap());
     };
+    assert_graphvis_snapshots!(df);
+
 
     df.run_available_sync();
 
@@ -289,6 +302,8 @@ pub fn test_reduce_singleton_push() {
             -> map(|x| (context.current_tick(), x))
             -> for_each(|x| filter_send.send(x).unwrap());
     };
+    assert_graphvis_snapshots!(df);
+
 
     df.run_available_sync();
 
@@ -372,6 +387,8 @@ pub fn test_multi_tick() {
             -> map(|x| (context.current_tick(), x.into_reveal()))
             -> for_each(|x| max_send.send(x).unwrap());
     };
+    assert_graphvis_snapshots!(df);
+
 
     df.run_available_sync();
     assert_eq!(

--- a/dfir_rs/tests/surface_singleton.rs
+++ b/dfir_rs/tests/surface_singleton.rs
@@ -30,7 +30,6 @@ pub fn test_state() {
     };
     assert_graphvis_snapshots!(df);
 
-
     df.run_available_sync();
 
     assert_eq!(
@@ -75,7 +74,6 @@ pub fn test_state_unused() {
         max_of_stream2 = stream2 -> state::<'static, Max<_>>();
     };
     assert_graphvis_snapshots!(df);
-
 
     df.run_available_sync();
 }
@@ -143,7 +141,6 @@ pub fn test_fold_cross() {
     };
     assert_graphvis_snapshots!(df);
 
-
     df.run_available_sync();
 
     assert_eq!(
@@ -186,7 +183,6 @@ pub fn test_fold_singleton() {
     };
     assert_graphvis_snapshots!(df);
 
-
     df.run_available_sync();
 
     assert_eq!(
@@ -224,7 +220,6 @@ pub fn test_fold_singleton_push() {
             -> for_each(|x| filter_send.send(x).unwrap());
     };
     assert_graphvis_snapshots!(df);
-
 
     df.run_available_sync();
 
@@ -265,7 +260,6 @@ pub fn test_reduce_singleton() {
     };
     assert_graphvis_snapshots!(df);
 
-
     df.run_available_sync();
 
     assert_eq!(
@@ -303,7 +297,6 @@ pub fn test_reduce_singleton_push() {
             -> for_each(|x| filter_send.send(x).unwrap());
     };
     assert_graphvis_snapshots!(df);
-
 
     df.run_available_sync();
 
@@ -388,7 +381,6 @@ pub fn test_multi_tick() {
             -> for_each(|x| max_send.send(x).unwrap());
     };
     assert_graphvis_snapshots!(df);
-
 
     df.run_available_sync();
     assert_eq!(

--- a/dfir_rs/tests/surface_state_scheduling.rs
+++ b/dfir_rs/tests/surface_state_scheduling.rs
@@ -10,25 +10,13 @@ pub fn test_repeat_iter() {
     let mut df = dfir_syntax_inline! {
         source_iter([1]) -> persist::<'static>() -> for_each(|v| out_send.send(v).unwrap());
     };
-    assert_eq!(
-        TickInstant::new(0),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(0), df.current_tick());
     df.run_tick_sync();
-    assert_eq!(
-        TickInstant::new(1),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(1), df.current_tick());
     df.run_tick_sync();
-    assert_eq!(
-        TickInstant::new(2),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(2), df.current_tick());
     df.run_tick_sync();
-    assert_eq!(
-        TickInstant::new(3),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(3), df.current_tick());
 
     assert_eq!(&[1, 1, 1], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 
@@ -42,25 +30,13 @@ pub fn test_fold_tick() {
     let mut df = dfir_syntax_inline! {
         source_iter([1]) -> fold::<'tick>(|| 0, |accum: &mut _, elem| *accum += elem) -> for_each(|v| out_send.send(v).unwrap());
     };
-    assert_eq!(
-        TickInstant::new(0),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(0), df.current_tick());
     df.run_tick_sync();
-    assert_eq!(
-        TickInstant::new(1),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(1), df.current_tick());
     df.run_tick_sync();
-    assert_eq!(
-        TickInstant::new(2),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(2), df.current_tick());
     df.run_tick_sync();
-    assert_eq!(
-        TickInstant::new(3),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(3), df.current_tick());
 
     assert_eq!(&[1, 0, 0], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 
@@ -74,25 +50,13 @@ pub fn test_fold_static() {
     let mut df = dfir_syntax_inline! {
         source_iter([1]) -> fold::<'static>(|| 0, |accum: &mut _, elem| *accum += elem) -> for_each(|v| out_send.send(v).unwrap());
     };
-    assert_eq!(
-        TickInstant::new(0),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(0), df.current_tick());
     df.run_tick_sync();
-    assert_eq!(
-        TickInstant::new(1),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(1), df.current_tick());
     df.run_tick_sync();
-    assert_eq!(
-        TickInstant::new(2),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(2), df.current_tick());
     df.run_tick_sync();
-    assert_eq!(
-        TickInstant::new(3),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(3), df.current_tick());
 
     assert_eq!(&[1, 1, 1], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 
@@ -106,25 +70,13 @@ pub fn test_reduce_tick() {
     let mut df = dfir_syntax_inline! {
         source_iter([1]) -> reduce::<'tick>(|a: &mut _, b| *a += b) -> for_each(|v| out_send.send(v).unwrap());
     };
-    assert_eq!(
-        TickInstant::new(0),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(0), df.current_tick());
     df.run_tick_sync();
-    assert_eq!(
-        TickInstant::new(1),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(1), df.current_tick());
     df.run_tick_sync();
-    assert_eq!(
-        TickInstant::new(2),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(2), df.current_tick());
     df.run_tick_sync();
-    assert_eq!(
-        TickInstant::new(3),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(3), df.current_tick());
 
     assert_eq!(&[1], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 
@@ -138,25 +90,13 @@ pub fn test_reduce_static() {
     let mut df = dfir_syntax_inline! {
         source_iter([1]) -> reduce::<'static>(|a: &mut _, b| *a += b) -> for_each(|v| out_send.send(v).unwrap());
     };
-    assert_eq!(
-        TickInstant::new(0),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(0), df.current_tick());
     df.run_tick_sync();
-    assert_eq!(
-        TickInstant::new(1),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(1), df.current_tick());
     df.run_tick_sync();
-    assert_eq!(
-        TickInstant::new(2),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(2), df.current_tick());
     df.run_tick_sync();
-    assert_eq!(
-        TickInstant::new(3),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(3), df.current_tick());
 
     assert_eq!(&[1, 1, 1], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 
@@ -170,25 +110,13 @@ pub fn test_fold_keyed_tick() {
     let mut df = dfir_syntax_inline! {
         source_iter([('a', 1), ('a', 2)]) -> fold_keyed::<'tick>(|| 0, |acc: &mut usize, item| { *acc += item; }) -> for_each(|v| out_send.send(v).unwrap());
     };
-    assert_eq!(
-        TickInstant::new(0),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(0), df.current_tick());
     df.run_tick_sync();
-    assert_eq!(
-        TickInstant::new(1),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(1), df.current_tick());
     df.run_tick_sync();
-    assert_eq!(
-        TickInstant::new(2),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(2), df.current_tick());
     df.run_tick_sync();
-    assert_eq!(
-        TickInstant::new(3),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(3), df.current_tick());
 
     assert_eq!(&[('a', 3)], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 
@@ -202,25 +130,13 @@ pub fn test_fold_keyed_static() {
     let mut df = dfir_syntax_inline! {
         source_iter([('a', 1), ('a', 2)]) -> fold_keyed::<'static>(|| 0, |acc: &mut usize, item| { *acc += item; }) -> for_each(|v| out_send.send(v).unwrap());
     };
-    assert_eq!(
-        TickInstant::new(0),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(0), df.current_tick());
     df.run_tick_sync();
-    assert_eq!(
-        TickInstant::new(1),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(1), df.current_tick());
     df.run_tick_sync();
-    assert_eq!(
-        TickInstant::new(2),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(2), df.current_tick());
     df.run_tick_sync();
-    assert_eq!(
-        TickInstant::new(3),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(3), df.current_tick());
 
     assert_eq!(
         &[('a', 3), ('a', 3), ('a', 3)],
@@ -241,60 +157,36 @@ pub fn test_resume_external_event() {
         source_stream(in_recv) -> fold::<'static>(|| 0, |a: &mut _, b| *a += b) -> for_each(|v| out_send.send(v).unwrap());
     };
 
-    assert_eq!(
-        TickInstant::new(0),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(0), df.current_tick());
     assert_eq!(&[] as &[usize], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 
     df.run_tick_sync();
-    assert_eq!(
-        TickInstant::new(1),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(1), df.current_tick());
     assert_eq!(&[0], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 
     df.run_tick_sync();
-    assert_eq!(
-        TickInstant::new(2),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(2), df.current_tick());
     assert_eq!(&[0], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 
     df.run_tick_sync();
-    assert_eq!(
-        TickInstant::new(3),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(3), df.current_tick());
     assert_eq!(&[0], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 
     df.run_available_sync();
-    assert_eq!(
-        TickInstant::new(4),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(4), df.current_tick());
     assert_eq!(&[0], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 
     in_send.send(1).unwrap();
     df.run_tick_sync();
-    assert_eq!(
-        TickInstant::new(5),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(5), df.current_tick());
     assert_eq!(&[1], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 
     in_send.send(2).unwrap();
     df.run_available_sync();
-    assert_eq!(
-        TickInstant::new(6),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(6), df.current_tick());
     assert_eq!(&[3], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 
     df.run_available_sync();
-    assert_eq!(
-        TickInstant::new(7),
-        df.current_tick()
-    );
+    assert_eq!(TickInstant::new(7), df.current_tick());
     assert_eq!(&[3], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 }

--- a/dfir_rs/tests/surface_state_scheduling.rs
+++ b/dfir_rs/tests/surface_state_scheduling.rs
@@ -1,4 +1,4 @@
-use dfir_rs::dfir_syntax;
+use dfir_rs::dfir_syntax_inline;
 use dfir_rs::scheduled::ticks::TickInstant;
 use dfir_rs::util::collect_ready;
 use multiplatform_test::multiplatform_test;
@@ -7,27 +7,27 @@ use multiplatform_test::multiplatform_test;
 pub fn test_repeat_iter() {
     let (out_send, mut out_recv) = dfir_rs::util::unbounded_channel::<usize>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter([1]) -> persist::<'static>() -> for_each(|v| out_send.send(v).unwrap());
     };
     assert_eq!(
-        (TickInstant::new(0), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(0),
+        df.current_tick()
     );
     df.run_tick_sync();
     assert_eq!(
-        (TickInstant::new(1), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(1),
+        df.current_tick()
     );
     df.run_tick_sync();
     assert_eq!(
-        (TickInstant::new(2), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(2),
+        df.current_tick()
     );
     df.run_tick_sync();
     assert_eq!(
-        (TickInstant::new(3), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(3),
+        df.current_tick()
     );
 
     assert_eq!(&[1, 1, 1], &*collect_ready::<Vec<_>, _>(&mut out_recv));
@@ -39,27 +39,27 @@ pub fn test_repeat_iter() {
 pub fn test_fold_tick() {
     let (out_send, mut out_recv) = dfir_rs::util::unbounded_channel::<usize>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter([1]) -> fold::<'tick>(|| 0, |accum: &mut _, elem| *accum += elem) -> for_each(|v| out_send.send(v).unwrap());
     };
     assert_eq!(
-        (TickInstant::new(0), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(0),
+        df.current_tick()
     );
     df.run_tick_sync();
     assert_eq!(
-        (TickInstant::new(1), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(1),
+        df.current_tick()
     );
     df.run_tick_sync();
     assert_eq!(
-        (TickInstant::new(2), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(2),
+        df.current_tick()
     );
     df.run_tick_sync();
     assert_eq!(
-        (TickInstant::new(3), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(3),
+        df.current_tick()
     );
 
     assert_eq!(&[1, 0, 0], &*collect_ready::<Vec<_>, _>(&mut out_recv));
@@ -71,27 +71,27 @@ pub fn test_fold_tick() {
 pub fn test_fold_static() {
     let (out_send, mut out_recv) = dfir_rs::util::unbounded_channel::<usize>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter([1]) -> fold::<'static>(|| 0, |accum: &mut _, elem| *accum += elem) -> for_each(|v| out_send.send(v).unwrap());
     };
     assert_eq!(
-        (TickInstant::new(0), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(0),
+        df.current_tick()
     );
     df.run_tick_sync();
     assert_eq!(
-        (TickInstant::new(1), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(1),
+        df.current_tick()
     );
     df.run_tick_sync();
     assert_eq!(
-        (TickInstant::new(2), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(2),
+        df.current_tick()
     );
     df.run_tick_sync();
     assert_eq!(
-        (TickInstant::new(3), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(3),
+        df.current_tick()
     );
 
     assert_eq!(&[1, 1, 1], &*collect_ready::<Vec<_>, _>(&mut out_recv));
@@ -103,27 +103,27 @@ pub fn test_fold_static() {
 pub fn test_reduce_tick() {
     let (out_send, mut out_recv) = dfir_rs::util::unbounded_channel::<usize>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter([1]) -> reduce::<'tick>(|a: &mut _, b| *a += b) -> for_each(|v| out_send.send(v).unwrap());
     };
     assert_eq!(
-        (TickInstant::new(0), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(0),
+        df.current_tick()
     );
     df.run_tick_sync();
     assert_eq!(
-        (TickInstant::new(1), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(1),
+        df.current_tick()
     );
     df.run_tick_sync();
     assert_eq!(
-        (TickInstant::new(2), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(2),
+        df.current_tick()
     );
     df.run_tick_sync();
     assert_eq!(
-        (TickInstant::new(3), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(3),
+        df.current_tick()
     );
 
     assert_eq!(&[1], &*collect_ready::<Vec<_>, _>(&mut out_recv));
@@ -135,27 +135,27 @@ pub fn test_reduce_tick() {
 pub fn test_reduce_static() {
     let (out_send, mut out_recv) = dfir_rs::util::unbounded_channel::<usize>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter([1]) -> reduce::<'static>(|a: &mut _, b| *a += b) -> for_each(|v| out_send.send(v).unwrap());
     };
     assert_eq!(
-        (TickInstant::new(0), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(0),
+        df.current_tick()
     );
     df.run_tick_sync();
     assert_eq!(
-        (TickInstant::new(1), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(1),
+        df.current_tick()
     );
     df.run_tick_sync();
     assert_eq!(
-        (TickInstant::new(2), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(2),
+        df.current_tick()
     );
     df.run_tick_sync();
     assert_eq!(
-        (TickInstant::new(3), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(3),
+        df.current_tick()
     );
 
     assert_eq!(&[1, 1, 1], &*collect_ready::<Vec<_>, _>(&mut out_recv));
@@ -167,27 +167,27 @@ pub fn test_reduce_static() {
 pub fn test_fold_keyed_tick() {
     let (out_send, mut out_recv) = dfir_rs::util::unbounded_channel::<(char, usize)>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter([('a', 1), ('a', 2)]) -> fold_keyed::<'tick>(|| 0, |acc: &mut usize, item| { *acc += item; }) -> for_each(|v| out_send.send(v).unwrap());
     };
     assert_eq!(
-        (TickInstant::new(0), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(0),
+        df.current_tick()
     );
     df.run_tick_sync();
     assert_eq!(
-        (TickInstant::new(1), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(1),
+        df.current_tick()
     );
     df.run_tick_sync();
     assert_eq!(
-        (TickInstant::new(2), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(2),
+        df.current_tick()
     );
     df.run_tick_sync();
     assert_eq!(
-        (TickInstant::new(3), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(3),
+        df.current_tick()
     );
 
     assert_eq!(&[('a', 3)], &*collect_ready::<Vec<_>, _>(&mut out_recv));
@@ -199,27 +199,27 @@ pub fn test_fold_keyed_tick() {
 pub fn test_fold_keyed_static() {
     let (out_send, mut out_recv) = dfir_rs::util::unbounded_channel::<(char, usize)>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter([('a', 1), ('a', 2)]) -> fold_keyed::<'static>(|| 0, |acc: &mut usize, item| { *acc += item; }) -> for_each(|v| out_send.send(v).unwrap());
     };
     assert_eq!(
-        (TickInstant::new(0), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(0),
+        df.current_tick()
     );
     df.run_tick_sync();
     assert_eq!(
-        (TickInstant::new(1), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(1),
+        df.current_tick()
     );
     df.run_tick_sync();
     assert_eq!(
-        (TickInstant::new(2), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(2),
+        df.current_tick()
     );
     df.run_tick_sync();
     assert_eq!(
-        (TickInstant::new(3), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(3),
+        df.current_tick()
     );
 
     assert_eq!(
@@ -237,64 +237,64 @@ pub fn test_resume_external_event() {
     let (in_send, in_recv) = dfir_rs::util::unbounded_channel::<usize>();
     let (out_send, mut out_recv) = dfir_rs::util::unbounded_channel::<usize>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_stream(in_recv) -> fold::<'static>(|| 0, |a: &mut _, b| *a += b) -> for_each(|v| out_send.send(v).unwrap());
     };
 
     assert_eq!(
-        (TickInstant::new(0), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(0),
+        df.current_tick()
     );
     assert_eq!(&[] as &[usize], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 
     df.run_tick_sync();
     assert_eq!(
-        (TickInstant::new(1), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(1),
+        df.current_tick()
     );
     assert_eq!(&[0], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 
     df.run_tick_sync();
     assert_eq!(
-        (TickInstant::new(2), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(2),
+        df.current_tick()
     );
     assert_eq!(&[0], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 
     df.run_tick_sync();
     assert_eq!(
-        (TickInstant::new(3), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(3),
+        df.current_tick()
     );
     assert_eq!(&[0], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 
     df.run_available_sync();
     assert_eq!(
-        (TickInstant::new(4), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(4),
+        df.current_tick()
     );
     assert_eq!(&[0], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 
     in_send.send(1).unwrap();
     df.run_tick_sync();
     assert_eq!(
-        (TickInstant::new(5), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(5),
+        df.current_tick()
     );
     assert_eq!(&[1], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 
     in_send.send(2).unwrap();
     df.run_available_sync();
     assert_eq!(
-        (TickInstant::new(6), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(6),
+        df.current_tick()
     );
     assert_eq!(&[3], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 
     df.run_available_sync();
     assert_eq!(
-        (TickInstant::new(7), 0),
-        (df.current_tick(), df.current_stratum())
+        TickInstant::new(7),
+        df.current_tick()
     );
     assert_eq!(&[3], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 }

--- a/dfir_rs/tests/surface_unique.rs
+++ b/dfir_rs/tests/surface_unique.rs
@@ -1,17 +1,16 @@
 use dfir_rs::util::collect_ready;
-use dfir_rs::{assert_graphvis_snapshots, dfir_syntax};
+use dfir_rs::{dfir_syntax, dfir_syntax_inline};
 use multiplatform_test::multiplatform_test;
 
 #[multiplatform_test]
 pub fn test_unique() {
     let (items_send, items_recv) = dfir_rs::util::unbounded_channel::<usize>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_stream(items_recv)
             -> unique()
             -> for_each(|v| print!("{:?}, ", v));
     };
-    assert_graphvis_snapshots!(df);
     df.run_available_sync();
 
     print!("\nA: ");
@@ -37,14 +36,13 @@ pub fn test_unique() {
 pub fn test_unique_tick_pull() {
     let (out_send, mut out_recv) = dfir_rs::util::unbounded_channel::<usize>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter(0..10) -> persist::<'static>() -> m1;
         source_iter(5..15) -> persist::<'static>() -> m1;
         m1 = union() -> unique::<'tick>() -> m2;
         source_iter(0..0) -> persist::<'static>() -> m2; // Extra union to force `unique()` to be pull.
         m2 = union() -> for_each(|v| out_send.send(v).unwrap());
     };
-    assert_graphvis_snapshots!(df);
     df.run_tick_sync();
     let mut out: Vec<_> = collect_ready(&mut out_recv);
     out.sort_unstable();
@@ -60,14 +58,13 @@ pub fn test_unique_tick_pull() {
 pub fn test_unique_static_pull() {
     let (out_send, mut out_recv) = dfir_rs::util::unbounded_channel::<usize>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter(0..10) -> persist::<'static>() -> m1;
         source_iter(5..15) -> persist::<'static>() -> m1;
         m1 = union() -> unique::<'static>() -> m2;
         source_iter(0..0) -> persist::<'static>() -> m2; // Extra union to force `unique()` to be pull.
         m2 = union() -> for_each(|v| out_send.send(v).unwrap());
     };
-    assert_graphvis_snapshots!(df);
     df.run_tick_sync();
     let mut out: Vec<_> = collect_ready(&mut out_recv);
     out.sort_unstable();
@@ -83,14 +80,13 @@ pub fn test_unique_static_pull() {
 pub fn test_unique_tick_push() {
     let (out_send, mut out_recv) = dfir_rs::util::unbounded_channel::<usize>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter(0..10) -> persist::<'static>() -> pivot;
         source_iter(5..15) -> persist::<'static>() -> pivot;
         pivot = union() -> tee();
         pivot -> unique::<'tick>() -> for_each(|v| out_send.send(v).unwrap());
         pivot -> for_each(std::mem::drop); // Force to be push.
     };
-    assert_graphvis_snapshots!(df);
     df.run_tick_sync();
     let mut out: Vec<_> = collect_ready(&mut out_recv);
     out.sort_unstable();
@@ -106,14 +102,13 @@ pub fn test_unique_tick_push() {
 pub fn test_unique_static_push() {
     let (out_send, mut out_recv) = dfir_rs::util::unbounded_channel::<usize>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_syntax_inline! {
         source_iter(0..10) -> persist::<'static>() -> pivot;
         source_iter(5..15) -> persist::<'static>() -> pivot;
         pivot = union() -> tee();
         pivot -> unique::<'static>() -> for_each(|v| out_send.send(v).unwrap());
         pivot -> for_each(std::mem::drop); // Force to be push.
     };
-    assert_graphvis_snapshots!(df);
     df.run_tick_sync();
     let mut out: Vec<_> = collect_ready(&mut out_recv);
     out.sort_unstable();

--- a/dfir_rs/tests/surface_unique.rs
+++ b/dfir_rs/tests/surface_unique.rs
@@ -1,6 +1,5 @@
-use dfir_rs::assert_graphvis_snapshots;
 use dfir_rs::util::collect_ready;
-use dfir_rs::{dfir_syntax, dfir_syntax_inline};
+use dfir_rs::{assert_graphvis_snapshots, dfir_syntax, dfir_syntax_inline};
 use multiplatform_test::multiplatform_test;
 
 #[multiplatform_test]

--- a/dfir_rs/tests/surface_unique.rs
+++ b/dfir_rs/tests/surface_unique.rs
@@ -1,3 +1,4 @@
+use dfir_rs::assert_graphvis_snapshots;
 use dfir_rs::util::collect_ready;
 use dfir_rs::{dfir_syntax, dfir_syntax_inline};
 use multiplatform_test::multiplatform_test;
@@ -11,6 +12,7 @@ pub fn test_unique() {
             -> unique()
             -> for_each(|v| print!("{:?}, ", v));
     };
+    assert_graphvis_snapshots!(df);
     df.run_available_sync();
 
     print!("\nA: ");
@@ -43,6 +45,7 @@ pub fn test_unique_tick_pull() {
         source_iter(0..0) -> persist::<'static>() -> m2; // Extra union to force `unique()` to be pull.
         m2 = union() -> for_each(|v| out_send.send(v).unwrap());
     };
+    assert_graphvis_snapshots!(df);
     df.run_tick_sync();
     let mut out: Vec<_> = collect_ready(&mut out_recv);
     out.sort_unstable();
@@ -65,6 +68,7 @@ pub fn test_unique_static_pull() {
         source_iter(0..0) -> persist::<'static>() -> m2; // Extra union to force `unique()` to be pull.
         m2 = union() -> for_each(|v| out_send.send(v).unwrap());
     };
+    assert_graphvis_snapshots!(df);
     df.run_tick_sync();
     let mut out: Vec<_> = collect_ready(&mut out_recv);
     out.sort_unstable();
@@ -87,6 +91,7 @@ pub fn test_unique_tick_push() {
         pivot -> unique::<'tick>() -> for_each(|v| out_send.send(v).unwrap());
         pivot -> for_each(std::mem::drop); // Force to be push.
     };
+    assert_graphvis_snapshots!(df);
     df.run_tick_sync();
     let mut out: Vec<_> = collect_ready(&mut out_recv);
     out.sort_unstable();
@@ -109,6 +114,7 @@ pub fn test_unique_static_push() {
         pivot -> unique::<'static>() -> for_each(|v| out_send.send(v).unwrap());
         pivot -> for_each(std::mem::drop); // Force to be push.
     };
+    assert_graphvis_snapshots!(df);
     df.run_tick_sync();
     let mut out: Vec<_> = collect_ready(&mut out_recv);
     out.sort_unstable();

--- a/dfir_rs/tests/surface_zip_unzip.rs
+++ b/dfir_rs/tests/surface_zip_unzip.rs
@@ -7,7 +7,7 @@ pub fn test_zip_basic() {
     let (result_send, mut result_recv) =
         dfir_rs::util::unbounded_channel::<(usize, &'static str)>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_iter(0..5) -> [0]my_zip;
         source_iter(["Hello", "World"]) -> [1]my_zip;
         my_zip = zip() -> for_each(|pair| result_send.send(pair).unwrap());
@@ -60,7 +60,7 @@ pub fn test_zip_longest_basic() {
     let (result_send, mut result_recv) =
         dfir_rs::util::unbounded_channel::<EitherOrBoth<usize, &'static str>>();
 
-    let mut df = dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         source_iter(0..5) -> [0]my_zip_longest;
         source_iter(["Hello", "World"]) -> [1]my_zip_longest;
         my_zip_longest = zip_longest() -> for_each(|pair| result_send.send(pair).unwrap());
@@ -84,7 +84,7 @@ pub fn test_zip_longest_basic() {
 pub fn test_unzip_basic() {
     let (send0, mut recv0) = dfir_rs::util::unbounded_channel::<&'static str>();
     let (send1, mut recv1) = dfir_rs::util::unbounded_channel::<&'static str>();
-    let mut df = dfir_syntax! {
+    let mut df = dfir_rs::dfir_syntax_inline! {
         my_unzip = source_iter(vec![("Hello", "Foo"), ("World", "Bar")]) -> unzip();
         my_unzip[0] -> for_each(|v| send0.send(v).unwrap());
         my_unzip[1] -> for_each(|v| send1.send(v).unwrap());


### PR DESCRIPTION
Three changes stacked:

1. feat(dfir_rs): expose `current_tick()` on `InlineDfir` via shared `Rc<Cell<TickInstant>>`
   - Resolves #2741
   - Shares tick counter between InlineContext (inside closure) and InlineDfir (outer handle)
   - Updated codegen in dfir_lang and dfir_macro

2. refactor(dfir_rs): convert 55+ non-blocked tests to dfir_syntax_inline!
   - surface_scan.rs (8/8), surface_state_scheduling.rs (8/8),
     surface_difference.rs (8/10), surface_codegen.rs (17/20),
     surface_fold.rs (6/7), surface_fold_keyed.rs (4/5),
     surface_reduce_keyed.rs (3/4), surface_unique.rs (5/6),
     surface_zip_unzip.rs (3/5), surface_lattice_fold.rs (1/3)
   - Tests with loop {} blocks or intra-tick cycles remain on dfir_syntax!

3. fix(dfir_lang): include singleton reference edges in inline topological sort
   - Root cause of "behavioral differences" blocker for surface_singleton.rs
   - Singleton refs (`#name`) now create ordering constraints in the topo sort
   - Converts surface_singleton.rs (10/10 tests) to dfir_syntax_inline!