### PR TITLE
test(dfir_rs): re-add assert_graphvis_snapshots! calls for inline DFIR tests

### DIFF
--- a/dfir_rs/tests/surface_async.rs
+++ b/dfir_rs/tests/surface_async.rs
@@ -8,7 +8,7 @@ use std::net::{Ipv4Addr, SocketAddr};
 
 use bytes::Bytes;
 use dfir_rs::util::{collect_ready_async, tcp_lines};
-use dfir_rs::{dfir_syntax_inline, rassert, rassert_eq};
+use dfir_rs::{assert_graphvis_snapshots, dfir_syntax_inline, rassert, rassert_eq};
 use multiplatform_test::multiplatform_test;
 use tokio::net::{TcpListener, TcpStream, UdpSocket};
 use tokio::task::LocalSet;
@@ -215,6 +215,7 @@ pub async fn test_echo() {
     let mut df = dfir_syntax_inline! {
         source_stream(lines_recv) -> dest_sink(stdout_lines);
     };
+    assert_graphvis_snapshots!(df);
     df.run_available().await;
 
     lines_send.send("Hello".to_owned()).unwrap();

--- a/dfir_rs/tests/surface_book.rs
+++ b/dfir_rs/tests/surface_book.rs
@@ -1,3 +1,4 @@
+use dfir_rs::assert_graphvis_snapshots;
 use multiplatform_test::multiplatform_test;
 
 #[multiplatform_test]
@@ -8,6 +9,7 @@ fn test_surface_flows_1() {
         my_tee[1] -> map(|x| x.to_lowercase()) -> [1]my_union;
         my_union = union() -> for_each(|x| println!("{}", x));
     };
+    assert_graphvis_snapshots!(df);
     df.run_available_sync();
 }
 

--- a/dfir_rs/tests/surface_cross_singleton.rs
+++ b/dfir_rs/tests/surface_cross_singleton.rs
@@ -1,6 +1,5 @@
-use dfir_rs::assert_graphvis_snapshots;
-use dfir_rs::dfir_syntax_inline;
 use dfir_rs::util::collect_ready;
+use dfir_rs::{assert_graphvis_snapshots, dfir_syntax_inline};
 use multiplatform_test::multiplatform_test;
 
 #[multiplatform_test(test, wasm, env_tracing)]

--- a/dfir_rs/tests/surface_cross_singleton.rs
+++ b/dfir_rs/tests/surface_cross_singleton.rs
@@ -1,3 +1,4 @@
+use dfir_rs::assert_graphvis_snapshots;
 use dfir_rs::dfir_syntax_inline;
 use dfir_rs::util::collect_ready;
 use multiplatform_test::multiplatform_test;
@@ -14,6 +15,7 @@ pub fn test_basic() {
 
         join -> for_each(|x| egress_tx.send(x).unwrap());
     };
+    assert_graphvis_snapshots!(df);
 
     df.run_available_sync();
     let out: Vec<_> = collect_ready(&mut egress_rx);
@@ -54,6 +56,7 @@ pub fn test_union_defer_tick() {
         joined_folded = cross_singleton();
         deferred_stream = joined_folded -> fold(|| 0, |_, _| {}) -> flat_map(|_| []);
     };
+    assert_graphvis_snapshots!(df);
 
     df.run_available_sync();
     let out: Vec<_> = collect_ready(&mut egress_rx);

--- a/dfir_rs/tests/surface_defer_signal.rs
+++ b/dfir_rs/tests/surface_defer_signal.rs
@@ -1,6 +1,5 @@
-use dfir_rs::assert_graphvis_snapshots;
-use dfir_rs::dfir_syntax_inline;
 use dfir_rs::util::collect_ready;
+use dfir_rs::{assert_graphvis_snapshots, dfir_syntax_inline};
 use multiplatform_test::multiplatform_test;
 
 #[multiplatform_test]

