### PR TITLE
feat(hydro_lang): add .name() for labeling dataflow edges

### DIFF
--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -1794,6 +1794,8 @@ pub struct HydroIrOpMetadata {
     pub cpu_usage: Option<f64>,
     pub network_recv_cpu_usage: Option<f64>,
     pub id: Option<usize>,
+    /// User-provided display name for this node (used in coordination analysis output).
+    pub name: Option<String>,
 }
 
 impl HydroIrOpMetadata {
@@ -1811,6 +1813,7 @@ impl HydroIrOpMetadata {
             cpu_usage: None,
             network_recv_cpu_usage: None,
             id: None,
+            name: None,
         }
     }
 }

--- a/hydro_lang/src/live_collections/keyed_singleton.rs
+++ b/hydro_lang/src/live_collections/keyed_singleton.rs
@@ -287,6 +287,13 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound> KeyedSingleton<K, V, L, 
     pub fn location(&self) -> &L {
         &self.location
     }
+
+    /// Assigns a human-readable name to this keyed singleton for use in analysis
+    /// output and graph visualization.
+    pub fn name(self, name: impl Into<String>) -> Self {
+        self.ir_node.borrow_mut().metadata_mut().op.name = Some(name.into());
+        self
+    }
 }
 
 #[cfg(stageleft_runtime)]

--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -288,6 +288,13 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
         &self.location
     }
 
+    /// Assigns a human-readable name to this keyed stream for use in analysis
+    /// output and graph visualization.
+    pub fn name(self, name: impl Into<String>) -> Self {
+        self.ir_node.borrow_mut().metadata_mut().op.name = Some(name.into());
+        self
+    }
+
     /// Explicitly "casts" the keyed stream to a type with a different ordering
     /// guarantee for each group. Useful in unsafe code where the ordering cannot be proven
     /// by the type-system.

--- a/hydro_lang/src/live_collections/optional.rs
+++ b/hydro_lang/src/live_collections/optional.rs
@@ -328,6 +328,13 @@ where
         &self.location
     }
 
+    /// Assigns a human-readable name to this optional for use in analysis
+    /// output and graph visualization.
+    pub fn name(self, name: impl Into<String>) -> Self {
+        self.ir_node.borrow_mut().metadata_mut().op.name = Some(name.into());
+        self
+    }
+
     /// Transforms the optional value by applying a function `f` to it,
     /// continuously as the input is updated.
     ///

--- a/hydro_lang/src/live_collections/singleton.rs
+++ b/hydro_lang/src/live_collections/singleton.rs
@@ -326,6 +326,13 @@ where
         &self.location
     }
 
+    /// Assigns a human-readable name to this singleton for use in analysis
+    /// output and graph visualization.
+    pub fn name(self, name: impl Into<String>) -> Self {
+        self.ir_node.borrow_mut().metadata_mut().op.name = Some(name.into());
+        self
+    }
+
     /// Drops the monotonicity property of the [`Singleton`].
     pub fn ignore_monotonic(self) -> Singleton<T, L, B::UnderlyingBound> {
         if B::bound_kind() == B::UnderlyingBound::bound_kind() {

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -1118,6 +1118,21 @@ where
         )
     }
 
+    /// Assigns a human-readable name to this stream for use in analysis output
+    /// and graph visualization.
+    ///
+    /// The name appears in the coordination analysis report and dataflow graphs
+    /// instead of the generic operator name.
+    ///
+    /// # Example
+    /// ```ignore
+    /// tx_responses.name("tx_responses").for_each(q!(|_| {}));
+    /// ```
+    pub fn name(self, name: impl Into<String>) -> Self {
+        self.ir_node.borrow_mut().metadata_mut().op.name = Some(name.into());
+        self
+    }
+
     /// Executes the provided closure for every element in this stream.
     ///
     /// Because the closure may have side effects, the stream must have deterministic order
@@ -3052,6 +3067,18 @@ mod tests {
     use crate::networking::TCP;
     #[cfg(any(feature = "deploy", feature = "sim"))]
     use crate::nondet::nondet;
+
+    #[cfg(any(feature = "deploy", feature = "sim"))]
+    #[test]
+    fn stream_name_sets_metadata() {
+        let mut flow = FlowBuilder::new();
+        let p = flow.process::<()>();
+        let stream = p.source_iter(q!([1, 2, 3])).name("my_stream");
+        assert_eq!(
+            stream.ir_node.borrow().metadata().op.name.as_deref(),
+            Some("my_stream")
+        );
+    }
 
     mod backtrace_chained_ops;
 

--- a/hydro_lang/src/location/dynamic.rs
+++ b/hydro_lang/src/location/dynamic.rs
@@ -119,6 +119,7 @@ impl LocationId {
                 cpu_usage: None,
                 network_recv_cpu_usage: None,
                 id: None,
+                name: None,
             },
         }
     }


### PR DESCRIPTION
Adds a `.name()` method to all LiveCollection types (Stream, KeyedStream, Singleton, Optional, KeyedSingleton) that assigns a human-readable label to a dataflow edge. The label appears in coordination analysis reports and can be used by graph visualization. Follows Flink's convention.

## Usage
```rust
tx_responses.name("tx_responses").for_each(q!(|_| {}));
```

In the (upcoming) coordination analysis output:
```
✓ tx_responses @ service.rs:204:10 — CONVERGENT
```

Instead of the generic:
```
✓ foreach @ service.rs:204:10 — CONVERGENT
```

Similarly can be exploited in the viz tools (will be a separate PR).

**Note**: this is independent of the channel names inside transport that are used for deployment.

## Changes
- `compile/ir/mod.rs`: Added `name: Option<String>` to `HydroIrOpMetadata`
- `live_collections/{stream,keyed_stream,singleton,optional,keyed_singleton}`: Added `.name()` method
- `location/dynamic.rs`: Thread `name: None` through metadata constructor
- `stream/mod.rs`: Added test for name metadata