### PR TITLE
feat(hydro_lang)!: replace `NoTick`/`NoAtomic` with `TopLevel`, track consistency in the type system

### DIFF
--- a/docs/docs/hydro/learn/quickstart/partitioned-counter.mdx
+++ b/docs/docs/hydro/learn/quickstart/partitioned-counter.mdx
@@ -27,16 +27,16 @@ Before partitioning the counter, you need to make the `keyed_counter_service` fu
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/keyed_counter.rs">src/keyed_counter.rs</Link>
 } showLineNumbers={8}>{getLines(keyedCounterSrc, 8, 14, `
-pub fn keyed_counter_service<'a, L: Location<'a> + NoTick>(
+pub fn keyed_counter_service<'a, L: Location<'a>>(
     increment_requests: KeyedStream<u32, String, L, Unbounded>,
     get_requests: KeyedStream<u32, String, L, Unbounded>,
 ) -> (
     KeyedStream<u32, String, L, Unbounded>,
-    KeyedStream<u32, (String, usize), L, Unbounded, NoOrder>,
+    KeyedStream<u32, (String, usize), L::DropConsistency, Unbounded, NoOrder>,
 ) {
 `)}</CodeBlock>
 
-The `L: Location<'a> + NoTick` bound means the function works with any location that that is outside a `Tick` (like `Process` or `Cluster`). This lets you reuse the same counter logic whether it runs on a single process or several cluster members. The rest of the function body remains unchanged, it already works with any location type.
+The `L: Location<'a>` bound means the function works with any location. This lets you reuse the same counter logic whether it runs on a single process or several cluster members. The rest of the function body remains unchanged, it already works with any location type. You'll notice that we also had to modify the location type parameter for the second output stream (the lookup responses), to be `L::DropConsistency`. In addition to tracking determinism, Hydro also tracks whether _eventual consistency_ is guaranteed across several replicas. Now that we scale the service across replicas, Hydro points out that even if the requests are the same across several replicas, the responses may be different because the service uses an asynchronous snapshot of the counter state. Hence, the responses stream is tagged with `L::DropConsistency`. Note that the `current_count` is still tagged with `L`, because the counter state is consistent - it's just the responses that read from it that may diverge.
 
 ## Introducing Clusters
 

--- a/docs/docs/hydro/reference/locations/clusters.md
+++ b/docs/docs/hydro/reference/locations/clusters.md
@@ -124,7 +124,7 @@ on_worker.send(&p2, TCP.fail_stop().bincode())
 # }));
 ```
 
-This API requires a [non-determinism guard](../live-collections/determinism.md#unsafe-operations-in-hydro), because the set of cluster members may asynchronously change over time. Depending on when we are notified of membership changes, we will broadcast to different members. Under the hood, the `broadcast` API uses a list of members of the cluster provided by the deployment system. To manually access this list, you can use the `source_cluster_members` method to get a stream of membership events (cluster members joining or leaving):
+This API requires a [non-determinism guard](../live-collections/determinism.md#unsafe-operations-in-hydro), because the set of cluster members may asynchronously change over time. Depending on when we are notified of membership changes, we will broadcast to different members. Under the hood, the `broadcast` API uses a list of members of the cluster provided by the deployment system. To manually access this list, you can use the `source_cluster_membership_stream` method to get a stream of membership events (cluster members joining or leaving):
 
 ```rust
 # use hydro_lang::prelude::*;
@@ -134,7 +134,7 @@ let p1 = flow.process::<()>();
 let workers: Cluster<()> = flow.cluster::<()>();
 # // do nothing on each worker
 # workers.source_iter(q!(vec![])).for_each(q!(|_: ()| {}));
-let cluster_members = p1.source_cluster_members(&workers);
+let cluster_members = p1.source_cluster_membership_stream(&workers, nondet!(/** late joiners may miss events */));
 # cluster_members.entries().send(&p2, TCP.fail_stop().bincode())
 // if there are 4 members in the cluster, we would see a join event for each
 // { MemberId::<Worker>(0): [MembershipEvent::Join], MemberId::<Worker>(2): [MembershipEvent::Join], ... }

--- a/hydro_lang/src/compile/built.rs
+++ b/hydro_lang/src/compile/built.rs
@@ -162,6 +162,7 @@ impl<'a> BuiltFlow<'a> {
             cluster_max_sizes: SparseSecondaryMap::new(),
             externals_port_registry: Default::default(),
             test_safety_only: false,
+            skip_consistency_assertions: false,
             unit_test_fuzz_iterations: 8192,
             _phantom: PhantomData,
         }

--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -28,7 +28,7 @@ use crate::compile::builder::ClockId;
 use crate::compile::builder::{CycleId, ExternalPortId};
 #[cfg(feature = "build")]
 use crate::compile::deploy_provider::{Deploy, Node, RegisterPort};
-use crate::location::dynamic::LocationId;
+use crate::location::dynamic::{ClusterConsistency, LocationId};
 use crate::location::{LocationKey, NetworkHint};
 
 pub mod backtrace;
@@ -652,6 +652,17 @@ pub trait DfirBuilder {
         in_kind: &CollectionKind,
         op_meta: &HydroIrOpMetadata,
     ) -> Option<syn::Ident>;
+
+    /// Inserts necessary code to validate a manual assertion that at this point the
+    /// input live collection is consistent. In production, this is a no-op, but in simulation
+    /// this will (not yet implemented) inject assertions that validate consistency.
+    fn assert_is_consistent(
+        &mut self,
+        trusted: bool,
+        location: &LocationId,
+        in_ident: syn::Ident,
+        out_ident: &syn::Ident,
+    );
 }
 
 #[cfg(feature = "build")]
@@ -919,6 +930,23 @@ impl DfirBuilder for SecondaryMap<LocationKey, FlatGraphBuilder> {
     ) -> Option<syn::Ident> {
         None
     }
+
+    fn assert_is_consistent(
+        &mut self,
+        _trusted: bool,
+        location: &LocationId,
+        in_ident: syn::Ident,
+        out_ident: &syn::Ident,
+    ) {
+        let builder = self.get_dfir_mut(location);
+        builder.add_dfir(
+            parse_quote! {
+                #out_ident = #in_ident;
+            },
+            None,
+            None,
+        );
+    }
 }
 
 #[cfg(feature = "build")]