--- a/dfir_rs/tests/surface_defer_signal.rs
+++ b/dfir_rs/tests/surface_defer_signal.rs
@@ -1,3 +1,4 @@
+use dfir_rs::assert_graphvis_snapshots;
 use dfir_rs::dfir_syntax_inline;
 use dfir_rs::util::collect_ready;
 use multiplatform_test::multiplatform_test;
@@ -14,6 +15,7 @@ pub fn test_basic_2() {
 
         gate -> for_each(|x| egress_tx.send(x).unwrap());
     };
+    assert_graphvis_snapshots!(df);
 
     df.run_available_sync();
     let out: Vec<_> = collect_ready(&mut egress_rx);

--- a/dfir_rs/tests/surface_forwardref.rs
+++ b/dfir_rs/tests/surface_forwardref.rs
@@ -1,6 +1,5 @@
-use dfir_rs::assert_graphvis_snapshots;
-use dfir_rs::dfir_syntax_inline;
 use dfir_rs::util::collect_ready;
+use dfir_rs::{assert_graphvis_snapshots, dfir_syntax_inline};
 use multiplatform_test::multiplatform_test;
 
 #[multiplatform_test]

--- a/dfir_rs/tests/surface_forwardref.rs
+++ b/dfir_rs/tests/surface_forwardref.rs
@@ -1,3 +1,4 @@
+use dfir_rs::assert_graphvis_snapshots;
 use dfir_rs::dfir_syntax_inline;
 use dfir_rs::util::collect_ready;
 use multiplatform_test::multiplatform_test;
@@ -10,6 +11,7 @@ pub fn test_forwardref_basic_forward() {
         source_iter(0..10) -> forward_ref;
         forward_ref = for_each(|v| out_send.send(v).unwrap());
     };
