### PR TITLE
[experiment] feat(hydro_lang): add durable_broadcast API and ChannelDelivery semantics

### DIFF
--- a/hydro_lang/src/deploy/deploy_graph.rs
+++ b/hydro_lang/src/deploy/deploy_graph.rs
@@ -63,9 +63,7 @@ impl<'a> Deploy<'a> for HydroDeploy {
         networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr) {
         match networking_info {
-            crate::networking::NetworkingInfo::Tcp {
-                fault: crate::networking::TcpFault::FailStop,
-            } => {}
+            crate::networking::NetworkingInfo::Tcp { fault: crate::networking::TcpFault::FailStop } | crate::networking::NetworkingInfo::Durable { fault: crate::networking::TcpFault::FailStop, .. } => {}
             _ => panic!("Unsupported networking info: {:?}", networking_info),
         }
         let p1_port = p1_port.as_str();
@@ -111,9 +109,7 @@ impl<'a> Deploy<'a> for HydroDeploy {
         networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr) {
         match networking_info {
-            crate::networking::NetworkingInfo::Tcp {
-                fault: crate::networking::TcpFault::FailStop,
-            } => {}
+            crate::networking::NetworkingInfo::Tcp { fault: crate::networking::TcpFault::FailStop } | crate::networking::NetworkingInfo::Durable { fault: crate::networking::TcpFault::FailStop, .. } => {}
             _ => panic!("Unsupported networking info: {:?}", networking_info),
         }
         let p1_port = p1_port.as_str();
@@ -171,9 +167,7 @@ impl<'a> Deploy<'a> for HydroDeploy {
         networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr) {
         match networking_info {
-            crate::networking::NetworkingInfo::Tcp {
-                fault: crate::networking::TcpFault::FailStop,
-            } => {}
+            crate::networking::NetworkingInfo::Tcp { fault: crate::networking::TcpFault::FailStop } | crate::networking::NetworkingInfo::Durable { fault: crate::networking::TcpFault::FailStop, .. } => {}
             _ => panic!("Unsupported networking info: {:?}", networking_info),
         }
         let c1_port = c1_port.as_str();
@@ -223,9 +217,7 @@ impl<'a> Deploy<'a> for HydroDeploy {
         networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr) {
         match networking_info {
-            crate::networking::NetworkingInfo::Tcp {
-                fault: crate::networking::TcpFault::FailStop,
-            } => {}
+            crate::networking::NetworkingInfo::Tcp { fault: crate::networking::TcpFault::FailStop } | crate::networking::NetworkingInfo::Durable { fault: crate::networking::TcpFault::FailStop, .. } => {}
             _ => panic!("Unsupported networking info: {:?}", networking_info),
         }
         let c1_port = c1_port.as_str();

--- a/hydro_lang/src/deploy/deploy_graph_containerized.rs
+++ b/hydro_lang/src/deploy/deploy_graph_containerized.rs
@@ -916,9 +916,7 @@ impl<'a> Deploy<'a> for DockerDeploy {
         networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr) {
         match networking_info {
-            crate::networking::NetworkingInfo::Tcp {
-                fault: crate::networking::TcpFault::FailStop,
-            } => {}
+            crate::networking::NetworkingInfo::Tcp { fault: crate::networking::TcpFault::FailStop } | crate::networking::NetworkingInfo::Durable { fault: crate::networking::TcpFault::FailStop, .. } => {}
             _ => panic!("Unsupported networking info: {:?}", networking_info),
         }
 
@@ -953,9 +951,7 @@ impl<'a> Deploy<'a> for DockerDeploy {
         networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr) {
         match networking_info {
-            crate::networking::NetworkingInfo::Tcp {
-                fault: crate::networking::TcpFault::FailStop,
-            } => {}
+            crate::networking::NetworkingInfo::Tcp { fault: crate::networking::TcpFault::FailStop } | crate::networking::NetworkingInfo::Durable { fault: crate::networking::TcpFault::FailStop, .. } => {}
             _ => panic!("Unsupported networking info: {:?}", networking_info),
         }
 
@@ -989,9 +985,7 @@ impl<'a> Deploy<'a> for DockerDeploy {
         networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr) {
         match networking_info {
-            crate::networking::NetworkingInfo::Tcp {
-                fault: crate::networking::TcpFault::FailStop,
-            } => {}
+            crate::networking::NetworkingInfo::Tcp { fault: crate::networking::TcpFault::FailStop } | crate::networking::NetworkingInfo::Durable { fault: crate::networking::TcpFault::FailStop, .. } => {}
             _ => panic!("Unsupported networking info: {:?}", networking_info),
         }
 
@@ -1026,9 +1020,7 @@ impl<'a> Deploy<'a> for DockerDeploy {
         networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr) {
         match networking_info {
-            crate::networking::NetworkingInfo::Tcp {
-                fault: crate::networking::TcpFault::FailStop,
-            } => {}
+            crate::networking::NetworkingInfo::Tcp { fault: crate::networking::TcpFault::FailStop } | crate::networking::NetworkingInfo::Durable { fault: crate::networking::TcpFault::FailStop, .. } => {}
             _ => panic!("Unsupported networking info: {:?}", networking_info),
         }
 

--- a/hydro_lang/src/deploy/deploy_graph_containerized_ecs.rs
+++ b/hydro_lang/src/deploy/deploy_graph_containerized_ecs.rs
@@ -440,14 +440,12 @@ impl<'a> Deploy<'a> for EcsDeploy {
         networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr) {
         match networking_info {
-            crate::networking::NetworkingInfo::Tcp {
-                fault: crate::networking::TcpFault::FailStop,
-            } => {}
+            crate::networking::NetworkingInfo::Tcp { fault: crate::networking::TcpFault::FailStop } | crate::networking::NetworkingInfo::Durable { fault: crate::networking::TcpFault::FailStop, .. } => {}
             _ => panic!("Unsupported networking info: {:?}", networking_info),
         }
 
         deploy_containerized_o2o(
-            &p2.name,
+              &p2.name,
             name.expect("channel name is required for containerized deployment"),
         )
     }
@@ -480,9 +478,7 @@ impl<'a> Deploy<'a> for EcsDeploy {
         networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr) {
         match networking_info {
-            crate::networking::NetworkingInfo::Tcp {
-                fault: crate::networking::TcpFault::FailStop,
-            } => {}
+            crate::networking::NetworkingInfo::Tcp { fault: crate::networking::TcpFault::FailStop } | crate::networking::NetworkingInfo::Durable { fault: crate::networking::TcpFault::FailStop, .. } => {}
             _ => panic!("Unsupported networking info: {:?}", networking_info),
         }
 
@@ -519,9 +515,7 @@ impl<'a> Deploy<'a> for EcsDeploy {
         networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr) {
         match networking_info {
-            crate::networking::NetworkingInfo::Tcp {
-                fault: crate::networking::TcpFault::FailStop,
-            } => {}
+            crate::networking::NetworkingInfo::Tcp { fault: crate::networking::TcpFault::FailStop } | crate::networking::NetworkingInfo::Durable { fault: crate::networking::TcpFault::FailStop, .. } => {}
             _ => panic!("Unsupported networking info: {:?}", networking_info),
         }
 
@@ -559,9 +553,7 @@ impl<'a> Deploy<'a> for EcsDeploy {
         networking_info: &crate::networking::NetworkingInfo,
     ) -> (syn::Expr, syn::Expr) {
         match networking_info {
-            crate::networking::NetworkingInfo::Tcp {
-                fault: crate::networking::TcpFault::FailStop,
-            } => {}
+            crate::networking::NetworkingInfo::Tcp { fault: crate::networking::TcpFault::FailStop } | crate::networking::NetworkingInfo::Durable { fault: crate::networking::TcpFault::FailStop, .. } => {}
             _ => panic!("Unsupported networking info: {:?}", networking_info),
         }
 

--- a/hydro_lang/src/deploy/maelstrom/deploy_maelstrom.rs
+++ b/hydro_lang/src/deploy/maelstrom/deploy_maelstrom.rs
@@ -117,7 +117,7 @@ impl<'a> Deploy<'a> for MaelstromDeploy {
     ) -> (syn::Expr, syn::Expr) {
         use crate::networking::{NetworkingInfo, TcpFault};
         match networking_info {
-            NetworkingInfo::Tcp { fault } => match (fault, env.nemesis.as_deref()) {
+            NetworkingInfo::Tcp { fault } | NetworkingInfo::Durable { fault, .. } => match (fault, env.nemesis.as_deref()) {
                 (TcpFault::Lossy | TcpFault::LossyDelayedForever, _) => {} /* lossy/delayed are always allowed */
                 (_, None) => {} // no nemesis means any fault model is fine
                 (TcpFault::FailStop, Some("partition")) => {

--- a/hydro_lang/src/live_collections/stream/networking.rs
+++ b/hydro_lang/src/live_collections/stream/networking.rs
@@ -425,6 +425,78 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Process<'a, L>
             .into_keyed()
             .demux_static(to, via)
     }
+
+    /// Broadcasts elements of this stream to all members of a dynamic cluster with
+    /// durable delivery guarantees.
+    ///
+    /// Unlike [`Stream::broadcast`], which only guarantees delivery to members that
+    /// are present when each element is sent, `durable_broadcast` guarantees that
+    /// every cluster member — including late joiners — receives the complete stream.
+    ///
+    /// The durability mechanism (journal replay, state transfer, etc.) is external
+    /// to Hydro. The `manual_proof` asserts the following properties:
+    ///
+    /// 1. **Replay soundness**: the external store faithfully persists all elements
+    ///    written to it, and replays them correctly on restore. For snapshot-based
+    ///    restore: applying the snapshot then replaying the log tail produces the
+    ///    same state as processing the full log from the beginning.
+    ///
+    /// 2. **Gap-freeness**: the combination of restore + live traffic delivers every
+    ///    element with no gaps at the cutover seam. This includes:
+    ///    - No elements lost between the last restored element and the first live element
+    ///    - Buffering or coordination during restore prevents missed elements
+    ///    - Duplicates at the boundary are acceptable (downstream must be idempotent
+    ///      or perform explicit deduplication)
+    ///
+    /// The resulting stream has [`AtLeastOnce`] retries semantics because replay
+    /// may deliver duplicates at the recovery boundary.
+    pub fn durable_broadcast<L2: 'a, N: NetworkFor<T>>(
+        self,
+        to: &Cluster<'a, L2>,
+        via: N,
+        _durability_proof: crate::properties::ManualProof,
+    ) -> Stream<T, Cluster<'a, L2>, Unbounded, <O as MinOrder<N::OrderingGuarantee>>::Min, super::AtLeastOnce>
+    where
+        T: Clone + Serialize + DeserializeOwned,
+        O: MinOrder<N::OrderingGuarantee>,
+    {
+        let durable_via = crate::networking::DurableTransport::new(via);
+        let ids = track_membership(self.location.source_cluster_members(to));
+        sliced! {
+            let members_snapshot = use(ids, crate::nondet::nondet!(/** durable broadcast: membership tracking */));
+            let elements = use(self, crate::nondet::nondet!(/** durable broadcast: element batching */));
+
+            let current_members = members_snapshot.filter(q!(|b| *b));
+            elements.repeat_with_keys(current_members)
+        }
+        .demux(to, durable_via)
+        .weaken_retries::<super::AtLeastOnce>()
+    }
+
+    /// Broadcasts elements of this stream to all members of a static cluster with
+    /// durable delivery guarantees.
+    ///
+    /// Unlike [`Stream::durable_broadcast`] for dynamic clusters, this does not need
+    /// membership tracking since [`StaticCluster`] membership is fixed. The durability
+    /// mechanism (journal replay, state transfer, etc.) ensures that members recover
+    /// all elements after a failure.
+    ///
+    /// The `manual_proof` asserts replay soundness and gap-freeness (same as
+    /// [`Stream::durable_broadcast`]).
+    pub fn durable_broadcast_static<L2: 'a, N: NetworkFor<T>>(
+        self,
+        to: &crate::location::StaticCluster<'a, L2>,
+        via: N,
+        _durability_proof: crate::properties::ManualProof,
+    ) -> Stream<T, crate::location::StaticCluster<'a, L2>, Unbounded, NoOrder, super::AtLeastOnce>
+    where
+        T: Clone + Serialize + DeserializeOwned,
+        O: MinOrder<N::OrderingGuarantee>,
+    {
+        let durable_via = crate::networking::DurableTransport::new(via);
+        self.broadcast_static(to, durable_via)
+            .weaken_retries::<super::AtLeastOnce>()
+    }
 }
 
 impl<'a, T, L: Location<'a> + NoTick, B: Boundedness> Stream<T, L, B, TotalOrder, ExactlyOnce> {

--- a/hydro_lang/src/networking/mod.rs
+++ b/hydro_lang/src/networking/mod.rs
@@ -148,6 +148,25 @@ pub enum TcpFault {
     LossyDelayedForever,
 }
 
+/// End-to-end delivery guarantee for a network channel.
+///
+/// Describes what the recipient is guaranteed to see relative to what the
+/// sender produced. This is a property of the channel (transport + lifecycle),
+/// not just the transport.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ChannelDelivery {
+    /// Every element sent arrives exactly once, in order.
+    /// If the connection fails, the stream dies (no partial delivery after reconnect).
+    ExactlyOnceOrdered,
+    /// Every element sent arrives at least once, in order.
+    /// Duplicates possible at recovery boundaries.
+    AtLeastOnceOrdered,
+    /// Every element sent arrives at least once. No order guarantee.
+    AtLeastOnceUnordered,
+    /// Elements may be lost. No order guarantee.
+    BestEffort,
+}
+
 /// Describes the networking configuration for a network channel at the IR level.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum NetworkingInfo {
@@ -156,6 +175,52 @@ pub enum NetworkingInfo {
         /// The fault model for this TCP connection.
         fault: TcpFault,
     },
+    /// A durable network channel that guarantees complete delivery
+    /// from the first item, even for late-joining cluster members.
+    /// The delivery guarantee is provided by an external mechanism
+    /// (journal replay, state transfer, etc.) asserted via manual_proof.
+    Durable {
+        /// The underlying transport's fault model.
+        fault: TcpFault,
+        /// The end-to-end delivery guarantee including recovery.
+        delivery: ChannelDelivery,
+    },
+}
+
+impl NetworkingInfo {
+    /// Returns the end-to-end delivery guarantee for this channel.
+    pub fn delivery(&self) -> ChannelDelivery {
+        match self {
+            NetworkingInfo::Tcp { fault } => match fault {
+                TcpFault::FailStop => ChannelDelivery::ExactlyOnceOrdered,
+                TcpFault::Lossy => ChannelDelivery::BestEffort,
+                TcpFault::LossyDelayedForever => ChannelDelivery::BestEffort,
+            },
+            NetworkingInfo::Durable { delivery, .. } => *delivery,
+        }
+    }
+
+    /// Whether this channel guarantees no gaps (ExactlyOnce or AtLeastOnce).
+    pub fn is_gap_free(&self) -> bool {
+        matches!(
+            self.delivery(),
+            ChannelDelivery::ExactlyOnceOrdered
+                | ChannelDelivery::AtLeastOnceOrdered
+                | ChannelDelivery::AtLeastOnceUnordered
+        )
+    }
+
+    /// Whether this channel is durable (survives session restarts).
+    pub fn is_durable(&self) -> bool {
+        matches!(self, NetworkingInfo::Durable { .. })
+    }
+
+    /// Returns the underlying TCP fault model.
+    pub fn fault(&self) -> TcpFault {
+        match self {
+            NetworkingInfo::Tcp { fault } | NetworkingInfo::Durable { fault, .. } => *fault,
+        }
+    }
 }
 
 /// A network channel configuration with `T` as transport backend and `S` as the serialization
@@ -288,6 +353,50 @@ where
 
     fn networking_info() -> NetworkingInfo {
         Tr::networking_info()
+    }
+}
+
+/// Wraps a network configuration to indicate durable delivery.
+///
+/// A `DurableTransport<N>` delegates serialization and ordering to the inner
+/// transport `N`, but returns [`NetworkingInfo::Durable`] from
+/// [`NetworkFor::networking_info`], signaling to the coordination analysis
+/// that this channel provides complete delivery from the first item
+/// (via journal replay, state transfer, or similar mechanism).
+pub struct DurableTransport<N> {
+    inner: N,
+}
+
+impl<N> DurableTransport<N> {
+    /// Wraps a transport with durable delivery semantics.
+    pub fn new(inner: N) -> Self {
+        Self { inner }
+    }
+}
+
+#[sealed::sealed]
+impl<N: NetworkFor<T>, T: ?Sized> NetworkFor<T> for DurableTransport<N> {
+    type OrderingGuarantee = N::OrderingGuarantee;
+
+    fn serialize_thunk(is_demux: bool) -> syn::Expr {
+        N::serialize_thunk(is_demux)
+    }
+
+    fn deserialize_thunk(tagged: Option<&syn::Type>) -> syn::Expr {
+        N::deserialize_thunk(tagged)
+    }
+
+    fn name(&self) -> Option<&str> {
+        self.inner.name()
+    }
+
+    fn networking_info() -> NetworkingInfo {
+        let base = N::networking_info();
+        let fault = base.fault();
+        NetworkingInfo::Durable {
+            fault,
+            delivery: ChannelDelivery::AtLeastOnceOrdered,
+        }
     }
 }
 

--- a/hydro_lang/src/sim/builder.rs
+++ b/hydro_lang/src/sim/builder.rs
@@ -978,7 +978,7 @@ impl DfirBuilder for SimBuilder {
     ) {
         use crate::networking::{NetworkingInfo, TcpFault};
         match networking_info {
-            NetworkingInfo::Tcp { fault } => match fault {
+            NetworkingInfo::Tcp { fault } | NetworkingInfo::Durable { fault, .. } => match fault {
                 TcpFault::FailStop => {}
                 TcpFault::LossyDelayedForever => {
                     assert!(


### PR DESCRIPTION
## Summary

Add infrastructure for network channels with durable delivery guarantees (journal replay, state transfer, etc.).

## Motivation

`broadcast` only guarantees delivery to members present when each element is sent. For systems like MicroDB where a Paxos log is replayed to late-joining replicas, the channel semantics are stronger — every member eventually receives the complete stream. The type system and IR should capture this so coordination analysis can reason about it.

## Design

- `ChannelDelivery` enum: `ExactlyOnceOrdered`, `AtLeastOnceOrdered`, `AtLeastOnceUnordered`, `BestEffort`
- `NetworkingInfo::Durable { fault, delivery }` variant for channels with replay/recovery
- `NetworkingInfo` helper methods: `delivery()`, `is_gap_free()`, `is_durable()`, `fault()`
- `DurableTransport<N>` wrapper that delegates to inner transport but returns `NetworkingInfo::Durable`
- `Stream::durable_broadcast()` for dynamic `Cluster` with `manual_proof` for durability assertion
- `Stream::durable_broadcast_static()` for `StaticCluster` (simpler: no membership tracking needed)
- All deploy/sim match sites handle the `Durable` variant

## Dependencies

Depends on #2790 (StaticCluster).

## Stack

This is PR 3 of 5:
1. `join-bounded` — #2778
2. `pr/static-cluster` — #2790
3. **`pr/durable-broadcast`** ← this PR
4. `pr/ir-algebraic-properties`
5. `pr/analysis-json`