@@ -980,7 +1008,7 @@ impl HydroRoot {
         &mut self,
         extra_stmts: &mut SparseSecondaryMap<LocationKey, Vec<syn::Stmt>>,
         seen_tees: &mut SeenSharedNodes,
-        seen_cluster_members: &mut HashSet<(LocationId, LocationId)>,
+        seen_cluster_members: &mut HashSet<(LocationId, LocationKey)>,
         processes: &SparseSecondaryMap<LocationKey, D::Process>,
         clusters: &SparseSecondaryMap<LocationKey, D::Cluster>,
         externals: &SparseSecondaryMap<LocationKey, D::External>,
@@ -1297,7 +1325,7 @@ impl HydroRoot {
                     match state {
                         ClusterMembersState::Uninit => {
                             let at_location = metadata.location_id.root().clone();
-                            let key = (at_location.clone(), LocationId::Cluster(location_id.key()));
+                            let key = (at_location.clone(), location_id.key());
                             if refcell_seen_cluster_members.borrow_mut().insert(key) {
                                 // First occurrence: call cluster_membership_stream and mark as Stream.
                                 let expr = stageleft::QuotedWithContext::splice_untyped_ctx(
@@ -2137,6 +2165,7 @@ impl CollectionKind {
 pub struct HydroIrMetadata {
     pub location_id: LocationId,
     pub collection_kind: CollectionKind,
+    pub consistency: Option<ClusterConsistency>,
     pub cardinality: Option<usize>,
     pub tag: Option<String>,
     pub op: HydroIrOpMetadata,
@@ -2484,6 +2513,12 @@ pub enum HydroNode {
         input: Box<HydroNode>,
         metadata: HydroIrMetadata,
     },
+
+    AssertIsConsistent {
+        inner: Box<HydroNode>,
+        trusted: bool,
+        metadata: HydroIrMetadata,
+    },
 }
 
 pub type SeenSharedNodes = HashMap<*const RefCell<HydroNode>, Rc<RefCell<HydroNode>>>;
@@ -2573,7 +2608,8 @@ impl HydroNode {
             | HydroNode::BeginAtomic { inner, .. }
             | HydroNode::EndAtomic { inner, .. }
             | HydroNode::Batch { inner, .. }
-            | HydroNode::YieldConcat { inner, .. } => {
+            | HydroNode::YieldConcat { inner, .. }
+            | HydroNode::AssertIsConsistent { inner, .. } => {
                 transform(inner.as_mut(), seen_tees);
             }
 
@@ -2671,6 +2707,15 @@ impl HydroNode {
                 trusted,
                 metadata,
             } => HydroNode::ObserveNonDet {
+                inner: Box::new(inner.deep_clone(seen_tees)),
+                trusted: *trusted,
+                metadata: metadata.clone(),
+            },
+            HydroNode::AssertIsConsistent {
+                inner,
+                trusted,
+                metadata,
+            } => HydroNode::AssertIsConsistent {
                 inner: Box::new(inner.deep_clone(seen_tees)),
                 trusted: *trusted,
                 metadata: metadata.clone(),
@@ -3044,6 +3089,31 @@ impl HydroNode {
 
                         *next_stmt_id += 1;
                         // input_ident stays on stack as output
+                    }
+
+                    HydroNode::AssertIsConsistent { inner, trusted, .. } => {
+                        let inner_ident = ident_stack.pop().unwrap();
+
+                        let out_ident =
+                            syn::Ident::new(&format!("stream_{}", *next_stmt_id), Span::call_site());
+
+                        match builders_or_callback {
+                            BuildersOrCallback::Builders(graph_builders) => {
+                                graph_builders.assert_is_consistent(
+                                    *trusted,
+                                    &inner.metadata().location_id,
+                                    inner_ident,
+                                    &out_ident,
+                                );
+                            }
+                            BuildersOrCallback::Callback(_, node_callback) => {
+                                node_callback(node, next_stmt_id);
+                            }
+                        }
+
+                        *next_stmt_id += 1;
+
+                        ident_stack.push(out_ident);
                     }
 
                     HydroNode::ObserveNonDet {
@@ -4718,7 +4788,9 @@ impl HydroNode {
             HydroNode::Placeholder => {
                 panic!()
             }
-            HydroNode::Cast { .. } | HydroNode::ObserveNonDet { .. } => {}
+            HydroNode::Cast { .. }
+            | HydroNode::ObserveNonDet { .. }
+            | HydroNode::AssertIsConsistent { .. } => {}
             HydroNode::Source { source, .. } => match source {
                 HydroSource::Stream(expr) | HydroSource::Iter(expr) => transform(expr),
                 HydroSource::ExternalNetwork()
@@ -4806,6 +4878,7 @@ impl HydroNode {
             }
             HydroNode::Cast { metadata, .. }
             | HydroNode::ObserveNonDet { metadata, .. }
+            | HydroNode::AssertIsConsistent { metadata, .. }
             | HydroNode::Source { metadata, .. }
             | HydroNode::SingletonSource { metadata, .. }
             | HydroNode::CycleSource { metadata, .. }
@@ -4862,6 +4935,7 @@ impl HydroNode {
             }
             HydroNode::Cast { metadata, .. }
             | HydroNode::ObserveNonDet { metadata, .. }
+            | HydroNode::AssertIsConsistent { metadata, .. }
             | HydroNode::Source { metadata, .. }
             | HydroNode::SingletonSource { metadata, .. }
             | HydroNode::CycleSource { metadata, .. }
@@ -4927,7 +5001,8 @@ impl HydroNode {
             | HydroNode::YieldConcat { inner, .. }
             | HydroNode::BeginAtomic { inner, .. }
             | HydroNode::EndAtomic { inner, .. }
-            | HydroNode::Batch { inner, .. } => {
+            | HydroNode::Batch { inner, .. }
+            | HydroNode::AssertIsConsistent { inner, .. } => {
                 vec![inner]
             }
             HydroNode::Chain { first, second, .. } => {
@@ -5008,6 +5083,7 @@ impl HydroNode {
             }
             HydroNode::Cast { .. } => "Cast()".to_owned(),
             HydroNode::ObserveNonDet { .. } => "ObserveNonDet()".to_owned(),
+            HydroNode::AssertIsConsistent { .. } => "AssertIsConsistent()".to_owned(),
             HydroNode::Source { source, .. } => format!("Source({:?})", source),
             HydroNode::SingletonSource {
                 value,
@@ -5264,7 +5340,7 @@ mod test {
         ignore = "expects inclusion of feature-gated fields"
     )]
     fn hydro_node_size() {
-        assert_eq!(size_of::<HydroNode>(), 256);
+        assert_eq!(size_of::<HydroNode>(), 264);
     }
 
     #[test]

--- a/hydro_lang/src/compile/ir/snapshots/hydro_lang__compile__ir__serde_test__tests__ir_json_snapshot.snap
+++ b/hydro_lang/src/compile/ir/snapshots/hydro_lang__compile__ir__serde_test__tests__ir_json_snapshot.snap
@@ -36,6 +36,7 @@ expression: json
                           "element_type": "i32"
                         }
                       },
+                      "consistency": null,
                       "cardinality": null,
                       "tag": null,
                       "op": {
@@ -62,6 +63,7 @@ expression: json
                       "element_type": "i32"
                     }
                   },
+                  "consistency": null,
                   "cardinality": null,
                   "tag": null,
                   "op": {
@@ -89,6 +91,7 @@ expression: json
                 "element_type": "i32"
               }
             },
+            "consistency": null,
             "cardinality": null,
             "tag": null,
             "op": {
@@ -131,6 +134,7 @@ expression: json
                 "element_type": "i32"
               }
             },
+            "consistency": null,
             "cardinality": null,
             "tag": null,
             "op": {

--- a/hydro_lang/src/deploy/maelstrom/deploy_runtime_maelstrom.rs
+++ b/hydro_lang/src/deploy/maelstrom/deploy_runtime_maelstrom.rs
@@ -21,7 +21,7 @@ use crate::live_collections::keyed_stream::KeyedStream;
 use crate::live_collections::stream::{ExactlyOnce, NoOrder, TotalOrder};
 use crate::location::dynamic::LocationId;
 use crate::location::member_id::TaglessMemberId;
-use crate::location::{Cluster, LocationKey, MembershipEvent, NoTick};
+use crate::location::{Cluster, LocationKey, MembershipEvent};
 use crate::nondet::nondet;
 
 /// Maelstrom message envelope structure.

--- a/hydro_lang/src/deploy/maelstrom/mod.rs
+++ b/hydro_lang/src/deploy/maelstrom/mod.rs
@@ -6,7 +6,7 @@ use serde::de::DeserializeOwned;
 use crate::forward_handle::ForwardHandle;
 use crate::live_collections::KeyedStream;
 use crate::live_collections::stream::TotalOrder;
-use crate::location::{Cluster, NoTick};
+use crate::location::Cluster;
 use crate::nondet::nondet;
 
 #[cfg(stageleft_runtime)]
@@ -39,10 +39,7 @@ pub fn maelstrom_bidi_clients<'a, C, In: DeserializeOwned, Out: Serialize>(
 ) -> (
     KeyedStream<String, In, Cluster<'a, C>>,
     ForwardHandle<'a, KeyedStream<String, Out, Cluster<'a, C>>>,
-)
-where
-    Cluster<'a, C>: NoTick,
-{
+) {
     use stageleft::q;
 
     use crate::location::Location;

--- a/hydro_lang/src/forward_handle.rs
+++ b/hydro_lang/src/forward_handle.rs
@@ -50,6 +50,8 @@ where
 {
     type Location: Location<'a>;
 
+    fn location(&self) -> &Self::Location;
+
     fn create_source_with_initial(
         cycle_id: CycleId,
         initial: Self,

--- a/hydro_lang/src/lib.rs
+++ b/hydro_lang/src/lib.rs
@@ -58,7 +58,7 @@ pub mod prelude {
     pub use crate::location::{Cluster, External, Location as _, Process, Tick};
     pub use crate::networking::TCP;
     pub use crate::nondet::{NonDet, nondet};
-    pub use crate::properties::{ManualProof, manual_proof};
+    pub use crate::properties::{ConsistencyProof, ManualProof, manual_proof};
 
     /// A macro to set up a Hydro crate.
     #[macro_export]

--- a/hydro_lang/src/live_collections/batch_atomic.rs
+++ b/hydro_lang/src/live_collections/batch_atomic.rs
@@ -3,12 +3,12 @@ use crate::live_collections::keyed_singleton::KeyedSingletonBound;
 use crate::live_collections::singleton::SingletonBound;
 use crate::live_collections::stream::{Ordering, Retries};
 use crate::location::tick::Tick;
-use crate::location::{Atomic, Location, NoTick};
+use crate::location::{Atomic, Location};
 use crate::nondet::nondet;
 
 /// Helper trait for live collections which can be batched back into a tick from a matching
 /// atomic region. Used in [`super::Stream::across_ticks`]
-pub trait BatchAtomic {
+pub trait BatchAtomic<'a> {
     /// The type of the stream when returned to the tick.
     type Batched;
 
@@ -16,10 +16,10 @@ pub trait BatchAtomic {
     fn batched_atomic(self) -> Self::Batched;
 }
 
-impl<'a, L: Location<'a> + NoTick, T, O: Ordering, R: Retries> BatchAtomic
+impl<'a, L: Location<'a>, T, O: Ordering, R: Retries> BatchAtomic<'a>
     for super::Stream<T, Atomic<L>, Unbounded, O, R>
 {
-    type Batched = super::Stream<T, Tick<L>, Bounded, O, R>;
+    type Batched = super::Stream<T, Tick<L::DropConsistency>, Bounded, O, R>;
 
     fn batched_atomic(self) -> Self::Batched {
         let tick = self.location.tick.clone();
@@ -27,10 +27,10 @@ impl<'a, L: Location<'a> + NoTick, T, O: Ordering, R: Retries> BatchAtomic
     }
 }
 
-impl<'a, L: Location<'a> + NoTick, T, B: SingletonBound> BatchAtomic
+impl<'a, L: Location<'a>, T, B: SingletonBound> BatchAtomic<'a>
     for super::Singleton<T, Atomic<L>, B>
 {
-    type Batched = super::Singleton<T, Tick<L>, Bounded>;
+    type Batched = super::Singleton<T, Tick<L::DropConsistency>, Bounded>;
 
     fn batched_atomic(self) -> Self::Batched {
         let tick = self.location.tick.clone();
@@ -38,8 +38,8 @@ impl<'a, L: Location<'a> + NoTick, T, B: SingletonBound> BatchAtomic
     }
 }
 
-impl<'a, L: Location<'a> + NoTick, T> BatchAtomic for super::Optional<T, Atomic<L>, Unbounded> {
-    type Batched = super::Optional<T, Tick<L>, Bounded>;
+impl<'a, L: Location<'a>, T> BatchAtomic<'a> for super::Optional<T, Atomic<L>, Unbounded> {
+    type Batched = super::Optional<T, Tick<L::DropConsistency>, Bounded>;
 
     fn batched_atomic(self) -> Self::Batched {
         let tick = self.location.tick.clone();
@@ -47,10 +47,10 @@ impl<'a, L: Location<'a> + NoTick, T> BatchAtomic for super::Optional<T, Atomic<
     }
 }
 
-impl<'a, L: Location<'a> + NoTick, K, V, B: KeyedSingletonBound<ValueBound = Unbounded>> BatchAtomic
+impl<'a, L: Location<'a>, K, V, B: KeyedSingletonBound<ValueBound = Unbounded>> BatchAtomic<'a>
     for super::KeyedSingleton<K, V, Atomic<L>, B>
 {
-    type Batched = super::KeyedSingleton<K, V, Tick<L>, Bounded>;
+    type Batched = super::KeyedSingleton<K, V, Tick<L::DropConsistency>, Bounded>;
 
     fn batched_atomic(self) -> Self::Batched {
         let tick = self.location.tick.clone();

--- a/hydro_lang/src/live_collections/keyed_singleton.rs
+++ b/hydro_lang/src/live_collections/keyed_singleton.rs
@@ -25,7 +25,7 @@ use crate::live_collections::stream::{Ordering, Retries};
 #[cfg(stageleft_runtime)]
 use crate::location::dynamic::{DynLocation, LocationId};
 use crate::location::tick::DeferTick;
-use crate::location::{Atomic, Location, NoTick, Tick, check_matching_location};
+use crate::location::{Atomic, Location, Tick, check_matching_location};
 use crate::manual_expr::ManualExpr;
 use crate::nondet::{NonDet, nondet};
 use crate::properties::manual_proof;
@@ -183,7 +183,7 @@ impl<'a, K: Clone, V: Clone, Loc: Location<'a>, Bound: KeyedSingletonBound> Clon
 impl<'a, K, V, L, B: KeyedSingletonBound> CycleCollection<'a, ForwardRef>
     for KeyedSingleton<K, V, L, B>
 where
-    L: Location<'a> + NoTick,
+    L: Location<'a>,
 {
     type Location = L;
 
@@ -229,7 +229,7 @@ where
 impl<'a, K, V, L, B: KeyedSingletonBound> ReceiverComplete<'a, ForwardRef>
     for KeyedSingleton<K, V, L, B>
 where
-    L: Location<'a> + NoTick,
+    L: Location<'a>,
 {
     fn complete(self, cycle_id: CycleId, expected_location: LocationId) {
         assert_eq!(
@@ -286,6 +286,68 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound> KeyedSingleton<K, V, L, 
     /// Returns the [`Location`] where this keyed singleton is being materialized.
     pub fn location(&self) -> &L {
         &self.location
+    }
+
+    /// Weakens the consistency of this live collection to not guarantee any consistency across
+    /// cluster members (if this collection is on a cluster).
+    pub fn weaken_consistency(self) -> KeyedSingleton<K, V, L::DropConsistency, B>
+    where
+        L: Location<'a>,
+    {
+        if L::consistency()
+            .is_none_or(|c| c == crate::location::dynamic::ClusterConsistency::NoConsistency)
+        {
+            // already no consistency
+            KeyedSingleton::new(
+                self.location.drop_consistency(),
+                self.ir_node.replace(HydroNode::Placeholder),
+            )
+        } else {
+            KeyedSingleton::new(
+                self.location.drop_consistency(),
+                HydroNode::Cast {
+                    inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                    metadata: self
+                        .location
+                        .drop_consistency()
+                        .new_node_metadata(
+                            KeyedSingleton::<K, V, L::DropConsistency, B>::collection_kind(),
+                        ),
+                },
+            )
+        }
+    }
+
+    /// Casts this live collection to have the consistency guarantees specified in the given
+    /// location type parameter. The developer must ensure that the strengthened consistency
+    /// is actually guaranteed, via the proof field (see [`crate::prelude::manual_proof`]).
+    pub fn assert_has_consistency_of<L2: Location<'a, DropConsistency = L::DropConsistency>>(
+        self,
+        _proof: impl crate::properties::ConsistencyProof,
+    ) -> KeyedSingleton<K, V, L2, B>
+    where
+        L: Location<'a>,
+    {
+        if L::consistency() == L2::consistency() {
+            // already consistent
+            KeyedSingleton::new(
+                self.location.with_consistency_of(),
+                self.ir_node.replace(HydroNode::Placeholder),
+            )
+        } else {
+            KeyedSingleton::new(
+                self.location.with_consistency_of(),
+                HydroNode::AssertIsConsistent {
+                    inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                    trusted: false,
+                    metadata: self
+                        .location
+                        .clone()
+                        .with_consistency_of::<L2>()
+                        .new_node_metadata(KeyedSingleton::<K, V, L2, B>::collection_kind()),
+                },
+            )
+        }
     }
 }
 
@@ -503,7 +565,7 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound> KeyedSingleton<K, V, L, 
                 key_count_inside_tick(me.snapshot(&tick, nondet!(/** eventually stabilizes */)))
                     .latest();
             Singleton::new(
-                out.location.clone(),
+                self.location.clone(),
                 out.ir_node.replace(HydroNode::Placeholder),
             )
         } else {
@@ -578,7 +640,7 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound> KeyedSingleton<K, V, L, 
             )
             .latest();
             Singleton::new(
-                out.location.clone(),
+                self.location.clone(),
                 out.ir_node.replace(HydroNode::Placeholder),
             )
         } else {
@@ -1251,7 +1313,7 @@ where
 
 impl<'a, K, V, L, B: KeyedSingletonBound> KeyedSingleton<K, V, Atomic<L>, B>
 where
-    L: Location<'a> + NoTick,
+    L: Location<'a>,
 {
     /// Yields the elements of this keyed singleton back into a top-level, asynchronous execution context.
     /// See [`KeyedSingleton::atomic`] for more details.
@@ -1334,14 +1396,14 @@ where
     /// # Non-Determinism
     /// Because this picks a snapshot of each entry, which is continuously changing, each output has a
     /// non-deterministic set of entries since each snapshot can be at an arbitrary point in time.
-    pub fn snapshot(
+    pub fn snapshot<L2: Location<'a, DropConsistency = L::DropConsistency>>(
         self,
-        tick: &Tick<L>,
+        tick: &Tick<L2>,
         _nondet: NonDet,
-    ) -> KeyedSingleton<K, V, Tick<L>, Bounded> {
+    ) -> KeyedSingleton<K, V, Tick<L::DropConsistency>, Bounded> {
         assert_eq!(Location::id(tick.outer()), Location::id(&self.location));
         KeyedSingleton::new(
-            tick.clone(),
+            tick.drop_consistency(),
             HydroNode::Batch {
                 inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: tick
@@ -1353,7 +1415,7 @@ where
 
 impl<'a, K, V, L, B: KeyedSingletonBound<ValueBound = Unbounded>> KeyedSingleton<K, V, Atomic<L>, B>
 where
-    L: Location<'a> + NoTick,
+    L: Location<'a>,
 {
     /// Returns a keyed singleton with a snapshot of each key-value entry, consistent with the
     /// state of the keyed singleton being atomically processed.
@@ -1361,13 +1423,13 @@ where
     /// # Non-Determinism
     /// Because this picks a snapshot of each entry, which is continuously changing, each output has a
     /// non-deterministic set of entries since each snapshot can be at an arbitrary point in time.
-    pub fn snapshot_atomic(
+    pub fn snapshot_atomic<L2: Location<'a, DropConsistency = L::DropConsistency>>(
         self,
-        tick: &Tick<L>,
+        tick: &Tick<L2>,
         _nondet: NonDet,
-    ) -> KeyedSingleton<K, V, Tick<L>, Bounded> {
+    ) -> KeyedSingleton<K, V, Tick<L::DropConsistency>, Bounded> {
         KeyedSingleton::new(
-            tick.clone(),
+            tick.drop_consistency(),
             HydroNode::Batch {
                 inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: tick
@@ -1509,13 +1571,14 @@ where
     /// # Non-Determinism
     /// Because this picks a batch of asynchronously added entries, each output keyed singleton
     /// has a non-deterministic set of key-value pairs.
-    pub fn batch(self, tick: &Tick<L>, _nondet: NonDet) -> KeyedSingleton<K, V, Tick<L>, Bounded>
-    where
-        L: NoTick,
-    {
+    pub fn batch<L2: Location<'a, DropConsistency = L::DropConsistency>>(
+        self,
+        tick: &Tick<L2>,
+        _nondet: NonDet,
+    ) -> KeyedSingleton<K, V, Tick<L::DropConsistency>, Bounded> {
         assert_eq!(Location::id(tick.outer()), Location::id(&self.location));
         KeyedSingleton::new(
-            tick.clone(),
+            tick.drop_consistency(),
             HydroNode::Batch {
                 inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: tick
@@ -1527,7 +1590,7 @@ where
 
 impl<'a, K, V, L, B: KeyedSingletonBound<ValueBound = Bounded>> KeyedSingleton<K, V, Atomic<L>, B>
 where
-    L: Location<'a> + NoTick,
+    L: Location<'a>,
 {
     /// Returns a keyed singleton with entries consisting of _new_ key-value pairs that are being
     /// atomically processed.
@@ -1538,14 +1601,14 @@ where
     /// # Non-Determinism
     /// Because this picks a batch of asynchronously added entries, each output keyed singleton
     /// has a non-deterministic set of key-value pairs.
-    pub fn batch_atomic(
+    pub fn batch_atomic<L2: Location<'a, DropConsistency = L::DropConsistency>>(
         self,
-        tick: &Tick<L>,
+        tick: &Tick<L2>,
         nondet: NonDet,
-    ) -> KeyedSingleton<K, V, Tick<L>, Bounded> {
+    ) -> KeyedSingleton<K, V, Tick<L::DropConsistency>, Bounded> {
         let _ = nondet;
         KeyedSingleton::new(
-            tick.clone(),
+            tick.drop_consistency(),
             HydroNode::Batch {
                 inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: tick

--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -30,7 +30,7 @@ use crate::live_collections::stream::{
 #[cfg(stageleft_runtime)]
 use crate::location::dynamic::{DynLocation, LocationId};
 use crate::location::tick::DeferTick;
-use crate::location::{Atomic, Location, NoTick, Tick, check_matching_location};
+use crate::location::{Atomic, Location, Tick, check_matching_location};
 use crate::manual_expr::ManualExpr;
 use crate::nondet::{NonDet, nondet};
 use crate::properties::{
@@ -174,7 +174,7 @@ where
 impl<'a, K, V, L, B: Boundedness, O: Ordering, R: Retries> CycleCollection<'a, ForwardRef>
     for KeyedStream<K, V, L, B, O, R>
 where
-    L: Location<'a> + NoTick,
+    L: Location<'a>,
 {
     type Location = L;
 
@@ -195,7 +195,7 @@ where
 impl<'a, K, V, L, B: Boundedness, O: Ordering, R: Retries> ReceiverComplete<'a, ForwardRef>
     for KeyedStream<K, V, L, B, O, R>
 where
-    L: Location<'a> + NoTick,
+    L: Location<'a>,
 {
     fn complete(self, cycle_id: CycleId, expected_location: LocationId) {
         assert_eq!(
@@ -288,6 +288,67 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
         &self.location
     }
 
+    /// Weakens the consistency of this live collection to not guarantee any consistency across
+    /// cluster members (if this collection is on a cluster).
+    pub fn weaken_consistency(self) -> KeyedStream<K, V, L::DropConsistency, B, O, R>
+    where
+        L: Location<'a>,
+    {
+        if L::consistency()
+            .is_none_or(|c| c == crate::location::dynamic::ClusterConsistency::NoConsistency)
+        {
+            // already no consistency
+            KeyedStream::new(
+                self.location.drop_consistency(),
+                self.ir_node.replace(HydroNode::Placeholder),
+            )
+        } else {
+            KeyedStream::new(
+                self.location.drop_consistency(),
+                HydroNode::Cast {
+                    inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                    metadata: self
+                        .location
+                        .drop_consistency()
+                        .new_node_metadata(
+                            KeyedStream::<K, V, L::DropConsistency, B>::collection_kind(),
+                        ),
+                },
+            )
+        }
+    }
+
+    /// Casts this live collection to have the consistency guarantees specified in the given
+    /// location type parameter. The developer must ensure that the strengthened consistency
+    /// is actually guaranteed, via the proof field (see [`crate::prelude::manual_proof`]).
+    pub fn assert_has_consistency_of<L2: Location<'a, DropConsistency = L::DropConsistency>>(
+        self,
+        _proof: impl crate::properties::ConsistencyProof,
+    ) -> KeyedStream<K, V, L2, B, O, R>
+    where
+        L: Location<'a>,
+    {
+        if L::consistency() == L2::consistency() {
+            KeyedStream::new(
+                self.location.with_consistency_of(),
+                self.ir_node.replace(HydroNode::Placeholder),
+            )
+        } else {
+            KeyedStream::new(
+                self.location.with_consistency_of(),
+                HydroNode::AssertIsConsistent {
+                    inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                    trusted: false,
+                    metadata: self
+                        .location
+                        .clone()
+                        .with_consistency_of::<L2>()
+                        .new_node_metadata(KeyedStream::<K, V, L2, B, O, R>::collection_kind()),
+                },
+            )
+        }
+    }
+
     /// Turns this [`KeyedStream`] into a [`Stream`] preserving ordering, under the invariant
     /// assumption that there is at most one key. If this invariant is broken, the program
     /// may exhibit undefined behavior, so uses must be carefully vetted.
@@ -346,31 +407,31 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     /// This function is used as an escape hatch, and any mistakes in the
     /// provided ordering guarantee will propagate into the guarantees
     /// for the rest of the program.
-    pub fn assume_ordering<O2: Ordering>(self, _nondet: NonDet) -> KeyedStream<K, V, L, B, O2, R> {
+    pub fn assume_ordering<O2: Ordering>(
+        self,
+        _nondet: NonDet,
+    ) -> KeyedStream<K, V, L::DropConsistency, B, O2, R> {
         if O::ORDERING_KIND == O2::ORDERING_KIND {
-            KeyedStream::new(
-                self.location.clone(),
-                self.ir_node.replace(HydroNode::Placeholder),
-            )
+            self.use_ordering_type().weaken_consistency()
         } else if O2::ORDERING_KIND == StreamOrder::NoOrder {
             // We can always weaken the ordering guarantee
+            let target_location = self.location.drop_consistency();
             KeyedStream::new(
-                self.location.clone(),
+                target_location.clone(),
                 HydroNode::Cast {
                     inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
-                    metadata: self
-                        .location
+                    metadata: target_location
                         .new_node_metadata(KeyedStream::<K, V, L, B, O2, R>::collection_kind()),
                 },
             )
         } else {
+            let target_location = self.location.drop_consistency();
             KeyedStream::new(
-                self.location.clone(),
+                target_location.clone(),
                 HydroNode::ObserveNonDet {
                     inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                     trusted: false,
-                    metadata: self
-                        .location
+                    metadata: target_location
                         .new_node_metadata(KeyedStream::<K, V, L, B, O2, R>::collection_kind()),
                 },
             )
@@ -422,7 +483,16 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     /// enforcing that `O2` is weaker than the input ordering guarantee.
     pub fn weaken_ordering<O2: WeakerOrderingThan<O>>(self) -> KeyedStream<K, V, L, B, O2, R> {
         let nondet = nondet!(/** this is a weaker ordering guarantee, so it is safe to assume */);
-        self.assume_ordering::<O2>(nondet)
+        self.assume_ordering_trusted::<O2>(nondet)
+    }
+
+    /// Strengthens the ordering guarantee to `TotalOrder`, given that `O: IsOrdered`, which
+    /// implies that `O == TotalOrder`.
+    pub fn make_totally_ordered(self) -> KeyedStream<K, V, L, B, TotalOrder, R>
+    where
+        O: IsOrdered,
+    {
+        self.assume_ordering_trusted(nondet!(/** no-op */))
     }
 
     /// Explicitly "casts" the keyed stream to a type with a different retries
@@ -433,7 +503,46 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     /// This function is used as an escape hatch, and any mistakes in the
     /// provided retries guarantee will propagate into the guarantees
     /// for the rest of the program.
-    pub fn assume_retries<R2: Retries>(self, _nondet: NonDet) -> KeyedStream<K, V, L, B, O, R2> {
+    pub fn assume_retries<R2: Retries>(
+        self,
+        _nondet: NonDet,
+    ) -> KeyedStream<K, V, L::DropConsistency, B, O, R2> {
+        if R::RETRIES_KIND == R2::RETRIES_KIND {
+            KeyedStream::new(
+                self.location.drop_consistency(),
+                self.ir_node.replace(HydroNode::Placeholder),
+            )
+        } else if R2::RETRIES_KIND == StreamRetry::AtLeastOnce {
+            // We can always weaken the retries guarantee
+            let target_location = self.location.drop_consistency();
+            KeyedStream::new(
+                target_location.clone(),
+                HydroNode::Cast {
+                    inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                    metadata: target_location
+                        .new_node_metadata(KeyedStream::<K, V, L, B, O, R2>::collection_kind()),
+                },
+            )
+        } else {
+            let target_location = self.location.drop_consistency();
+            KeyedStream::new(
+                target_location.clone(),
+                HydroNode::ObserveNonDet {
+                    inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                    trusted: false,
+                    metadata: target_location
+                        .new_node_metadata(KeyedStream::<K, V, L, B, O, R2>::collection_kind()),
+                },
+            )
+        }
+    }
+
+    // only for internal APIs that have been carefully vetted to ensure that the non-determinism
+    // is not observable
+    fn assume_retries_trusted<R2: Retries>(
+        self,
+        _nondet: NonDet,
+    ) -> KeyedStream<K, V, L, B, O, R2> {
         if R::RETRIES_KIND == R2::RETRIES_KIND {
             KeyedStream::new(
                 self.location.clone(),
@@ -455,7 +564,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
                 self.location.clone(),
                 HydroNode::ObserveNonDet {
                     inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
-                    trusted: false,
+                    trusted: true,
                     metadata: self
                         .location
                         .new_node_metadata(KeyedStream::<K, V, L, B, O, R2>::collection_kind()),
@@ -475,16 +584,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     /// enforcing that `R2` is weaker than the input retries guarantee.
     pub fn weaken_retries<R2: WeakerRetryThan<R>>(self) -> KeyedStream<K, V, L, B, O, R2> {
         let nondet = nondet!(/** this is a weaker retries guarantee, so it is safe to assume */);
-        self.assume_retries::<R2>(nondet)
-    }
-
-    /// Strengthens the ordering guarantee to `TotalOrder`, given that `O: IsOrdered`, which
-    /// implies that `O == TotalOrder`.
-    pub fn make_totally_ordered(self) -> KeyedStream<K, V, L, B, TotalOrder, R>
-    where
-        O: IsOrdered,
-    {
-        self.assume_ordering(nondet!(/** no-op */))
+        self.assume_retries_trusted::<R2>(nondet)
     }
 
     /// Strengthens the retry guarantee to `ExactlyOnce`, given that `R: IsExactlyOnce`, which
@@ -493,7 +593,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     where
         R: IsExactlyOnce,
     {
-        self.assume_retries(nondet!(/** no-op */))
+        self.assume_retries_trusted(nondet!(/** no-op */))
     }
 
     /// Strengthens the boundedness guarantee to `Bounded`, given that `B: IsBounded`, which
@@ -571,17 +671,20 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     /// # Non-Determinism
     /// The interleaving of entries across different keys is non-deterministic.
     /// Within each key, the original order is preserved.
-    pub fn entries_partially_ordered(self, _nondet: NonDet) -> Stream<(K, V), L, B, TotalOrder, R>
+    pub fn entries_partially_ordered(
+        self,
+        _nondet: NonDet,
+    ) -> Stream<(K, V), L::DropConsistency, B, TotalOrder, R>
     where
         O: IsOrdered,
     {
+        let target_location = self.location.drop_consistency();
         Stream::new(
-            self.location.clone(),
+            target_location.clone(),
             HydroNode::ObserveNonDet {
                 inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 trusted: false,
-                metadata: self
-                    .location
+                metadata: target_location
                     .new_node_metadata(Stream::<(K, V), L, B, TotalOrder, R>::collection_kind()),
             },
         )
@@ -1875,6 +1978,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
                     .new_node_metadata(KeyedSingleton::<K, A, L, B2>::collection_kind()),
             },
         )
+        .assert_has_consistency_of(manual_proof!(/** algebraic properties */))
     }
 
     /// Like [`Stream::reduce`] but in the spirit of SQL `GROUP BY`, aggregates the values in each
@@ -1937,6 +2041,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
                     .new_node_metadata(KeyedSingleton::<K, V, L, B>::collection_kind()),
             },
         )
+        .assert_has_consistency_of(manual_proof!(/** algebraic properties */))
     }
 
     /// A special case of [`KeyedStream::reduce`] where tuples with keys less than the watermark
@@ -1999,6 +2104,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
                     .new_node_metadata(KeyedSingleton::<K, V, L, B>::collection_kind()),
             },
         )
+        .assert_has_consistency_of(manual_proof!(/** algebraic properties */))
     }
 
     /// Given a bounded stream of keys `K`, returns a new keyed stream containing only the groups
@@ -2395,11 +2501,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
         V: Eq + Hash + Clone,
         V2: Clone,
     {
-        self.lookup_keyed_stream(
-            lookup
-                .into_keyed_stream()
-                .assume_retries::<R>(nondet!(/** Retries are irrelevant for keyed singletons */)),
-        )
+        self.lookup_keyed_stream(lookup.into_keyed_stream().weaken_retries::<R>())
     }
 
     /// For each value in `self`, find the matching key in `lookup`.
@@ -2501,15 +2603,15 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     ///
     /// # Non-Determinism
     /// The batch boundaries are non-deterministic and may change across executions.
-    pub fn batch(
+    pub fn batch<L2: Location<'a, DropConsistency = L::DropConsistency>>(
         self,
-        tick: &Tick<L>,
+        tick: &Tick<L2>,
         nondet: NonDet,
-    ) -> KeyedStream<K, V, Tick<L>, Bounded, O, R> {
+    ) -> KeyedStream<K, V, Tick<L::DropConsistency>, Bounded, O, R> {
         let _ = nondet;
         assert_eq!(Location::id(tick.outer()), Location::id(&self.location));
         KeyedStream::new(
-            tick.clone(),
+            tick.drop_consistency(),
             HydroNode::Batch {
                 inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: tick.new_node_metadata(
@@ -2558,9 +2660,7 @@ impl<'a, K1, K2, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     }
 }
 
-impl<'a, K, V, L: Location<'a> + NoTick, O: Ordering, R: Retries>
-    KeyedStream<K, V, L, Unbounded, O, R>
-{
+impl<'a, K, V, L: Location<'a>, O: Ordering, R: Retries> KeyedStream<K, V, L, Unbounded, O, R> {
     /// Produces a new keyed stream that "merges" the inputs by interleaving the elements
     /// of any overlapping groups. The result has [`NoOrder`] on each group because the
     /// order of interleaving is not guaranteed. If the keys across both inputs do not overlap,
@@ -2630,7 +2730,7 @@ impl<'a, K, V, L: Location<'a> + NoTick, O: Ordering, R: Retries>
 
 impl<'a, K, V, L, B: Boundedness, O: Ordering, R: Retries> KeyedStream<K, V, Atomic<L>, B, O, R>
 where
-    L: Location<'a> + NoTick,
+    L: Location<'a>,
 {
     /// Returns a keyed stream corresponding to the latest batch of elements being atomically
     /// processed. These batches are guaranteed to be contiguous across ticks and preserve
@@ -2639,14 +2739,14 @@ where
     ///
     /// # Non-Determinism
     /// The batch boundaries are non-deterministic and may change across executions.
-    pub fn batch_atomic(
+    pub fn batch_atomic<L2: Location<'a, DropConsistency = L::DropConsistency>>(
         self,
-        tick: &Tick<L>,
+        tick: &Tick<L2>,
         nondet: NonDet,
-    ) -> KeyedStream<K, V, Tick<L>, Bounded, O, R> {
+    ) -> KeyedStream<K, V, Tick<L::DropConsistency>, Bounded, O, R> {
         let _ = nondet;
         KeyedStream::new(
-            tick.clone(),
+            tick.drop_consistency(),
             HydroNode::Batch {
                 inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: tick.new_node_metadata(
@@ -2774,7 +2874,7 @@ where
     /// # }));
     /// # }
     /// ```
-    pub fn across_ticks<Out: BatchAtomic>(
+    pub fn across_ticks<Out: BatchAtomic<'a>>(
         self,
         thunk: impl FnOnce(KeyedStream<K, V, Atomic<L>, Unbounded, O, R>) -> Out,
     ) -> Out::Batched {

--- a/hydro_lang/src/live_collections/keyed_stream/networking.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/networking.rs
@@ -8,6 +8,7 @@ use super::KeyedStream;
 use crate::compile::ir::{DebugInstantiate, HydroNode};
 use crate::live_collections::boundedness::{Boundedness, Unbounded};
 use crate::live_collections::stream::{MinOrder, Ordering, Retries, Stream};
+use crate::location::cluster::{Consistency, NoConsistency};
 #[cfg(stageleft_runtime)]
 use crate::location::dynamic::DynLocation;
 use crate::location::{Cluster, MemberId, Process};
@@ -102,11 +103,19 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
     /// # }));
     /// # }
     /// ```
+    #[expect(clippy::type_complexity, reason = "DropConsistency type")]
     pub fn demux<N: NetworkFor<T>>(
         self,
         to: &Cluster<'a, L2>,
         via: N,
-    ) -> Stream<T, Cluster<'a, L2>, Unbounded, <O as MinOrder<N::OrderingGuarantee>>::Min, R>
+    ) -> Stream<
+        T,
+        // NoConsistency because there each replica member may receive different streams
+        Cluster<'a, L2, NoConsistency>,
+        Unbounded,
+        <O as MinOrder<N::OrderingGuarantee>>::Min,
+        R,
+    >
     where
         T: Serialize + DeserializeOwned,
         O: MinOrder<N::OrderingGuarantee>,
@@ -229,7 +238,14 @@ impl<'a, K, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
         self,
         to: &Cluster<'a, L2>,
         via: N,
-    ) -> KeyedStream<K, T, Cluster<'a, L2>, Unbounded, <O as MinOrder<N::OrderingGuarantee>>::Min, R>
+    ) -> KeyedStream<
+        K,
+        T,
+        Cluster<'a, L2, NoConsistency>,
+        Unbounded,
+        <O as MinOrder<N::OrderingGuarantee>>::Min,
+        R,
+    >
     where
         K: Serialize + DeserializeOwned,
         T: Serialize + DeserializeOwned,
@@ -273,8 +289,8 @@ impl<'a, K, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
     }
 }
 
-impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
-    KeyedStream<MemberId<L2>, T, Cluster<'a, L>, B, O, R>
+impl<'a, T, L, L2, B: Boundedness, C: Consistency, O: Ordering, R: Retries>
+    KeyedStream<MemberId<L2>, T, Cluster<'a, L, C>, B, O, R>
 {
     #[deprecated = "use KeyedStream::demux(..., TCP.fail_stop().bincode()) instead"]
     /// Sends each group of this stream at each source member to a specific member of a destination
@@ -389,7 +405,7 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
     ) -> KeyedStream<
         MemberId<L>,
         T,
-        Cluster<'a, L2>,
+        Cluster<'a, L2, NoConsistency>,
         Unbounded,
         <O as MinOrder<N::OrderingGuarantee>>::Min,
         R,
@@ -431,8 +447,8 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
     }
 }
 
-impl<'a, K, V, L, B: Boundedness, O: Ordering, R: Retries>
-    KeyedStream<K, V, Cluster<'a, L>, B, O, R>
+impl<'a, K, V, L, B: Boundedness, C: Consistency, O: Ordering, R: Retries>
+    KeyedStream<K, V, Cluster<'a, L, C>, B, O, R>
 {
     #[expect(clippy::type_complexity, reason = "compound key types with ordering")]
     #[deprecated = "use KeyedStream::send(..., TCP.fail_stop().bincode()) instead"]

--- a/hydro_lang/src/live_collections/optional.rs
+++ b/hydro_lang/src/live_collections/optional.rs
@@ -19,8 +19,8 @@ use crate::forward_handle::{ForwardRef, TickCycle};
 use crate::live_collections::singleton::SingletonBound;
 #[cfg(stageleft_runtime)]
 use crate::location::dynamic::{DynLocation, LocationId};
-use crate::location::tick::{Atomic, DeferTick, NoAtomic};
-use crate::location::{Location, NoTick, Tick, check_matching_location};
+use crate::location::tick::{Atomic, DeferTick};
+use crate::location::{Location, Tick, TopLevel, check_matching_location};
 use crate::nondet::{NonDet, nondet};
 use crate::prelude::KeyedSingleton;
 
@@ -60,7 +60,7 @@ impl<T, L, B: Boundedness> Drop for Optional<T, L, B> {
 impl<'a, T, L> From<Optional<T, L, Bounded>> for Optional<T, L, Unbounded>
 where
     T: Clone,
-    L: Location<'a> + NoTick,
+    L: Location<'a>,
 {
     fn from(value: Optional<T, L, Bounded>) -> Self {
         let tick = value.location().tick();
@@ -100,6 +100,10 @@ where
 {
     type Location = Tick<L>;
 
+    fn location(&self) -> &Self::Location {
+        self.location()
+    }
+
     fn create_source_with_initial(cycle_id: CycleId, initial: Self, location: Tick<L>) -> Self {
         let from_previous_tick: Optional<T, Tick<L>, Bounded> = Optional::new(
             location.clone(),
@@ -138,47 +142,9 @@ where
     }
 }
 
-impl<'a, T, L> CycleCollection<'a, ForwardRef> for Optional<T, Tick<L>, Bounded>
-where
-    L: Location<'a>,
-{
-    type Location = Tick<L>;
-
-    fn create_source(cycle_id: CycleId, location: Tick<L>) -> Self {
-        Optional::new(
-            location.clone(),
-            HydroNode::CycleSource {
-                cycle_id,
-                metadata: location.new_node_metadata(Self::collection_kind()),
-            },
-        )
-    }
-}
-
-impl<'a, T, L> ReceiverComplete<'a, ForwardRef> for Optional<T, Tick<L>, Bounded>
-where
-    L: Location<'a>,
-{
-    fn complete(self, cycle_id: CycleId, expected_location: LocationId) {
-        assert_eq!(
-            Location::id(&self.location),
-            expected_location,
-            "locations do not match"
-        );
-        self.location
-            .flow_state()
-            .borrow_mut()
-            .push_root(HydroRoot::CycleSink {
-                cycle_id,
-                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
-                op_metadata: HydroIrOpMetadata::new(),
-            });
-    }
-}
-
 impl<'a, T, L, B: Boundedness> CycleCollection<'a, ForwardRef> for Optional<T, L, B>
 where
-    L: Location<'a> + NoTick,
+    L: Location<'a>,
 {
     type Location = L;
 
@@ -195,7 +161,7 @@ where
 
 impl<'a, T, L, B: Boundedness> ReceiverComplete<'a, ForwardRef> for Optional<T, L, B>
 where
-    L: Location<'a> + NoTick,
+    L: Location<'a>,
 {
     fn complete(self, cycle_id: CycleId, expected_location: LocationId) {
         assert_eq!(
@@ -326,6 +292,66 @@ where
     /// Returns the [`Location`] where this optional is being materialized.
     pub fn location(&self) -> &L {
         &self.location
+    }
+
+    /// Weakens the consistency of this live collection to not guarantee any consistency across
+    /// cluster members (if this collection is on a cluster).
+    pub fn weaken_consistency(self) -> Optional<T, L::DropConsistency, B>
+    where
+        L: Location<'a>,
+    {
+        if L::consistency()
+            .is_none_or(|c| c == crate::location::dynamic::ClusterConsistency::NoConsistency)
+        {
+            // already no consistency
+            Optional::new(
+                self.location.drop_consistency(),
+                self.ir_node.replace(HydroNode::Placeholder),
+            )
+        } else {
+            Optional::new(
+                self.location.drop_consistency(),
+                HydroNode::Cast {
+                    inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                    metadata: self
+                        .location
+                        .clone()
+                        .drop_consistency()
+                        .new_node_metadata(Optional::<T, L::DropConsistency, B>::collection_kind()),
+                },
+            )
+        }
+    }
+
+    /// Casts this live collection to have the consistency guarantees specified in the given
+    /// location type parameter. The developer must ensure that the strengthened consistency
+    /// is actually guaranteed, via the proof field (see [`crate::prelude::manual_proof`]).
+    pub fn assert_has_consistency_of<L2: Location<'a, DropConsistency = L::DropConsistency>>(
+        self,
+        _proof: impl crate::properties::ConsistencyProof,
+    ) -> Optional<T, L2, B>
+    where
+        L: Location<'a>,
+    {
+        if L::consistency() == L2::consistency() {
+            Optional::new(
+                self.location.with_consistency_of(),
+                self.ir_node.replace(HydroNode::Placeholder),
+            )
+        } else {
+            Optional::new(
+                self.location.with_consistency_of(),
+                HydroNode::AssertIsConsistent {
+                    inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                    trusted: false,
+                    metadata: self
+                        .location
+                        .clone()
+                        .with_consistency_of::<L2>()
+                        .new_node_metadata(Optional::<T, L2, B>::collection_kind()),
+                },
+            )
+        }
     }
 
     /// Transforms the optional value by applying a function `f` to it,
@@ -635,16 +661,14 @@ where
         if L::is_top_level()
             && let Some(tick) = self.location.try_tick()
         {
+            let self_location = self.location().clone();
             let out = zip_inside_tick(
                 self.snapshot(&tick, nondet!(/** eventually stabilizes */)),
                 other.snapshot(&tick, nondet!(/** eventually stabilizes */)),
             )
             .latest();
 
-            Optional::new(
-                out.location.clone(),
-                out.ir_node.replace(HydroNode::Placeholder),
-            )
+            Optional::new(self_location, out.ir_node.replace(HydroNode::Placeholder))
         } else {
             zip_inside_tick(self, other)
         }
@@ -687,16 +711,14 @@ where
             && !B::BOUNDED // only if unbounded we need to use a tick
             && let Some(tick) = self.location.try_tick()
         {
+            let self_location = self.location().clone();
             let out = or_inside_tick(
                 self.snapshot(&tick, nondet!(/** eventually stabilizes */)),
                 other.snapshot(&tick, nondet!(/** eventually stabilizes */)),
             )
             .latest();
 
-            Optional::new(
-                out.location.clone(),
-                out.ir_node.replace(HydroNode::Placeholder),
-            )
+            Optional::new(self_location, out.ir_node.replace(HydroNode::Placeholder))
         } else {
             Optional::new(
                 self.location.clone(),
@@ -955,10 +977,11 @@ where
         T: Clone,
     {
         // TODO(shadaj): avoid printing simulator logs for this snapshot
-        self.snapshot(
+        let inner = self.snapshot(
             tick,
             nondet!(/** bounded top-level optional so deterministic */),
-        )
+        );
+        Optional::new(tick.clone(), inner.ir_node.replace(HydroNode::Placeholder))
     }
 
     /// Converts this optional into a [`Stream`] containing a single element, the value, if it is
@@ -1206,7 +1229,7 @@ where
 
 impl<'a, T, L, B: Boundedness> Optional<T, Atomic<L>, B>
 where
-    L: Location<'a> + NoTick,
+    L: Location<'a>,
 {
     /// Returns an optional value corresponding to the latest snapshot of the optional
     /// being atomically processed. The snapshot at tick `t + 1` is guaranteed to include
@@ -1218,9 +1241,13 @@ where
     /// Because this picks a snapshot of a optional whose value is continuously changing,
     /// the output optional has a non-deterministic value since the snapshot can be at an
     /// arbitrary point in time.
-    pub fn snapshot_atomic(self, tick: &Tick<L>, _nondet: NonDet) -> Optional<T, Tick<L>, Bounded> {
+    pub fn snapshot_atomic<L2: Location<'a, DropConsistency = L::DropConsistency>>(
+        self,
+        tick: &Tick<L2>,
+        _nondet: NonDet,
+    ) -> Optional<T, Tick<L::DropConsistency>, Bounded> {
         Optional::new(
-            tick.clone(),
+            tick.drop_consistency(),
             HydroNode::Batch {
                 inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: tick
@@ -1283,10 +1310,14 @@ where
     /// Because this picks a snapshot of a optional whose value is continuously changing,
     /// the output optional has a non-deterministic value since the snapshot can be at an
     /// arbitrary point in time.
-    pub fn snapshot(self, tick: &Tick<L>, _nondet: NonDet) -> Optional<T, Tick<L>, Bounded> {
+    pub fn snapshot<L2: Location<'a, DropConsistency = L::DropConsistency>>(
+        self,
+        tick: &Tick<L2>,
+        _nondet: NonDet,
+    ) -> Optional<T, Tick<L::DropConsistency>, Bounded> {
         assert_eq!(Location::id(tick.outer()), Location::id(&self.location));
         Optional::new(
-            tick.clone(),
+            tick.drop_consistency(),
             HydroNode::Batch {
                 inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: tick
@@ -1302,10 +1333,10 @@ where
     /// At runtime, the optional will be arbitrarily sampled as fast as possible, but due
     /// to non-deterministic batching and arrival of inputs, the output stream is
     /// non-deterministic.
-    pub fn sample_eager(self, nondet: NonDet) -> Stream<T, L, Unbounded, TotalOrder, AtLeastOnce>
-    where
-        L: NoTick,
-    {
+    pub fn sample_eager(
+        self,
+        nondet: NonDet,
+    ) -> Stream<T, L::DropConsistency, Unbounded, TotalOrder, AtLeastOnce> {
         let tick = self.location.tick();
         self.snapshot(&tick, nondet).all_ticks().weaken_retries()
     }
@@ -1323,9 +1354,9 @@ where
         self,
         interval: impl QuotedWithContext<'a, std::time::Duration, L> + Copy + 'a,
         nondet: NonDet,
-    ) -> Stream<T, L, Unbounded, TotalOrder, AtLeastOnce>
+    ) -> Stream<T, L::DropConsistency, Unbounded, TotalOrder, AtLeastOnce>
     where
-        L: NoTick + NoAtomic,
+        L: TopLevel<'a>,
     {
         let samples = self.location.source_interval(interval);
         let tick = self.location.tick();

--- a/hydro_lang/src/live_collections/singleton.rs
+++ b/hydro_lang/src/live_collections/singleton.rs
@@ -21,8 +21,8 @@ use crate::forward_handle::{CycleCollection, CycleCollectionWithInitial, Receive
 use crate::forward_handle::{ForwardRef, TickCycle};
 #[cfg(stageleft_runtime)]
 use crate::location::dynamic::{DynLocation, LocationId};
-use crate::location::tick::{Atomic, NoAtomic};
-use crate::location::{Location, NoTick, Tick, check_matching_location};
+use crate::location::tick::Atomic;
+use crate::location::{Location, Tick, TopLevel, check_matching_location};
 use crate::nondet::{NonDet, nondet};
 use crate::properties::{
     ApplyMonotoneStream, ApplyOrderPreservingSingleton, MapFuncAlgebra, Proved,
@@ -130,7 +130,7 @@ impl<T, L, B: SingletonBound> Drop for Singleton<T, L, B> {
 impl<'a, T, L> From<Singleton<T, L, Bounded>> for Singleton<T, L, Unbounded>
 where
     T: Clone,
-    L: Location<'a> + NoTick,
+    L: Location<'a>,
 {
     fn from(value: Singleton<T, L, Bounded>) -> Self {
         let tick = value.location().tick();
@@ -143,6 +143,10 @@ where
     L: Location<'a>,
 {
     type Location = Tick<L>;
+
+    fn location(&self) -> &Self::Location {
+        self.location()
+    }
 
     fn create_source_with_initial(cycle_id: CycleId, initial: Self, location: Tick<L>) -> Self {
         let from_previous_tick: Optional<T, Tick<L>, Bounded> = Optional::new(
@@ -182,47 +186,9 @@ where
     }
 }
 
-impl<'a, T, L> CycleCollection<'a, ForwardRef> for Singleton<T, Tick<L>, Bounded>
-where
-    L: Location<'a>,
-{
-    type Location = Tick<L>;
-
-    fn create_source(cycle_id: CycleId, location: Tick<L>) -> Self {
-        Singleton::new(
-            location.clone(),
-            HydroNode::CycleSource {
-                cycle_id,
-                metadata: location.new_node_metadata(Self::collection_kind()),
-            },
-        )
-    }
-}
-
-impl<'a, T, L> ReceiverComplete<'a, ForwardRef> for Singleton<T, Tick<L>, Bounded>
-where
-    L: Location<'a>,
-{
-    fn complete(self, cycle_id: CycleId, expected_location: LocationId) {
-        assert_eq!(
-            Location::id(&self.location),
-            expected_location,
-            "locations do not match"
-        );
-        self.location
-            .flow_state()
-            .borrow_mut()
-            .push_root(HydroRoot::CycleSink {
-                cycle_id,
-                input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
-                op_metadata: HydroIrOpMetadata::new(),
-            });
-    }
-}
-
 impl<'a, T, L, B: SingletonBound> CycleCollection<'a, ForwardRef> for Singleton<T, L, B>
 where
-    L: Location<'a> + NoTick,
+    L: Location<'a>,
 {
     type Location = L;
 
@@ -239,7 +205,7 @@ where
 
 impl<'a, T, L, B: SingletonBound> ReceiverComplete<'a, ForwardRef> for Singleton<T, L, B>
 where
-    L: Location<'a> + NoTick,
+    L: Location<'a>,
 {
     fn complete(self, cycle_id: CycleId, expected_location: LocationId) {
         assert_eq!(
@@ -382,6 +348,68 @@ where
             unreachable!()
         };
         crate::singleton_ref::SingletonRef::new(Rc::clone(&inner.0))
+    }
+
+    /// Weakens the consistency of this live collection to not guarantee any consistency across
+    /// cluster members (if this collection is on a cluster).
+    pub fn weaken_consistency(self) -> Singleton<T, L::DropConsistency, B>
+    where
+        L: Location<'a>,
+    {
+        if L::consistency()
+            .is_none_or(|c| c == crate::location::dynamic::ClusterConsistency::NoConsistency)
+        {
+            // already no consistency
+            Singleton::new(
+                self.location.drop_consistency(),
+                self.ir_node.replace(HydroNode::Placeholder),
+            )
+        } else {
+            Singleton::new(
+                self.location.drop_consistency(),
+                HydroNode::Cast {
+                    inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                    metadata:
+                        self.location
+                            .clone()
+                            .drop_consistency()
+                            .new_node_metadata(
+                                Singleton::<T, L::DropConsistency, B>::collection_kind(),
+                            ),
+                },
+            )
+        }
+    }
+
+    /// Casts this live collection to have the consistency guarantees specified in the given
+    /// location type parameter. The developer must ensure that the strengthened consistency
+    /// is actually guaranteed, via the proof field (see [`crate::prelude::manual_proof`]).
+    pub fn assert_has_consistency_of<L2: Location<'a, DropConsistency = L::DropConsistency>>(
+        self,
+        _proof: impl crate::properties::ConsistencyProof,
+    ) -> Singleton<T, L2, B>
+    where
+        L: Location<'a>,
+    {
+        if L::consistency() == L2::consistency() {
+            Singleton::new(
+                self.location.with_consistency_of(),
+                self.ir_node.replace(HydroNode::Placeholder),
+            )
+        } else {
+            Singleton::new(
+                self.location.with_consistency_of(),
+                HydroNode::AssertIsConsistent {
+                    inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                    trusted: false,
+                    metadata: self
+                        .location
+                        .clone()
+                        .with_consistency_of::<L2>()
+                        .new_node_metadata(Singleton::<T, L2, B>::collection_kind()),
+                },
+            )
+        }
     }
 
     /// Drops the monotonicity property of the [`Singleton`].
@@ -716,6 +744,7 @@ where
         if L::is_top_level()
             && let Some(tick) = self.location.try_tick()
         {
+            let self_location = self.location().clone();
             let other_location = <Self as ZipResult<'a, O>>::other_location(&other);
             let out = zip_inside_tick(
                 self.snapshot(&tick, nondet!(/** eventually stabilizes */)),
@@ -735,10 +764,7 @@ where
             )
             .latest();
 
-            Self::make(
-                out.location.clone(),
-                out.ir_node.replace(HydroNode::Placeholder),
-            )
+            Self::make(self_location, out.ir_node.replace(HydroNode::Placeholder))
         } else {
             Self::make(
                 self.location.clone(),
@@ -949,6 +975,7 @@ where
         B: IsMonotonic,
     {
         let threshold = threshold.make_bounded();
+        let self_location = self.location().clone();
         match self.try_make_bounded() {
             Ok(bounded) => {
                 let uncasted = threshold
@@ -975,7 +1002,7 @@ where
                 };
 
                 Stream::new(
-                    uncasted.location.clone(),
+                    self_location,
                     uncasted.ir_node.replace(HydroNode::Placeholder),
                 )
             }
@@ -1100,7 +1127,7 @@ where
 
 impl<'a, T, L, B: SingletonBound> Singleton<T, Atomic<L>, B>
 where
-    L: Location<'a> + NoTick,
+    L: Location<'a>,
 {
     /// Returns a singleton value corresponding to the latest snapshot of the singleton
     /// being atomically processed. The snapshot at tick `t + 1` is guaranteed to include
@@ -1112,13 +1139,13 @@ where
     /// Because this picks a snapshot of a singleton whose value is continuously changing,
     /// the output singleton has a non-deterministic value since the snapshot can be at an
     /// arbitrary point in time.
-    pub fn snapshot_atomic(
+    pub fn snapshot_atomic<L2: Location<'a, DropConsistency = L::DropConsistency>>(
         self,
-        tick: &Tick<L>,
+        tick: &Tick<L2>,
         _nondet: NonDet,
-    ) -> Singleton<T, Tick<L>, Bounded> {
+    ) -> Singleton<T, Tick<L::DropConsistency>, Bounded> {
         Singleton::new(
-            tick.clone(),
+            tick.drop_consistency(),
             HydroNode::Batch {
                 inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: tick
@@ -1181,10 +1208,14 @@ where
     /// Because this picks a snapshot of a singleton whose value is continuously changing,
     /// the output singleton has a non-deterministic value since the snapshot can be at an
     /// arbitrary point in time.
-    pub fn snapshot(self, tick: &Tick<L>, _nondet: NonDet) -> Singleton<T, Tick<L>, Bounded> {
+    pub fn snapshot<L2: Location<'a, DropConsistency = L::DropConsistency>>(
+        self,
+        tick: &Tick<L2>,
+        _nondet: NonDet,
+    ) -> Singleton<T, Tick<L::DropConsistency>, Bounded> {
         assert_eq!(Location::id(tick.outer()), Location::id(&self.location));
         Singleton::new(
-            tick.clone(),
+            tick.drop_consistency(),
             HydroNode::Batch {
                 inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: tick
@@ -1200,10 +1231,10 @@ where
     /// At runtime, the singleton will be arbitrarily sampled as fast as possible, but due
     /// to non-deterministic batching and arrival of inputs, the output stream is
     /// non-deterministic.
-    pub fn sample_eager(self, nondet: NonDet) -> Stream<T, L, Unbounded, TotalOrder, AtLeastOnce>
-    where
-        L: NoTick,
-    {
+    pub fn sample_eager(
+        self,
+        nondet: NonDet,
+    ) -> Stream<T, L::DropConsistency, Unbounded, TotalOrder, AtLeastOnce> {
         sliced! {
             let snapshot = use(self, nondet);
             snapshot.into_stream()
@@ -1224,9 +1255,9 @@ where
         self,
         interval: impl QuotedWithContext<'a, std::time::Duration, L> + Copy + 'a,
         nondet: NonDet,
-    ) -> Stream<T, L, Unbounded, TotalOrder, AtLeastOnce>
+    ) -> Stream<T, L::DropConsistency, Unbounded, TotalOrder, AtLeastOnce>
     where
-        L: NoTick + NoAtomic,
+        L: TopLevel<'a>,
     {
         let samples = self.location.source_interval(interval);
         sliced! {
@@ -1265,16 +1296,20 @@ where
     /// Clones this bounded singleton into a tick, returning a singleton that has the
     /// same value as the outer singleton. Because the outer singleton is bounded, this
     /// is deterministic because there is only a single immutable version.
-    pub fn clone_into_tick(self, tick: &Tick<L>) -> Singleton<T, Tick<L>, Bounded>
+    pub fn clone_into_tick<L2: Location<'a, DropConsistency = L::DropConsistency>>(
+        self,
+        tick: &Tick<L2>,
+    ) -> Singleton<T, Tick<L2>, Bounded>
     where
         B: IsBounded,
         T: Clone,
     {
         // TODO(shadaj): avoid printing simulator logs for this snapshot
-        self.snapshot(
+        let inner = self.snapshot(
             tick,
             nondet!(/** bounded top-level singleton so deterministic */),
-        )
+        );
+        Singleton::new(tick.clone(), inner.ir_node.replace(HydroNode::Placeholder))
     }
 
     /// Converts this singleton into a [`Stream`] containing a single element, the value.

--- a/hydro_lang/src/live_collections/sliced/mod.rs
+++ b/hydro_lang/src/live_collections/sliced/mod.rs
@@ -4,7 +4,7 @@ pub mod style;
 
 use super::boundedness::{Bounded, Unbounded};
 use super::stream::{Ordering, Retries};
-use crate::location::{Location, NoTick, Tick};
+use crate::location::{Location, Tick};
 
 #[doc(hidden)]
 #[macro_export]
@@ -190,7 +190,7 @@ pub trait Slicable<'a, L: Location<'a>> {
     type Backtrace;
 
     /// Gets the location associated with this live collection.
-    fn get_location(&self) -> &L;
+    fn get_location(&self) -> L;
 
     /// Creates a tick that is appropriate for the collection's location.
     fn create_tick(&self) -> Tick<L> {
@@ -249,7 +249,7 @@ impl<'a, L: Location<'a>> Slicable<'a, L> for () {
     type Slice = ();
     type Backtrace = ();
 
-    fn get_location(&self) -> &L {
+    fn get_location(&self) -> L {
         unreachable!()
     }
 
@@ -268,7 +268,7 @@ macro_rules! impl_slicable_for_tuple {
             type Slice = ($($T::Slice,)+);
             type Backtrace = ($($T::Backtrace,)+);
 
-            fn get_location(&self) -> &L {
+            fn get_location(&self) -> L {
                 self.0.get_location()
             }
 
@@ -451,7 +451,7 @@ impl<'a, K, V, L: Location<'a>, O: Ordering, R: Retries> Unslicable
 }
 
 // Unslicable implementations for Atomic-wrapped bounded collections
-impl<'a, T, L: Location<'a> + NoTick, O: Ordering, R: Retries> Unslicable
+impl<'a, T, L: Location<'a>, O: Ordering, R: Retries> Unslicable
     for style::Atomic<super::Stream<T, Tick<L>, Bounded, O, R>>
 {
     type Unsliced = super::Stream<T, crate::location::Atomic<L>, Unbounded, O, R>;
@@ -461,9 +461,7 @@ impl<'a, T, L: Location<'a> + NoTick, O: Ordering, R: Retries> Unslicable
     }
 }
 
-impl<'a, T, L: Location<'a> + NoTick> Unslicable
-    for style::Atomic<super::Singleton<T, Tick<L>, Bounded>>
-{
+impl<'a, T, L: Location<'a>> Unslicable for style::Atomic<super::Singleton<T, Tick<L>, Bounded>> {
     type Unsliced = super::Singleton<T, crate::location::Atomic<L>, Unbounded>;
 
     fn unslice(self) -> Self::Unsliced {
@@ -471,9 +469,7 @@ impl<'a, T, L: Location<'a> + NoTick> Unslicable
     }
 }
 
-impl<'a, T, L: Location<'a> + NoTick> Unslicable
-    for style::Atomic<super::Optional<T, Tick<L>, Bounded>>
-{
+impl<'a, T, L: Location<'a>> Unslicable for style::Atomic<super::Optional<T, Tick<L>, Bounded>> {
     type Unsliced = super::Optional<T, crate::location::Atomic<L>, Unbounded>;
 
     fn unslice(self) -> Self::Unsliced {
@@ -481,7 +477,7 @@ impl<'a, T, L: Location<'a> + NoTick> Unslicable
     }
 }
 
-impl<'a, K, V, L: Location<'a> + NoTick, O: Ordering, R: Retries> Unslicable
+impl<'a, K, V, L: Location<'a>, O: Ordering, R: Retries> Unslicable
     for style::Atomic<super::KeyedStream<K, V, Tick<L>, Bounded, O, R>>
 {
     type Unsliced = super::KeyedStream<K, V, crate::location::Atomic<L>, Unbounded, O, R>;

--- a/hydro_lang/src/live_collections/sliced/style.rs
+++ b/hydro_lang/src/live_collections/sliced/style.rs
@@ -11,8 +11,8 @@ use crate::live_collections::boundedness::{Bounded, Boundedness, Unbounded};
 use crate::live_collections::keyed_singleton::{BoundedValue, KeyedSingletonBound};
 use crate::live_collections::singleton::SingletonBound;
 use crate::live_collections::stream::{Ordering, Retries};
+use crate::location::Location;
 use crate::location::tick::{DeferTick, Tick};
-use crate::location::{Location, NoTick};
 use crate::nondet::NonDet;
 
 /// Default style wrapper that stores a collection and its non-determinism guard.
@@ -70,14 +70,14 @@ pub fn atomic<T>(t: T, nondet: NonDet) -> Atomic<T> {
 )]
 pub fn state<
     'a,
-    S: CycleCollectionWithInitial<'a, TickCycle, Location = Tick<L>>,
+    S: CycleCollectionWithInitial<'a, TickCycle, Location = Tick<L::DropConsistency>>,
     L: Location<'a>,
 >(
     tick: &Tick<L>,
     initial_fn: impl FnOnce(&Tick<L>) -> S,
 ) -> (TickCycleHandle<'a, S>, S) {
     let initial = initial_fn(tick);
-    tick.cycle_with_initial(initial)
+    initial.location().clone().cycle_with_initial(initial)
 }
 
 /// Creates a stateful cycle without an initial value for use in `sliced!`.
@@ -91,108 +91,114 @@ pub fn state<
 )]
 pub fn state_null<
     'a,
-    S: CycleCollection<'a, TickCycle, Location = Tick<L>> + DeferTick,
-    L: Location<'a> + NoTick,
+    S: CycleCollection<'a, TickCycle, Location = Tick<L::DropConsistency>> + DeferTick,
+    L: Location<'a>,
 >(
     tick: &Tick<L>,
 ) -> (TickCycleHandle<'a, S>, S) {
-    tick.cycle::<S>()
+    tick.cycle::<S, _>()
 }
 
 // ============================================================================
 // Default style Slicable implementations
+//
+// All of these drop consistency because they are performing non-deterministic
+// batching / snapshotting.
 // ============================================================================
 
-impl<'a, T, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries> Slicable<'a, L>
-    for Default<crate::live_collections::Stream<T, L, B, O, R>>
+impl<'a, T, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
+    Slicable<'a, L::DropConsistency> for Default<crate::live_collections::Stream<T, L, B, O, R>>
 {
-    type Slice = crate::live_collections::Stream<T, Tick<L>, Bounded, O, R>;
+    type Slice = crate::live_collections::Stream<T, Tick<L::DropConsistency>, Bounded, O, R>;
     type Backtrace = crate::compile::ir::backtrace::Backtrace;
 
-    fn get_location(&self) -> &L {
-        self.collection.location()
+    fn get_location(&self) -> L::DropConsistency {
+        self.collection.location().drop_consistency()
     }
-    fn slice(self, tick: &Tick<L>, backtrace: Self::Backtrace) -> Self::Slice {
+    fn slice(self, tick: &Tick<L::DropConsistency>, backtrace: Self::Backtrace) -> Self::Slice {
         let out = self.collection.batch(tick, self.nondet);
         out.ir_node.borrow_mut().op_metadata_mut().backtrace = backtrace;
         out
     }
 }
 
-impl<'a, T, L: Location<'a>, B: SingletonBound> Slicable<'a, L>
+impl<'a, T, L: Location<'a>, B: SingletonBound> Slicable<'a, L::DropConsistency>
     for Default<crate::live_collections::Singleton<T, L, B>>
 {
-    type Slice = crate::live_collections::Singleton<T, Tick<L>, Bounded>;
+    type Slice = crate::live_collections::Singleton<T, Tick<L::DropConsistency>, Bounded>;
     type Backtrace = crate::compile::ir::backtrace::Backtrace;
 
-    fn get_location(&self) -> &L {
-        self.collection.location()
+    fn get_location(&self) -> L::DropConsistency {
+        self.collection.location().drop_consistency()
     }
-    fn slice(self, tick: &Tick<L>, backtrace: Self::Backtrace) -> Self::Slice {
+    fn slice(self, tick: &Tick<L::DropConsistency>, backtrace: Self::Backtrace) -> Self::Slice {
         let out = self.collection.snapshot(tick, self.nondet);
         out.ir_node.borrow_mut().op_metadata_mut().backtrace = backtrace;
         out
     }
 }
 
-impl<'a, T, L: Location<'a>, B: Boundedness> Slicable<'a, L>
+impl<'a, T, L: Location<'a>, B: Boundedness> Slicable<'a, L::DropConsistency>
     for Default<crate::live_collections::Optional<T, L, B>>
 {
-    type Slice = crate::live_collections::Optional<T, Tick<L>, Bounded>;
+    type Slice = crate::live_collections::Optional<T, Tick<L::DropConsistency>, Bounded>;
     type Backtrace = crate::compile::ir::backtrace::Backtrace;
 
-    fn get_location(&self) -> &L {
-        self.collection.location()
+    fn get_location(&self) -> L::DropConsistency {
+        self.collection.location().drop_consistency()
     }
-    fn slice(self, tick: &Tick<L>, backtrace: Self::Backtrace) -> Self::Slice {
+    fn slice(self, tick: &Tick<L::DropConsistency>, backtrace: Self::Backtrace) -> Self::Slice {
         let out = self.collection.snapshot(tick, self.nondet);
         out.ir_node.borrow_mut().op_metadata_mut().backtrace = backtrace;
         out
     }
 }
 
-impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries> Slicable<'a, L>
+impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
+    Slicable<'a, L::DropConsistency>
     for Default<crate::live_collections::KeyedStream<K, V, L, B, O, R>>
 {
-    type Slice = crate::live_collections::KeyedStream<K, V, Tick<L>, Bounded, O, R>;
+    type Slice =
+        crate::live_collections::KeyedStream<K, V, Tick<L::DropConsistency>, Bounded, O, R>;
     type Backtrace = crate::compile::ir::backtrace::Backtrace;
 
-    fn get_location(&self) -> &L {
-        self.collection.location()
+    fn get_location(&self) -> L::DropConsistency {
+        self.collection.location().drop_consistency()
     }
-    fn slice(self, tick: &Tick<L>, backtrace: Self::Backtrace) -> Self::Slice {
+    fn slice(self, tick: &Tick<L::DropConsistency>, backtrace: Self::Backtrace) -> Self::Slice {
         let out = self.collection.batch(tick, self.nondet);
         out.ir_node.borrow_mut().op_metadata_mut().backtrace = backtrace;
         out
     }
 }
 
-impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound<ValueBound = Unbounded>> Slicable<'a, L>
+impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound<ValueBound = Unbounded>>
+    Slicable<'a, L::DropConsistency>
     for Default<crate::live_collections::KeyedSingleton<K, V, L, B>>
 {
-    type Slice = crate::live_collections::KeyedSingleton<K, V, Tick<L>, Bounded>;
+    type Slice = crate::live_collections::KeyedSingleton<K, V, Tick<L::DropConsistency>, Bounded>;
     type Backtrace = crate::compile::ir::backtrace::Backtrace;
 
-    fn get_location(&self) -> &L {
-        self.collection.location()
+    fn get_location(&self) -> L::DropConsistency {
+        self.collection.location().drop_consistency()
     }
-    fn slice(self, tick: &Tick<L>, backtrace: Self::Backtrace) -> Self::Slice {
+    fn slice(self, tick: &Tick<L::DropConsistency>, backtrace: Self::Backtrace) -> Self::Slice {
         let out = self.collection.snapshot(tick, self.nondet);
         out.ir_node.borrow_mut().op_metadata_mut().backtrace = backtrace;
         out
     }
 }
 
-impl<'a, K, V, L: Location<'a> + NoTick> Slicable<'a, L>
+impl<'a, K, V, L: Location<'a>> Slicable<'a, L::DropConsistency>
     for Default<crate::live_collections::KeyedSingleton<K, V, L, BoundedValue>>
 {
-    type Slice = crate::live_collections::KeyedSingleton<K, V, Tick<L>, Bounded>;
+    type Slice = crate::live_collections::KeyedSingleton<K, V, Tick<L::DropConsistency>, Bounded>;
     type Backtrace = crate::compile::ir::backtrace::Backtrace;
 
-    fn get_location(&self) -> &L {
-        self.collection.location()
+    fn get_location(&self) -> L::DropConsistency {
+        self.collection.location().drop_consistency()
     }
-    fn slice(self, tick: &Tick<L>, backtrace: Self::Backtrace) -> Self::Slice {
+    fn slice(self, tick: &Tick<L::DropConsistency>, backtrace: Self::Backtrace) -> Self::Slice {
         let out = self.collection.batch(tick, self.nondet);
         out.ir_node.borrow_mut().op_metadata_mut().backtrace = backtrace;
         out
@@ -203,99 +209,102 @@ impl<'a, K, V, L: Location<'a> + NoTick> Slicable<'a, L>
 // Atomic style Slicable implementations
 // ============================================================================
 
-impl<'a, T, L: Location<'a> + NoTick, B: Boundedness, O: Ordering, R: Retries> Slicable<'a, L>
+impl<'a, T, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
+    Slicable<'a, L::DropConsistency>
     for Atomic<crate::live_collections::Stream<T, crate::location::Atomic<L>, B, O, R>>
 {
-    type Slice = crate::live_collections::Stream<T, Tick<L>, Bounded, O, R>;
+    type Slice = crate::live_collections::Stream<T, Tick<L::DropConsistency>, Bounded, O, R>;
     type Backtrace = crate::compile::ir::backtrace::Backtrace;
-    fn get_location(&self) -> &L {
-        &self.collection.location().tick.l
+    fn get_location(&self) -> L::DropConsistency {
+        self.collection.location().tick.l.drop_consistency()
     }
 
-    fn slice(self, tick: &Tick<L>, backtrace: Self::Backtrace) -> Self::Slice {
+    fn slice(self, tick: &Tick<L::DropConsistency>, backtrace: Self::Backtrace) -> Self::Slice {
         let out = self.collection.batch_atomic(tick, self.nondet);
         out.ir_node.borrow_mut().op_metadata_mut().backtrace = backtrace;
         out
     }
 }
 
-impl<'a, T, L: Location<'a> + NoTick, B: SingletonBound> Slicable<'a, L>
+impl<'a, T, L: Location<'a>, B: SingletonBound> Slicable<'a, L::DropConsistency>
     for Atomic<crate::live_collections::Singleton<T, crate::location::Atomic<L>, B>>
 {
-    type Slice = crate::live_collections::Singleton<T, Tick<L>, Bounded>;
+    type Slice = crate::live_collections::Singleton<T, Tick<L::DropConsistency>, Bounded>;
     type Backtrace = crate::compile::ir::backtrace::Backtrace;
-    fn get_location(&self) -> &L {
-        &self.collection.location().tick.l
+    fn get_location(&self) -> L::DropConsistency {
+        self.collection.location().tick.l.drop_consistency()
     }
 
-    fn slice(self, tick: &Tick<L>, backtrace: Self::Backtrace) -> Self::Slice {
+    fn slice(self, tick: &Tick<L::DropConsistency>, backtrace: Self::Backtrace) -> Self::Slice {
         let out = self.collection.snapshot_atomic(tick, self.nondet);
         out.ir_node.borrow_mut().op_metadata_mut().backtrace = backtrace;
         out
     }
 }
 
-impl<'a, T, L: Location<'a> + NoTick, B: Boundedness> Slicable<'a, L>
+impl<'a, T, L: Location<'a>, B: Boundedness> Slicable<'a, L::DropConsistency>
     for Atomic<crate::live_collections::Optional<T, crate::location::Atomic<L>, B>>
 {
-    type Slice = crate::live_collections::Optional<T, Tick<L>, Bounded>;
+    type Slice = crate::live_collections::Optional<T, Tick<L::DropConsistency>, Bounded>;
     type Backtrace = crate::compile::ir::backtrace::Backtrace;
-    fn get_location(&self) -> &L {
-        &self.collection.location().tick.l
+    fn get_location(&self) -> L::DropConsistency {
+        self.collection.location().tick.l.drop_consistency()
     }
 
-    fn slice(self, tick: &Tick<L>, backtrace: Self::Backtrace) -> Self::Slice {
+    fn slice(self, tick: &Tick<L::DropConsistency>, backtrace: Self::Backtrace) -> Self::Slice {
         let out = self.collection.snapshot_atomic(tick, self.nondet);
         out.ir_node.borrow_mut().op_metadata_mut().backtrace = backtrace;
         out
     }
 }
 
-impl<'a, K, V, L: Location<'a> + NoTick, B: Boundedness, O: Ordering, R: Retries> Slicable<'a, L>
+impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
+    Slicable<'a, L::DropConsistency>
     for Atomic<crate::live_collections::KeyedStream<K, V, crate::location::Atomic<L>, B, O, R>>
 {
-    type Slice = crate::live_collections::KeyedStream<K, V, Tick<L>, Bounded, O, R>;
+    type Slice =
+        crate::live_collections::KeyedStream<K, V, Tick<L::DropConsistency>, Bounded, O, R>;
     type Backtrace = crate::compile::ir::backtrace::Backtrace;
-    fn get_location(&self) -> &L {
-        &self.collection.location().tick.l
+    fn get_location(&self) -> L::DropConsistency {
+        self.collection.location().tick.l.drop_consistency()
     }
 
-    fn slice(self, tick: &Tick<L>, backtrace: Self::Backtrace) -> Self::Slice {
+    fn slice(self, tick: &Tick<L::DropConsistency>, backtrace: Self::Backtrace) -> Self::Slice {
         let out = self.collection.batch_atomic(tick, self.nondet);
         out.ir_node.borrow_mut().op_metadata_mut().backtrace = backtrace;
         out
     }
 }
 
-impl<'a, K, V, L: Location<'a> + NoTick, B: KeyedSingletonBound<ValueBound = Unbounded>>
-    Slicable<'a, L>
+impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound<ValueBound = Unbounded>>
+    Slicable<'a, L::DropConsistency>
     for Atomic<crate::live_collections::KeyedSingleton<K, V, crate::location::Atomic<L>, B>>
 {
-    type Slice = crate::live_collections::KeyedSingleton<K, V, Tick<L>, Bounded>;
+    type Slice = crate::live_collections::KeyedSingleton<K, V, Tick<L::DropConsistency>, Bounded>;
     type Backtrace = crate::compile::ir::backtrace::Backtrace;
-    fn get_location(&self) -> &L {
-        &self.collection.location().tick.l
+    fn get_location(&self) -> L::DropConsistency {
+        self.collection.location().tick.l.drop_consistency()
     }
 
-    fn slice(self, tick: &Tick<L>, backtrace: Self::Backtrace) -> Self::Slice {
+    fn slice(self, tick: &Tick<L::DropConsistency>, backtrace: Self::Backtrace) -> Self::Slice {
         let out = self.collection.snapshot_atomic(tick, self.nondet);
         out.ir_node.borrow_mut().op_metadata_mut().backtrace = backtrace;
         out
     }
 }
 
-impl<'a, K, V, L: Location<'a> + NoTick> Slicable<'a, L>
+impl<'a, K, V, L: Location<'a>> Slicable<'a, L::DropConsistency>
     for Atomic<
         crate::live_collections::KeyedSingleton<K, V, crate::location::Atomic<L>, BoundedValue>,
     >
 {
-    type Slice = crate::live_collections::KeyedSingleton<K, V, Tick<L>, Bounded>;
+    type Slice = crate::live_collections::KeyedSingleton<K, V, Tick<L::DropConsistency>, Bounded>;
     type Backtrace = crate::compile::ir::backtrace::Backtrace;
-    fn get_location(&self) -> &L {
-        &self.collection.location().tick.l
+    fn get_location(&self) -> L::DropConsistency {
+        self.collection.location().tick.l.drop_consistency()
     }
 
-    fn slice(self, tick: &Tick<L>, backtrace: Self::Backtrace) -> Self::Slice {
+    fn slice(self, tick: &Tick<L::DropConsistency>, backtrace: Self::Backtrace) -> Self::Slice {
         let out = self.collection.batch_atomic(tick, self.nondet);
         out.ir_node.borrow_mut().op_metadata_mut().backtrace = backtrace;
         out

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -26,8 +26,8 @@ use crate::live_collections::batch_atomic::BatchAtomic;
 use crate::live_collections::singleton::SingletonBound;
 #[cfg(stageleft_runtime)]
 use crate::location::dynamic::{DynLocation, LocationId};
-use crate::location::tick::{Atomic, DeferTick, NoAtomic};
-use crate::location::{Location, NoTick, Tick, check_matching_location};
+use crate::location::tick::{Atomic, DeferTick};
+use crate::location::{Location, Tick, TopLevel, check_matching_location};
 use crate::manual_expr::ManualExpr;
 use crate::nondet::{NonDet, nondet};
 use crate::prelude::manual_proof;
@@ -294,6 +294,10 @@ where
 {
     type Location = Tick<L>;
 
+    fn location(&self) -> &Self::Location {
+        self.location()
+    }
+
     fn create_source_with_initial(cycle_id: CycleId, initial: Self, location: Tick<L>) -> Self {
         let from_previous_tick: Stream<T, Tick<L>, Bounded, O, R> = Stream::new(
             location.clone(),
@@ -335,7 +339,7 @@ where
 impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> CycleCollection<'a, ForwardRef>
     for Stream<T, L, B, O, R>
 where
-    L: Location<'a> + NoTick,
+    L: Location<'a>,
 {
     type Location = L;
 
@@ -353,7 +357,7 @@ where
 impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> ReceiverComplete<'a, ForwardRef>
     for Stream<T, L, B, O, R>
 where
-    L: Location<'a> + NoTick,
+    L: Location<'a>,
 {
     fn complete(self, cycle_id: CycleId, expected_location: LocationId) {
         assert_eq!(
@@ -422,6 +426,99 @@ where
     /// Returns the [`Location`] where this stream is being materialized.
     pub fn location(&self) -> &L {
         &self.location
+    }
+
+    /// Weakens the consistency of this live collection to not guarantee any consistency across
+    /// cluster members (if this collection is on a cluster).
+    pub fn weaken_consistency(self) -> Stream<T, L::DropConsistency, B, O, R>
+    where
+        L: Location<'a>,
+    {
+        if L::consistency()
+            .is_none_or(|c| c == crate::location::dynamic::ClusterConsistency::NoConsistency)
+        {
+            // already no consistency
+            Stream::new(
+                self.location.drop_consistency(),
+                self.ir_node.replace(HydroNode::Placeholder),
+            )
+        } else {
+            Stream::new(
+                self.location.drop_consistency(),
+                HydroNode::Cast {
+                    inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                    metadata: self.location.drop_consistency().new_node_metadata(Stream::<
+                        T,
+                        L::DropConsistency,
+                        B,
+                        O,
+                        R,
+                    >::collection_kind(
+                    )),
+                },
+            )
+        }
+    }
+
+    /// Casts this live collection to have the consistency guarantees specified in the given
+    /// location type parameter. The developer must ensure that the strengthened consistency
+    /// is actually guaranteed, via the proof field (see [`crate::prelude::manual_proof`]).
+    pub fn assert_has_consistency_of<L2: Location<'a, DropConsistency = L::DropConsistency>>(
+        self,
+        _proof: impl crate::properties::ConsistencyProof,
+    ) -> Stream<T, L2, B, O, R>
+    where
+        L: Location<'a>,
+    {
+        if L::consistency() == L2::consistency() {
+            Stream::new(
+                self.location.with_consistency_of(),
+                self.ir_node.replace(HydroNode::Placeholder),
+            )
+        } else {
+            Stream::new(
+                self.location.with_consistency_of(),
+                HydroNode::AssertIsConsistent {
+                    inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                    trusted: false,
+                    metadata: self
+                        .location
+                        .clone()
+                        .with_consistency_of::<L2>()
+                        .new_node_metadata(Stream::<T, L2, B, O, R>::collection_kind()),
+                },
+            )
+        }
+    }
+
+    pub(crate) fn assert_has_consistency_of_trusted<
+        L2: Location<'a, DropConsistency = L::DropConsistency>,
+    >(
+        self,
+        _proof: impl crate::properties::ConsistencyProof,
+    ) -> Stream<T, L2, B, O, R>
+    where
+        L: Location<'a>,
+    {
+        if L::consistency() == L2::consistency() {
+            Stream::new(
+                self.location.with_consistency_of(),
+                self.ir_node.replace(HydroNode::Placeholder),
+            )
+        } else {
+            Stream::new(
+                self.location.with_consistency_of(),
+                HydroNode::AssertIsConsistent {
+                    inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                    trusted: true,
+                    metadata: self
+                        .location
+                        .clone()
+                        .with_consistency_of::<L2>()
+                        .new_node_metadata(Stream::<T, L2, B, O, R>::collection_kind()),
+                },
+            )
+        }
     }
 
     pub(crate) fn collection_kind() -> CollectionKind {
@@ -1106,12 +1203,13 @@ where
     /// # }));
     /// # }
     /// ```
-    pub fn inspect<F>(self, f: impl IntoQuotedMut<'a, F, L>) -> Self
+    pub fn inspect<F>(self, f: impl IntoQuotedMut<'a, F, L::DropConsistency>) -> Self
     where
         F: Fn(&T) + 'a,
     {
         let f = crate::singleton_ref::with_singleton_capture(|| {
-            f.splice_fn1_borrow_ctx(&self.location).into()
+            f.splice_fn1_borrow_ctx(&self.location.drop_consistency())
+                .into()
         });
 
         Stream::new(
@@ -1248,7 +1346,7 @@ where
         // Only assume_retries (for idempotence), not assume_ordering.
         // The fold hook in the simulator handles ordering non-determinism directly.
         let nondet = nondet!(/** the combinator function is commutative and idempotent */);
-        let retried: Stream<T, L, B, O, ExactlyOnce> = self.assume_retries(nondet);
+        let retried: Stream<T, L::DropConsistency, B, O, ExactlyOnce> = self.assume_retries(nondet);
 
         let core = HydroNode::Fold {
             init,
@@ -1256,10 +1354,15 @@ where
             input: Box::new(retried.ir_node.replace(HydroNode::Placeholder)),
             metadata: retried
                 .location
-                .new_node_metadata(Singleton::<A, L, B2>::collection_kind()),
+                .new_node_metadata(Singleton::<A, L::DropConsistency, B2>::collection_kind()),
+            // we do not guarantee consistency at this point because if the algebraic properties
+            // do not hold in practice, replica consistency may fail to be maintained, so we
+            // would like the simulator to assert consistency; in the future, this will be dynamic
+            // based on the proof mechanism
         };
 
         Singleton::new(retried.location.clone(), core)
+            .assert_has_consistency_of(manual_proof!(/** algebraic properties */))
     }
 
     /// Combines elements of the stream into an [`Optional`], by starting with the first element in the stream,
@@ -1297,17 +1400,19 @@ where
         proof.register_proof(&f);
 
         let nondet = nondet!(/** the combinator function is commutative and idempotent */);
-        let ordered_etc: Stream<T, L, B> = self.assume_retries(nondet).assume_ordering(nondet);
+        let ordered_etc: Stream<T, L::DropConsistency, B> =
+            self.assume_retries(nondet).assume_ordering(nondet);
 
         let core = HydroNode::Reduce {
             f: f.into(),
             input: Box::new(ordered_etc.ir_node.replace(HydroNode::Placeholder)),
             metadata: ordered_etc
                 .location
-                .new_node_metadata(Optional::<T, L, B>::collection_kind()),
+                .new_node_metadata(Optional::<T, L::DropConsistency, B>::collection_kind()),
         };
 
         Optional::new(ordered_etc.location.clone(), core)
+            .assert_has_consistency_of(manual_proof!(/** algebraic properties */))
     }
 
     /// Computes the maximum element in the stream as an [`Optional`], which
@@ -1799,9 +1904,9 @@ where
         self,
         interval: impl QuotedWithContext<'a, std::time::Duration, L> + Copy + 'a,
         nondet: NonDet,
-    ) -> Stream<T, L, Unbounded, O, AtLeastOnce>
+    ) -> Stream<T, L::DropConsistency, Unbounded, O, AtLeastOnce>
     where
-        L: NoTick + NoAtomic,
+        L: TopLevel<'a>,
     {
         let samples = self.location.source_interval(interval);
 
@@ -1823,11 +1928,11 @@ where
     /// detected based on when the next sample is taken.
     pub fn timeout(
         self,
-        duration: impl QuotedWithContext<'a, std::time::Duration, Tick<L>> + Copy + 'a,
+        duration: impl QuotedWithContext<'a, std::time::Duration, Tick<L::DropConsistency>> + Copy + 'a,
         nondet: NonDet,
-    ) -> Optional<(), L, Unbounded>
+    ) -> Optional<(), L::DropConsistency, Unbounded>
     where
-        L: NoTick + NoAtomic,
+        L: TopLevel<'a>,
     {
         let tick = self.location.tick();
 
@@ -1887,10 +1992,14 @@ where
     ///
     /// # Non-Determinism
     /// The batch boundaries are non-deterministic and may change across executions.
-    pub fn batch(self, tick: &Tick<L>, _nondet: NonDet) -> Stream<T, Tick<L>, Bounded, O, R> {
+    pub fn batch<L2: Location<'a, DropConsistency = L::DropConsistency>>(
+        self,
+        tick: &Tick<L2>,
+        _nondet: NonDet,
+    ) -> Stream<T, Tick<L::DropConsistency>, Bounded, O, R> {
         assert_eq!(Location::id(tick.outer()), Location::id(&self.location));
         Stream::new(
-            tick.clone(),
+            tick.drop_consistency(),
             HydroNode::Batch {
                 inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: tick
@@ -1951,28 +2060,31 @@ where
     /// This function is used as an escape hatch, and any mistakes in the
     /// provided ordering guarantee will propagate into the guarantees
     /// for the rest of the program.
-    pub fn assume_ordering<O2: Ordering>(self, _nondet: NonDet) -> Stream<T, L, B, O2, R> {
+    pub fn assume_ordering<O2: Ordering>(
+        self,
+        _nondet: NonDet,
+    ) -> Stream<T, L::DropConsistency, B, O2, R> {
         if O::ORDERING_KIND == O2::ORDERING_KIND {
-            self.use_ordering_type()
+            self.use_ordering_type().weaken_consistency()
         } else if O2::ORDERING_KIND == StreamOrder::NoOrder {
             // We can always weaken the ordering guarantee
+            let target_location = self.location().drop_consistency();
             Stream::new(
-                self.location.clone(),
+                target_location.clone(),
                 HydroNode::Cast {
                     inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
-                    metadata: self
-                        .location
+                    metadata: target_location
                         .new_node_metadata(Stream::<T, L, B, O2, R>::collection_kind()),
                 },
             )
         } else {
+            let target_location = self.location().drop_consistency();
             Stream::new(
-                self.location.clone(),
+                target_location.clone(),
                 HydroNode::ObserveNonDet {
                     inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                     trusted: false,
-                    metadata: self
-                        .location
+                    metadata: target_location
                         .new_node_metadata(Stream::<T, L, B, O2, R>::collection_kind()),
                 },
             )
@@ -1988,7 +2100,9 @@ where
         if B::BOUNDED {
             self.assume_ordering_trusted(nondet)
         } else {
-            self.assume_ordering(nondet)
+            let self_location = self.location.clone();
+            let inner: Stream<T, L::DropConsistency, B, O2, R> = self.assume_ordering(nondet);
+            Stream::new(self_location, inner.ir_node.replace(HydroNode::Placeholder))
         }
     }
 
@@ -1999,10 +2113,7 @@ where
         _nondet: NonDet,
     ) -> Stream<T, L, B, O2, R> {
         if O::ORDERING_KIND == O2::ORDERING_KIND {
-            Stream::new(
-                self.location.clone(),
-                self.ir_node.replace(HydroNode::Placeholder),
-            )
+            self.use_ordering_type()
         } else if O2::ORDERING_KIND == StreamOrder::NoOrder {
             // We can always weaken the ordering guarantee
             Stream::new(
@@ -2039,7 +2150,7 @@ where
     /// enforcing that `O2` is weaker than the input ordering guarantee.
     pub fn weaken_ordering<O2: WeakerOrderingThan<O>>(self) -> Stream<T, L, B, O2, R> {
         let nondet = nondet!(/** this is a weaker ordering guarantee, so it is safe to assume */);
-        self.assume_ordering::<O2>(nondet)
+        self.assume_ordering_trusted::<O2>(nondet)
     }
 
     /// Strengthens the ordering guarantee to `TotalOrder`, given that `O: IsOrdered`, which
@@ -2048,7 +2159,7 @@ where
     where
         O: IsOrdered,
     {
-        self.assume_ordering(nondet!(/** no-op */))
+        self.assume_ordering_trusted(nondet!(/** no-op */))
     }
 
     /// Explicitly "casts" the stream to a type with a different retries
@@ -2059,31 +2170,34 @@ where
     /// This function is used as an escape hatch, and any mistakes in the
     /// provided retries guarantee will propagate into the guarantees
     /// for the rest of the program.
-    pub fn assume_retries<R2: Retries>(self, _nondet: NonDet) -> Stream<T, L, B, O, R2> {
+    pub fn assume_retries<R2: Retries>(
+        self,
+        _nondet: NonDet,
+    ) -> Stream<T, L::DropConsistency, B, O, R2> {
         if R::RETRIES_KIND == R2::RETRIES_KIND {
             Stream::new(
-                self.location.clone(),
+                self.location.drop_consistency(),
                 self.ir_node.replace(HydroNode::Placeholder),
             )
         } else if R2::RETRIES_KIND == StreamRetry::AtLeastOnce {
             // We can always weaken the retries guarantee
+            let target_location = self.location.drop_consistency();
             Stream::new(
-                self.location.clone(),
+                target_location.clone(),
                 HydroNode::Cast {
                     inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
-                    metadata: self
-                        .location
+                    metadata: target_location
                         .new_node_metadata(Stream::<T, L, B, O, R2>::collection_kind()),
                 },
             )
         } else {
+            let target_location = self.location.drop_consistency();
             Stream::new(
-                self.location.clone(),
+                target_location.clone(),
                 HydroNode::ObserveNonDet {
                     inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                     trusted: false,
-                    metadata: self
-                        .location
+                    metadata: target_location
                         .new_node_metadata(Stream::<T, L, B, O, R2>::collection_kind()),
                 },
             )
@@ -2134,7 +2248,7 @@ where
     /// enforcing that `R2` is weaker than the input retries guarantee.
     pub fn weaken_retries<R2: WeakerRetryThan<R>>(self) -> Stream<T, L, B, O, R2> {
         let nondet = nondet!(/** this is a weaker retry guarantee, so it is safe to assume */);
-        self.assume_retries::<R2>(nondet)
+        self.assume_retries_trusted::<R2>(nondet)
     }
 
     /// Strengthens the retry guarantee to `ExactlyOnce`, given that `R: IsExactlyOnce`, which
@@ -2143,7 +2257,7 @@ where
     where
         R: IsExactlyOnce,
     {
-        self.assume_retries(nondet!(/** no-op */))
+        self.assume_retries_trusted(nondet!(/** no-op */))
     }
 
     /// Strengthens the boundedness guarantee to `Bounded`, given that `B: IsBounded`, which
@@ -2243,7 +2357,7 @@ where
     }
 }
 
-impl<'a, T, L: Location<'a> + NoTick, O: Ordering, R: Retries> Stream<T, L, Unbounded, O, R> {
+impl<'a, T, L: Location<'a>, O: Ordering, R: Retries> Stream<T, L, Unbounded, O, R> {
     /// Produces a new stream that merges the elements of the two input streams.
     /// The result has [`NoOrder`] because the order of merging is not guaranteed.
     ///
@@ -2335,18 +2449,19 @@ impl<'a, T, L: Location<'a>, B: Boundedness, R: Retries> Stream<T, L, B, TotalOr
         self,
         other: Stream<T, L, B, TotalOrder, R2>,
         _nondet: NonDet,
-    ) -> Stream<T, L, B, TotalOrder, <R as MinRetries<R2>>::Min>
+    ) -> Stream<T, L::DropConsistency, B, TotalOrder, <R as MinRetries<R2>>::Min>
     where
         R: MinRetries<R2>,
     {
+        let target_location = self.location().drop_consistency();
         Stream::new(
-            self.location.clone(),
+            target_location.clone(),
             HydroNode::MergeOrdered {
                 first: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 second: Box::new(other.ir_node.replace(HydroNode::Placeholder)),
-                metadata: self.location.new_node_metadata(Stream::<
+                metadata: target_location.new_node_metadata(Stream::<
                     T,
-                    L,
+                    L::DropConsistency,
                     B,
                     TotalOrder,
                     <R as MinRetries<R2>>::Min,
@@ -2824,7 +2939,7 @@ where
 
 impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Atomic<L>, B, O, R>
 where
-    L: Location<'a> + NoTick,
+    L: Location<'a>,
 {
     /// Returns a stream corresponding to the latest batch of elements being atomically
     /// processed. These batches are guaranteed to be contiguous across ticks and preserve
@@ -2832,13 +2947,13 @@ where
     ///
     /// # Non-Determinism
     /// The batch boundaries are non-deterministic and may change across executions.
-    pub fn batch_atomic(
+    pub fn batch_atomic<L2: Location<'a, DropConsistency = L::DropConsistency>>(
         self,
-        tick: &Tick<L>,
+        tick: &Tick<L2>,
         _nondet: NonDet,
-    ) -> Stream<T, Tick<L>, Bounded, O, R> {
+    ) -> Stream<T, Tick<L::DropConsistency>, Bounded, O, R> {
         Stream::new(
-            tick.clone(),
+            tick.drop_consistency(),
             HydroNode::Batch {
                 inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: tick
@@ -2866,7 +2981,7 @@ where
 
 impl<'a, F, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<F, L, B, O, R>
 where
-    L: Location<'a> + NoTick + NoAtomic,
+    L: TopLevel<'a>,
     F: Future<Output = T>,
 {
     /// Consumes a stream of `Future<T>`, produces a new stream of the resulting `T` outputs.
@@ -3029,7 +3144,7 @@ where
     /// # }));
     /// # }
     /// ```
-    pub fn across_ticks<Out: BatchAtomic>(
+    pub fn across_ticks<Out: BatchAtomic<'a>>(
         self,
         thunk: impl FnOnce(Stream<T, Atomic<L>, Unbounded, O, R>) -> Out,
     ) -> Out::Batched {

--- a/hydro_lang/src/live_collections/stream/networking.rs
+++ b/hydro_lang/src/live_collections/stream/networking.rs
@@ -16,19 +16,20 @@ use crate::live_collections::sliced::sliced;
 use crate::live_collections::stream::Retries;
 #[cfg(feature = "sim")]
 use crate::location::LocationKey;
-use crate::location::cluster::ClusterIds;
+use crate::location::cluster::{ClusterIds, Consistency, EventualConsistency, NoConsistency};
 #[cfg(stageleft_runtime)]
 use crate::location::dynamic::DynLocation;
 use crate::location::external_process::ExternalBincodeStream;
-use crate::location::{Cluster, External, Location, MemberId, MembershipEvent, NoTick, Process};
+use crate::location::{Cluster, External, Location, MemberId, MembershipEvent, Process};
 use crate::networking::{NetworkFor, TCP};
-use crate::nondet::NonDet;
+use crate::nondet::{NonDet, nondet};
+use crate::properties::manual_proof;
 #[cfg(feature = "sim")]
 use crate::sim::SimReceiver;
 use crate::staging_util::get_this_crate;
 
 // same as the one in `hydro_std`, but internal use only
-fn track_membership<'a, C, L: Location<'a> + NoTick>(
+fn track_membership<'a, C, L: Location<'a>>(
     membership: KeyedStream<MemberId<C>, MembershipEvent, L, Unbounded>,
 ) -> KeyedSingleton<MemberId<C>, bool, L, Unbounded> {
     membership.fold(
@@ -299,7 +300,10 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Process<'a, L>
         T: Clone + Serialize + DeserializeOwned,
         O: MinOrder<N::OrderingGuarantee>,
     {
-        let ids = track_membership(self.location.source_cluster_members(to));
+        let ids = track_membership(self.location.source_cluster_membership_stream(
+            to,
+            nondet!(/** dropped prefixes don't affect broadcast */),
+        ));
         sliced! {
             let members_snapshot = use(ids, nondet_membership);
             let elements = use(self, nondet_membership);
@@ -310,6 +314,7 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Process<'a, L>
         .demux(to, via)
     }
 
+    #[expect(clippy::type_complexity, reason = "guarantees eventual consistency")]
     /// Broadcasts elements of this stream to all members of a cluster,
     /// assuming membership is closed (fixed at deploy time).
     ///
@@ -351,7 +356,13 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Process<'a, L>
         self,
         to: &Cluster<'a, L2>,
         via: N,
-    ) -> Stream<T, Cluster<'a, L2>, Unbounded, <O as MinOrder<N::OrderingGuarantee>>::Min, R>
+    ) -> Stream<
+        T,
+        Cluster<'a, L2, EventualConsistency>,
+        Unbounded,
+        <O as MinOrder<N::OrderingGuarantee>>::Min,
+        R,
+    >
     where
         T: Clone + Serialize + DeserializeOwned,
         O: MinOrder<N::OrderingGuarantee>,
@@ -370,6 +381,7 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Process<'a, L>
             .map(q!(|(data, member_id)| (member_id, data)))
             .into_keyed()
             .demux(to, via)
+            .assert_has_consistency_of_trusted(manual_proof!(/** closed broadcast will materialze the same elements on each member */))
     }
 
     /// Sends the elements of this stream to an external (non-Hydro) process, using [`bincode`]
@@ -452,7 +464,7 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Process<'a, L>
     }
 }
 
-impl<'a, T, L: Location<'a> + NoTick, B: Boundedness> Stream<T, L, B, TotalOrder, ExactlyOnce> {
+impl<'a, T, L: Location<'a>, B: Boundedness> Stream<T, L, B, TotalOrder, ExactlyOnce> {
     /// Creates an external output for embedded deployment mode.
     ///
     /// The `name` parameter specifies the name of the field in the generated
@@ -559,11 +571,18 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
     /// # }));
     /// # }
     /// ```
+    #[expect(clippy::type_complexity, reason = "DropConsistency type")]
     pub fn demux<N: NetworkFor<T>>(
         self,
         to: &Cluster<'a, L2>,
         via: N,
-    ) -> Stream<T, Cluster<'a, L2>, Unbounded, <O as MinOrder<N::OrderingGuarantee>>::Min, R>
+    ) -> Stream<
+        T,
+        Cluster<'a, L2, NoConsistency>,
+        Unbounded,
+        <O as MinOrder<N::OrderingGuarantee>>::Min,
+        R,
+    >
     where
         T: Serialize + DeserializeOwned,
         O: MinOrder<N::OrderingGuarantee>,
@@ -684,7 +703,10 @@ impl<'a, T, L, B: Boundedness> Stream<T, Process<'a, L>, B, TotalOrder, ExactlyO
     where
         T: Serialize + DeserializeOwned,
     {
-        let ids = track_membership(self.location.source_cluster_members(to));
+        let ids = track_membership(self.location.source_cluster_membership_stream(
+            to,
+            nondet!(/** dropped prefixes don't affect broadcast */),
+        ));
         sliced! {
             let members_snapshot = use(ids, nondet_membership);
             let elements = use(self.enumerate(), nondet_membership);
@@ -709,7 +731,9 @@ impl<'a, T, L, B: Boundedness> Stream<T, Process<'a, L>, B, TotalOrder, ExactlyO
     }
 }
 
-impl<'a, T, L, B: Boundedness> Stream<T, Cluster<'a, L>, B, TotalOrder, ExactlyOnce> {
+impl<'a, T, L, B: Boundedness, C: Consistency>
+    Stream<T, Cluster<'a, L, C>, B, TotalOrder, ExactlyOnce>
+{
     #[deprecated = "use Stream::round_robin(..., TCP.fail_stop().bincode()) instead"]
     /// Distributes elements of this stream to cluster members in a round-robin fashion, using
     /// [`bincode`] to serialize/deserialize messages.
@@ -827,7 +851,10 @@ impl<'a, T, L, B: Boundedness> Stream<T, Cluster<'a, L>, B, TotalOrder, ExactlyO
     where
         T: Serialize + DeserializeOwned,
     {
-        let ids = track_membership(self.location.source_cluster_members(to));
+        let ids = track_membership(self.location.source_cluster_membership_stream(
+            to,
+            nondet!(/** dropped prefixes don't affect broadcast */),
+        ));
         sliced! {
             let members_snapshot = use(ids, nondet_membership);
             let elements = use(self.enumerate(), nondet_membership);
@@ -852,7 +879,9 @@ impl<'a, T, L, B: Boundedness> Stream<T, Cluster<'a, L>, B, TotalOrder, ExactlyO
     }
 }
 
-impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Cluster<'a, L>, B, O, R> {
+impl<'a, T, L, B: Boundedness, C: Consistency, O: Ordering, R: Retries>
+    Stream<T, Cluster<'a, L, C>, B, O, R>
+{
     #[deprecated = "use Stream::send(..., TCP.fail_stop().bincode()) instead"]
     /// "Moves" elements of this stream from a cluster to a process by sending them over the network,
     /// using [`bincode`] to serialize/deserialize messages.
@@ -1151,7 +1180,10 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Cluster<'a, L>
         T: Clone + Serialize + DeserializeOwned,
         O: MinOrder<N::OrderingGuarantee>,
     {
-        let ids = track_membership(self.location.source_cluster_members(to));
+        let ids = track_membership(self.location.source_cluster_membership_stream(
+            to,
+            nondet!(/** dropped prefixes don't affect broadcast */),
+        ));
         sliced! {
             let members_snapshot = use(ids, nondet_membership);
             let elements = use(self, nondet_membership);
@@ -1211,8 +1243,8 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Cluster<'a, L>
     }
 }
 
-impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
-    Stream<(MemberId<L2>, T), Cluster<'a, L>, B, O, R>
+impl<'a, T, L, L2, B: Boundedness, C: Consistency, O: Ordering, R: Retries>
+    Stream<(MemberId<L2>, T), Cluster<'a, L, C>, B, O, R>
 {
     #[deprecated = "use Stream::demux(..., TCP.fail_stop().bincode()) instead"]
     /// Sends elements of this stream at each source member to specific members of a destination
@@ -1324,7 +1356,7 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
     ) -> KeyedStream<
         MemberId<L>,
         T,
-        Cluster<'a, L2>,
+        Cluster<'a, L2, NoConsistency>,
         Unbounded,
         <O as MinOrder<N::OrderingGuarantee>>::Min,
         R,

--- a/hydro_lang/src/location/cluster.rs
+++ b/hydro_lang/src/location/cluster.rs
@@ -20,9 +20,35 @@ use stageleft::{QuotedWithContextWithProps, quote_type};
 use super::dynamic::LocationId;
 use super::{Location, MemberId};
 use crate::compile::builder::FlowState;
-use crate::location::LocationKey;
+use crate::location::dynamic::ClusterConsistency;
 use crate::location::member_id::TaglessMemberId;
+use crate::location::{LocationKey, TopLevel};
 use crate::staging_util::{Invariant, get_this_crate};
+
+/// A marker trait for levels of consistency that can be guaranteed for a live collection placed
+/// across members of a cluster.
+pub trait Consistency {
+    /// Gets the runtime enum variant associated with this consistency level.
+    fn consistency() -> ClusterConsistency;
+}
+
+/// No consistency is guaranteed across cluster members, which means that the live collection
+/// may take on arbitrarily different values across members.
+pub enum NoConsistency {}
+impl Consistency for NoConsistency {
+    fn consistency() -> ClusterConsistency {
+        ClusterConsistency::NoConsistency
+    }
+}
+
+/// Eventual consistency is guaranteed across cluster members, which means that at steady-state
+/// the live collection will always resolve to the same value across all members of the cluster.
+pub enum EventualConsistency {}
+impl Consistency for EventualConsistency {
+    fn consistency() -> ClusterConsistency {
+        ClusterConsistency::EventualConsistency
+    }
+}
 
 /// A multi-node location representing a group of identical processes.
 ///
@@ -33,26 +59,26 @@ use crate::staging_util::{Invariant, get_this_crate};
 /// The `ClusterTag` type parameter is a phantom tag used to distinguish between
 /// different clusters in the type system, preventing accidental mixing of
 /// member IDs across clusters.
-pub struct Cluster<'a, ClusterTag> {
+pub struct Cluster<'a, ClusterTag, Con: Consistency = NoConsistency> {
     pub(crate) key: LocationKey,
     pub(crate) flow_state: FlowState,
-    pub(crate) _phantom: Invariant<'a, ClusterTag>,
+    pub(crate) _phantom: Invariant<'a, (ClusterTag, Con)>,
 }
 
-impl<C> Debug for Cluster<'_, C> {
+impl<C, Con: Consistency> Debug for Cluster<'_, C, Con> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "Cluster({})", self.key)
     }
 }
 
-impl<C> Eq for Cluster<'_, C> {}
-impl<C> PartialEq for Cluster<'_, C> {
+impl<C, Con: Consistency> Eq for Cluster<'_, C, Con> {}
+impl<C, Con: Consistency> PartialEq for Cluster<'_, C, Con> {
     fn eq(&self, other: &Self) -> bool {
         self.key == other.key && FlowState::ptr_eq(&self.flow_state, &other.flow_state)
     }
 }
 
-impl<C> Clone for Cluster<'_, C> {
+impl<C, Con: Consistency> Clone for Cluster<'_, C, Con> {
     fn clone(&self) -> Self {
         Cluster {
             key: self.key,
@@ -62,8 +88,8 @@ impl<C> Clone for Cluster<'_, C> {
     }
 }
 
-impl<'a, C> super::dynamic::DynLocation for Cluster<'a, C> {
-    fn id(&self) -> LocationId {
+impl<'a, C, Con: Consistency> super::dynamic::DynLocation for Cluster<'a, C, Con> {
+    fn dyn_id(&self) -> LocationId {
         LocationId::Cluster(self.key)
     }
 
@@ -78,15 +104,43 @@ impl<'a, C> super::dynamic::DynLocation for Cluster<'a, C> {
     fn multiversioned(&self) -> bool {
         false // TODO(shadaj): enable multiversioning support for clusters
     }
+
+    fn cluster_consistency() -> Option<ClusterConsistency> {
+        Some(Con::consistency())
+    }
 }
 
-impl<'a, C> Location<'a> for Cluster<'a, C> {
-    type Root = Cluster<'a, C>;
+impl<'a, C, Con: Consistency> Location<'a> for Cluster<'a, C, Con> {
+    type Root = Cluster<'a, C, Con>;
+
+    type DropConsistency = Cluster<'a, C, NoConsistency>;
+
+    fn consistency() -> Option<ClusterConsistency> {
+        Some(Con::consistency())
+    }
 
     fn root(&self) -> Self::Root {
         self.clone()
     }
+
+    fn drop_consistency(&self) -> Self::DropConsistency {
+        Cluster {
+            key: self.key,
+            flow_state: self.flow_state.clone(),
+            _phantom: PhantomData,
+        }
+    }
+
+    fn from_drop_consistency(l2: Self::DropConsistency) -> Self {
+        Cluster {
+            key: l2.key,
+            flow_state: l2.flow_state,
+            _phantom: PhantomData,
+        }
+    }
 }
+
+impl<'a, C, Con: Consistency> TopLevel<'a> for Cluster<'a, C, Con> {}
 
 #[cfg(feature = "sim")]
 impl<'a, C> Cluster<'a, C> {
@@ -339,7 +393,7 @@ mod tests {
         let node = flow.process::<()>();
 
         let out_recv = node
-            .source_cluster_members(&cluster)
+            .source_cluster_membership_stream(&cluster, nondet!(/** test */))
             .entries()
             .map(q!(|(id, v)| (id, v)))
             .sim_output();

--- a/hydro_lang/src/location/dynamic.rs
+++ b/hydro_lang/src/location/dynamic.rs
@@ -15,6 +15,15 @@ use crate::compile::{
 };
 use crate::location::LocationType;
 
+/// An enumeration representing the consistency guarantee of a live collection on a cluster.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Serialize, Deserialize)]
+pub enum ClusterConsistency {
+    /// No consistency is guaranteed, see [`super::cluster::NoConsistency`].
+    NoConsistency,
+    /// Eventual consistency is guaranteed, see [`super::cluster::EventualConsistency`].
+    EventualConsistency,
+}
+
 /// An enumeration representing a location heirarchy, including "virtual" locations (atomic/tick).
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Serialize, Deserialize)]
 pub enum LocationId {
@@ -105,7 +114,11 @@ impl LocationId {
         }
     }
 
-    pub fn new_node_metadata(self, collection_kind: CollectionKind) -> HydroIrMetadata {
+    pub fn new_node_metadata(
+        self,
+        collection_kind: CollectionKind,
+        consistency: Option<ClusterConsistency>,
+    ) -> HydroIrMetadata {
         use crate::compile::ir::HydroIrOpMetadata;
         use crate::compile::ir::backtrace::Backtrace;
 
@@ -114,6 +127,7 @@ impl LocationId {
             collection_kind,
             cardinality: None,
             tag: None,
+            consistency,
             op: HydroIrOpMetadata {
                 backtrace: Backtrace::get_backtrace(3),
                 cpu_usage: None,
@@ -126,13 +140,15 @@ impl LocationId {
 
 #[cfg(stageleft_runtime)]
 pub(crate) trait DynLocation: Clone {
-    fn id(&self) -> LocationId;
+    fn dyn_id(&self) -> LocationId;
 
     fn flow_state(&self) -> &FlowState;
     fn is_top_level() -> bool;
     fn multiversioned(&self) -> bool;
+    fn cluster_consistency() -> Option<ClusterConsistency>;
 
     fn new_node_metadata(&self, collection_kind: CollectionKind) -> HydroIrMetadata {
-        self.id().new_node_metadata(collection_kind)
+        self.dyn_id()
+            .new_node_metadata(collection_kind, Self::cluster_consistency())
     }
 }

--- a/hydro_lang/src/location/mod.rs
+++ b/hydro_lang/src/location/mod.rs
@@ -43,11 +43,14 @@ use crate::live_collections::singleton::Singleton;
 use crate::live_collections::stream::{
     ExactlyOnce, NoOrder, Ordering, Retries, Stream, TotalOrder,
 };
-use crate::location::dynamic::LocationId;
+#[cfg(stageleft_runtime)]
+use crate::location::dynamic::DynLocation;
+use crate::location::dynamic::{ClusterConsistency, LocationId};
 use crate::location::external_process::{
     ExternalBincodeBidi, ExternalBincodeSink, ExternalBytesPort, Many, NotMany,
 };
 use crate::nondet::NonDet;
+use crate::properties::manual_proof;
 #[cfg(feature = "sim")]
 use crate::sim::SimSender;
 use crate::staging_util::get_this_crate;
@@ -67,7 +70,7 @@ pub mod member_id;
 pub use member_id::{MemberId, TaglessMemberId};
 
 pub mod tick;
-pub use tick::{Atomic, NoTick, Tick};
+pub use tick::{Atomic, Tick};
 
 /// An event indicating a change in membership status of a location in a group
 /// (e.g. a node in a [`Cluster`] or an external client connection).
@@ -172,6 +175,9 @@ pub enum LocationType {
     External,
 }
 
+/// A top-level location (i.e. a [`Process`] or [`Cluster`]) that is outside a tick / atomic region.
+pub trait TopLevel<'a>: Location<'a> {}
+
 /// A location where data can be materialized and computation can be executed.
 ///
 /// Hydro is a **global**, **distributed** programming model. This means that the data
@@ -189,18 +195,34 @@ pub enum LocationType {
     private_bounds,
     reason = "only internal Hydro code can define location types"
 )]
-pub trait Location<'a>: dynamic::DynLocation {
+pub trait Location<'a>: DynLocation {
     /// The root location type for this location.
     ///
     /// For top-level locations like [`Process`] and [`Cluster`], this is `Self`.
     /// For nested locations like [`Tick`], this is the root location that contains it.
     type Root: Location<'a>;
 
+    /// Location type with consistency guarantees dropped for the live collection on it.
+    type DropConsistency: Location<'a, DropConsistency = Self::DropConsistency>;
+
     /// Returns the root location for this location.
     ///
     /// For top-level locations like [`Process`] and [`Cluster`], this returns `self`.
     /// For nested locations like [`Tick`], this returns the root location that contains it.
     fn root(&self) -> Self::Root;
+
+    /// This location but with consistency guarantees dropped for the live collection
+    fn drop_consistency(&self) -> Self::DropConsistency;
+    /// Gets the runtime enum variant for the current consistency level, if this is a cluster.
+    fn consistency() -> Option<ClusterConsistency>;
+
+    /// Updates the consistency guarantees to match that of the given location.
+    fn with_consistency_of<L2: Location<'a, DropConsistency = Self::DropConsistency>>(&self) -> L2 {
+        L2::from_drop_consistency(self.drop_consistency())
+    }
+
+    #[doc(hidden)]
+    fn from_drop_consistency(l2: Self::DropConsistency) -> Self;
 
     /// Attempts to create a new [`Tick`] clock domain at this location.
     ///
@@ -222,7 +244,7 @@ pub trait Location<'a>: dynamic::DynLocation {
 
     /// Returns the unique identifier for this location.
     fn id(&self) -> LocationId {
-        dynamic::DynLocation::id(self)
+        DynLocation::dyn_id(self)
     }
 
     /// Creates a new [`Tick`] clock domain at this location.
@@ -250,10 +272,11 @@ pub trait Location<'a>: dynamic::DynLocation {
     /// # }));
     /// # }
     /// ```
-    fn tick(&self) -> Tick<Self>
-    where
-        Self: NoTick,
-    {
+    fn tick(&self) -> Tick<Self> {
+        if let LocationId::Tick(_, _) = self.id() {
+            panic!("cannot create nested ticks");
+        }
+
         let id = self.flow_state().borrow_mut().next_clock_id();
         Tick {
             id,
@@ -287,7 +310,7 @@ pub trait Location<'a>: dynamic::DynLocation {
     /// ```
     fn spin(&self) -> Stream<(), Self, Unbounded, TotalOrder, ExactlyOnce>
     where
-        Self: Sized + NoTick,
+        Self: TopLevel<'a> + Sized,
     {
         Stream::new(
             self.clone(),
@@ -327,20 +350,21 @@ pub trait Location<'a>: dynamic::DynLocation {
     fn source_stream<T, E>(
         &self,
         e: impl QuotedWithContext<'a, E, Self>,
-    ) -> Stream<T, Self, Unbounded, TotalOrder, ExactlyOnce>
+    ) -> Stream<T, Self::DropConsistency, Unbounded, TotalOrder, ExactlyOnce>
     where
         E: FuturesStream<Item = T> + Unpin,
-        Self: Sized + NoTick,
+        Self: TopLevel<'a> + Sized,
     {
         let e = e.splice_untyped_ctx(self);
 
+        let target_location = self.drop_consistency();
         Stream::new(
-            self.clone(),
+            target_location.clone(),
             HydroNode::Source {
                 source: HydroSource::Stream(e.into()),
-                metadata: self.new_node_metadata(Stream::<
+                metadata: target_location.new_node_metadata(Stream::<
                     T,
-                    Self,
+                    Self::DropConsistency,
                     Unbounded,
                     TotalOrder,
                     ExactlyOnce,
@@ -373,24 +397,30 @@ pub trait Location<'a>: dynamic::DynLocation {
     fn source_iter<T, E>(
         &self,
         e: impl QuotedWithContext<'a, E, Self>,
-    ) -> Stream<T, Self, Bounded, TotalOrder, ExactlyOnce>
+    ) -> Stream<T, Self::DropConsistency, Bounded, TotalOrder, ExactlyOnce>
     where
         E: IntoIterator<Item = T>,
         Self: Sized,
     {
         let e = e.splice_typed_ctx(self);
 
+        let target_location = self.drop_consistency();
         Stream::new(
-            self.clone(),
+            target_location.clone(),
             HydroNode::Source {
                 source: HydroSource::Iter(e.into()),
-                metadata: self.new_node_metadata(
-                    Stream::<T, Self, Bounded, TotalOrder, ExactlyOnce>::collection_kind(),
-                ),
+                metadata: target_location.new_node_metadata(Stream::<
+                    T,
+                    Self::DropConsistency,
+                    Bounded,
+                    TotalOrder,
+                    ExactlyOnce,
+                >::collection_kind()),
             },
         )
     }
 
+    #[deprecated(note = "use .source_cluster_membership_stream(...) instead")]
     /// Creates a stream of membership events for a cluster.
     ///
     /// This stream emits [`MembershipEvent::Joined`] when a cluster member joins
@@ -399,6 +429,11 @@ pub trait Location<'a>: dynamic::DynLocation {
     ///
     /// This is useful for implementing protocols that need to track cluster membership,
     /// such as broadcasting to all members or detecting failures.
+    ///
+    /// # Non-Determinism
+    /// This stream is non-deterministic because the timing of membership events, for example
+    /// if a node leaves, the membership event may not be received if the node left before the
+    /// stream was created.
     ///
     /// # Example
     /// ```rust
@@ -410,7 +445,7 @@ pub trait Location<'a>: dynamic::DynLocation {
     /// let workers: Cluster<()> = flow.cluster::<()>();
     /// # // do nothing on each worker
     /// # workers.source_iter(q!(vec![])).for_each(q!(|_: ()| {}));
-    /// let cluster_members = p1.source_cluster_members(&workers);
+    /// let cluster_members = p1.source_cluster_members(&workers, nondet!(/** late joiners may miss events */));
     /// # cluster_members.entries().send(&p2, TCP.fail_stop().bincode())
     /// // if there are 4 members in the cluster, we would see a join event for each
     /// // { MemberId::<Worker>(0): [MembershipEvent::Join], MemberId::<Worker>(2): [MembershipEvent::Join], ... }
@@ -427,21 +462,73 @@ pub trait Location<'a>: dynamic::DynLocation {
     fn source_cluster_members<C: 'a>(
         &self,
         cluster: &Cluster<'a, C>,
-    ) -> KeyedStream<MemberId<C>, MembershipEvent, Self, Unbounded>
+        nondet_start: NonDet,
+    ) -> KeyedStream<MemberId<C>, MembershipEvent, Self::DropConsistency, Unbounded>
     where
-        Self: Sized + NoTick,
+        Self: TopLevel<'a> + Sized,
     {
+        self.source_cluster_membership_stream(cluster, nondet_start)
+    }
+
+    /// Creates a stream of membership events for a cluster.
+    ///
+    /// This stream emits [`MembershipEvent::Joined`] when a cluster member joins
+    /// and [`MembershipEvent::Left`] when a cluster member leaves. The stream is
+    /// keyed by the [`MemberId`] of the cluster member.
+    ///
+    /// This is useful for implementing protocols that need to track cluster membership,
+    /// such as broadcasting to all members or detecting failures.
+    ///
+    /// # Non-Determinism
+    /// This stream is non-deterministic because the timing of membership events, for example
+    /// if a node leaves, the membership event may not be received if the node left before the
+    /// stream was created.
+    ///
+    /// # Example
+    /// ```rust
+    /// # #[cfg(feature = "deploy")] {
+    /// # use hydro_lang::prelude::*;
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(hydro_lang::test_util::multi_location_test(|flow, p2| {
+    /// let p1 = flow.process::<()>();
+    /// let workers: Cluster<()> = flow.cluster::<()>();
+    /// # // do nothing on each worker
+    /// # workers.source_iter(q!(vec![])).for_each(q!(|_: ()| {}));
+    /// let cluster_members = p1.source_cluster_membership_stream(&workers, nondet!(/** late joiners may miss events */));
+    /// # cluster_members.entries().send(&p2, TCP.fail_stop().bincode())
+    /// // if there are 4 members in the cluster, we would see a join event for each
+    /// // { MemberId::<Worker>(0): [MembershipEvent::Join], MemberId::<Worker>(2): [MembershipEvent::Join], ... }
+    /// # }, |mut stream| async move {
+    /// # let mut results = Vec::new();
+    /// # for w in 0..4 {
+    /// #     results.push(format!("{:?}", stream.next().await.unwrap()));
+    /// # }
+    /// # results.sort();
+    /// # assert_eq!(results, vec!["(MemberId::<()>(0), Joined)", "(MemberId::<()>(1), Joined)", "(MemberId::<()>(2), Joined)", "(MemberId::<()>(3), Joined)"]);
+    /// # }));
+    /// # }
+    /// ```
+    fn source_cluster_membership_stream<C: 'a>(
+        &self,
+        cluster: &Cluster<'a, C>,
+        _nondet_start: NonDet,
+    ) -> KeyedStream<MemberId<C>, MembershipEvent, Self::DropConsistency, Unbounded>
+    where
+        Self: TopLevel<'a> + Sized,
+    {
+        let target_consistency = self.drop_consistency();
         Stream::new(
-            self.clone(),
+            target_consistency.clone(),
             HydroNode::Source {
                 source: HydroSource::ClusterMembers(cluster.id(), ClusterMembersState::Uninit),
-                metadata: self.new_node_metadata(Stream::<
+                metadata: target_consistency.new_node_metadata(Stream::<
                     (TaglessMemberId, MembershipEvent),
                     Self,
                     Unbounded,
                     TotalOrder,
                     ExactlyOnce,
-                >::collection_kind()),
+                >::collection_kind(
+                )),
             },
         )
         .map(q!(|(k, v)| (MemberId::from_tagless(k), v)))
@@ -460,15 +547,15 @@ pub trait Location<'a>: dynamic::DynLocation {
         from: &External<L>,
     ) -> (
         ExternalBytesPort,
-        Stream<BytesMut, Self, Unbounded, TotalOrder, ExactlyOnce>,
+        Stream<BytesMut, Self::DropConsistency, Unbounded, TotalOrder, ExactlyOnce>,
     )
     where
-        Self: Sized + NoTick,
+        Self: TopLevel<'a> + Sized,
     {
         let (port, stream, sink) =
             self.bind_single_client::<_, Bytes, LengthDelimitedCodec>(from, NetworkHint::Auto);
 
-        sink.complete(self.source_iter(q!([])));
+        sink.complete(stream.location().source_iter(q!([])));
 
         (port, stream)
     }
@@ -485,14 +572,14 @@ pub trait Location<'a>: dynamic::DynLocation {
         from: &External<L>,
     ) -> (
         ExternalBincodeSink<T, NotMany, O, R>,
-        Stream<T, Self, Unbounded, O, R>,
+        Stream<T, Self::DropConsistency, Unbounded, O, R>,
     )
     where
-        Self: Sized + NoTick,
+        Self: TopLevel<'a> + Sized,
         T: Serialize + DeserializeOwned,
     {
         let (port, stream, sink) = self.bind_single_client_bincode::<_, T, ()>(from);
-        sink.complete(self.source_iter(q!([])));
+        sink.complete(stream.location().source_iter(q!([])));
 
         (
             ExternalBincodeSink {
@@ -512,9 +599,12 @@ pub trait Location<'a>: dynamic::DynLocation {
     #[expect(clippy::type_complexity, reason = "stream markers")]
     fn sim_input<T, O: Ordering, R: Retries>(
         &self,
-    ) -> (SimSender<T, O, R>, Stream<T, Self, Unbounded, O, R>)
+    ) -> (
+        SimSender<T, O, R>,
+        Stream<T, Self::DropConsistency, Unbounded, O, R>,
+    )
     where
-        Self: Sized + NoTick,
+        Self: TopLevel<'a> + Sized,
         T: Serialize + DeserializeOwned,
     {
         let external_location: External<'a, ()> = External {
@@ -536,17 +626,18 @@ pub trait Location<'a>: dynamic::DynLocation {
     fn embedded_input<T>(
         &self,
         name: impl Into<String>,
-    ) -> Stream<T, Self, Unbounded, TotalOrder, ExactlyOnce>
+    ) -> Stream<T, Self::DropConsistency, Unbounded, TotalOrder, ExactlyOnce>
     where
-        Self: Sized + NoTick,
+        Self: TopLevel<'a> + Sized,
     {
         let ident = syn::Ident::new(&name.into(), Span::call_site());
 
+        let target_location = self.drop_consistency();
         Stream::new(
-            self.clone(),
+            target_location.clone(),
             HydroNode::Source {
                 source: HydroSource::Embedded(ident),
-                metadata: self.new_node_metadata(Stream::<
+                metadata: target_location.new_node_metadata(Stream::<
                     T,
                     Self,
                     Unbounded,
@@ -562,17 +653,22 @@ pub trait Location<'a>: dynamic::DynLocation {
     /// The `name` parameter specifies the name of the generated function parameter
     /// that will supply data to this singleton at runtime. The generated function will
     /// accept a plain `T` parameter with this name.
-    fn embedded_singleton_input<T>(&self, name: impl Into<String>) -> Singleton<T, Self, Bounded>
+    fn embedded_singleton_input<T>(
+        &self,
+        name: impl Into<String>,
+    ) -> Singleton<T, Self::DropConsistency, Bounded>
     where
-        Self: Sized + NoTick,
+        Self: TopLevel<'a> + Sized,
     {
         let ident = syn::Ident::new(&name.into(), Span::call_site());
 
+        let target_location = self.drop_consistency();
         Singleton::new(
-            self.clone(),
+            target_location.clone(),
             HydroNode::Source {
                 source: HydroSource::EmbeddedSingleton(ident),
-                metadata: self.new_node_metadata(Singleton::<T, Self, Bounded>::collection_kind()),
+                metadata: target_location
+                    .new_node_metadata(Singleton::<T, Self, Bounded>::collection_kind()),
             },
         )
     }
@@ -628,16 +724,22 @@ pub trait Location<'a>: dynamic::DynLocation {
         port_hint: NetworkHint,
     ) -> (
         ExternalBytesPort<NotMany>,
-        Stream<<Codec as Decoder>::Item, Self, Unbounded, TotalOrder, ExactlyOnce>,
-        ForwardHandle<'a, Stream<T, Self, Unbounded, TotalOrder, ExactlyOnce>>,
+        Stream<<Codec as Decoder>::Item, Self::DropConsistency, Unbounded, TotalOrder, ExactlyOnce>,
+        ForwardHandle<'a, Stream<T, Self::DropConsistency, Unbounded, TotalOrder, ExactlyOnce>>,
     )
     where
-        Self: Sized + NoTick,
+        Self: TopLevel<'a> + Sized,
     {
         let next_external_port_id = from.flow_state.borrow_mut().next_external_port();
+        let target_consistency = self.drop_consistency();
 
-        let (fwd_ref, to_sink) =
-            self.forward_ref::<Stream<T, Self, Unbounded, TotalOrder, ExactlyOnce>>();
+        let (fwd_ref, to_sink) = target_consistency.forward_ref::<Stream<
+            T,
+            Self::DropConsistency,
+            Unbounded,
+            TotalOrder,
+            ExactlyOnce,
+        >>();
         let mut flow_state_borrow = self.flow_state().borrow_mut();
 
         flow_state_borrow.push_root(HydroRoot::SendExternal {
@@ -653,12 +755,12 @@ pub trait Location<'a>: dynamic::DynLocation {
 
         let raw_stream: Stream<
             Result<<Codec as Decoder>::Item, <Codec as Decoder>::Error>,
-            Self,
+            Self::DropConsistency,
             Unbounded,
             TotalOrder,
             ExactlyOnce,
         > = Stream::new(
-            self.clone(),
+            target_consistency.clone(),
             HydroNode::ExternalInput {
                 from_external_key: from.key,
                 from_port_id: next_external_port_id,
@@ -667,13 +769,14 @@ pub trait Location<'a>: dynamic::DynLocation {
                 port_hint,
                 instantiate_fn: DebugInstantiate::Building,
                 deserialize_fn: None,
-                metadata: self.new_node_metadata(Stream::<
+                metadata: target_consistency.new_node_metadata(Stream::<
                     Result<<Codec as Decoder>::Item, <Codec as Decoder>::Error>,
-                    Self,
+                    Self::DropConsistency,
                     Unbounded,
                     TotalOrder,
                     ExactlyOnce,
-                >::collection_kind()),
+                >::collection_kind(
+                )),
             },
         );
 
@@ -703,16 +806,22 @@ pub trait Location<'a>: dynamic::DynLocation {
         from: &External<L>,
     ) -> (
         ExternalBincodeBidi<InT, OutT, NotMany>,
-        Stream<InT, Self, Unbounded, TotalOrder, ExactlyOnce>,
-        ForwardHandle<'a, Stream<OutT, Self, Unbounded, TotalOrder, ExactlyOnce>>,
+        Stream<InT, Self::DropConsistency, Unbounded, TotalOrder, ExactlyOnce>,
+        ForwardHandle<'a, Stream<OutT, Self::DropConsistency, Unbounded, TotalOrder, ExactlyOnce>>,
     )
     where
-        Self: Sized + NoTick,
+        Self: TopLevel<'a> + Sized,
     {
         let next_external_port_id = from.flow_state.borrow_mut().next_external_port();
 
-        let (fwd_ref, to_sink) =
-            self.forward_ref::<Stream<OutT, Self, Unbounded, TotalOrder, ExactlyOnce>>();
+        let target_consistency = self.drop_consistency();
+        let (fwd_ref, to_sink) = target_consistency.forward_ref::<Stream<
+            OutT,
+            Self::DropConsistency,
+            Unbounded,
+            TotalOrder,
+            ExactlyOnce,
+        >>();
         let mut flow_state_borrow = self.flow_state().borrow_mut();
 
         let root = get_this_crate();
@@ -744,25 +853,27 @@ pub trait Location<'a>: dynamic::DynLocation {
             }
         };
 
-        let raw_stream: Stream<InT, Self, Unbounded, TotalOrder, ExactlyOnce> = Stream::new(
-            self.clone(),
-            HydroNode::ExternalInput {
-                from_external_key: from.key,
-                from_port_id: next_external_port_id,
-                from_many: false,
-                codec_type: quote_type::<LengthDelimitedCodec>().into(),
-                port_hint: NetworkHint::Auto,
-                instantiate_fn: DebugInstantiate::Building,
-                deserialize_fn: Some(deser_fn.into()),
-                metadata: self.new_node_metadata(Stream::<
-                    InT,
-                    Self,
-                    Unbounded,
-                    TotalOrder,
-                    ExactlyOnce,
-                >::collection_kind()),
-            },
-        );
+        let raw_stream: Stream<InT, Self::DropConsistency, Unbounded, TotalOrder, ExactlyOnce> =
+            Stream::new(
+                target_consistency.clone(),
+                HydroNode::ExternalInput {
+                    from_external_key: from.key,
+                    from_port_id: next_external_port_id,
+                    from_many: false,
+                    codec_type: quote_type::<LengthDelimitedCodec>().into(),
+                    port_hint: NetworkHint::Auto,
+                    instantiate_fn: DebugInstantiate::Building,
+                    deserialize_fn: Some(deser_fn.into()),
+                    metadata: target_consistency.new_node_metadata(Stream::<
+                        InT,
+                        Self::DropConsistency,
+                        Unbounded,
+                        TotalOrder,
+                        ExactlyOnce,
+                    >::collection_kind(
+                    )),
+                },
+            );
 
         (
             ExternalBincodeBidi {
@@ -793,17 +904,41 @@ pub trait Location<'a>: dynamic::DynLocation {
         port_hint: NetworkHint,
     ) -> (
         ExternalBytesPort<Many>,
-        KeyedStream<u64, <Codec as Decoder>::Item, Self, Unbounded, TotalOrder, ExactlyOnce>,
-        KeyedStream<u64, MembershipEvent, Self, Unbounded, TotalOrder, ExactlyOnce>,
-        ForwardHandle<'a, KeyedStream<u64, T, Self, Unbounded, NoOrder, ExactlyOnce>>,
+        KeyedStream<
+            u64,
+            <Codec as Decoder>::Item,
+            Self::DropConsistency,
+            Unbounded,
+            TotalOrder,
+            ExactlyOnce,
+        >,
+        KeyedStream<
+            u64,
+            MembershipEvent,
+            Self::DropConsistency,
+            Unbounded,
+            TotalOrder,
+            ExactlyOnce,
+        >,
+        ForwardHandle<
+            'a,
+            KeyedStream<u64, T, Self::DropConsistency, Unbounded, NoOrder, ExactlyOnce>,
+        >,
     )
     where
-        Self: Sized + NoTick,
+        Self: TopLevel<'a> + Sized,
     {
         let next_external_port_id = from.flow_state.borrow_mut().next_external_port();
 
-        let (fwd_ref, to_sink) =
-            self.forward_ref::<KeyedStream<u64, T, Self, Unbounded, NoOrder, ExactlyOnce>>();
+        let target_consistency = self.drop_consistency();
+        let (fwd_ref, to_sink) = target_consistency.forward_ref::<KeyedStream<
+            u64,
+            T,
+            Self::DropConsistency,
+            Unbounded,
+            NoOrder,
+            ExactlyOnce,
+        >>();
         let mut flow_state_borrow = self.flow_state().borrow_mut();
 
         flow_state_borrow.push_root(HydroRoot::SendExternal {
@@ -819,12 +954,12 @@ pub trait Location<'a>: dynamic::DynLocation {
 
         let raw_stream: Stream<
             Result<(u64, <Codec as Decoder>::Item), <Codec as Decoder>::Error>,
-            Self,
+            Self::DropConsistency,
             Unbounded,
             TotalOrder,
             ExactlyOnce,
         > = Stream::new(
-            self.clone(),
+            target_consistency.clone(),
             HydroNode::ExternalInput {
                 from_external_key: from.key,
                 from_port_id: next_external_port_id,
@@ -833,13 +968,14 @@ pub trait Location<'a>: dynamic::DynLocation {
                 port_hint,
                 instantiate_fn: DebugInstantiate::Building,
                 deserialize_fn: None,
-                metadata: self.new_node_metadata(Stream::<
+                metadata: target_consistency.new_node_metadata(Stream::<
                     Result<(u64, <Codec as Decoder>::Item), <Codec as Decoder>::Error>,
-                    Self,
+                    Self::DropConsistency,
                     Unbounded,
                     TotalOrder,
                     ExactlyOnce,
-                >::collection_kind()),
+                >::collection_kind(
+                )),
             },
         );
 
@@ -854,22 +990,23 @@ pub trait Location<'a>: dynamic::DynLocation {
         let raw_membership_stream: KeyedStream<
             u64,
             bool,
-            Self,
+            Self::DropConsistency,
             Unbounded,
             TotalOrder,
             ExactlyOnce,
         > = KeyedStream::new(
-            self.clone(),
+            target_consistency.clone(),
             HydroNode::Source {
                 source: HydroSource::Stream(membership_stream_expr.into()),
-                metadata: self.new_node_metadata(KeyedStream::<
+                metadata: target_consistency.new_node_metadata(KeyedStream::<
                     u64,
                     bool,
-                    Self,
+                    Self::DropConsistency,
                     Unbounded,
                     TotalOrder,
                     ExactlyOnce,
-                >::collection_kind()),
+                >::collection_kind(
+                )),
             },
         );
 
@@ -914,17 +1051,34 @@ pub trait Location<'a>: dynamic::DynLocation {
         from: &External<L>,
     ) -> (
         ExternalBincodeBidi<InT, OutT, Many>,
-        KeyedStream<u64, InT, Self, Unbounded, TotalOrder, ExactlyOnce>,
-        KeyedStream<u64, MembershipEvent, Self, Unbounded, TotalOrder, ExactlyOnce>,
-        ForwardHandle<'a, KeyedStream<u64, OutT, Self, Unbounded, NoOrder, ExactlyOnce>>,
+        KeyedStream<u64, InT, Self::DropConsistency, Unbounded, TotalOrder, ExactlyOnce>,
+        KeyedStream<
+            u64,
+            MembershipEvent,
+            Self::DropConsistency,
+            Unbounded,
+            TotalOrder,
+            ExactlyOnce,
+        >,
+        ForwardHandle<
+            'a,
+            KeyedStream<u64, OutT, Self::DropConsistency, Unbounded, NoOrder, ExactlyOnce>,
+        >,
     )
     where
-        Self: Sized + NoTick,
+        Self: TopLevel<'a> + Sized,
     {
         let next_external_port_id = from.flow_state.borrow_mut().next_external_port();
 
-        let (fwd_ref, to_sink) =
-            self.forward_ref::<KeyedStream<u64, OutT, Self, Unbounded, NoOrder, ExactlyOnce>>();
+        let target_consistency = self.drop_consistency();
+        let (fwd_ref, to_sink) = target_consistency.forward_ref::<KeyedStream<
+            u64,
+            OutT,
+            Self::DropConsistency,
+            Unbounded,
+            NoOrder,
+            ExactlyOnce,
+        >>();
         let mut flow_state_borrow = self.flow_state().borrow_mut();
 
         let root = get_this_crate();
@@ -956,27 +1110,34 @@ pub trait Location<'a>: dynamic::DynLocation {
             }
         };
 
-        let raw_stream: KeyedStream<u64, InT, Self, Unbounded, TotalOrder, ExactlyOnce> =
-            KeyedStream::new(
-                self.clone(),
-                HydroNode::ExternalInput {
-                    from_external_key: from.key,
-                    from_port_id: next_external_port_id,
-                    from_many: true,
-                    codec_type: quote_type::<LengthDelimitedCodec>().into(),
-                    port_hint: NetworkHint::Auto,
-                    instantiate_fn: DebugInstantiate::Building,
-                    deserialize_fn: Some(deser_fn.into()),
-                    metadata: self.new_node_metadata(KeyedStream::<
-                        u64,
-                        InT,
-                        Self,
-                        Unbounded,
-                        TotalOrder,
-                        ExactlyOnce,
-                    >::collection_kind()),
-                },
-            );
+        let raw_stream: KeyedStream<
+            u64,
+            InT,
+            Self::DropConsistency,
+            Unbounded,
+            TotalOrder,
+            ExactlyOnce,
+        > = KeyedStream::new(
+            target_consistency.clone(),
+            HydroNode::ExternalInput {
+                from_external_key: from.key,
+                from_port_id: next_external_port_id,
+                from_many: true,
+                codec_type: quote_type::<LengthDelimitedCodec>().into(),
+                port_hint: NetworkHint::Auto,
+                instantiate_fn: DebugInstantiate::Building,
+                deserialize_fn: Some(deser_fn.into()),
+                metadata: target_consistency.new_node_metadata(KeyedStream::<
+                    u64,
+                    InT,
+                    Self::DropConsistency,
+                    Unbounded,
+                    TotalOrder,
+                    ExactlyOnce,
+                >::collection_kind(
+                )),
+            },
+        );
 
         let membership_stream_ident = syn::Ident::new(
             &format!(
@@ -989,22 +1150,23 @@ pub trait Location<'a>: dynamic::DynLocation {
         let raw_membership_stream: KeyedStream<
             u64,
             bool,
-            Self,
+            Self::DropConsistency,
             Unbounded,
             TotalOrder,
             ExactlyOnce,
         > = KeyedStream::new(
-            self.clone(),
+            target_consistency.clone(),
             HydroNode::Source {
                 source: HydroSource::Stream(membership_stream_expr.into()),
-                metadata: self.new_node_metadata(KeyedStream::<
+                metadata: target_consistency.new_node_metadata(KeyedStream::<
                     u64,
                     bool,
-                    Self,
+                    Self::DropConsistency,
                     Unbounded,
                     TotalOrder,
                     ExactlyOnce,
-                >::collection_kind()),
+                >::collection_kind(
+                )),
             },
         );
 
@@ -1087,7 +1249,7 @@ pub trait Location<'a>: dynamic::DynLocation {
         ForwardHandle<'a, Stream<OutT, Self, Unbounded, NoOrder, ExactlyOnce>>,
     )
     where
-        Self: Sized + NoTick,
+        Self: Sized + TopLevel<'a>,
     {
         let location_key = Location::id(self).key();
 
@@ -1163,18 +1325,26 @@ pub trait Location<'a>: dynamic::DynLocation {
     /// # }));
     /// # }
     /// ```
-    fn singleton<T>(&self, e: impl QuotedWithContext<'a, T, Self>) -> Singleton<T, Self, Bounded>
+    fn singleton<T>(
+        &self,
+        e: impl QuotedWithContext<'a, T, Self>,
+    ) -> Singleton<T, Self::DropConsistency, Bounded>
     where
-        Self: Sized + NoTick,
+        Self: Sized,
     {
         let e = e.splice_untyped_ctx(self);
 
+        let target_location = self.drop_consistency();
         Singleton::new(
-            self.clone(),
+            target_location.clone(),
             HydroNode::SingletonSource {
                 value: e.into(),
                 first_tick_only: false,
-                metadata: self.new_node_metadata(Singleton::<T, Self, Bounded>::collection_kind()),
+                metadata: target_location.new_node_metadata(Singleton::<
+                    T,
+                    Self::DropConsistency,
+                    Bounded,
+                >::collection_kind()),
             },
         )
     }
@@ -1204,10 +1374,10 @@ pub trait Location<'a>: dynamic::DynLocation {
     fn singleton_future<F>(
         &self,
         e: impl QuotedWithContext<'a, F, Self>,
-    ) -> Singleton<F::Output, Self, Bounded>
+    ) -> Singleton<F::Output, Self::DropConsistency, Bounded>
     where
         F: Future,
-        Self: Sized + NoTick,
+        Self: Sized,
     {
         self.singleton(e).resolve_future_blocking()
     }
@@ -1225,12 +1395,15 @@ pub trait Location<'a>: dynamic::DynLocation {
         interval: impl QuotedWithContext<'a, Duration, Self> + Copy + 'a,
     ) -> Stream<(), Self, Unbounded, TotalOrder, ExactlyOnce>
     where
-        Self: Sized + NoTick,
+        Self: TopLevel<'a> + Sized,
     {
         self.source_stream(q!(tokio_stream::StreamExt::map(
             tokio_stream::wrappers::IntervalStream::new(tokio::time::interval(interval)),
             |_| ()
         )))
+        .assert_has_consistency_of_trusted(
+            manual_proof!(/** interval does not reveal timestamps */),
+        )
     }
 
     /// Generates a stream that emits `()` at a fixed interval, after an
@@ -1245,7 +1418,7 @@ pub trait Location<'a>: dynamic::DynLocation {
         interval: impl QuotedWithContext<'a, Duration, Self> + Copy + 'a,
     ) -> Stream<(), Self, Unbounded, TotalOrder, ExactlyOnce>
     where
-        Self: Sized + NoTick,
+        Self: TopLevel<'a> + Sized,
     {
         self.source_stream(q!(tokio_stream::StreamExt::map(
             tokio_stream::wrappers::IntervalStream::new(tokio::time::interval_at(
@@ -1254,24 +1427,9 @@ pub trait Location<'a>: dynamic::DynLocation {
             )),
             |_| ()
         )))
-    }
-
-    /// Returns the current wall-clock time as a [`Singleton`] containing a
-    /// [`tokio::time::Instant`].
-    ///
-    /// # Non-Determinism
-    /// Reading wall-clock time is inherently non-deterministic because the
-    /// value depends on when the tick executes. A [`NonDet`] guard is required
-    /// to acknowledge this.
-    fn current_tick_instant(
-        &self,
-        _nondet: NonDet,
-    ) -> Singleton<tokio::time::Instant, Tick<Self>, Bounded>
-    where
-        Self: Sized + NoTick,
-    {
-        let tick = self.tick();
-        tick.singleton(q!(tokio::time::Instant::now()))
+        .assert_has_consistency_of_trusted(
+            manual_proof!(/** interval does not reveal timestamps */),
+        )
     }
 
     /// Creates a forward reference, allowing a stream to be used before its source is defined.

--- a/hydro_lang/src/location/process.rs
+++ b/hydro_lang/src/location/process.rs
@@ -15,7 +15,7 @@ use std::marker::PhantomData;
 
 use super::{Location, LocationId};
 use crate::compile::builder::FlowState;
-use crate::location::LocationKey;
+use crate::location::{LocationKey, TopLevel};
 use crate::staging_util::Invariant;
 
 /// A single-node location in a distributed Hydro program.
@@ -64,7 +64,7 @@ impl<P> Clone for Process<'_, P> {
 }
 
 impl<'a, P> super::dynamic::DynLocation for Process<'a, P> {
-    fn id(&self) -> LocationId {
+    fn dyn_id(&self) -> LocationId {
         LocationId::Process(self.key)
     }
 
@@ -79,12 +79,32 @@ impl<'a, P> super::dynamic::DynLocation for Process<'a, P> {
     fn multiversioned(&self) -> bool {
         false // processes are always single-versioned
     }
+
+    fn cluster_consistency() -> Option<super::dynamic::ClusterConsistency> {
+        None
+    }
 }
 
 impl<'a, P> Location<'a> for Process<'a, P> {
     type Root = Self;
 
+    type DropConsistency = Self;
+
+    fn consistency() -> Option<super::dynamic::ClusterConsistency> {
+        None
+    }
+
     fn root(&self) -> Self::Root {
         self.clone()
     }
+
+    fn drop_consistency(&self) -> Self::DropConsistency {
+        self.clone()
+    }
+
+    fn from_drop_consistency(l2: Self::DropConsistency) -> Self {
+        l2
+    }
 }
+
+impl<'a, P> TopLevel<'a> for Process<'a, P> {}

--- a/hydro_lang/src/location/tick.rs
+++ b/hydro_lang/src/location/tick.rs
@@ -5,7 +5,7 @@
 //! for implementing iterative algorithms, synchronizing data across multiple
 //! streams, and performing aggregations over windows of data.
 //!
-//! A tick is created from a top-level location (such as [`Process`] or [`Cluster`])
+//! A tick is created from a top-level location (such as [`super::Process`] or [`super::Cluster`])
 //! using [`Location::tick`]. Once inside a tick, bounded live collections can be
 //! manipulated with operations like fold, reduce, and cross-product, and the
 //! results can be emitted back to the unbounded stream using methods like
@@ -13,53 +13,23 @@
 //!
 //! The [`Atomic`] wrapper provides atomicity guarantees within a tick, ensuring
 //! that reads and writes within a tick are serialized.
-//!
-//! The [`NoTick`] marker trait is used to constrain APIs that should only be
-//! called on top-level locations (not inside a tick), while [`NoAtomic`] constrains
-//! APIs that should not be called inside an atomic context.
 
-use sealed::sealed;
 use stageleft::{QuotedWithContext, q};
 
 #[cfg(stageleft_runtime)]
 use super::dynamic::DynLocation;
-use super::{Cluster, Location, LocationId, Process};
+use super::{Location, LocationId};
 use crate::compile::builder::{ClockId, FlowState};
 use crate::compile::ir::{HydroNode, HydroSource};
 #[cfg(stageleft_runtime)]
 use crate::forward_handle::{CycleCollection, CycleCollectionWithInitial};
 use crate::forward_handle::{TickCycle, TickCycleHandle};
+use crate::live_collections::Singleton;
 use crate::live_collections::boundedness::Bounded;
 use crate::live_collections::optional::Optional;
-use crate::live_collections::singleton::Singleton;
 use crate::live_collections::stream::{ExactlyOnce, Stream, TotalOrder};
-use crate::nondet::nondet;
-
-/// Marker trait for locations that are **not** inside a [`Tick`] clock domain.
-///
-/// This trait is implemented by top-level locations such as [`Process`] and [`Cluster`],
-/// as well as [`Atomic`]. It is used to constrain APIs that should only be called
-/// outside of a tick context (e.g., creating a new tick or sourcing external data).
-#[sealed]
-pub trait NoTick {}
-#[sealed]
-impl<T> NoTick for Process<'_, T> {}
-#[sealed]
-impl<T> NoTick for Cluster<'_, T> {}
-
-/// Marker trait for locations that are **not** inside an [`Atomic`] context.
-///
-/// This trait is implemented by top-level locations ([`Process`], [`Cluster`]) and
-/// by [`Tick`]. It is used to constrain APIs that should not be called from within
-/// an atomic block.
-#[sealed]
-pub trait NoAtomic {}
-#[sealed]
-impl<T> NoAtomic for Process<'_, T> {}
-#[sealed]
-impl<T> NoAtomic for Cluster<'_, T> {}
-#[sealed]
-impl<'a, L> NoAtomic for Tick<L> where L: Location<'a> {}
+use crate::location::TopLevel;
+use crate::nondet::{NonDet, nondet};
 
 /// A location wrapper that provides atomicity guarantees within a [`Tick`].
 ///
@@ -77,8 +47,8 @@ pub struct Atomic<Loc> {
 }
 
 impl<L: DynLocation> DynLocation for Atomic<L> {
-    fn id(&self) -> LocationId {
-        LocationId::Atomic(Box::new(self.tick.id()))
+    fn dyn_id(&self) -> LocationId {
+        LocationId::Atomic(Box::new(self.tick.dyn_id()))
     }
 
     fn flow_state(&self) -> &FlowState {
@@ -92,6 +62,10 @@ impl<L: DynLocation> DynLocation for Atomic<L> {
     fn multiversioned(&self) -> bool {
         self.tick.multiversioned()
     }
+
+    fn cluster_consistency() -> Option<super::dynamic::ClusterConsistency> {
+        L::cluster_consistency()
+    }
 }
 
 impl<'a, L> Location<'a> for Atomic<L>
@@ -100,13 +74,28 @@ where
 {
     type Root = L::Root;
 
+    type DropConsistency = Atomic<L::DropConsistency>;
+
+    fn consistency() -> Option<super::dynamic::ClusterConsistency> {
+        L::consistency()
+    }
+
     fn root(&self) -> Self::Root {
         self.tick.root()
     }
-}
 
-#[sealed]
-impl<L> NoTick for Atomic<L> {}
+    fn drop_consistency(&self) -> Self::DropConsistency {
+        Atomic {
+            tick: self.tick.drop_consistency(),
+        }
+    }
+
+    fn from_drop_consistency(l2: Self::DropConsistency) -> Self {
+        Atomic {
+            tick: Tick::from_drop_consistency(l2.tick),
+        }
+    }
+}
 
 /// Trait for live collections that can be deferred by one tick.
 ///
@@ -128,8 +117,8 @@ pub struct Tick<L> {
 }
 
 impl<L: DynLocation> DynLocation for Tick<L> {
-    fn id(&self) -> LocationId {
-        LocationId::Tick(self.id, Box::new(self.l.id()))
+    fn dyn_id(&self) -> LocationId {
+        LocationId::Tick(self.id, Box::new(self.l.dyn_id()))
     }
 
     fn flow_state(&self) -> &FlowState {
@@ -143,6 +132,10 @@ impl<L: DynLocation> DynLocation for Tick<L> {
     fn multiversioned(&self) -> bool {
         self.l.multiversioned()
     }
+
+    fn cluster_consistency() -> Option<super::dynamic::ClusterConsistency> {
+        L::cluster_consistency()
+    }
 }
 
 impl<'a, L> Location<'a> for Tick<L>
@@ -151,8 +144,28 @@ where
 {
     type Root = L::Root;
 
+    type DropConsistency = Tick<L::DropConsistency>;
+
+    fn consistency() -> Option<super::dynamic::ClusterConsistency> {
+        L::consistency()
+    }
+
     fn root(&self) -> Self::Root {
         self.l.root()
+    }
+
+    fn drop_consistency(&self) -> Self::DropConsistency {
+        Tick {
+            id: self.id,
+            l: self.l.drop_consistency(),
+        }
+    }
+
+    fn from_drop_consistency(l2: Self::DropConsistency) -> Self {
+        Tick {
+            id: l2.id,
+            l: L::from_drop_consistency(l2.l),
+        }
     }
 }
 
@@ -178,7 +191,7 @@ where
         batch_size: impl QuotedWithContext<'a, usize, L> + Copy + 'a,
     ) -> Stream<(), Self, Bounded, TotalOrder, ExactlyOnce>
     where
-        L: NoTick,
+        L: TopLevel<'a>,
     {
         let out = self
             .l
@@ -186,32 +199,8 @@ where
             .flat_map_ordered(q!(move |_| 0..batch_size))
             .map(q!(|_| ()));
 
-        out.batch(self, nondet!(/** at runtime, `spin` produces a single value per tick, so each batch is guaranteed to be the same size. */))
-    }
-
-    /// Constructs a [`Singleton`] materialized inside this tick with the given static value.
-    ///
-    /// The singleton will have the provided value on every tick. This is useful
-    /// for providing constant values to computations inside a tick.
-    ///
-    /// See also: [`Location::singleton`], for creating a singleton _not_ inside a tick.
-    pub fn singleton<T>(
-        &self,
-        e: impl QuotedWithContext<'a, T, Tick<L>>,
-    ) -> Singleton<T, Self, Bounded>
-    where
-        T: Clone,
-    {
-        let e = e.splice_untyped_ctx(self);
-
-        Singleton::new(
-            self.clone(),
-            HydroNode::SingletonSource {
-                value: e.into(),
-                first_tick_only: false,
-                metadata: self.new_node_metadata(Singleton::<T, Self, Bounded>::collection_kind()),
-            },
-        )
+        let inner = out.batch(self, nondet!(/** at runtime, `spin` produces a single value per tick, so each batch is guaranteed to be the same size. */));
+        Stream::new(self.clone(), inner.ir_node.replace(HydroNode::Placeholder))
     }
 
     /// Creates an [`Optional`] which has a null value on every tick.
@@ -288,6 +277,24 @@ where
         )
     }
 
+    /// Returns the current wall-clock time as a [`Singleton`] containing a
+    /// [`tokio::time::Instant`].
+    ///
+    /// # Non-Determinism
+    /// Reading wall-clock time is inherently non-deterministic because the
+    /// value depends on when the tick executes. A [`NonDet`] guard is required
+    /// to acknowledge this.
+    pub fn current_tick_instant(
+        &self,
+        _nondet: NonDet,
+    ) -> Singleton<tokio::time::Instant, Tick<L::DropConsistency>, Bounded>
+    where
+        Self: Sized,
+    {
+        // TODO(shadaj): this is a simulator hole, should be reported as unsupported until it is
+        self.singleton(q!(tokio::time::Instant::now()))
+    }
+
     /// Creates a feedback cycle within this tick for implementing iterative computations.
     ///
     /// Returns a handle that must be completed with the actual collection, and a placeholder
@@ -300,15 +307,16 @@ where
         private_bounds,
         reason = "only Hydro collections can implement ReceiverComplete"
     )]
-    pub fn cycle<S>(&self) -> (TickCycleHandle<'a, S>, S)
+    pub fn cycle<S, L2: Location<'a, DropConsistency = Tick<L::DropConsistency>>>(
+        &self,
+    ) -> (TickCycleHandle<'a, S>, S)
     where
-        S: CycleCollection<'a, TickCycle, Location = Self> + DeferTick,
-        L: NoTick,
+        S: CycleCollection<'a, TickCycle, Location = L2> + DeferTick,
     {
         let cycle_id = self.flow_state().borrow_mut().next_cycle_id();
         (
             TickCycleHandle::new(cycle_id, Location::id(self)),
-            S::create_source(cycle_id, self.clone()).defer_tick(),
+            S::create_source(cycle_id, self.clone().with_consistency_of()).defer_tick(),
         )
     }
 
@@ -322,15 +330,18 @@ where
         private_bounds,
         reason = "only Hydro collections can implement ReceiverComplete"
     )]
-    pub fn cycle_with_initial<S>(&self, initial: S) -> (TickCycleHandle<'a, S>, S)
+    pub fn cycle_with_initial<S, L2: Location<'a, DropConsistency = Tick<L::DropConsistency>>>(
+        &self,
+        initial: S,
+    ) -> (TickCycleHandle<'a, S>, S)
     where
-        S: CycleCollectionWithInitial<'a, TickCycle, Location = Self>,
+        S: CycleCollectionWithInitial<'a, TickCycle, Location = L2>,
     {
         let cycle_id = self.flow_state().borrow_mut().next_cycle_id();
         (
             TickCycleHandle::new(cycle_id, Location::id(self)),
             // no need to defer_tick, create_source_with_initial does it for us
-            S::create_source_with_initial(cycle_id, initial, self.clone()),
+            S::create_source_with_initial(cycle_id, initial, self.clone().with_consistency_of()),
         )
     }
 }

--- a/hydro_lang/src/properties/mod.rs
+++ b/hydro_lang/src/properties/mod.rs
@@ -45,6 +45,10 @@ pub trait OrderPreservingProof {
     fn register_proof(&self, expr: &syn::Expr);
 }
 
+/// A trait for proof mechanisms that can validate consistency of a collection.
+#[sealed::sealed]
+pub trait ConsistencyProof {}
+
 /// A hand-written human proof of the correctness property.
 ///
 /// To create a manual proof, use the [`manual_proof!`] macro, which takes in a doc comment
@@ -66,6 +70,8 @@ impl MonotoneProof for ManualProof {
 impl OrderPreservingProof for ManualProof {
     fn register_proof(&self, _expr: &syn::Expr) {}
 }
+#[sealed::sealed]
+impl ConsistencyProof for ManualProof {}
 
 #[doc(inline)]
 pub use crate::__manual_proof__ as manual_proof;

--- a/hydro_lang/src/sim/builder.rs
+++ b/hydro_lang/src/sim/builder.rs
@@ -35,6 +35,7 @@ pub struct SimBuilder {
     pub cluster_tick_dfirs: BTreeMap<LocationId, FlatGraphBuilder>,
     pub next_hoff_id: usize,
     pub test_safety_only: bool,
+    pub skip_consistency_assertions: bool,
 }
 
 impl SimBuilder {
@@ -1655,6 +1656,30 @@ impl DfirBuilder for SimBuilder {
         );
 
         Some(out_ident)
+    }
+
+    fn assert_is_consistent(
+        &mut self,
+        trusted: bool,
+        location: &LocationId,
+        in_ident: syn::Ident,
+        out_ident: &syn::Ident,
+    ) {
+        if self.skip_consistency_assertions || trusted {
+            let builder = self.get_dfir_mut(location);
+            builder.add_dfir(
+                parse_quote! {
+                    #out_ident = #in_ident;
+                },
+                None,
+                None,
+            );
+        } else {
+            // TODO(shadaj): inject assertions that validate consistency in simulation
+            panic!(
+                "validating consistency assertions is not yet supported in the simulator; call `.skip_consistency_assertions()` on the SimFlow to skip them"
+            );
+        }
     }
 }
 

--- a/hydro_lang/src/sim/flow.rs
+++ b/hydro_lang/src/sim/flow.rs
@@ -38,6 +38,11 @@ pub struct SimFlow<'a> {
     /// When true, the simulator only tests safety properties (not liveness).
     pub(crate) test_safety_only: bool,
 
+    /// When true, consistency assertions are skipped (treated as identity no-ops).
+    /// When false (default), encountering a consistency assertion panics because
+    /// validating consistency assertions is not yet supported in the simulator.
+    pub(crate) skip_consistency_assertions: bool,
+
     /// Number of iterations to use for fuzzing, defaults to 8192
     pub(crate) unit_test_fuzz_iterations: usize,
 
@@ -61,6 +66,15 @@ impl<'a> SimFlow<'a> {
     /// program eventually makes progress.
     pub fn test_safety_only(mut self) -> Self {
         self.test_safety_only = true;
+        self
+    }
+
+    /// Opts in to skipping consistency assertions. When enabled, `assert_is_consistent`
+    /// nodes are treated as identity no-ops in the simulator. When disabled (the default),
+    /// encountering a consistency assertion will panic because validating consistency
+    /// assertions is not yet supported in the simulator.
+    pub fn skip_consistency_assertions(mut self) -> Self {
+        self.skip_consistency_assertions = true;
         self
     }
 
@@ -119,6 +133,7 @@ impl<'a> SimFlow<'a> {
             extra_stmts_cluster: BTreeMap::new(),
             next_hoff_id: 0,
             test_safety_only: self.test_safety_only,
+            skip_consistency_assertions: self.skip_consistency_assertions,
         };
 
         // Ensure the default (0) external is always present.

--- a/hydro_lang/src/sim/tests/trophies/sequence_payloads.rs
+++ b/hydro_lang/src/sim/tests/trophies/sequence_payloads.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::forward_handle::TickCycleHandle;
 use crate::live_collections::stream::NoOrder;
-use crate::location::{Location, NoTick};
+use crate::location::Location;
 use crate::prelude::*;
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
@@ -26,15 +26,15 @@ struct SequencedKv {
 }
 
 #[expect(clippy::type_complexity, reason = "Paxos internals")]
-fn sequence_payloads_old<'a, L: Location<'a> + NoTick>(
+fn sequence_payloads_old<'a, L: Location<'a>>(
     replica_tick: &Tick<L>,
     p_to_replicas: Stream<SequencedKv, L, Unbounded, NoOrder>,
 ) -> (
-    Stream<SequencedKv, Tick<L>, Bounded>,
-    TickCycleHandle<'a, Optional<usize, Tick<L>, Bounded>>,
+    Stream<SequencedKv, Tick<L::DropConsistency>, Bounded>,
+    TickCycleHandle<'a, Optional<usize, Tick<L::DropConsistency>, Bounded>>,
 ) {
     let (r_buffered_payloads_complete_cycle, r_buffered_payloads) =
-        replica_tick.cycle::<Stream<SequencedKv, Tick<L>, Bounded>>();
+        replica_tick.cycle::<Stream<SequencedKv, Tick<L::DropConsistency>, Bounded>, _>();
 
     let r_sorted_payloads = p_to_replicas
         .batch(replica_tick, nondet!(
@@ -45,7 +45,7 @@ fn sequence_payloads_old<'a, L: Location<'a> + NoTick>(
         .sort();
     // Create a cycle since we'll use this seq before we define it
     let (r_highest_seq_complete_cycle, r_highest_seq) =
-        replica_tick.cycle::<Optional<usize, _, _>>();
+        replica_tick.cycle::<Optional<usize, Tick<L::DropConsistency>, _>, _>();
     // Find highest the sequence number of any payload that can be processed in this tick. This is the payload right before a hole.
     let r_highest_seq_processable_payload = r_sorted_payloads
         .clone()

--- a/hydro_lang/src/sim/tests/trophies/snapshots/trace_snapshot.snap
+++ b/hydro_lang/src/sim/tests/trophies/snapshots/trace_snapshot.snap
@@ -2,7 +2,6 @@
 source: hydro_lang/src/sim/tests/trophies/sequence_payloads.rs
 expression: log_str
 ---
-
 Running Tick
 * --> src/sim/tests/trophies/sequence_payloads.rs:40:10
 *  |        .batch(replica_tick, nondet!(

--- a/hydro_lang/src/viz/render.rs
+++ b/hydro_lang/src/viz/render.rs
@@ -1208,6 +1208,9 @@ impl HydroNode {
 
             // Transform operations with Stream edges - grouped by node/edge type
             HydroNode::Cast { inner, metadata }
+            | HydroNode::AssertIsConsistent {
+                inner, metadata, ..
+            }
             | HydroNode::DeferTick {
                 input: inner,
                 metadata,

--- a/hydro_std/src/compartmentalize.rs
+++ b/hydro_std/src/compartmentalize.rs
@@ -1,7 +1,7 @@
 use hydro_lang::live_collections::boundedness::Boundedness;
 use hydro_lang::live_collections::stream::{NoOrder, Ordering};
 use hydro_lang::location::cluster::CLUSTER_SELF_ID;
-use hydro_lang::location::{Location, MemberId, NoTick};
+use hydro_lang::location::{Location, MemberId};
 use hydro_lang::prelude::*;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -71,7 +71,7 @@ where
     }
 }
 
-pub trait DecoupleProcessStream<'a, T, L: Location<'a> + NoTick, B, Order: Ordering> {
+pub trait DecoupleProcessStream<'a, T, L: Location<'a>, B, Order: Ordering> {
     fn decouple_process<P2>(
         self,
         other: &Process<'a, P2>,

--- a/hydro_std/src/quorum.rs
+++ b/hydro_std/src/quorum.rs
@@ -1,13 +1,13 @@
 use std::hash::Hash;
 
 use hydro_lang::live_collections::stream::{NoOrder, Ordering};
-use hydro_lang::location::{Location, NoTick};
+use hydro_lang::location::Location;
 use hydro_lang::prelude::*;
 
 #[expect(clippy::type_complexity, reason = "stream types with ordering")]
 pub fn collect_quorum_with_response<
     'a,
-    L: Location<'a> + NoTick,
+    L: Location<'a>,
     Order: Ordering,
     K: Clone + Eq + Hash,
     V: Clone,
@@ -79,7 +79,7 @@ pub fn collect_quorum_with_response<
     };
 
     (
-        quorums,
+        quorums.assert_has_consistency_of(manual_proof!(/** TODO */)),
         responses.filter_map(q!(move |(key, res)| match res {
             Ok(_) => None,
             Err(e) => Some((key, e)),
@@ -88,13 +88,7 @@ pub fn collect_quorum_with_response<
 }
 
 #[expect(clippy::type_complexity, reason = "stream types with ordering")]
-pub fn collect_quorum<
-    'a,
-    L: Location<'a> + NoTick,
-    Order: Ordering,
-    K: Clone + Eq + Hash,
-    E: Clone,
->(
+pub fn collect_quorum<'a, L: Location<'a>, Order: Ordering, K: Clone + Eq + Hash, E: Clone>(
     responses: Stream<(K, Result<(), E>), L, Unbounded, Order>,
     min: usize,
     max: usize,
@@ -155,7 +149,7 @@ pub fn collect_quorum<
     };
 
     (
-        just_reached_quorum,
+        just_reached_quorum.assert_has_consistency_of(manual_proof!(/** TODO */)),
         responses.filter_map(q!(move |(key, res)| match res {
             Ok(_) => None,
             Err(e) => Some((key, e)),

--- a/hydro_std/src/request_response.rs
+++ b/hydro_std/src/request_response.rs
@@ -1,7 +1,7 @@
 use std::hash::Hash;
 
 use hydro_lang::live_collections::stream::NoOrder;
-use hydro_lang::location::{Location, NoTick};
+use hydro_lang::location::Location;
 use hydro_lang::prelude::*;
 
 type JoinResponses<K, M, V, L> = Stream<(K, (M, V)), L, Unbounded, NoOrder>;
@@ -12,10 +12,10 @@ type JoinResponses<K, M, V, L> = Stream<(K, (M, V)), L, Unbounded, NoOrder>;
 /// The metadata must be generated in the same or a previous tick than the response,
 /// typically at request time. Only one response element should be produced with a given
 /// key, same for the metadata stream.
-pub fn join_responses<'a, K: Clone + Eq + Hash, M: Clone, V: Clone, L: Location<'a> + NoTick>(
+pub fn join_responses<'a, K: Clone + Eq + Hash, M: Clone, V: Clone, L: Location<'a>>(
     responses: Stream<(K, V), L, Unbounded, NoOrder>,
     metadata: Stream<(K, M), Tick<L>, Bounded, NoOrder>,
-) -> JoinResponses<K, M, V, L> {
+) -> JoinResponses<K, M, V, L::DropConsistency> {
     sliced! {
         let mut remaining_to_join = use::state_null::<Stream<(K, M), _, _, NoOrder>>();
 

--- a/hydro_test/src/cluster/kv_replica/mod.rs
+++ b/hydro_test/src/cluster/kv_replica/mod.rs
@@ -81,7 +81,7 @@ pub fn kv_replica<'a, K: KvKey, V: KvValue>(
 
     // Send checkpoints to the acceptors when we've processed enough payloads
     let (r_checkpointed_seqs_complete_cycle, r_checkpointed_seqs) =
-        replica_tick.cycle::<Optional<usize, _, _>>();
+        replica_tick.cycle::<Optional<usize, _, _>, _>();
     let r_max_checkpointed_seq = r_checkpointed_seqs
         .into_stream()
         .across_ticks(|s| s.max())

--- a/hydro_test/src/cluster/kv_replica/sequence_payloads.rs
+++ b/hydro_test/src/cluster/kv_replica/sequence_payloads.rs
@@ -1,20 +1,20 @@
 use hydro_lang::forward_handle::TickCycleHandle;
 use hydro_lang::live_collections::stream::NoOrder;
-use hydro_lang::location::{Location, NoTick};
+use hydro_lang::location::Location;
 use hydro_lang::prelude::*;
 
 use super::{KvKey, KvValue, SequencedKv};
 
 #[expect(clippy::type_complexity, reason = "Paxos internals")]
-pub fn sequence_payloads<'a, K: KvKey, V: KvValue, L: Location<'a> + NoTick>(
+pub fn sequence_payloads<'a, K: KvKey, V: KvValue, L: Location<'a>>(
     replica_tick: &Tick<L>,
     p_to_replicas: Stream<SequencedKv<K, V>, L, Unbounded, NoOrder>,
 ) -> (
-    Stream<SequencedKv<K, V>, Tick<L>, Bounded>,
-    TickCycleHandle<'a, Singleton<usize, Tick<L>, Bounded>>,
+    Stream<SequencedKv<K, V>, Tick<L::DropConsistency>, Bounded>,
+    TickCycleHandle<'a, Singleton<usize, Tick<L::DropConsistency>, Bounded>>,
 ) {
     let (r_buffered_payloads_complete_cycle, r_buffered_payloads) =
-        replica_tick.cycle::<Stream<SequencedKv<K, V>, Tick<L>, Bounded>>();
+        replica_tick.cycle::<Stream<SequencedKv<K, V>, Tick<L::DropConsistency>, Bounded>, _>();
     // p_to_replicas.inspect(q!(|payload: ReplicaPayload| println!("Replica received payload: {:?}", payload)));
     let r_sorted_payloads = p_to_replicas.batch(replica_tick, nondet!(
             /// because we fill slots one-by-one, we can safely batch

--- a/hydro_test/src/cluster/paxos.rs
+++ b/hydro_test/src/cluster/paxos.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use hydro_lang::live_collections::sliced::yield_atomic;
 use hydro_lang::live_collections::stream::{AtLeastOnce, NoOrder, TotalOrder};
 use hydro_lang::location::cluster::CLUSTER_SELF_ID;
-use hydro_lang::location::{Atomic, Location, MemberId, NoTick};
+use hydro_lang::location::{Atomic, Location, MemberId};
 use hydro_lang::prelude::*;
 use hydro_std::quorum::{collect_quorum, collect_quorum_with_response};
 use hydro_std::request_response::join_responses;
@@ -770,10 +770,10 @@ fn sequence_payload<'a, P: PaxosPayload>(
 }
 
 // Proposer logic to send p2as, outputting the next slot and the p2as to send to acceptors.
-pub fn index_payloads<'a, L: Location<'a> + NoTick, P: PaxosPayload>(
+pub fn index_payloads<'a, L: Location<'a>, P: PaxosPayload>(
     p_max_slot: Optional<usize, Tick<L>, Bounded>,
     c_to_proposers: Stream<P, Tick<L>, Bounded>,
-) -> Stream<(usize, P), Tick<L>, Bounded> {
+) -> Stream<(usize, P), Tick<L::DropConsistency>, Bounded> {
     let tick = c_to_proposers.location().clone();
     let sliced_result = sliced! {
         let mut next_slot = use::state(|l| l.singleton(q!(0)));

--- a/hydro_test/src/cluster/simple_cluster.rs
+++ b/hydro_test/src/cluster/simple_cluster.rs
@@ -1,6 +1,6 @@
 use hydro_lang::live_collections::stream::TotalOrder;
+use hydro_lang::location::MemberId;
 use hydro_lang::location::cluster::CLUSTER_SELF_ID;
-use hydro_lang::location::{MemberId, MembershipEvent};
 use hydro_lang::prelude::*;
 use hydro_std::compartmentalize::{DecoupleClusterStream, DecoupleProcessStream, PartitionStream};
 use stageleft::IntoQuotedMut;
@@ -52,25 +52,16 @@ pub fn simple_cluster<'a>(flow: &mut FlowBuilder<'a>) -> (Process<'a, ()>, Clust
     let cluster = flow.cluster();
 
     let numbers = process.source_iter(q!(0..5));
-    let ids = process
-        .source_cluster_members(&cluster)
-        .entries()
-        .filter_map(q!(|(i, e)| match e {
-            MembershipEvent::Joined => Some(i),
-            MembershipEvent::Left => None,
-        }));
-
-    ids.cross_product(numbers)
-        .map(q!(|(id, n)| (id.clone(), (id, n))))
-        .demux(&cluster, TCP.fail_stop().bincode())
+    numbers
+        .broadcast_closed(&cluster, TCP.fail_stop().bincode())
         .inspect(q!(move |n| println!(
-            "cluster received: {:?} (self cluster id: {})",
+            "cluster received: {} (self cluster id: {})",
             n, CLUSTER_SELF_ID
         )))
         .send(&process, TCP.fail_stop().bincode())
         .entries()
         .assume_ordering::<TotalOrder>(nondet!(/** testing, order does not matter */))
-        .for_each(q!(|(id, d)| println!("node received: ({}, {:?})", id, d)));
+        .for_each(q!(|(id, d)| println!("node received: ({}, {})", id, d)));
 
     (process, cluster)
 }
@@ -121,8 +112,8 @@ mod tests {
                 assert_eq!(
                     stdout.recv().await.unwrap(),
                     format!(
-                        "cluster received: (MemberId::<()>({}), {}) (self cluster id: MemberId::<()>({}))",
-                        i, j, i
+                        "cluster received: {} (self cluster id: MemberId::<()>({}))",
+                        j, i
                     )
                 );
             }
@@ -137,12 +128,7 @@ mod tests {
         for (i, n) in node_outs.into_iter().enumerate() {
             assert_eq!(
                 n,
-                format!(
-                    "node received: (MemberId::<()>({}), (MemberId::<()>({}), {}))",
-                    i / 5,
-                    i / 5,
-                    i % 5
-                )
+                format!("node received: (MemberId::<()>({}), {})", i / 5, i % 5)
             );
         }
     }

--- a/hydro_test/src/cluster/snapshots/simple_cluster_ir.snap
+++ b/hydro_test/src/cluster/snapshots/simple_cluster_ir.snap
@@ -4,7 +4,7 @@ expression: built.ir()
 ---
 [
     ForEach {
-        f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32)) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: simple_cluster :: * ; | (id , d) | println ! ("node received: ({}, {:?})" , id , d) }),
+        f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: simple_cluster :: * ; | (id , d) | println ! ("node received: ({}, {})" , id , d) }),
         input: ObserveNonDet {
             inner: Cast {
                 inner: Cast {
@@ -14,119 +14,82 @@ expression: built.ir()
                             fault: FailStop,
                         },
                         serialize_fn: Some(
-                            hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32) , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
+                            hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < i32 , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
                         ),
                         instantiate_fn: <network instantiate>,
                         deserialize_fn: Some(
-                            | res | { let (id , b) = res . unwrap () ; (hydro_lang :: __staged :: location :: MemberId :: < () > :: from_tagless (id as hydro_lang :: __staged :: location :: TaglessMemberId) , hydro_lang :: runtime_support :: bincode :: deserialize :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32) > (& b) . unwrap ()) },
+                            | res | { let (id , b) = res . unwrap () ; (hydro_lang :: __staged :: location :: MemberId :: < () > :: from_tagless (id as hydro_lang :: __staged :: location :: TaglessMemberId) , hydro_lang :: runtime_support :: bincode :: deserialize :: < i32 > (& b) . unwrap ()) },
                         ),
                         input: Inspect {
-                            f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: simple_cluster :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: __staged :: location :: MemberId :: < () > :: from_tagless ((__hydro_lang_cluster_self_id_loc2v1) . clone ()) ; move | n | println ! ("cluster received: {:?} (self cluster id: {})" , n , CLUSTER_SELF_ID__free) }),
-                            input: Network {
-                                name: None,
-                                networking_info: Tcp {
-                                    fault: FailStop,
-                                },
-                                serialize_fn: Some(
-                                    hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32)) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
-                                ),
-                                instantiate_fn: <network instantiate>,
-                                deserialize_fn: Some(
-                                    | res | { hydro_lang :: runtime_support :: bincode :: deserialize :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32) > (& res . unwrap ()) . unwrap () },
-                                ),
-                                input: Cast {
-                                    inner: Map {
-                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: simple_cluster :: * ; | (id , n) | (id . clone () , (id , n)) }),
-                                        input: Map {
-                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (() , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32)) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | (() , (v1 , v2)) | (v1 , v2) }),
-                                            input: JoinHalf {
-                                                left: Map {
-                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , (() , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | v | (() , v) }),
-                                                    input: FilterMap {
-                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , core :: option :: Option < hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: simple_cluster :: * ; | (i , e) | match e { MembershipEvent :: Joined => Some (i) , MembershipEvent :: Left => None , } }),
-                                                        input: Cast {
-                                                            inner: Cast {
-                                                                inner: Map {
-                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | (k , v) | (MemberId :: from_tagless (k) , v) }),
-                                                                    input: Source {
-                                                                        source: ClusterMembers(
-                                                                            Cluster(loc2v1),
-                                                                            Uninit,
-                                                                        ),
-                                                                        metadata: HydroIrMetadata {
-                                                                            location_id: Process(loc1v1),
-                                                                            collection_kind: Stream {
-                                                                                bound: Unbounded,
-                                                                                order: TotalOrder,
-                                                                                retry: ExactlyOnce,
-                                                                                element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
-                                                                            },
-                                                                        },
-                                                                    },
-                                                                    metadata: HydroIrMetadata {
-                                                                        location_id: Process(loc1v1),
-                                                                        collection_kind: Stream {
-                                                                            bound: Unbounded,
-                                                                            order: TotalOrder,
-                                                                            retry: ExactlyOnce,
-                                                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
-                                                                        },
-                                                                    },
-                                                                },
-                                                                metadata: HydroIrMetadata {
-                                                                    location_id: Process(loc1v1),
-                                                                    collection_kind: KeyedStream {
-                                                                        bound: Unbounded,
-                                                                        value_order: TotalOrder,
-                                                                        value_retry: ExactlyOnce,
-                                                                        key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () >,
-                                                                        value_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent,
-                                                                    },
-                                                                },
-                                                            },
+                            f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < i32 , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: simple_cluster :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: __staged :: location :: MemberId :: < () > :: from_tagless ((__hydro_lang_cluster_self_id_loc2v1) . clone ()) ; move | n | println ! ("cluster received: {} (self cluster id: {})" , n , CLUSTER_SELF_ID__free) }),
+                            input: AssertIsConsistent {
+                                inner: Network {
+                                    name: None,
+                                    networking_info: Tcp {
+                                        fault: FailStop,
+                                    },
+                                    serialize_fn: Some(
+                                        hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , i32) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
+                                    ),
+                                    instantiate_fn: <network instantiate>,
+                                    deserialize_fn: Some(
+                                        | res | { hydro_lang :: runtime_support :: bincode :: deserialize :: < i32 > (& res . unwrap ()) . unwrap () },
+                                    ),
+                                    input: Cast {
+                                        inner: Map {
+                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (i32 , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () >) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | (data , member_id) | (member_id , data) }),
+                                            input: Map {
+                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (() , (i32 , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () >)) , (i32 , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | (() , (v1 , v2)) | (v1 , v2) }),
+                                                input: JoinHalf {
+                                                    left: Map {
+                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < i32 , (() , i32) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | v | (() , v) }),
+                                                        input: Source {
+                                                            source: Iter(
+                                                                stageleft :: runtime_support :: type_hint :: < std :: ops :: Range < i32 > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: simple_cluster :: * ; 0 .. 5 }),
+                                                            ),
                                                             metadata: HydroIrMetadata {
                                                                 location_id: Process(loc1v1),
                                                                 collection_kind: Stream {
-                                                                    bound: Unbounded,
-                                                                    order: NoOrder,
+                                                                    bound: Bounded,
+                                                                    order: TotalOrder,
                                                                     retry: ExactlyOnce,
-                                                                    element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
+                                                                    element_type: i32,
                                                                 },
                                                             },
                                                         },
-                                                        metadata: HydroIrMetadata {
-                                                            location_id: Process(loc1v1),
-                                                            collection_kind: Stream {
-                                                                bound: Unbounded,
-                                                                order: NoOrder,
-                                                                retry: ExactlyOnce,
-                                                                element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () >,
-                                                            },
-                                                        },
-                                                    },
-                                                    metadata: HydroIrMetadata {
-                                                        location_id: Process(loc1v1),
-                                                        collection_kind: Stream {
-                                                            bound: Unbounded,
-                                                            order: NoOrder,
-                                                            retry: ExactlyOnce,
-                                                            element_type: (() , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () >),
-                                                        },
-                                                    },
-                                                },
-                                                right: Map {
-                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < i32 , (() , i32) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | v | (() , v) }),
-                                                    input: Source {
-                                                        source: Iter(
-                                                            stageleft :: runtime_support :: type_hint :: < std :: ops :: Range < i32 > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: simple_cluster :: * ; 0 .. 5 }),
-                                                        ),
                                                         metadata: HydroIrMetadata {
                                                             location_id: Process(loc1v1),
                                                             collection_kind: Stream {
                                                                 bound: Bounded,
                                                                 order: TotalOrder,
                                                                 retry: ExactlyOnce,
-                                                                element_type: i32,
+                                                                element_type: (() , i32),
+                                                            },
+                                                        },
+                                                    },
+                                                    right: Map {
+                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , (() , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | v | (() , v) }),
+                                                        input: Source {
+                                                            source: Iter(
+                                                                stageleft :: runtime_support :: type_hint :: < std :: iter :: Map < std :: slice :: Iter < '_ , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId > , _ > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; let cluster_ids__free = __hydro_lang_cluster_ids_loc2v1 ; cluster_ids__free . iter () . map (| id | MemberId :: from_tagless (id . clone ())) }),
+                                                            ),
+                                                            metadata: HydroIrMetadata {
+                                                                location_id: Process(loc1v1),
+                                                                collection_kind: Stream {
+                                                                    bound: Bounded,
+                                                                    order: TotalOrder,
+                                                                    retry: ExactlyOnce,
+                                                                    element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () >,
+                                                                },
+                                                            },
+                                                        },
+                                                        metadata: HydroIrMetadata {
+                                                            location_id: Process(loc1v1),
+                                                            collection_kind: Stream {
+                                                                bound: Bounded,
+                                                                order: TotalOrder,
+                                                                retry: ExactlyOnce,
+                                                                element_type: (() , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () >),
                                                             },
                                                         },
                                                     },
@@ -136,25 +99,25 @@ expression: built.ir()
                                                             bound: Bounded,
                                                             order: TotalOrder,
                                                             retry: ExactlyOnce,
-                                                            element_type: (() , i32),
+                                                            element_type: (() , (i32 , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () >)),
                                                         },
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
                                                     location_id: Process(loc1v1),
                                                     collection_kind: Stream {
-                                                        bound: Unbounded,
-                                                        order: NoOrder,
+                                                        bound: Bounded,
+                                                        order: TotalOrder,
                                                         retry: ExactlyOnce,
-                                                        element_type: (() , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32)),
+                                                        element_type: (i32 , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () >),
                                                     },
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_id: Process(loc1v1),
                                                 collection_kind: Stream {
-                                                    bound: Unbounded,
-                                                    order: NoOrder,
+                                                    bound: Bounded,
+                                                    order: TotalOrder,
                                                     retry: ExactlyOnce,
                                                     element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32),
                                                 },
@@ -162,32 +125,33 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_id: Process(loc1v1),
-                                            collection_kind: Stream {
-                                                bound: Unbounded,
-                                                order: NoOrder,
-                                                retry: ExactlyOnce,
-                                                element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32)),
+                                            collection_kind: KeyedStream {
+                                                bound: Bounded,
+                                                value_order: TotalOrder,
+                                                value_retry: ExactlyOnce,
+                                                key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () >,
+                                                value_type: i32,
                                             },
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Process(loc1v1),
-                                        collection_kind: KeyedStream {
+                                        location_id: Cluster(loc2v1),
+                                        collection_kind: Stream {
                                             bound: Unbounded,
-                                            value_order: NoOrder,
-                                            value_retry: ExactlyOnce,
-                                            key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () >,
-                                            value_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32),
+                                            order: TotalOrder,
+                                            retry: ExactlyOnce,
+                                            element_type: i32,
                                         },
                                     },
                                 },
+                                trusted: true,
                                 metadata: HydroIrMetadata {
                                     location_id: Cluster(loc2v1),
                                     collection_kind: Stream {
                                         bound: Unbounded,
-                                        order: NoOrder,
+                                        order: TotalOrder,
                                         retry: ExactlyOnce,
-                                        element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32),
+                                        element_type: i32,
                                     },
                                 },
                             },
@@ -195,9 +159,9 @@ expression: built.ir()
                                 location_id: Cluster(loc2v1),
                                 collection_kind: Stream {
                                     bound: Unbounded,
-                                    order: NoOrder,
+                                    order: TotalOrder,
                                     retry: ExactlyOnce,
-                                    element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32),
+                                    element_type: i32,
                                 },
                             },
                         },
@@ -205,9 +169,9 @@ expression: built.ir()
                             location_id: Process(loc1v1),
                             collection_kind: Stream {
                                 bound: Unbounded,
-                                order: NoOrder,
+                                order: TotalOrder,
                                 retry: ExactlyOnce,
-                                element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32)),
+                                element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32),
                             },
                         },
                     },
@@ -215,10 +179,10 @@ expression: built.ir()
                         location_id: Process(loc1v1),
                         collection_kind: KeyedStream {
                             bound: Unbounded,
-                            value_order: NoOrder,
+                            value_order: TotalOrder,
                             value_retry: ExactlyOnce,
                             key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () >,
-                            value_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32),
+                            value_type: i32,
                         },
                     },
                 },
@@ -228,7 +192,7 @@ expression: built.ir()
                         bound: Unbounded,
                         order: NoOrder,
                         retry: ExactlyOnce,
-                        element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32)),
+                        element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32),
                     },
                 },
             },
@@ -239,7 +203,7 @@ expression: built.ir()
                     bound: Unbounded,
                     order: TotalOrder,
                     retry: ExactlyOnce,
-                    element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32)),
+                    element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32),
                 },
             },
         },

--- a/hydro_test/src/embedded/m2m_broadcast.rs
+++ b/hydro_test/src/embedded/m2m_broadcast.rs
@@ -9,10 +9,10 @@ pub fn m2m_broadcast<'a>(
     dst: &Cluster<'a, Dst>,
     input: Stream<String, Cluster<'a, Src>>,
 ) -> Stream<(MemberId<Src>, String), Cluster<'a, Dst>, Unbounded, NoOrder> {
-    // used to test that we can call `source_cluster members` multiple times
+    // used to test that we can call `source_cluster_membership_stream` multiple times
     input
         .location()
-        .source_cluster_members(dst)
+        .source_cluster_membership_stream(dst, nondet!(/** test */))
         .entries()
         .assume_ordering::<TotalOrder>(nondet!(/** test */))
         .for_each(q!(|_| {}));

--- a/hydro_test/src/tutorials/keyed_counter.rs
+++ b/hydro_test/src/tutorials/keyed_counter.rs
@@ -1,16 +1,16 @@
 use hydro_lang::live_collections::stream::NoOrder;
-use hydro_lang::location::{Location, NoTick};
+use hydro_lang::location::Location;
 use hydro_lang::prelude::*;
 
 pub struct CounterServer;
 
 #[expect(clippy::type_complexity, reason = "output types with orderings")]
-pub fn keyed_counter_service<'a, L: Location<'a> + NoTick>(
+pub fn keyed_counter_service<'a, L: Location<'a>>(
     increment_requests: KeyedStream<u32, String, L, Unbounded>,
     get_requests: KeyedStream<u32, String, L, Unbounded>,
 ) -> (
     KeyedStream<u32, String, L, Unbounded>,
-    KeyedStream<u32, (String, usize), L, Unbounded, NoOrder>,
+    KeyedStream<u32, (String, usize), L::DropConsistency, Unbounded, NoOrder>,
 ) {
     let increment_request_processing = increment_requests.atomic();
     let current_count = increment_request_processing

--- a/hydro_test/src/tutorials/keyed_counter_non_atomic.rs
+++ b/hydro_test/src/tutorials/keyed_counter_non_atomic.rs
@@ -1,16 +1,16 @@
 use hydro_lang::live_collections::stream::{NoOrder, Ordering};
-use hydro_lang::location::{Location, NoTick};
+use hydro_lang::location::Location;
 use hydro_lang::prelude::*;
 
 pub struct CounterServer;
 
 #[expect(clippy::type_complexity, reason = "output types with orderings")]
-pub fn keyed_counter_service_buggy<'a, L: Location<'a> + NoTick, O: Ordering>(
+pub fn keyed_counter_service_buggy<'a, L: Location<'a>, O: Ordering>(
     increment_requests: KeyedStream<u32, String, L, Unbounded, O>,
     get_requests: KeyedStream<u32, String, L, Unbounded, O>,
 ) -> (
     KeyedStream<u32, String, L, Unbounded, O>,
-    KeyedStream<u32, (String, usize), L, Unbounded, NoOrder>,
+    KeyedStream<u32, (String, usize), L::DropConsistency, Unbounded, NoOrder>,
 ) {
     let current_count = increment_requests
         .clone()

--- a/template/hydro/.prompts/challenge-keyed-counter.md
+++ b/template/hydro/.prompts/challenge-keyed-counter.md
@@ -34,18 +34,18 @@ You are helping the developer build a keyed counter service where a single serve
 
 ```rust
 use hydro_lang::live_collections::stream::NoOrder;
-use hydro_lang::location::{Location, NoTick};
+use hydro_lang::location::Location;
 use hydro_lang::prelude::*;
 
 pub struct CounterServer;
 
 #[expect(clippy::type_complexity, reason = "output types with orderings")]
-pub fn keyed_counter_service<'a, L: Location<'a> + NoTick>(
+pub fn keyed_counter_service<'a, L: Location<'a>>(
     increment_requests: KeyedStream<u32, String, L, Unbounded>,
     get_requests: KeyedStream<u32, String, L, Unbounded>,
 ) -> (
     KeyedStream<u32, String, L, Unbounded>,
-    KeyedStream<u32, (String, usize), L, Unbounded, NoOrder>,
+    KeyedStream<u32, (String, usize), L::DropConsistency, Unbounded, NoOrder>,
 ) {
     let increment_request_processing = increment_requests.atomic();
     let current_count = increment_request_processing


### PR DESCRIPTION
Breaking Changes:
- Removed `NoTick` and `NoAtomic`, enforcement of no nested ticks is now handled at staging time. Added `TopLevel` to restrict I/O operators to be outside a `Tick` / `Atomic`.
- Added a type parameter to `Cluster` and a field to `LocationId::Cluster` that tracks the consistency guarantee of the live collection at that location
- `Location::source_cluster_membership_stream` (renamed + deprecated from `Location::source_cluster_members`) now requires a `nondet!` since late-joiners will see a non-deterministic suffix of the stream. In a follow up PR, we will replace the now-deprecated `source_cluster_members` to instead offer an API that aggregates into a `KeyedSingleton`, which will be guaranteed deterministic and consistent
- `Location::current_tick_instant` has been moved to be on `Tick`, since wall clock time can only be read in a tick context