+    assert_graphvis_snapshots!(df);
     df.run_available_sync();
 
     assert_eq!(
@@ -26,6 +28,7 @@ pub fn test_forwardref_basic_backward() {
         forward_ref -> for_each(|v| out_send.send(v).unwrap());
         forward_ref = source_iter(0..10);
     };
+    assert_graphvis_snapshots!(df);
     df.run_available_sync();
 
     assert_eq!(
@@ -43,6 +46,7 @@ pub fn test_forwardref_basic_middle() {
         forward_ref -> for_each(|v| out_send.send(v).unwrap());
         forward_ref = identity();
     };
+    assert_graphvis_snapshots!(df);
     df.run_available_sync();
 
     assert_eq!(

--- a/dfir_rs/tests/surface_join_fused.rs
+++ b/dfir_rs/tests/surface_join_fused.rs
@@ -4,6 +4,7 @@ use std::rc::Rc;
 
 use dfir_rs::dfir_pipes::pull::{Fold, Reduce};
 use dfir_rs::dfir_syntax_inline;
+use dfir_rs::assert_graphvis_snapshots;
 use dfir_rs::lattices::set_union::SetUnionSingletonSet;
 use dfir_rs::scheduled::ticks::TickInstant;
 use lattices::Merge;
@@ -42,6 +43,7 @@ pub fn tick_tick_lhs_blocking_rhs_streaming() {
         my_join = join_fused_lhs(Fold::new(SetUnionHashSet::default, |state, delta| { Merge::merge(state, delta); }))
             -> for_each(|x| results_inner.borrow_mut().entry(context.current_tick()).or_default().push(x));
     };
+    assert_graphvis_snapshots!(df);
     df.run_available_sync();
 
     assert_contains_each_by_tick!(
@@ -70,6 +72,7 @@ pub fn static_tick_lhs_blocking_rhs_streaming() {
         my_join = join_fused_lhs::<'static, 'tick>(Fold::new(SetUnionHashSet::default, |state, delta| { Merge::merge(state, delta); }))
             -> for_each(|x| results_inner.borrow_mut().entry(context.current_tick()).or_default().push(x));
     };
+    assert_graphvis_snapshots!(df);
     df.run_available_sync();
 
     assert_contains_each_by_tick!(
@@ -108,6 +111,7 @@ pub fn static_static_lhs_blocking_rhs_streaming() {
         my_join = join_fused_lhs::<'static, 'static>(Fold::new(SetUnionHashSet::default, |state, delta| { Merge::merge(state, delta); }))
             -> for_each(|x| results_inner.borrow_mut().entry(context.current_tick()).or_default().push(x));
     };
+    assert_graphvis_snapshots!(df);
     df.run_available_sync();
 
     #[rustfmt::skip]
@@ -137,6 +141,7 @@ pub fn tick_tick_lhs_streaming_rhs_blocking() {
         my_join = join_fused_rhs(Fold::new(SetUnionHashSet::default, |state, delta| { Merge::merge(state, delta); }))
             -> for_each(|x| results_inner.borrow_mut().entry(context.current_tick()).or_default().push(x));
     };
+    assert_graphvis_snapshots!(df);
     df.run_available_sync();
 
     assert_contains_each_by_tick!(
@@ -165,6 +170,7 @@ pub fn static_tick_lhs_streaming_rhs_blocking() {
         my_join = join_fused_rhs::<'static, 'tick>(Fold::new(SetUnionHashSet::default, |state, delta| { Merge::merge(state, delta); }))
             -> for_each(|x| results_inner.borrow_mut().entry(context.current_tick()).or_default().push(x));
     };
+    assert_graphvis_snapshots!(df);
     df.run_available_sync();
 
     assert_contains_each_by_tick!(
@@ -204,6 +210,7 @@ pub fn static_static_lhs_streaming_rhs_blocking() {
             -> inspect(|x| println!("{}, {x:?}", context.current_tick()))
             -> for_each(|x| results_inner.borrow_mut().entry(context.current_tick()).or_default().push(x));
     };
+    assert_graphvis_snapshots!(df);
     df.run_available_sync();
 
     #[rustfmt::skip]
@@ -236,6 +243,7 @@ pub fn tick_tick_lhs_fold_rhs_reduce() {
             )
             -> for_each(|x| results_inner.borrow_mut().entry(context.current_tick()).or_default().push(x));
     };
+    assert_graphvis_snapshots!(df);
     df.run_available_sync();
 
     assert_contains_each_by_tick!(

--- a/dfir_rs/tests/surface_join_fused.rs
+++ b/dfir_rs/tests/surface_join_fused.rs
@@ -3,10 +3,9 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 use dfir_rs::dfir_pipes::pull::{Fold, Reduce};
-use dfir_rs::dfir_syntax_inline;
-use dfir_rs::assert_graphvis_snapshots;
 use dfir_rs::lattices::set_union::SetUnionSingletonSet;
 use dfir_rs::scheduled::ticks::TickInstant;
+use dfir_rs::{assert_graphvis_snapshots, dfir_syntax_inline};
 use lattices::Merge;
 use lattices::set_union::SetUnionHashSet;
 use multiplatform_test::multiplatform_test;

--- a/dfir_rs/tests/surface_lattice_bimorphism.rs
+++ b/dfir_rs/tests/surface_lattice_bimorphism.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
+use dfir_rs::assert_graphvis_snapshots;
 use dfir_rs::dfir_syntax_inline;
 use dfir_rs::util::collect_ready;
 use lattices::GhtType;
@@ -30,6 +31,7 @@ pub fn test_cartesian_product() {
             -> for_each(|x| out_send.send(x).unwrap());
     };
 
+    assert_graphvis_snapshots!(df);
     df.run_available_sync();
 
     assert_eq!(
@@ -63,6 +65,7 @@ pub fn test_cartesian_product_1401() {
         my_join = lattice_bimorphism(CartesianProductBimorphism::<HashSet<_>>::default(), #lhs, #rhs)
             -> for_each(|x| out_send.send(x).unwrap());
     };
+    assert_graphvis_snapshots!(df);
     df.run_available_sync();
 
     assert_eq!(
@@ -90,6 +93,7 @@ pub fn test_join() {
             -> for_each(|x| out_send.send(x).unwrap());
     };
 
+    assert_graphvis_snapshots!(df);
     df.run_available_sync();
 
     assert_eq!(
@@ -130,6 +134,7 @@ pub fn test_cartesian_product_tick_state() {
             -> inspect(|x| println!("{:?}: {:?}", context.current_tick(), x))
             -> for_each(|x| out_send.send(x).unwrap());
     };
+    assert_graphvis_snapshots!(df);
 
     for x in 0..3 {
         lhs_send.send(x).unwrap();

--- a/dfir_rs/tests/surface_lattice_bimorphism.rs
+++ b/dfir_rs/tests/surface_lattice_bimorphism.rs
@@ -1,8 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
-use dfir_rs::assert_graphvis_snapshots;
-use dfir_rs::dfir_syntax_inline;
 use dfir_rs::util::collect_ready;
+use dfir_rs::{assert_graphvis_snapshots, dfir_syntax_inline};
 use lattices::GhtType;
 use lattices::ght::GeneralizedHashTrieNode;
 use lattices::ght::lattice::{DeepJoinLatticeBimorphism, GhtBimorphism};

--- a/dfir_rs/tests/surface_lattice_bimorphism_persist_insertion.rs
+++ b/dfir_rs/tests/surface_lattice_bimorphism_persist_insertion.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use dfir_rs::assert_graphvis_snapshots;
 use dfir_rs::dfir_syntax_inline;
 use dfir_rs::scheduled::context::InlineDfirErased;
 use dfir_rs::util::collect_ready;
@@ -63,6 +64,7 @@ pub fn test_cartesian_product_multi_tick() {
             -> for_each(|x| out_send.send(x).unwrap());
     };
 
+    assert_graphvis_snapshots!(df);
     check_cartesian_product_multi_tick(df.into_erased(), lhs_send, rhs_send, out_recv);
 }
 
@@ -90,6 +92,7 @@ pub fn test_cartesian_product_multi_tick_tee() {
             -> for_each(|x| out_send.send(x).unwrap());
     };
 
+    assert_graphvis_snapshots!(df);
     check_cartesian_product_multi_tick(df.into_erased(), lhs_send, rhs_send, out_recv);
 }
 
@@ -116,5 +119,6 @@ pub fn test_cartesian_product_multi_tick_identity() {
             -> for_each(|x| out_send.send(x).unwrap());
     };
 
+    assert_graphvis_snapshots!(df);
     check_cartesian_product_multi_tick(df.into_erased(), lhs_send, rhs_send, out_recv);
 }

--- a/dfir_rs/tests/surface_lattice_bimorphism_persist_insertion.rs
+++ b/dfir_rs/tests/surface_lattice_bimorphism_persist_insertion.rs
@@ -1,9 +1,8 @@
 use std::collections::HashSet;
 
-use dfir_rs::assert_graphvis_snapshots;
-use dfir_rs::dfir_syntax_inline;
 use dfir_rs::scheduled::context::InlineDfirErased;
 use dfir_rs::util::collect_ready;
+use dfir_rs::{assert_graphvis_snapshots, dfir_syntax_inline};
 use lattices::set_union::{CartesianProductBimorphism, SetUnionHashSet, SetUnionSingletonSet};
 use multiplatform_test::multiplatform_test;
 use tokio::sync::mpsc::UnboundedSender;

--- a/dfir_rs/tests/surface_multiset_delta.rs
+++ b/dfir_rs/tests/surface_multiset_delta.rs
@@ -1,6 +1,5 @@
-use dfir_rs::assert_graphvis_snapshots;
-use dfir_rs::dfir_syntax_inline;
 use dfir_rs::util::collect_ready;
+use dfir_rs::{assert_graphvis_snapshots, dfir_syntax_inline};
 use multiplatform_test::multiplatform_test;
 
 #[multiplatform_test]

--- a/dfir_rs/tests/surface_multiset_delta.rs
+++ b/dfir_rs/tests/surface_multiset_delta.rs
@@ -1,3 +1,4 @@
+use dfir_rs::assert_graphvis_snapshots;
 use dfir_rs::dfir_syntax_inline;
 use dfir_rs::util::collect_ready;
 use multiplatform_test::multiplatform_test;
@@ -12,6 +13,7 @@ pub fn test_multiset_delta() {
             -> multiset_delta()
             -> for_each(|x| result_send.send(x).unwrap());
     };
+    assert_graphvis_snapshots!(flow);
 
     input_send.send(3).unwrap();
     input_send.send(4).unwrap();

--- a/dfir_rs/tests/surface_short_circuit_state.rs
+++ b/dfir_rs/tests/surface_short_circuit_state.rs
@@ -2,6 +2,7 @@
 //! See https://github.com/hydro-project/hydro/issues/2334
 use std::time::Duration;
 
+use dfir_rs::assert_graphvis_snapshots;
 use dfir_rs::dfir_syntax_inline;
 use dfir_rs::util::collect_ready_async;
 use multiplatform_test::multiplatform_test;
@@ -27,6 +28,8 @@ async fn test_resolve_futures_cross_singleton() {
         source_stream(singleton_recv) -> [single]cs;
         cs = cross_singleton() -> map(|(millis, ())| millis) -> for_each(|millis| output_send.send(millis).unwrap());
     };
+
+    assert_graphvis_snapshots!(df);
 
     items_send.send(500).unwrap();
     items_send.send(510).unwrap();

--- a/dfir_rs/tests/surface_short_circuit_state.rs
+++ b/dfir_rs/tests/surface_short_circuit_state.rs
@@ -2,9 +2,8 @@
 //! See https://github.com/hydro-project/hydro/issues/2334
 use std::time::Duration;
 
-use dfir_rs::assert_graphvis_snapshots;
-use dfir_rs::dfir_syntax_inline;
 use dfir_rs::util::collect_ready_async;
+use dfir_rs::{assert_graphvis_snapshots, dfir_syntax_inline};
 use multiplatform_test::multiplatform_test;
 
 #[multiplatform_test(dfir)]

--- a/dfir_rs/tests/surface_sort.rs
+++ b/dfir_rs/tests/surface_sort.rs
@@ -1,3 +1,4 @@
+use dfir_rs::assert_graphvis_snapshots;
 use dfir_rs::dfir_syntax_inline;
 use dfir_rs::util::collect_ready;
 use multiplatform_test::multiplatform_test;
@@ -11,6 +12,7 @@ pub fn test_sort() {
             -> sort()
             -> for_each(|v| print!("{:?}, ", v));
     };
+    assert_graphvis_snapshots!(df);
     df.run_available_sync();
 
     print!("\nA: ");
@@ -39,6 +41,7 @@ pub fn test_sort_by_key() {
             -> sort_by_key(|(k, _v)| k)
             -> for_each(|v| println!("{:?}", v));
     };
+    assert_graphvis_snapshots!(df);
     df.run_available_sync();
     println!();
 }

--- a/dfir_rs/tests/surface_sort.rs
+++ b/dfir_rs/tests/surface_sort.rs
@@ -1,6 +1,5 @@
-use dfir_rs::assert_graphvis_snapshots;
-use dfir_rs::dfir_syntax_inline;
 use dfir_rs::util::collect_ready;
+use dfir_rs::{assert_graphvis_snapshots, dfir_syntax_inline};
 use multiplatform_test::multiplatform_test;
 
 #[multiplatform_test]


### PR DESCRIPTION
PR #2763 removed assert_graphvis_snapshots! calls when converting tests from dfir_syntax! to dfir_syntax_inline! because InlineDfir lacked meta_graph() support. Now that meta_graph() is available, re-add all 26 removed calls across 11 test files:

- surface_async.rs (1 call)
- surface_book.rs (1 call)
- surface_cross_singleton.rs (2 calls)
- surface_defer_signal.rs (1 call)
- surface_forwardref.rs (3 calls)
- surface_join_fused.rs (7 calls)
- surface_lattice_bimorphism.rs (4 calls)
- surface_lattice_bimorphism_persist_insertion.rs (3 calls)
- surface_multiset_delta.rs (1 call)
- surface_short_circuit_state.rs (1 call)
- surface_sort.rs (2 calls)