### PR TITLE
[experiment] feat(hydro_lang): add StaticCluster location type with complete networking

### DIFF
--- a/hydro_lang/src/compile/builder.rs
+++ b/hydro_lang/src/compile/builder.rs
@@ -177,6 +177,16 @@ impl<'a> FlowBuilder<'a> {
         }
     }
 
+    pub fn static_cluster<C>(&mut self) -> crate::location::StaticCluster<'a, C> {
+        let key = self.locations.insert(LocationType::StaticCluster);
+        self.location_names.insert(key, type_name::<C>().to_owned());
+        crate::location::StaticCluster {
+            key,
+            flow_state: self.flow_state().clone(),
+            _phantom: PhantomData,
+        }
+    }
+
     pub fn external<E>(&mut self) -> External<'a, E> {
         let key = self.locations.insert(LocationType::External);
         self.location_names.insert(key, type_name::<E>().to_owned());

--- a/hydro_lang/src/compile/built.rs
+++ b/hydro_lang/src/compile/built.rs
@@ -229,7 +229,7 @@ impl<'a> BuiltFlow<'a> {
                         },
                     );
                 }
-                LocationType::Cluster => {
+                LocationType::Cluster | LocationType::StaticCluster => {
                     clusters.insert(
                         key,
                         SimNode {

--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -815,7 +815,8 @@ impl HydroRoot {
                                         )
                                     }
                                 }
-                                LocationId::Cluster(cluster_key) => {
+                                LocationId::Cluster(cluster_key)
+                                | LocationId::StaticCluster(cluster_key) => {
                                     let from_node = clusters
                                         .get(*cluster_key)
                                         .unwrap_or_else(|| {
@@ -863,7 +864,7 @@ impl HydroRoot {
                         _ => panic!("Embedded output must have Stream collection kind"),
                     };
                     let location_key = match input.metadata().location_id.root() {
-                        LocationId::Process(key) | LocationId::Cluster(key) => *key,
+                        LocationId::Process(key) | LocationId::Cluster(key) | LocationId::StaticCluster(key) => *key,
                         _ => panic!("Embedded output must be on a process or cluster"),
                     };
                     D::register_embedded_output(
@@ -964,7 +965,8 @@ impl HydroRoot {
                                         D::e2o_connect(&from_node, &sink_port, &to_node, &source_port, *from_many, *port_hint),
                                     )
                                 }
-                                LocationId::Cluster(cluster_key) => {
+                                LocationId::Cluster(cluster_key)
+                                | LocationId::StaticCluster(cluster_key) => {
                                     let to_node = clusters
                                         .get(*cluster_key)
                                         .unwrap_or_else(|| {
@@ -1010,7 +1012,7 @@ impl HydroRoot {
                         _ => panic!("Embedded source must have Stream collection kind"),
                     };
                     let location_key = match metadata.location_id.root() {
-                        LocationId::Process(key) | LocationId::Cluster(key) => *key,
+                        LocationId::Process(key) | LocationId::Cluster(key) | LocationId::StaticCluster(key) => *key,
                         _ => panic!("Embedded source must be on a process or cluster"),
                     };
                     D::register_embedded_stream_input(
@@ -1025,7 +1027,7 @@ impl HydroRoot {
                         _ => panic!("EmbeddedSingleton source must have Singleton collection kind"),
                     };
                     let location_key = match metadata.location_id.root() {
-                        LocationId::Process(key) | LocationId::Cluster(key) => *key,
+                        LocationId::Process(key) | LocationId::Cluster(key) | LocationId::StaticCluster(key) => *key,
                         _ => panic!("EmbeddedSingleton source must be on a process or cluster"),
                     };
                     D::register_embedded_singleton_input(
@@ -1038,7 +1040,7 @@ impl HydroRoot {
                     match state {
                         ClusterMembersState::Uninit => {
                             let at_location = metadata.location_id.root().clone();
-                            let key = (at_location.clone(), LocationId::Cluster(location_id.key()));
+                            let key = (at_location.clone(), location_id.clone());
                             if refcell_seen_cluster_members.borrow_mut().insert(key) {
                                 // First occurrence: call cluster_membership_stream and mark as Stream.
                                 let expr = stageleft::QuotedWithContext::splice_untyped_ctx(
@@ -1482,7 +1484,7 @@ fn remap_location(loc: &mut LocationId, uf: &mut HashMap<ClockId, ClockId>) {
         LocationId::Atomic(inner) => {
             remap_location(inner, uf);
         }
-        LocationId::Process(_) | LocationId::Cluster(_) => {}
+        LocationId::Process(_) | LocationId::Cluster(_) | LocationId::StaticCluster(_) => {}
     }
 }
 
@@ -4499,7 +4501,8 @@ where
                 D::o2o_connect(&from_node, &sink_port, &to_node, &source_port),
             )
         }
-        (&LocationId::Process(from), &LocationId::Cluster(to)) => {
+        (&LocationId::Process(from), &LocationId::Cluster(to))
+        | (&LocationId::Process(from), &LocationId::StaticCluster(to)) => {
             let from_node = processes
                 .get(from)
                 .unwrap_or_else(|| {
@@ -4529,7 +4532,8 @@ where
                 D::o2m_connect(&from_node, &sink_port, &to_node, &source_port),
             )
         }
-        (&LocationId::Cluster(from), &LocationId::Process(to)) => {
+        (&LocationId::Cluster(from), &LocationId::Process(to))
+        | (&LocationId::StaticCluster(from), &LocationId::Process(to)) => {
             let from_node = clusters
                 .get(from)
                 .unwrap_or_else(|| {
@@ -4559,7 +4563,10 @@ where
                 D::m2o_connect(&from_node, &sink_port, &to_node, &source_port),
             )
         }
-        (&LocationId::Cluster(from), &LocationId::Cluster(to)) => {
+        (&LocationId::Cluster(from), &LocationId::Cluster(to))
+        | (&LocationId::StaticCluster(from), &LocationId::Cluster(to))
+        | (&LocationId::Cluster(from), &LocationId::StaticCluster(to))
+        | (&LocationId::StaticCluster(from), &LocationId::StaticCluster(to)) => {
             let from_node = clusters
                 .get(from)
                 .unwrap_or_else(|| {

--- a/hydro_lang/src/lib.rs
+++ b/hydro_lang/src/lib.rs
@@ -55,7 +55,7 @@ pub mod prelude {
     pub use crate::live_collections::singleton::Singleton;
     pub use crate::live_collections::sliced::sliced;
     pub use crate::live_collections::stream::Stream;
-    pub use crate::location::{Cluster, External, Location as _, Process, Tick};
+    pub use crate::location::{Cluster, External, Location as _, Process, StaticCluster, Tick};
     pub use crate::networking::TCP;
     pub use crate::nondet::{NonDet, nondet};
     pub use crate::properties::{ManualProof, manual_proof};

--- a/hydro_lang/src/live_collections/keyed_stream/networking.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/networking.rs
@@ -141,6 +141,42 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
             },
         )
     }
+
+    /// Sends each group of this stream to a specific member of a static cluster.
+    ///
+    /// Like [`KeyedStream::demux`] but targets a [`StaticCluster`](crate::location::StaticCluster)
+    /// with fixed membership.
+    pub fn demux_static<N: NetworkFor<T>>(
+        self,
+        to: &crate::location::StaticCluster<'a, L2>,
+        via: N,
+    ) -> Stream<T, crate::location::StaticCluster<'a, L2>, Unbounded, <O as MinOrder<N::OrderingGuarantee>>::Min, R>
+    where
+        T: Serialize + DeserializeOwned,
+        O: MinOrder<N::OrderingGuarantee>,
+    {
+        let serialize_pipeline = Some(N::serialize_thunk(true));
+        let deserialize_pipeline = Some(N::deserialize_thunk(None));
+
+        Stream::new(
+            to.clone(),
+            HydroNode::Network {
+                name: via.name().map(ToOwned::to_owned),
+                networking_info: N::networking_info(),
+                serialize_fn: serialize_pipeline.map(|e| e.into()),
+                instantiate_fn: DebugInstantiate::Building,
+                deserialize_fn: deserialize_pipeline.map(|e| e.into()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                metadata: to.new_node_metadata(Stream::<
+                    T,
+                    crate::location::StaticCluster<'a, L2>,
+                    Unbounded,
+                    <O as MinOrder<N::OrderingGuarantee>>::Min,
+                    R,
+                >::collection_kind()),
+            },
+        )
+    }
 }
 
 impl<'a, K, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
@@ -602,6 +638,148 @@ impl<'a, K, V, L, B: Boundedness, O: Ordering, R: Retries>
                 metadata: to.new_node_metadata(Stream::<
                     (MemberId<L>, (K, V)),
                     Cluster<'a, L2>,
+                    Unbounded,
+                    <O as MinOrder<N::OrderingGuarantee>>::Min,
+                    R,
+                >::collection_kind()),
+            },
+        );
+
+        raw_stream
+            .map(q!(|(sender, (k, v))| ((sender, k), v)))
+            .into_keyed()
+    }
+}
+
+// === StaticCluster KeyedStream networking ===
+
+impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
+    KeyedStream<MemberId<L2>, T, crate::location::StaticCluster<'a, L>, B, O, R>
+{
+    /// Sends each group to a specific member of a destination static cluster using [`bincode`].
+    pub fn demux_bincode(
+        self,
+        other: &crate::location::StaticCluster<'a, L2>,
+    ) -> KeyedStream<MemberId<L>, T, crate::location::StaticCluster<'a, L2>, Unbounded, O, R>
+    where
+        T: Serialize + DeserializeOwned,
+    {
+        self.demux(other, TCP.fail_stop().bincode())
+    }
+
+    /// Sends each group to a specific member of a destination static cluster.
+    #[expect(clippy::type_complexity, reason = "MinOrder projection in return type")]
+    pub fn demux<N: NetworkFor<T>>(
+        self,
+        to: &crate::location::StaticCluster<'a, L2>,
+        via: N,
+    ) -> KeyedStream<
+        MemberId<L>,
+        T,
+        crate::location::StaticCluster<'a, L2>,
+        Unbounded,
+        <O as MinOrder<N::OrderingGuarantee>>::Min,
+        R,
+    >
+    where
+        T: Serialize + DeserializeOwned,
+        O: MinOrder<N::OrderingGuarantee>,
+    {
+        let serialize_pipeline = Some(N::serialize_thunk(true));
+        let deserialize_pipeline = Some(N::deserialize_thunk(Some(&quote_type::<L>())));
+
+        let name = via.name();
+        if to.multiversioned() && name.is_none() {
+            panic!(
+                "Cannot send to a multiversioned location without a channel name. Please provide a name for the network."
+            );
+        }
+
+        KeyedStream::new(
+            to.clone(),
+            HydroNode::Network {
+                name: name.map(ToOwned::to_owned),
+                networking_info: N::networking_info(),
+                serialize_fn: serialize_pipeline.map(|e| e.into()),
+                instantiate_fn: DebugInstantiate::Building,
+                deserialize_fn: deserialize_pipeline.map(|e| e.into()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                metadata: to.new_node_metadata(KeyedStream::<
+                    MemberId<L>,
+                    T,
+                    crate::location::StaticCluster<'a, L2>,
+                    Unbounded,
+                    <O as MinOrder<N::OrderingGuarantee>>::Min,
+                    R,
+                >::collection_kind()),
+            },
+        )
+    }
+}
+
+impl<'a, K, V, L, B: Boundedness, O: Ordering, R: Retries>
+    KeyedStream<K, V, crate::location::StaticCluster<'a, L>, B, O, R>
+{
+    /// Sends elements from a static cluster to a process using [`bincode`].
+    #[expect(clippy::type_complexity, reason = "compound key types with ordering")]
+    pub fn send_bincode<L2>(
+        self,
+        other: &Process<'a, L2>,
+    ) -> KeyedStream<(MemberId<L>, K), V, Process<'a, L2>, Unbounded, O, R>
+    where
+        K: Serialize + DeserializeOwned,
+        V: Serialize + DeserializeOwned,
+    {
+        self.send(other, TCP.fail_stop().bincode())
+    }
+
+    /// Sends elements from a static cluster to a process.
+    #[expect(clippy::type_complexity, reason = "compound key types with ordering")]
+    pub fn send<L2, N: NetworkFor<(K, V)>>(
+        self,
+        to: &Process<'a, L2>,
+        via: N,
+    ) -> KeyedStream<
+        (MemberId<L>, K),
+        V,
+        Process<'a, L2>,
+        Unbounded,
+        <O as MinOrder<N::OrderingGuarantee>>::Min,
+        R,
+    >
+    where
+        K: Serialize + DeserializeOwned,
+        V: Serialize + DeserializeOwned,
+        O: MinOrder<N::OrderingGuarantee>,
+    {
+        let serialize_pipeline = Some(N::serialize_thunk(false));
+        let deserialize_pipeline = Some(N::deserialize_thunk(Some(&quote_type::<L>())));
+
+        let name = via.name();
+        if to.multiversioned() && name.is_none() {
+            panic!(
+                "Cannot send to a multiversioned location without a channel name. Please provide a name for the network."
+            );
+        }
+
+        let raw_stream: Stream<
+            (MemberId<L>, (K, V)),
+            Process<'a, L2>,
+            Unbounded,
+            <O as MinOrder<N::OrderingGuarantee>>::Min,
+            R,
+        > = Stream::new(
+            to.clone(),
+            HydroNode::Network {
+                name: name.map(ToOwned::to_owned),
+                networking_info: N::networking_info(),
+                serialize_fn: serialize_pipeline.map(|e| e.into()),
+                instantiate_fn: DebugInstantiate::Building,
+                deserialize_fn: deserialize_pipeline.map(|e| e.into()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                metadata: to.new_node_metadata(Stream::<
+                    (MemberId<L>, (K, V)),
+                    crate::location::StaticCluster<'a, L2>,
                     Unbounded,
                     <O as MinOrder<N::OrderingGuarantee>>::Min,
                     R,

--- a/hydro_lang/src/live_collections/stream/networking.rs
+++ b/hydro_lang/src/live_collections/stream/networking.rs
@@ -7,7 +7,7 @@ use serde::de::DeserializeOwned;
 use stageleft::{q, quote_type};
 use syn::parse_quote;
 
-use super::{ExactlyOnce, MinOrder, Ordering, Stream, TotalOrder};
+use super::{ExactlyOnce, MinOrder, NoOrder, Ordering, Stream, TotalOrder};
 use crate::compile::ir::{DebugInstantiate, HydroIrOpMetadata, HydroNode, HydroRoot};
 use crate::live_collections::boundedness::{Boundedness, Unbounded};
 use crate::live_collections::keyed_singleton::KeyedSingleton;
@@ -386,6 +386,44 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Process<'a, L>
         let external = self.send_bincode_external(&external_location);
 
         SimReceiver(external.port_id, PhantomData)
+    }
+
+    /// Broadcasts elements of this stream to all members of a static cluster using
+    /// [`bincode`] serialization.
+    ///
+    /// No [`NonDet`] guard needed since [`StaticCluster`] membership is fixed at deploy time.
+    pub fn broadcast_static_bincode<L2: 'a>(
+        self,
+        to: &crate::location::StaticCluster<'a, L2>,
+    ) -> Stream<T, crate::location::StaticCluster<'a, L2>, Unbounded, NoOrder, R>
+    where
+        T: Clone + Serialize + DeserializeOwned,
+    {
+        self.broadcast_static(to, TCP.fail_stop().bincode())
+    }
+
+    /// Broadcasts elements of this stream to all members of a static cluster.
+    ///
+    /// No [`NonDet`] guard needed since [`StaticCluster`] membership is fixed at deploy time.
+    /// Uses `cross_product` with the bounded member set — no ticks or nondet involved.
+    pub fn broadcast_static<L2: 'a, N: NetworkFor<T>>(
+        self,
+        to: &crate::location::StaticCluster<'a, L2>,
+        via: N,
+    ) -> Stream<T, crate::location::StaticCluster<'a, L2>, Unbounded, NoOrder, R>
+    where
+        T: Clone + Serialize + DeserializeOwned,
+        O: MinOrder<N::OrderingGuarantee>,
+    {
+        let member_ids = self.location.source_cluster_members_static(to)
+            .filter(q!(|event| matches!(event, crate::location::MembershipEvent::Joined)))
+            .keys()
+            .weaken_retries();
+
+        self.cross_product(member_ids)
+            .map(q!(|(data, member_id)| (member_id, data)))
+            .into_keyed()
+            .demux_static(to, via)
     }
 }
 
@@ -1260,6 +1298,146 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
         <O as MinOrder<N::OrderingGuarantee>>::Min,
         R,
     >
+    where
+        T: Serialize + DeserializeOwned,
+        O: MinOrder<N::OrderingGuarantee>,
+    {
+        self.into_keyed().demux(to, via)
+    }
+}
+
+// === StaticCluster outbound networking ===
+
+impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, crate::location::StaticCluster<'a, L>, B, O, R> {
+    /// Sends elements from a static cluster to a process.
+    pub fn send_bincode<L2>(
+        self,
+        other: &Process<'a, L2>,
+    ) -> KeyedStream<MemberId<L>, T, Process<'a, L2>, Unbounded, O, R>
+    where
+        T: Serialize + DeserializeOwned,
+    {
+        self.send(other, TCP.fail_stop().bincode())
+    }
+
+    /// Sends elements from a static cluster to a process using the given transport.
+    #[expect(clippy::type_complexity, reason = "MinOrder projection in return type")]
+    pub fn send<L2, N: NetworkFor<T>>(
+        self,
+        to: &Process<'a, L2>,
+        via: N,
+    ) -> KeyedStream<MemberId<L>, T, Process<'a, L2>, Unbounded, <O as MinOrder<N::OrderingGuarantee>>::Min, R>
+    where
+        T: Serialize + DeserializeOwned,
+        O: MinOrder<N::OrderingGuarantee>,
+    {
+        let serialize_pipeline = Some(N::serialize_thunk(false));
+        let deserialize_pipeline = Some(N::deserialize_thunk(Some(&quote_type::<L>())));
+
+        let raw_stream: Stream<(MemberId<L>, T), Process<'a, L2>, Unbounded, <O as MinOrder<N::OrderingGuarantee>>::Min, R> = Stream::new(
+            to.clone(),
+            HydroNode::Network {
+                name: via.name().map(ToOwned::to_owned),
+                networking_info: N::networking_info(),
+                serialize_fn: serialize_pipeline.map(|e| e.into()),
+                instantiate_fn: DebugInstantiate::Building,
+                deserialize_fn: deserialize_pipeline.map(|e| e.into()),
+                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                metadata: to.new_node_metadata(Stream::<
+                    (MemberId<L>, T), Process<'a, L2>, Unbounded,
+                    <O as MinOrder<N::OrderingGuarantee>>::Min, R,
+                >::collection_kind()),
+            },
+        );
+        raw_stream.into_keyed()
+    }
+
+    /// Broadcasts elements to all members of a destination static cluster using [`bincode`].
+    /// No [`NonDet`] guard needed since static cluster membership is fixed.
+    pub fn broadcast_bincode<L2: 'a>(
+        self,
+        other: &crate::location::StaticCluster<'a, L2>,
+    ) -> KeyedStream<MemberId<L>, T, crate::location::StaticCluster<'a, L2>, Unbounded, NoOrder, R>
+    where
+        T: Clone + Serialize + DeserializeOwned,
+    {
+        self.broadcast(other, TCP.fail_stop().bincode())
+    }
+
+    /// Broadcasts elements to all members of a destination static cluster.
+    /// No [`NonDet`] guard needed since static cluster membership is fixed.
+    #[expect(clippy::type_complexity, reason = "MinOrder projection in return type")]
+    pub fn broadcast<L2: 'a, N: NetworkFor<T>>(
+        self,
+        to: &crate::location::StaticCluster<'a, L2>,
+        via: N,
+    ) -> KeyedStream<MemberId<L>, T, crate::location::StaticCluster<'a, L2>, Unbounded, NoOrder, R>
+    where
+        T: Clone + Serialize + DeserializeOwned,
+        O: MinOrder<N::OrderingGuarantee>,
+    {
+        let member_ids = self.location.source_cluster_members_static(to)
+            .filter(q!(|event| matches!(event, crate::location::MembershipEvent::Joined)))
+            .keys()
+            .weaken_retries();
+
+        self.cross_product(member_ids)
+            .map(q!(|(data, member_id)| (member_id, data)))
+            .into_keyed()
+            .demux(to, via)
+    }
+
+    #[cfg(feature = "sim")]
+    /// Sets up a simulation output port for this static cluster stream.
+    pub fn sim_cluster_output(self) -> crate::sim::SimClusterReceiver<T, O, R>
+    where
+        T: Serialize + DeserializeOwned,
+    {
+        let external_location: External<'a, ()> = External {
+            key: LocationKey::FIRST,
+            flow_state: self.location.flow_state().clone(),
+            _phantom: PhantomData,
+        };
+
+        let serialize_pipeline = Some(serialize_bincode::<T>(false));
+        let mut flow_state_borrow = self.location.flow_state().borrow_mut();
+        let external_port_id = flow_state_borrow.next_external_port();
+        flow_state_borrow.push_root(HydroRoot::SendExternal {
+            to_external_key: external_location.key,
+            to_port_id: external_port_id,
+            to_many: false,
+            unpaired: true,
+            serialize_fn: serialize_pipeline.map(|e| e.into()),
+            instantiate_fn: DebugInstantiate::Building,
+            input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+            op_metadata: HydroIrOpMetadata::new(),
+        });
+
+        crate::sim::SimClusterReceiver(external_port_id, PhantomData)
+    }
+}
+
+impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
+    Stream<(MemberId<L2>, T), crate::location::StaticCluster<'a, L>, B, O, R>
+{
+    /// Sends elements to specific members of a destination static cluster using [`bincode`].
+    pub fn demux_bincode(
+        self,
+        other: &crate::location::StaticCluster<'a, L2>,
+    ) -> KeyedStream<MemberId<L>, T, crate::location::StaticCluster<'a, L2>, Unbounded, O, R>
+    where
+        T: Serialize + DeserializeOwned,
+    {
+        self.demux(other, TCP.fail_stop().bincode())
+    }
+
+    /// Sends elements to specific members of a destination static cluster.
+    #[expect(clippy::type_complexity, reason = "MinOrder projection in return type")]
+    pub fn demux<N: NetworkFor<T>>(
+        self,
+        to: &crate::location::StaticCluster<'a, L2>,
+        via: N,
+    ) -> KeyedStream<MemberId<L>, T, crate::location::StaticCluster<'a, L2>, Unbounded, <O as MinOrder<N::OrderingGuarantee>>::Min, R>
     where
         T: Serialize + DeserializeOwned,
         O: MinOrder<N::OrderingGuarantee>,

--- a/hydro_lang/src/location/cluster.rs
+++ b/hydro_lang/src/location/cluster.rs
@@ -185,6 +185,119 @@ impl<C> IsCluster for Cluster<'_, C> {
     type Tag = C;
 }
 
+impl<C> IsCluster for StaticCluster<'_, C> {
+    type Tag = C;
+}
+
+/// A multi-node location with fixed membership known at deploy time.
+///
+/// Unlike [`Cluster`], a `StaticCluster` does not support dynamic membership
+/// changes. All members are present for the entire execution. This enables
+/// stronger consistency guarantees: broadcasting to a `StaticCluster` does not
+/// require a [`NonDet`](crate::nondet::NonDet) guard because membership is not
+/// a source of nondeterminism.
+///
+/// The `ClusterTag` type parameter is a phantom tag used to distinguish between
+/// different clusters in the type system, preventing accidental mixing of
+/// member IDs across clusters.
+pub struct StaticCluster<'a, ClusterTag> {
+    pub(crate) key: LocationKey,
+    pub(crate) flow_state: FlowState,
+    pub(crate) _phantom: Invariant<'a, ClusterTag>,
+}
+
+impl<C> Debug for StaticCluster<'_, C> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "StaticCluster({})", self.key)
+    }
+}
+
+impl<C> Eq for StaticCluster<'_, C> {}
+impl<C> PartialEq for StaticCluster<'_, C> {
+    fn eq(&self, other: &Self) -> bool {
+        self.key == other.key && FlowState::ptr_eq(&self.flow_state, &other.flow_state)
+    }
+}
+
+impl<C> Clone for StaticCluster<'_, C> {
+    fn clone(&self) -> Self {
+        StaticCluster {
+            key: self.key,
+            flow_state: self.flow_state.clone(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, C> super::dynamic::DynLocation for StaticCluster<'a, C> {
+    fn id(&self) -> LocationId {
+        LocationId::StaticCluster(self.key)
+    }
+
+    fn flow_state(&self) -> &FlowState {
+        &self.flow_state
+    }
+
+    fn is_top_level() -> bool {
+        true
+    }
+
+    fn multiversioned(&self) -> bool {
+        false
+    }
+}
+
+impl<'a, C> Location<'a> for StaticCluster<'a, C> {
+    type Root = StaticCluster<'a, C>;
+
+    fn root(&self) -> Self::Root {
+        self.clone()
+    }
+}
+
+#[cfg(feature = "sim")]
+impl<'a, C> StaticCluster<'a, C> {
+    /// Sets up a simulated input port on this static cluster for testing.
+    ///
+    /// Returns a `SimClusterSender` that sends `(member_id, T)` messages targeting
+    /// specific cluster members, and a `Stream<T>` received by each member.
+    #[expect(clippy::type_complexity, reason = "stream markers")]
+    pub fn sim_input<T>(
+        &self,
+    ) -> (
+        crate::sim::SimClusterSender<
+            T,
+            crate::live_collections::stream::TotalOrder,
+            crate::live_collections::stream::ExactlyOnce,
+        >,
+        crate::live_collections::Stream<
+            T,
+            Self,
+            crate::live_collections::boundedness::Unbounded,
+            crate::live_collections::stream::TotalOrder,
+            crate::live_collections::stream::ExactlyOnce,
+        >,
+    )
+    where
+        T: serde::Serialize + serde::de::DeserializeOwned,
+    {
+        use crate::location::Location;
+
+        let external_location: crate::location::External<'a, ()> = crate::location::External {
+            key: LocationKey::FIRST,
+            flow_state: self.flow_state.clone(),
+            _phantom: PhantomData,
+        };
+
+        let (external, stream) = self.source_external_bincode(&external_location);
+
+        (
+            crate::sim::SimClusterSender(external.port_id, PhantomData),
+            stream,
+        )
+    }
+}
+
 /// A free variable representing the cluster's own ID. When spliced in
 /// a quoted snippet that will run on a cluster, this turns into a [`MemberId`].
 pub static CLUSTER_SELF_ID: ClusterSelfId = ClusterSelfId { _private: &() };
@@ -209,8 +322,9 @@ where
     where
         Self: Sized,
     {
-        let LocationId::Cluster(cluster_id) = ctx.root().id() else {
-            unreachable!()
+        let cluster_id = match ctx.root().id() {
+            LocationId::Cluster(id) | LocationId::StaticCluster(id) => id,
+            _ => unreachable!(),
         };
 
         let ident = syn::Ident::new(
@@ -346,6 +460,80 @@ mod tests {
 
         flow.sim()
             .with_cluster_size(&cluster, 2)
+            .exhaustive(async || {
+                out_recv
+                    .assert_yields_only_unordered(vec![
+                        (MemberId::from_raw_id(0), MembershipEvent::Joined),
+                        (MemberId::from_raw_id(1), MembershipEvent::Joined),
+                    ])
+                    .await;
+            });
+    }
+
+    #[cfg(feature = "sim")]
+    #[test]
+    fn sim_static_cluster_self_id() {
+        let mut flow = FlowBuilder::new();
+        let cluster = flow.static_cluster::<()>();
+        let node = flow.process::<()>();
+
+        let out_recv = cluster
+            .source_iter(q!(vec![CLUSTER_SELF_ID]))
+            .send(&node, TCP.fail_stop().bincode())
+            .values()
+            .sim_output();
+
+        flow.sim()
+            .with_static_cluster_size(&cluster, 3)
+            .exhaustive(async || {
+                out_recv
+                    .assert_yields_only_unordered([0, 1, 2].map(MemberId::from_raw_id))
+                    .await
+            });
+    }
+
+    #[cfg(feature = "sim")]
+    #[test]
+    fn sim_static_cluster_broadcast() {
+        let mut flow = FlowBuilder::new();
+        let source = flow.static_cluster::<()>();
+        let node = flow.process::<()>();
+
+        // Each member broadcasts 1 to all members, then sends to process
+        let out_recv = source
+            .source_iter(q!(vec![1i32]))
+            .broadcast(&source, TCP.fail_stop().bincode())
+            .values()
+            .send(&node, TCP.fail_stop().bincode())
+            .values()
+            .sim_output();
+
+        flow.sim()
+            .with_static_cluster_size(&source, 2)
+            .exhaustive(async || {
+                // 2 members each broadcast 1 to all 2 → 4 items at cluster,
+                // then each sends to process → 4 items
+                out_recv
+                    .assert_yields_only_unordered(vec![1i32; 4])
+                    .await
+            });
+    }
+
+    #[cfg(feature = "sim")]
+    #[test]
+    fn sim_static_cluster_membership() {
+        let mut flow = FlowBuilder::new();
+        let cluster = flow.static_cluster::<()>();
+        let node = flow.process::<()>();
+
+        let out_recv = node
+            .source_cluster_members_static(&cluster)
+            .entries()
+            .map(q!(|(id, v)| (id, v)))
+            .sim_output();
+
+        flow.sim()
+            .with_static_cluster_size(&cluster, 2)
             .exhaustive(async || {
                 out_recv
                     .assert_yields_only_unordered(vec![

--- a/hydro_lang/src/location/dynamic.rs
+++ b/hydro_lang/src/location/dynamic.rs
@@ -20,8 +20,10 @@ use crate::location::LocationType;
 pub enum LocationId {
     /// A process root location (i.e. a single node).
     Process(LocationKey),
-    /// A cluster root location (i.e. multiple nodes).
+    /// A cluster root location (i.e. multiple nodes) with dynamic membership.
     Cluster(LocationKey),
+    /// A cluster root location with fixed membership known at deploy time.
+    StaticCluster(LocationKey),
     /// An atomic region, within a tick.
     Atomic(
         /// The tick that the atomic region is associated with.
@@ -37,6 +39,7 @@ impl std::fmt::Debug for LocationId {
         match self {
             LocationId::Process(key) => write!(f, "Process({key})"),
             LocationId::Cluster(key) => write!(f, "Cluster({key})"),
+            LocationId::StaticCluster(key) => write!(f, "StaticCluster({key})"),
             LocationId::Atomic(tick) => write!(f, "Atomic({tick:?})"),
             LocationId::Tick(tick, id) => write!(f, "Tick({tick}, {id:?})"),
         }
@@ -49,6 +52,7 @@ impl LocationId {
         match self {
             LocationId::Process(_) => Some(LocationType::Process),
             LocationId::Cluster(_) => Some(LocationType::Cluster),
+            LocationId::StaticCluster(_) => Some(LocationType::StaticCluster),
             _ => None,
         }
     }
@@ -60,6 +64,7 @@ impl LocationId {
         match self {
             LocationId::Process(_) => self,
             LocationId::Cluster(_) => self,
+            LocationId::StaticCluster(_) => self,
             LocationId::Atomic(tick) => tick.root(),
             LocationId::Tick(_, id) => id.root(),
         }
@@ -67,7 +72,7 @@ impl LocationId {
 
     pub fn is_root(&self) -> bool {
         match self {
-            LocationId::Process(_) | LocationId::Cluster(_) => true,
+            LocationId::Process(_) | LocationId::Cluster(_) | LocationId::StaticCluster(_) => true,
             LocationId::Atomic(_) => false,
             LocationId::Tick(_, _) => false,
         }
@@ -75,7 +80,7 @@ impl LocationId {
 
     pub fn is_top_level(&self) -> bool {
         match self {
-            LocationId::Process(_) | LocationId::Cluster(_) => true,
+            LocationId::Process(_) | LocationId::Cluster(_) | LocationId::StaticCluster(_) => true,
             LocationId::Atomic(_) => true,
             LocationId::Tick(_, _) => false,
         }
@@ -85,8 +90,22 @@ impl LocationId {
         match self {
             LocationId::Process(id) => *id,
             LocationId::Cluster(id) => *id,
+            LocationId::StaticCluster(id) => *id,
             LocationId::Atomic(_) => panic!("cannot get raw id for atomic"),
             LocationId::Tick(_, _) => panic!("cannot get raw id for tick"),
+        }
+    }
+
+    /// Returns `true` if this is any kind of cluster (dynamic or static).
+    pub fn is_cluster(&self) -> bool {
+        matches!(self.root(), LocationId::Cluster(_) | LocationId::StaticCluster(_))
+    }
+
+    /// Returns the key if this is any kind of cluster, or `None` otherwise.
+    pub fn cluster_key(&self) -> Option<LocationKey> {
+        match self.root() {
+            LocationId::Cluster(key) | LocationId::StaticCluster(key) => Some(*key),
+            _ => None,
         }
     }
 

--- a/hydro_lang/src/location/mod.rs
+++ b/hydro_lang/src/location/mod.rs
@@ -61,7 +61,7 @@ pub mod process;
 pub use process::Process;
 
 pub mod cluster;
-pub use cluster::Cluster;
+pub use cluster::{Cluster, StaticCluster};
 
 pub mod member_id;
 pub use member_id::{MemberId, TaglessMemberId};
@@ -166,8 +166,10 @@ impl<Ctx> FreeVariableWithContextWithProps<Ctx, ()> for LocationKey {
 pub enum LocationType {
     /// A process (single node).
     Process,
-    /// A cluster (multiple nodes).
+    /// A cluster (multiple nodes) with dynamic membership.
     Cluster,
+    /// A cluster (multiple nodes) with fixed membership known at deploy time.
+    StaticCluster,
     /// An external client.
     External,
 }
@@ -439,6 +441,36 @@ pub trait Location<'a>: dynamic::DynLocation {
                     (TaglessMemberId, MembershipEvent),
                     Self,
                     Unbounded,
+                    TotalOrder,
+                    ExactlyOnce,
+                >::collection_kind()),
+            },
+        )
+        .map(q!(|(k, v)| (MemberId::from_tagless(k), v)))
+        .into_keyed()
+    }
+
+    /// Creates a stream of membership events for a static cluster.
+    ///
+    /// For a [`StaticCluster`], all members emit [`MembershipEvent::Joined`] at
+    /// startup and never emit [`MembershipEvent::Left`]. The returned stream has
+    /// the same type as [`Location::source_cluster_members`] for compatibility
+    /// with existing membership-tracking utilities.
+    fn source_cluster_members_static<C: 'a>(
+        &self,
+        cluster: &StaticCluster<'a, C>,
+    ) -> KeyedStream<MemberId<C>, MembershipEvent, Self, Bounded>
+    where
+        Self: Sized + NoTick,
+    {
+        Stream::new(
+            self.clone(),
+            HydroNode::Source {
+                source: HydroSource::ClusterMembers(cluster.id(), ClusterMembersState::Uninit),
+                metadata: self.new_node_metadata(Stream::<
+                    (TaglessMemberId, MembershipEvent),
+                    Self,
+                    Bounded,
                     TotalOrder,
                     ExactlyOnce,
                 >::collection_kind()),

--- a/hydro_lang/src/location/tick.rs
+++ b/hydro_lang/src/location/tick.rs
@@ -23,7 +23,7 @@ use stageleft::{QuotedWithContext, q};
 
 #[cfg(stageleft_runtime)]
 use super::dynamic::DynLocation;
-use super::{Cluster, Location, LocationId, Process};
+use super::{Cluster, Location, LocationId, Process, StaticCluster};
 use crate::compile::builder::{ClockId, FlowState};
 use crate::compile::ir::{HydroNode, HydroSource};
 #[cfg(stageleft_runtime)]
@@ -46,6 +46,8 @@ pub trait NoTick {}
 impl<T> NoTick for Process<'_, T> {}
 #[sealed]
 impl<T> NoTick for Cluster<'_, T> {}
+#[sealed]
+impl<T> NoTick for StaticCluster<'_, T> {}
 
 /// Marker trait for locations that are **not** inside an [`Atomic`] context.
 ///
@@ -58,6 +60,8 @@ pub trait NoAtomic {}
 impl<T> NoAtomic for Process<'_, T> {}
 #[sealed]
 impl<T> NoAtomic for Cluster<'_, T> {}
+#[sealed]
+impl<T> NoAtomic for StaticCluster<'_, T> {}
 #[sealed]
 impl<'a, L> NoAtomic for Tick<L> where L: Location<'a> {}
 

--- a/hydro_lang/src/sim/builder.rs
+++ b/hydro_lang/src/sim/builder.rs
@@ -43,7 +43,7 @@ impl SimBuilder {
             LocationId::Process(_) => {
                 self.extra_stmts_global.push(stmt);
             }
-            LocationId::Cluster(_) => {
+            LocationId::Cluster(_) | LocationId::StaticCluster(_) => {
                 self.extra_stmts_cluster
                     .entry(location.clone())
                     .or_default()
@@ -64,7 +64,7 @@ impl SimBuilder {
                     },
                 );
             }
-            LocationId::Cluster(_) => {
+            LocationId::Cluster(_) | LocationId::StaticCluster(_) => {
                 self.add_extra_stmt_internal(in_location, syn::parse_quote! {
                     __hydro_hooks.entry((#out_location_ser, Some(__current_cluster_id))).or_default().push(#expr);
                 });
@@ -85,7 +85,7 @@ impl SimBuilder {
                         },
                     );
                 }
-                LocationId::Cluster(_) => {
+                LocationId::Cluster(_) | LocationId::StaticCluster(_) => {
                     self.add_extra_stmt_internal(l.root(), syn::parse_quote! {
                         __hydro_inline_hooks.entry((#tick_location_ser, Some(__current_cluster_id))).or_default().push(#expr);
                     });
@@ -105,13 +105,13 @@ impl DfirBuilder for SimBuilder {
     fn get_dfir_mut(&mut self, location: &LocationId) -> &mut FlatGraphBuilder {
         match location {
             LocationId::Process(_) => self.process_graphs.entry(location.clone()).or_default(),
-            LocationId::Cluster(_) => self.cluster_graphs.entry(location.clone()).or_default(),
+            LocationId::Cluster(_) | LocationId::StaticCluster(_) => self.cluster_graphs.entry(location.clone()).or_default(),
             LocationId::Atomic(tick) => self.get_dfir_mut(tick.as_ref()),
             LocationId::Tick(_, l) => match l.root() {
                 LocationId::Process(_) => {
                     self.process_tick_dfirs.entry(location.clone()).or_default()
                 }
-                LocationId::Cluster(_) => {
+                LocationId::Cluster(_) | LocationId::StaticCluster(_) => {
                     self.cluster_tick_dfirs.entry(location.clone()).or_default()
                 }
                 _ => unreachable!(),
@@ -1039,7 +1039,7 @@ impl DfirBuilder for SimBuilder {
                     );
                 }
             }
-            (LocationId::Cluster(_), LocationId::Process(_)) => {
+            (LocationId::Cluster(_) | LocationId::StaticCluster(_), LocationId::Process(_)) => {
                 self.extra_stmts_global.push(syn::parse_quote! {
                     let (#sink, #source) = __root_dfir_rs::util::unbounded_channel::<(#root::__staged::location::TaglessMemberId, __root_dfir_rs::bytes::Bytes)>();
                 });
@@ -1087,7 +1087,7 @@ impl DfirBuilder for SimBuilder {
                     );
                 }
             }
-            (LocationId::Process(_), LocationId::Cluster(_)) => {
+            (LocationId::Process(_), LocationId::Cluster(_) | LocationId::StaticCluster(_)) => {
                 let sink_writer = syn::Ident::new(
                     &format!("__cloned_{}", sink.to_token_stream()),
                     Span::call_site(),
@@ -1147,7 +1147,7 @@ impl DfirBuilder for SimBuilder {
                     );
                 }
             }
-            (LocationId::Cluster(_), LocationId::Cluster(_)) => {
+            (LocationId::Cluster(_) | LocationId::StaticCluster(_), LocationId::Cluster(_) | LocationId::StaticCluster(_)) => {
                 let sink_writer = syn::Ident::new(
                     &format!("__cloned_{}", sink.to_token_stream()),
                     Span::call_site(),

--- a/hydro_lang/src/sim/flow.rs
+++ b/hydro_lang/src/sim/flow.rs
@@ -48,6 +48,16 @@ impl<'a> SimFlow<'a> {
         self
     }
 
+    /// Sets the maximum number of members for a static cluster in the simulation.
+    pub fn with_static_cluster_size<C>(
+        mut self,
+        cluster: &crate::location::StaticCluster<'a, C>,
+        max_size: usize,
+    ) -> Self {
+        self.cluster_max_sizes.insert(cluster.key, max_size);
+        self
+    }
+
     /// Opts in to safety-only testing, which is required when using
     /// [`lossy_delayed_forever`](crate::networking::NetworkingConfig::lossy_delayed_forever)
     /// networking.


### PR DESCRIPTION
## Summary

Add a `StaticCluster` location type for clusters whose membership is fixed at deploy time and never changes.

## Motivation

Dynamic `Cluster` membership tracking introduces nondeterminism (`nondet!` guards on `broadcast`, `sliced!` for membership snapshots). For clusters that are truly static — fixed replica sets, Paxos groups — this nondeterminism is unnecessary and makes coordination analysis harder.

## Design

- `StaticCluster<'a, L>` struct implementing `IsCluster`, `Location`, `NoTick`, `NoAtomic`
- `LocationId::StaticCluster` variant handled in IR lowering, sim, and deploy
- `FlowBuilder::static_cluster()` constructor
- `source_cluster_members_static()` returns a **Bounded** stream (fixed membership set)
- `broadcast_static` uses `cross_product` with the bounded member set — no `sliced!`/`nondet!`, fully deterministic
- Outbound networking: `send`, `broadcast_static`, `broadcast_static_bincode`, `demux_static`
- Inbound networking from `Process`: `broadcast_static`, `demux_static`
- Simulator support: `with_static_cluster_size`, `sim_input` on `StaticCluster`

## Dependencies

Depends on #2778 (join-bounded) for mixed-boundedness `cross_product`.

## Stack

This is PR 2 of 5:
1. `join-bounded` — #2778
2. **`pr/static-cluster`** ← this PR
3. `pr/durable-broadcast`
4. `pr/ir-algebraic-properties`
5. `pr/analysis-json`