### PR TITLE
refactor(dfir_lang): double-buffer defer_tick handoffs, remove intermediate subgraphs [ci-bench]

### DIFF
--- a/dfir_lang/src/graph/flat_to_partitioned.rs
+++ b/dfir_lang/src/graph/flat_to_partitioned.rs
@@ -374,63 +374,12 @@ fn order_subgraphs(
     // ensuring the consumer runs before the producer so data naturally defers
     // to the next tick via the handoff buffer.
     for (edge_id, delay_type) in tick_edges {
-        let (hoff, dst) = partitioned_graph.edge(edge_id);
-        // Ignore barriers within `loop {` blocks.
-        if partitioned_graph.node_loop(dst).is_some() {
-            continue;
-        }
-
-<<<<<<< conflict 1 of 1
-%%%%%%% diff from: rospmszn 5f4c17e7 "refactor(dfir_lang): replace stratification with plain topo sort, remove next_stratum" (parents of rebased revision)
-\\\\\\\        to: rospmszn e4bdfc7f "refactor(dfir_lang): replace stratification with plain topo sort, remove next_stratum" (rebase destination)
-         assert_eq!(1, partitioned_graph.node_predecessors(hoff).len());
-         let src = partitioned_graph
-             .node_predecessor_nodes(hoff)
-             .next()
-             .unwrap();
- 
-         let src_sg = partitioned_graph.node_subgraph(src).unwrap();
-         let dst_sg = partitioned_graph.node_subgraph(dst).unwrap();
-         let src_pos = sg_position[&src_sg];
-         let dst_pos = sg_position[&dst_sg];
-         let dst_span = partitioned_graph.node(dst).span();
- 
--        let is_lazy = matches!(delay_type, DelayType::TickLazy);
-         // If tick edge goes forward in topo order, need to inject a buffer subgraph.
--        // Or if lazy, always inject (to mark the handoff with the lazy delay type).
--        if src_pos <= dst_pos || is_lazy {
-+        if src_pos <= dst_pos {
-             // Before: A (src) -> H -> B (dst)
-             // Then add intermediate identity:
-             let (new_node_id, new_edge_id) = partitioned_graph.insert_intermediate_node(
-                 edge_id,
-                 // TODO(mingwei): Proper span w/ `parse_quote_spanned!`?
-                 GraphNode::Operator(parse_quote! { identity() }),
-             );
-             // Intermediate: A (src) -> H -> ID -> B (dst)
-             let hoff_node = GraphNode::Handoff {
-                 src_span: dst_span,
-                 dst_span,
-             };
-             let (hoff_node_id, _hoff_edge_id) =
-                 partitioned_graph.insert_intermediate_node(new_edge_id, hoff_node);
-             // After: A (src) -> H -> ID -> H' -> B (dst)
- 
-             // Create subgraph for the intermediate identity.
-             partitioned_graph
-                 .insert_subgraph(vec![new_node_id])
-                 .unwrap();
- 
-             // Mark H' as a tick-boundary back-edge.
-             partitioned_graph.set_handoff_delay_type(hoff_node_id, delay_type);
-         } else {
-             // Already a back-edge (src after dst in topo order).
-             // Mark the original handoff H as a tick-boundary back-edge.
-             partitioned_graph.set_handoff_delay_type(hoff, delay_type);
-         }
-+++++++ xqxnxvxo d6eedd0d "test: add test_mutual_defer_tick reproducing as_code topo sort cycle" (rebased revision)
+        let (hoff, _dst) = partitioned_graph.edge(edge_id);
+        assert!(matches!(
+            partitioned_graph.node(hoff),
+            GraphNode::Handoff { .. }
+        ));
         partitioned_graph.set_handoff_delay_type(hoff, delay_type);
->>>>>>> conflict 1 of 1 ends
     }
     Ok(())
 }

--- a/dfir_lang/src/graph/flat_to_partitioned.rs
+++ b/dfir_lang/src/graph/flat_to_partitioned.rs
@@ -350,29 +350,25 @@ fn order_subgraphs(
     }
 
     // Topological sort — rejects intra-tick cycles.
-    let _topo_sort_order = graph_algorithms::topo_sort(partitioned_graph.subgraph_ids(), |v| {
+    if let Err(cycle) = graph_algorithms::topo_sort(partitioned_graph.subgraph_ids(), |v| {
         sg_preds.get(&v).into_iter().flatten().copied()
-    });
-    match _topo_sort_order {
-        Ok(_) => {}
-        Err(cycle) => {
-            let span = cycle
-                .first()
-                .and_then(|&sg_id| partitioned_graph.subgraph(sg_id).first().copied())
-                .map(|n| partitioned_graph.node(n).span())
-                .unwrap_or_else(Span::call_site);
-            return Err(Diagnostic::spanned(
-                span,
-                Level::Error,
-                "Cyclical dataflow within a tick is not supported. Use `defer_tick()` or `defer_tick_lazy()` to break the cycle across ticks.",
-            ));
-        }
+    }) {
+        let span = cycle
+            .first()
+            .and_then(|&sg_id| partitioned_graph.subgraph(sg_id).first().copied())
+            .map(|n| partitioned_graph.node(n).span())
+            .unwrap_or_else(Span::call_site);
+        return Err(Diagnostic::spanned(
+            span,
+            Level::Error,
+            "Cyclical dataflow within a tick is not supported. Use `defer_tick()` or `defer_tick_lazy()` to break the cycle across ticks.",
+        ));
     }
 
     // Mark tick-boundary handoffs with their delay type.
-    // The `as_code` topo sort will reverse the ordering constraint for these,
-    // ensuring the consumer runs before the producer so data naturally defers
-    // to the next tick via the handoff buffer.
+    // These handoffs are excluded from the intra-tick topo ordering in
+    // `as_code`; instead, their double-buffered handoff semantics defer data
+    // across the tick boundary to the next tick.
     for (edge_id, delay_type) in tick_edges {
         let (hoff, _dst) = partitioned_graph.edge(edge_id);
         assert!(matches!(

--- a/dfir_lang/src/graph/flat_to_partitioned.rs
+++ b/dfir_lang/src/graph/flat_to_partitioned.rs
@@ -299,8 +299,8 @@ fn can_connect_colorize(
     can_connect
 }
 
-/// Topologically sorts subgraphs and injects intermediate identity subgraphs for `defer_tick`
-/// edges that go forward in the topological order (so they become back-edges).
+/// Topologically sorts subgraphs and marks tick-boundary (`defer_tick` / `defer_tick_lazy`)
+/// handoffs with their delay type for double-buffered codegen in `as_code`.
 ///
 /// Returns an error if there is an intra-tick cycle (i.e. the subgraph DAG has a cycle when
 /// tick-boundary edges are excluded).
@@ -391,7 +391,7 @@ pub fn partition_graph(flat_graph: DfirGraph) -> Result<DfirGraph, Diagnostic> {
     // Partition into subgraphs.
     make_subgraphs(&mut partitioned_graph, &mut barrier_crossers);
 
-    // Topologically order subgraphs and inject intermediate subgraphs for defer_tick edges.
+    // Topologically order subgraphs and mark tick-boundary handoffs for double-buffering.
     order_subgraphs(&mut partitioned_graph, &barrier_crossers)?;
 
     Ok(partitioned_graph)

--- a/dfir_lang/src/graph/flat_to_partitioned.rs
+++ b/dfir_lang/src/graph/flat_to_partitioned.rs
@@ -4,7 +4,6 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use proc_macro2::Span;
 use slotmap::{SecondaryMap, SparseSecondaryMap};
-use syn::parse_quote;
 
 use super::meta_graph::DfirGraph;
 use super::ops::{DelayType, FloType};
@@ -351,11 +350,11 @@ fn order_subgraphs(
     }
 
     // Topological sort — rejects intra-tick cycles.
-    let topo_sort_order = graph_algorithms::topo_sort(partitioned_graph.subgraph_ids(), |v| {
+    let _topo_sort_order = graph_algorithms::topo_sort(partitioned_graph.subgraph_ids(), |v| {
         sg_preds.get(&v).into_iter().flatten().copied()
     });
-    let topo_sort_order = match topo_sort_order {
-        Ok(order) => order,
+    match _topo_sort_order {
+        Ok(_) => {}
         Err(cycle) => {
             let span = cycle
                 .first()
@@ -368,18 +367,12 @@ fn order_subgraphs(
                 "Cyclical dataflow within a tick is not supported. Use `defer_tick()` or `defer_tick_lazy()` to break the cycle across ticks.",
             ));
         }
-    };
+    }
 
-    // Build a position map for the topo sort order.
-    let sg_position: BTreeMap<GraphSubgraphId, usize> = topo_sort_order
-        .iter()
-        .enumerate()
-        .map(|(i, &sg_id)| (sg_id, i))
-        .collect();
-
-    // Process tick-boundary edges: inject intermediate identity subgraphs where needed.
-    // TODO(cleanup): The intermediate identity subgraph injection is a workaround. In the future,
-    // handoff buffers should be sufficient without needing an extra subgraph.
+    // Mark tick-boundary handoffs with their delay type.
+    // The `as_code` topo sort will reverse the ordering constraint for these,
+    // ensuring the consumer runs before the producer so data naturally defers
+    // to the next tick via the handoff buffer.
     for (edge_id, delay_type) in tick_edges {
         let (hoff, dst) = partitioned_graph.edge(edge_id);
         // Ignore barriers within `loop {` blocks.
@@ -387,48 +380,57 @@ fn order_subgraphs(
             continue;
         }
 
-        assert_eq!(1, partitioned_graph.node_predecessors(hoff).len());
-        let src = partitioned_graph
-            .node_predecessor_nodes(hoff)
-            .next()
-            .unwrap();
-
-        let src_sg = partitioned_graph.node_subgraph(src).unwrap();
-        let dst_sg = partitioned_graph.node_subgraph(dst).unwrap();
-        let src_pos = sg_position[&src_sg];
-        let dst_pos = sg_position[&dst_sg];
-        let dst_span = partitioned_graph.node(dst).span();
-
-        // If tick edge goes forward in topo order, need to inject a buffer subgraph.
-        if src_pos <= dst_pos {
-            // Before: A (src) -> H -> B (dst)
-            // Then add intermediate identity:
-            let (new_node_id, new_edge_id) = partitioned_graph.insert_intermediate_node(
-                edge_id,
-                // TODO(mingwei): Proper span w/ `parse_quote_spanned!`?
-                GraphNode::Operator(parse_quote! { identity() }),
-            );
-            // Intermediate: A (src) -> H -> ID -> B (dst)
-            let hoff_node = GraphNode::Handoff {
-                src_span: dst_span,
-                dst_span,
-            };
-            let (hoff_node_id, _hoff_edge_id) =
-                partitioned_graph.insert_intermediate_node(new_edge_id, hoff_node);
-            // After: A (src) -> H -> ID -> H' -> B (dst)
-
-            // Create subgraph for the intermediate identity.
-            partitioned_graph
-                .insert_subgraph(vec![new_node_id])
-                .unwrap();
-
-            // Mark H' as a tick-boundary back-edge.
-            partitioned_graph.set_handoff_delay_type(hoff_node_id, delay_type);
-        } else {
-            // Already a back-edge (src after dst in topo order).
-            // Mark the original handoff H as a tick-boundary back-edge.
-            partitioned_graph.set_handoff_delay_type(hoff, delay_type);
-        }
+<<<<<<< conflict 1 of 1
+%%%%%%% diff from: rospmszn 5f4c17e7 "refactor(dfir_lang): replace stratification with plain topo sort, remove next_stratum" (parents of rebased revision)
+\\\\\\\        to: rospmszn e4bdfc7f "refactor(dfir_lang): replace stratification with plain topo sort, remove next_stratum" (rebase destination)
+         assert_eq!(1, partitioned_graph.node_predecessors(hoff).len());
+         let src = partitioned_graph
+             .node_predecessor_nodes(hoff)
+             .next()
+             .unwrap();
+ 
+         let src_sg = partitioned_graph.node_subgraph(src).unwrap();
+         let dst_sg = partitioned_graph.node_subgraph(dst).unwrap();
+         let src_pos = sg_position[&src_sg];
+         let dst_pos = sg_position[&dst_sg];
+         let dst_span = partitioned_graph.node(dst).span();
+ 
+-        let is_lazy = matches!(delay_type, DelayType::TickLazy);
+         // If tick edge goes forward in topo order, need to inject a buffer subgraph.
+-        // Or if lazy, always inject (to mark the handoff with the lazy delay type).
+-        if src_pos <= dst_pos || is_lazy {
++        if src_pos <= dst_pos {
+             // Before: A (src) -> H -> B (dst)
+             // Then add intermediate identity:
+             let (new_node_id, new_edge_id) = partitioned_graph.insert_intermediate_node(
+                 edge_id,
+                 // TODO(mingwei): Proper span w/ `parse_quote_spanned!`?
+                 GraphNode::Operator(parse_quote! { identity() }),
+             );
+             // Intermediate: A (src) -> H -> ID -> B (dst)
+             let hoff_node = GraphNode::Handoff {
+                 src_span: dst_span,
+                 dst_span,
+             };
+             let (hoff_node_id, _hoff_edge_id) =
+                 partitioned_graph.insert_intermediate_node(new_edge_id, hoff_node);
+             // After: A (src) -> H -> ID -> H' -> B (dst)
+ 
+             // Create subgraph for the intermediate identity.
+             partitioned_graph
+                 .insert_subgraph(vec![new_node_id])
+                 .unwrap();
+ 
+             // Mark H' as a tick-boundary back-edge.
+             partitioned_graph.set_handoff_delay_type(hoff_node_id, delay_type);
+         } else {
+             // Already a back-edge (src after dst in topo order).
+             // Mark the original handoff H as a tick-boundary back-edge.
+             partitioned_graph.set_handoff_delay_type(hoff, delay_type);
+         }
++++++++ xqxnxvxo d6eedd0d "test: add test_mutual_defer_tick reproducing as_code topo sort cycle" (rebased revision)
+        partitioned_graph.set_handoff_delay_type(hoff, delay_type);
+>>>>>>> conflict 1 of 1 ends
     }
     Ok(())
 }

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -855,19 +855,37 @@ impl DfirGraph {
             })
             .collect();
 
+        // For back-edge (defer_tick) handoffs, declare a second "back" buffer for
+        // double-buffering. At the start of each tick, the main buffer and back buffer
+        // are swapped so the consumer reads last tick's data while the producer writes
+        // to a fresh buffer.
+        let back_buffer_code: Vec<TokenStream> = handoff_nodes
+            .iter()
+            .filter(|(node_id, _)| self.handoff_delay_type(*node_id).is_some())
+            .map(|&(node_id, (src_span, dst_span))| {
+                let span = src_span.join(dst_span).unwrap_or(src_span);
+                let back_ident = Ident::new(&format!("hoff_{:?}_back", node_id.data()), span);
+                quote_spanned! {span=>
+                    let mut #back_ident: Vec<_> = Vec::new();
+                }
+            })
+            .collect();
+
         // 2. Collect subgraph handoffs (same as as_code).
         let subgraph_handoffs = self.helper_collect_subgraph_handoffs();
 
         // 3. Sort subgraphs topologically and collect non-lazy defer_tick buffer idents.
         //
         // Handoffs marked with a `DelayType` (Tick/TickLazy) are tick-boundary back-edges.
-        // For these, we reverse the ordering constraint (producer runs after consumer) to
-        // preserve the required same-tick ordering. Unmarked handoffs are forward edges.
+        // These are excluded from the topo sort (no ordering constraint). Double-buffering
+        // ensures data written by the producer in tick N is only visible to the consumer
+        // in tick N+1, regardless of execution order.
         //
         // While iterating handoffs, we also collect buffer idents for non-lazy tick-boundary
         // edges (defer_tick). When these buffers are non-empty at end of tick, we set
         // can_start_tick so that run_available continues ticking.
         let mut defer_tick_buf_idents: Vec<Ident> = Vec::new();
+        let mut back_edge_hoff_ids: BTreeSet<GraphNodeId> = BTreeSet::new();
         let all_subgraphs = {
             // Build predecessor map for subgraphs.
             let mut sg_preds = SecondaryMap::<_, Vec<_>>::with_capacity(self.subgraph_nodes.len());
@@ -887,10 +905,9 @@ impl DfirGraph {
                 }
                 if let Some(delay_type) = self.handoff_delay_type(hoff_id) {
                     debug_assert!(matches!(delay_type, DelayType::Tick | DelayType::TickLazy));
-                    // Tick/back-edge handoff: preserve the required same-tick ordering by
-                    // forcing the higher-order producer subgraph to run after the
-                    // lower-order consumer subgraph.
-                    sg_preds.entry(pred_sg).unwrap().or_default().push(succ_sg);
+                    // Tick/back-edge handoff: no ordering constraint. Double-buffering
+                    // handles the tick deferral regardless of execution order.
+                    back_edge_hoff_ids.insert(hoff_id);
 
                     // Non-lazy tick-boundary: defer_tick (not defer_tick_lazy).
                     if !matches!(delay_type, DelayType::TickLazy) {
@@ -936,6 +953,21 @@ impl DfirGraph {
                 .collect::<Vec<_>>()
         };
 
+        // Generate swap code for back-edge (defer_tick) handoffs.
+        // At the start of each tick, swap the main buffer and back buffer so the
+        // consumer reads last tick's data from the back buffer.
+        let back_edge_swap_code: Vec<TokenStream> = back_edge_hoff_ids
+            .iter()
+            .map(|&hoff_id| {
+                let span = self.nodes[hoff_id].span();
+                let buf_ident = Ident::new(&format!("hoff_{:?}_buf", hoff_id.data()), span);
+                let back_ident = Ident::new(&format!("hoff_{:?}_back", hoff_id.data()), span);
+                quote_spanned! {span=>
+                    ::std::mem::swap(&mut #buf_ident, &mut #back_ident);
+                }
+            })
+            .collect();
+
         let mut op_prologue_code = Vec::new();
         let mut op_prologue_after_code = Vec::new();
         let mut subgraph_blocks = Vec::new();
@@ -971,6 +1003,7 @@ impl DfirGraph {
                     .collect();
 
                 // Recv port code: drain from buffer into iterator, tracking if non-empty.
+                // For back-edge (defer_tick) handoffs, drain from the back buffer instead.
                 // Also update handoff metrics (measured at recv, not send — see graph.rs).
                 let recv_port_code: Vec<TokenStream> = recv_port_idents
                     .iter()
@@ -983,9 +1016,15 @@ impl DfirGraph {
                         // (e.g. dfir_expect_warnings!). TODO(#2781): define these once.
                         let work_done = Ident::new("__dfir_work_done", Span::call_site());
                         let metrics = Ident::new("__dfir_metrics", Span::call_site());
+                        // Back-edge handoffs drain from the back buffer (double-buffering).
+                        let drain_ident = if back_edge_hoff_ids.contains(&hoff_id) {
+                            Ident::new(&format!("hoff_{:?}_back", hoff_id.data()), buf_ident.span())
+                        } else {
+                            buf_ident.clone()
+                        };
                         quote_spanned! {port_ident.span()=>
                             {
-                                let hoff_len = #buf_ident.len();
+                                let hoff_len = #drain_ident.len();
                                 if hoff_len > 0 {
                                     #work_done = true;
                                 }
@@ -995,7 +1034,7 @@ impl DfirGraph {
                                 hoff_metrics.total_items_count.update(|x| x + hoff_len);
                                 hoff_metrics.curr_items_count.set(hoff_len);
                             }
-                            let #port_ident = #root::dfir_pipes::pull::iter(#buf_ident.drain(..));
+                            let #port_ident = #root::dfir_pipes::pull::iter(#drain_ident.drain(..));
                         }
                     })
                     .collect();
@@ -1488,6 +1527,7 @@ impl DfirGraph {
                 );
 
                 #( #buffer_code )*
+                #( #back_buffer_code )*
                 #( #op_prologue_code )*
                 #( #op_prologue_after_code )*
 
@@ -1499,6 +1539,9 @@ impl DfirGraph {
                 #[allow(unused_qualifications, unused_mut, unused_variables, clippy::await_holding_refcell_ref)]
                 let __dfir_inline_tick = async move |#df: &mut #root::scheduled::context::Context| {
                     let __dfir_metrics = #df.metrics();
+                    // Double-buffer swap for defer_tick handoffs: move last tick's
+                    // producer output into the back buffer for the consumer to drain.
+                    #( #back_edge_swap_code )*
                     #( #subgraph_blocks )*
 
                     // For non-lazy defer_tick: if any deferred buffer has data,

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -745,6 +745,16 @@ impl DfirGraph {
         Ident::new(&name, span)
     }
 
+    /// Helper to generate the main buffer `Ident` for a handoff node.
+    fn hoff_buf_ident(&self, hoff_id: GraphNodeId, span: Span) -> Ident {
+        Ident::new(&format!("hoff_{:?}_buf", hoff_id.data()), span)
+    }
+
+    /// Helper to generate the back (double-buffer) `Ident` for a handoff node.
+    fn hoff_back_ident(&self, hoff_id: GraphNodeId, span: Span) -> Ident {
+        Ident::new(&format!("hoff_{:?}_back", hoff_id.data()), span)
+    }
+
     /// For per-node singleton references. Helper to generate a deterministic `Ident` for the given node.
     fn node_as_singleton_ident(&self, node_id: GraphNodeId, span: Span) -> Ident {
         Ident::new(&format!("singleton_op_{:?}", node_id.data()), span)
@@ -848,23 +858,23 @@ impl DfirGraph {
             .iter()
             .map(|&(node_id, (src_span, dst_span))| {
                 let span = src_span.join(dst_span).unwrap_or(src_span);
-                let buf_ident = Ident::new(&format!("hoff_{:?}_buf", node_id.data()), span);
+                let buf_ident = self.hoff_buf_ident(node_id, span);
                 quote_spanned! {span=>
                     let mut #buf_ident: Vec<_> = Vec::new();
                 }
             })
             .collect();
 
-        // For back-edge (defer_tick) handoffs, declare a second "back" buffer for
-        // double-buffering. At the start of each tick, the main buffer and back buffer
-        // are swapped so the consumer reads last tick's data while the producer writes
-        // to a fresh buffer.
+        // For tick-boundary handoffs (`defer_tick` / `defer_tick_lazy`), declare a
+        // second "back" buffer for double-buffering. At the start of each tick, the
+        // main buffer and back buffer are swapped so the consumer reads last tick's
+        // data while the producer writes to a fresh buffer.
         let back_buffer_code: Vec<TokenStream> = handoff_nodes
             .iter()
             .filter(|(node_id, _)| self.handoff_delay_type(*node_id).is_some())
             .map(|&(node_id, (src_span, dst_span))| {
                 let span = src_span.join(dst_span).unwrap_or(src_span);
-                let back_ident = Ident::new(&format!("hoff_{:?}_back", node_id.data()), span);
+                let back_ident = self.hoff_back_ident(node_id, span);
                 quote_spanned! {span=>
                     let mut #back_ident: Vec<_> = Vec::new();
                 }
@@ -911,10 +921,7 @@ impl DfirGraph {
 
                     // Non-lazy tick-boundary: defer_tick (not defer_tick_lazy).
                     if !matches!(delay_type, DelayType::TickLazy) {
-                        defer_tick_buf_idents.push(Ident::new(
-                            &format!("hoff_{:?}_buf", hoff_id.data()),
-                            node.span(),
-                        ));
+                        defer_tick_buf_idents.push(self.hoff_buf_ident(hoff_id, node.span()));
                     }
                 } else {
                     sg_preds.entry(succ_sg).unwrap().or_default().push(pred_sg);
@@ -953,15 +960,15 @@ impl DfirGraph {
                 .collect::<Vec<_>>()
         };
 
-        // Generate swap code for back-edge (defer_tick) handoffs.
+        // Generate swap code for tick-boundary (defer_tick / defer_tick_lazy) handoffs.
         // At the start of each tick, swap the main buffer and back buffer so the
         // consumer reads last tick's data from the back buffer.
         let back_edge_swap_code: Vec<TokenStream> = back_edge_hoff_ids
             .iter()
             .map(|&hoff_id| {
                 let span = self.nodes[hoff_id].span();
-                let buf_ident = Ident::new(&format!("hoff_{:?}_buf", hoff_id.data()), span);
-                let back_ident = Ident::new(&format!("hoff_{:?}_back", hoff_id.data()), span);
+                let buf_ident = self.hoff_buf_ident(hoff_id, span);
+                let back_ident = self.hoff_back_ident(hoff_id, span);
                 quote_spanned! {span=>
                     ::std::mem::swap(&mut #buf_ident, &mut #back_ident);
                 }
@@ -989,17 +996,11 @@ impl DfirGraph {
                 // Map handoff node IDs to buffer idents.
                 let recv_buf_idents: Vec<Ident> = recv_hoffs
                     .iter()
-                    .map(|&hoff_id| {
-                        let span = self.nodes[hoff_id].span();
-                        Ident::new(&format!("hoff_{:?}_buf", hoff_id.data()), span)
-                    })
+                    .map(|&hoff_id| self.hoff_buf_ident(hoff_id, self.nodes[hoff_id].span()))
                     .collect();
                 let send_buf_idents: Vec<Ident> = send_hoffs
                     .iter()
-                    .map(|&hoff_id| {
-                        let span = self.nodes[hoff_id].span();
-                        Ident::new(&format!("hoff_{:?}_buf", hoff_id.data()), span)
-                    })
+                    .map(|&hoff_id| self.hoff_buf_ident(hoff_id, self.nodes[hoff_id].span()))
                     .collect();
 
                 // Recv port code: drain from buffer into iterator, tracking if non-empty.
@@ -1016,9 +1017,9 @@ impl DfirGraph {
                         // (e.g. dfir_expect_warnings!). TODO(#2781): define these once.
                         let work_done = Ident::new("__dfir_work_done", Span::call_site());
                         let metrics = Ident::new("__dfir_metrics", Span::call_site());
-                        // Back-edge handoffs drain from the back buffer (double-buffering).
+                        // Tick-boundary handoffs drain from the back buffer (double-buffering).
                         let drain_ident = if back_edge_hoff_ids.contains(&hoff_id) {
-                            Ident::new(&format!("hoff_{:?}_back", hoff_id.data()), buf_ident.span())
+                            self.hoff_back_ident(hoff_id, buf_ident.span())
                         } else {
                             buf_ident.clone()
                         };

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1018,6 +1018,7 @@ impl DfirGraph {
                         let work_done = Ident::new("__dfir_work_done", Span::call_site());
                         let metrics = Ident::new("__dfir_metrics", Span::call_site());
                         // Tick-boundary handoffs drain from the back buffer (double-buffering).
+                        // (Sending always writes to the regular buffer — no branch needed there.)
                         let drain_ident = if back_edge_hoff_ids.contains(&hoff_id) {
                             self.hoff_back_ident(hoff_id, buf_ident.span())
                         } else {

--- a/dfir_rs/tests/snapshots/surface_join__static_static@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_join__static_static@graphvis_dot.snap
@@ -18,12 +18,6 @@ digraph {
     n11v1 [label="(n11v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n12v1 [label="(n12v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n13v1 [label="(n13v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n14v1 [label="(n14v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n15v1 [label="(n15v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n16v1 [label="(n16v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n17v1 [label="(n17v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n18v1 [label="(n18v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n19v1 [label="(n19v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n1v1 -> n9v1 [label="0"]
     n2v1 -> n8v1
     n4v1 -> n8v1
@@ -33,15 +27,9 @@ digraph {
     n5v1 -> n13v1
     n8v1 -> n9v1 [label="1"]
     n9v1 -> n10v1
-    n11v1 -> n14v1
-    n12v1 -> n16v1
-    n13v1 -> n18v1
-    n14v1 -> n15v1
-    n15v1 -> n4v1 [color=red]
-    n16v1 -> n17v1
-    n17v1 -> n7v1 [color=red]
-    n18v1 -> n19v1
-    n19v1 -> n6v1 [color=red]
+    n11v1 -> n4v1 [color=red]
+    n12v1 -> n7v1 [color=red]
+    n13v1 -> n6v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
@@ -83,26 +71,5 @@ digraph {
             label="var unioner"
             n8v1
         }
-    }
-    subgraph sg_5v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_5v1"
-        n14v1
-    }
-    subgraph sg_6v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_6v1"
-        n16v1
-    }
-    subgraph sg_7v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_7v1"
-        n18v1
     }
 }

--- a/dfir_rs/tests/snapshots/surface_join__static_static@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_join__static_static@graphvis_mermaid.snap
@@ -21,12 +21,6 @@ linkStyle default stroke:#aaa
 11v1["(11v1) <code>handoff</code>"]:::otherClass
 12v1["(12v1) <code>handoff</code>"]:::otherClass
 13v1["(13v1) <code>handoff</code>"]:::otherClass
-14v1[\"(14v1) <code>identity()</code>"/]:::pullClass
-15v1["(15v1) <code>handoff</code>"]:::otherClass
-16v1[\"(16v1) <code>identity()</code>"/]:::pullClass
-17v1["(17v1) <code>handoff</code>"]:::otherClass
-18v1[\"(18v1) <code>identity()</code>"/]:::pullClass
-19v1["(19v1) <code>handoff</code>"]:::otherClass
 1v1-->|0|9v1
 2v1-->8v1
 4v1-->8v1
@@ -36,15 +30,9 @@ linkStyle default stroke:#aaa
 5v1-->13v1
 8v1-->|1|9v1
 9v1-->10v1
-11v1-->14v1
-12v1-->16v1
-13v1-->18v1
-14v1-->15v1
-15v1--o4v1; linkStyle 13 stroke:red
-16v1-->17v1
-17v1--o7v1; linkStyle 15 stroke:red
-18v1-->19v1
-19v1--o6v1; linkStyle 17 stroke:red
+11v1--o4v1; linkStyle 9 stroke:red
+12v1--o7v1; linkStyle 10 stroke:red
+13v1--o6v1; linkStyle 11 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
     3v1
 end
@@ -66,13 +54,4 @@ subgraph sg_4v1 ["sg_4v1"]
     subgraph sg_4v1_var_unioner ["var <tt>unioner</tt>"]
         8v1
     end
-end
-subgraph sg_5v1 ["sg_5v1"]
-    14v1
-end
-subgraph sg_6v1 ["sg_6v1"]
-    16v1
-end
-subgraph sg_7v1 ["sg_7v1"]
-    18v1
 end

--- a/dfir_rs/tests/snapshots/surface_join__static_tick@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_join__static_tick@graphvis_dot.snap
@@ -18,12 +18,6 @@ digraph {
     n11v1 [label="(n11v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n12v1 [label="(n12v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n13v1 [label="(n13v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n14v1 [label="(n14v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n15v1 [label="(n15v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n16v1 [label="(n16v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n17v1 [label="(n17v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n18v1 [label="(n18v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n19v1 [label="(n19v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n1v1 -> n9v1 [label="0"]
     n2v1 -> n8v1
     n4v1 -> n8v1
@@ -33,15 +27,9 @@ digraph {
     n5v1 -> n13v1
     n8v1 -> n9v1 [label="1"]
     n9v1 -> n10v1
-    n11v1 -> n14v1
-    n12v1 -> n16v1
-    n13v1 -> n18v1
-    n14v1 -> n15v1
-    n15v1 -> n4v1 [color=red]
-    n16v1 -> n17v1
-    n17v1 -> n7v1 [color=red]
-    n18v1 -> n19v1
-    n19v1 -> n6v1 [color=red]
+    n11v1 -> n4v1 [color=red]
+    n12v1 -> n7v1 [color=red]
+    n13v1 -> n6v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
@@ -83,26 +71,5 @@ digraph {
             label="var unioner"
             n8v1
         }
-    }
-    subgraph sg_5v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_5v1"
-        n14v1
-    }
-    subgraph sg_6v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_6v1"
-        n16v1
-    }
-    subgraph sg_7v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_7v1"
-        n18v1
     }
 }

--- a/dfir_rs/tests/snapshots/surface_join__static_tick@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_join__static_tick@graphvis_mermaid.snap
@@ -21,12 +21,6 @@ linkStyle default stroke:#aaa
 11v1["(11v1) <code>handoff</code>"]:::otherClass
 12v1["(12v1) <code>handoff</code>"]:::otherClass
 13v1["(13v1) <code>handoff</code>"]:::otherClass
-14v1[\"(14v1) <code>identity()</code>"/]:::pullClass
-15v1["(15v1) <code>handoff</code>"]:::otherClass
-16v1[\"(16v1) <code>identity()</code>"/]:::pullClass
-17v1["(17v1) <code>handoff</code>"]:::otherClass
-18v1[\"(18v1) <code>identity()</code>"/]:::pullClass
-19v1["(19v1) <code>handoff</code>"]:::otherClass
 1v1-->|0|9v1
 2v1-->8v1
 4v1-->8v1
@@ -36,15 +30,9 @@ linkStyle default stroke:#aaa
 5v1-->13v1
 8v1-->|1|9v1
 9v1-->10v1
-11v1-->14v1
-12v1-->16v1
-13v1-->18v1
-14v1-->15v1
-15v1--o4v1; linkStyle 13 stroke:red
-16v1-->17v1
-17v1--o7v1; linkStyle 15 stroke:red
-18v1-->19v1
-19v1--o6v1; linkStyle 17 stroke:red
+11v1--o4v1; linkStyle 9 stroke:red
+12v1--o7v1; linkStyle 10 stroke:red
+13v1--o6v1; linkStyle 11 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
     3v1
 end
@@ -66,13 +54,4 @@ subgraph sg_4v1 ["sg_4v1"]
     subgraph sg_4v1_var_unioner ["var <tt>unioner</tt>"]
         8v1
     end
-end
-subgraph sg_5v1 ["sg_5v1"]
-    14v1
-end
-subgraph sg_6v1 ["sg_6v1"]
-    16v1
-end
-subgraph sg_7v1 ["sg_7v1"]
-    18v1
 end

--- a/dfir_rs/tests/snapshots/surface_join__tick_static@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_join__tick_static@graphvis_dot.snap
@@ -18,12 +18,6 @@ digraph {
     n11v1 [label="(n11v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n12v1 [label="(n12v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n13v1 [label="(n13v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n14v1 [label="(n14v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n15v1 [label="(n15v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n16v1 [label="(n16v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n17v1 [label="(n17v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n18v1 [label="(n18v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n19v1 [label="(n19v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n1v1 -> n9v1 [label="0"]
     n2v1 -> n8v1
     n4v1 -> n8v1
@@ -33,15 +27,9 @@ digraph {
     n5v1 -> n13v1
     n8v1 -> n9v1 [label="1"]
     n9v1 -> n10v1
-    n11v1 -> n14v1
-    n12v1 -> n16v1
-    n13v1 -> n18v1
-    n14v1 -> n15v1
-    n15v1 -> n4v1 [color=red]
-    n16v1 -> n17v1
-    n17v1 -> n7v1 [color=red]
-    n18v1 -> n19v1
-    n19v1 -> n6v1 [color=red]
+    n11v1 -> n4v1 [color=red]
+    n12v1 -> n7v1 [color=red]
+    n13v1 -> n6v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
@@ -83,26 +71,5 @@ digraph {
             label="var unioner"
             n8v1
         }
-    }
-    subgraph sg_5v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_5v1"
-        n14v1
-    }
-    subgraph sg_6v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_6v1"
-        n16v1
-    }
-    subgraph sg_7v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_7v1"
-        n18v1
     }
 }

--- a/dfir_rs/tests/snapshots/surface_join__tick_static@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_join__tick_static@graphvis_mermaid.snap
@@ -21,12 +21,6 @@ linkStyle default stroke:#aaa
 11v1["(11v1) <code>handoff</code>"]:::otherClass
 12v1["(12v1) <code>handoff</code>"]:::otherClass
 13v1["(13v1) <code>handoff</code>"]:::otherClass
-14v1[\"(14v1) <code>identity()</code>"/]:::pullClass
-15v1["(15v1) <code>handoff</code>"]:::otherClass
-16v1[\"(16v1) <code>identity()</code>"/]:::pullClass
-17v1["(17v1) <code>handoff</code>"]:::otherClass
-18v1[\"(18v1) <code>identity()</code>"/]:::pullClass
-19v1["(19v1) <code>handoff</code>"]:::otherClass
 1v1-->|0|9v1
 2v1-->8v1
 4v1-->8v1
@@ -36,15 +30,9 @@ linkStyle default stroke:#aaa
 5v1-->13v1
 8v1-->|1|9v1
 9v1-->10v1
-11v1-->14v1
-12v1-->16v1
-13v1-->18v1
-14v1-->15v1
-15v1--o4v1; linkStyle 13 stroke:red
-16v1-->17v1
-17v1--o7v1; linkStyle 15 stroke:red
-18v1-->19v1
-19v1--o6v1; linkStyle 17 stroke:red
+11v1--o4v1; linkStyle 9 stroke:red
+12v1--o7v1; linkStyle 10 stroke:red
+13v1--o6v1; linkStyle 11 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
     3v1
 end
@@ -66,13 +54,4 @@ subgraph sg_4v1 ["sg_4v1"]
     subgraph sg_4v1_var_unioner ["var <tt>unioner</tt>"]
         8v1
     end
-end
-subgraph sg_5v1 ["sg_5v1"]
-    14v1
-end
-subgraph sg_6v1 ["sg_6v1"]
-    16v1
-end
-subgraph sg_7v1 ["sg_7v1"]
-    18v1
 end

--- a/dfir_rs/tests/snapshots/surface_join__tick_tick@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_join__tick_tick@graphvis_dot.snap
@@ -18,12 +18,6 @@ digraph {
     n11v1 [label="(n11v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n12v1 [label="(n12v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n13v1 [label="(n13v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n14v1 [label="(n14v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n15v1 [label="(n15v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n16v1 [label="(n16v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n17v1 [label="(n17v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n18v1 [label="(n18v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n19v1 [label="(n19v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n1v1 -> n9v1 [label="0"]
     n2v1 -> n8v1
     n4v1 -> n8v1
@@ -33,15 +27,9 @@ digraph {
     n5v1 -> n13v1
     n8v1 -> n9v1 [label="1"]
     n9v1 -> n10v1
-    n11v1 -> n14v1
-    n12v1 -> n16v1
-    n13v1 -> n18v1
-    n14v1 -> n15v1
-    n15v1 -> n4v1 [color=red]
-    n16v1 -> n17v1
-    n17v1 -> n7v1 [color=red]
-    n18v1 -> n19v1
-    n19v1 -> n6v1 [color=red]
+    n11v1 -> n4v1 [color=red]
+    n12v1 -> n7v1 [color=red]
+    n13v1 -> n6v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
@@ -83,26 +71,5 @@ digraph {
             label="var unioner"
             n8v1
         }
-    }
-    subgraph sg_5v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_5v1"
-        n14v1
-    }
-    subgraph sg_6v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_6v1"
-        n16v1
-    }
-    subgraph sg_7v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_7v1"
-        n18v1
     }
 }

--- a/dfir_rs/tests/snapshots/surface_join__tick_tick@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_join__tick_tick@graphvis_mermaid.snap
@@ -21,12 +21,6 @@ linkStyle default stroke:#aaa
 11v1["(11v1) <code>handoff</code>"]:::otherClass
 12v1["(12v1) <code>handoff</code>"]:::otherClass
 13v1["(13v1) <code>handoff</code>"]:::otherClass
-14v1[\"(14v1) <code>identity()</code>"/]:::pullClass
-15v1["(15v1) <code>handoff</code>"]:::otherClass
-16v1[\"(16v1) <code>identity()</code>"/]:::pullClass
-17v1["(17v1) <code>handoff</code>"]:::otherClass
-18v1[\"(18v1) <code>identity()</code>"/]:::pullClass
-19v1["(19v1) <code>handoff</code>"]:::otherClass
 1v1-->|0|9v1
 2v1-->8v1
 4v1-->8v1
@@ -36,15 +30,9 @@ linkStyle default stroke:#aaa
 5v1-->13v1
 8v1-->|1|9v1
 9v1-->10v1
-11v1-->14v1
-12v1-->16v1
-13v1-->18v1
-14v1-->15v1
-15v1--o4v1; linkStyle 13 stroke:red
-16v1-->17v1
-17v1--o7v1; linkStyle 15 stroke:red
-18v1-->19v1
-19v1--o6v1; linkStyle 17 stroke:red
+11v1--o4v1; linkStyle 9 stroke:red
+12v1--o7v1; linkStyle 10 stroke:red
+13v1--o6v1; linkStyle 11 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
     3v1
 end
@@ -66,13 +54,4 @@ subgraph sg_4v1 ["sg_4v1"]
     subgraph sg_4v1_var_unioner ["var <tt>unioner</tt>"]
         8v1
     end
-end
-subgraph sg_5v1 ["sg_5v1"]
-    14v1
-end
-subgraph sg_6v1 ["sg_6v1"]
-    16v1
-end
-subgraph sg_7v1 ["sg_7v1"]
-    18v1
 end

--- a/dfir_rs/tests/snapshots/surface_join_fused__static_static_lhs_blocking_rhs_streaming@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_join_fused__static_static_lhs_blocking_rhs_streaming@graphvis_dot.snap
@@ -20,12 +20,6 @@ digraph {
     n13v1 [label="(n13v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n14v1 [label="(n14v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n15v1 [label="(n15v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n16v1 [label="(n16v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n17v1 [label="(n17v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n18v1 [label="(n18v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n19v1 [label="(n19v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n20v1 [label="(n20v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n21v1 [label="(n21v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n2v1 -> n12v1
     n1v1 -> n2v1
     n3v1 -> n9v1
@@ -37,15 +31,9 @@ digraph {
     n9v1 -> n10v1 [label="1"]
     n10v1 -> n11v1
     n12v1 -> n10v1 [label="0", color=red]
-    n13v1 -> n16v1
-    n14v1 -> n18v1
-    n15v1 -> n20v1
-    n16v1 -> n17v1
-    n17v1 -> n5v1 [color=red]
-    n18v1 -> n19v1
-    n19v1 -> n8v1 [color=red]
-    n20v1 -> n21v1
-    n21v1 -> n7v1 [color=red]
+    n13v1 -> n5v1 [color=red]
+    n14v1 -> n8v1 [color=red]
+    n15v1 -> n7v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
@@ -94,26 +82,5 @@ digraph {
             label="var unioner"
             n9v1
         }
-    }
-    subgraph sg_6v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_6v1"
-        n16v1
-    }
-    subgraph sg_7v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_7v1"
-        n18v1
-    }
-    subgraph sg_8v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_8v1"
-        n20v1
     }
 }

--- a/dfir_rs/tests/snapshots/surface_join_fused__static_static_lhs_blocking_rhs_streaming@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_join_fused__static_static_lhs_blocking_rhs_streaming@graphvis_mermaid.snap
@@ -23,12 +23,6 @@ linkStyle default stroke:#aaa
 13v1["(13v1) <code>handoff</code>"]:::otherClass
 14v1["(14v1) <code>handoff</code>"]:::otherClass
 15v1["(15v1) <code>handoff</code>"]:::otherClass
-16v1[\"(16v1) <code>identity()</code>"/]:::pullClass
-17v1["(17v1) <code>handoff</code>"]:::otherClass
-18v1[\"(18v1) <code>identity()</code>"/]:::pullClass
-19v1["(19v1) <code>handoff</code>"]:::otherClass
-20v1[\"(20v1) <code>identity()</code>"/]:::pullClass
-21v1["(21v1) <code>handoff</code>"]:::otherClass
 2v1-->12v1
 1v1-->2v1
 3v1-->9v1
@@ -40,15 +34,9 @@ linkStyle default stroke:#aaa
 9v1-->|1|10v1
 10v1-->11v1
 12v1--x|0|10v1; linkStyle 10 stroke:red
-13v1-->16v1
-14v1-->18v1
-15v1-->20v1
-16v1-->17v1
-17v1--o5v1; linkStyle 15 stroke:red
-18v1-->19v1
-19v1--o8v1; linkStyle 17 stroke:red
-20v1-->21v1
-21v1--o7v1; linkStyle 19 stroke:red
+13v1--o5v1; linkStyle 11 stroke:red
+14v1--o8v1; linkStyle 12 stroke:red
+15v1--o7v1; linkStyle 13 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
     1v1
     2v1
@@ -73,13 +61,4 @@ subgraph sg_5v1 ["sg_5v1"]
     subgraph sg_5v1_var_unioner ["var <tt>unioner</tt>"]
         9v1
     end
-end
-subgraph sg_6v1 ["sg_6v1"]
-    16v1
-end
-subgraph sg_7v1 ["sg_7v1"]
-    18v1
-end
-subgraph sg_8v1 ["sg_8v1"]
-    20v1
 end

--- a/dfir_rs/tests/snapshots/surface_join_fused__static_static_lhs_streaming_rhs_blocking@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_join_fused__static_static_lhs_streaming_rhs_blocking@graphvis_dot.snap
@@ -21,12 +21,6 @@ digraph {
     n14v1 [label="(n14v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n15v1 [label="(n15v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n16v1 [label="(n16v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n17v1 [label="(n17v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n18v1 [label="(n18v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n19v1 [label="(n19v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n20v1 [label="(n20v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n21v1 [label="(n21v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n22v1 [label="(n22v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n2v1 -> n13v1
     n1v1 -> n2v1
     n3v1 -> n9v1
@@ -39,15 +33,9 @@ digraph {
     n11v1 -> n12v1
     n10v1 -> n11v1
     n13v1 -> n10v1 [label="1", color=red]
-    n14v1 -> n17v1
-    n15v1 -> n19v1
-    n16v1 -> n21v1
-    n17v1 -> n18v1
-    n18v1 -> n5v1 [color=red]
-    n19v1 -> n20v1
-    n20v1 -> n8v1 [color=red]
-    n21v1 -> n22v1
-    n22v1 -> n7v1 [color=red]
+    n14v1 -> n5v1 [color=red]
+    n15v1 -> n8v1 [color=red]
+    n16v1 -> n7v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
@@ -97,26 +85,5 @@ digraph {
             label="var unioner"
             n9v1
         }
-    }
-    subgraph sg_6v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_6v1"
-        n17v1
-    }
-    subgraph sg_7v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_7v1"
-        n19v1
-    }
-    subgraph sg_8v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_8v1"
-        n21v1
     }
 }

--- a/dfir_rs/tests/snapshots/surface_join_fused__static_static_lhs_streaming_rhs_blocking@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_join_fused__static_static_lhs_streaming_rhs_blocking@graphvis_mermaid.snap
@@ -24,12 +24,6 @@ linkStyle default stroke:#aaa
 14v1["(14v1) <code>handoff</code>"]:::otherClass
 15v1["(15v1) <code>handoff</code>"]:::otherClass
 16v1["(16v1) <code>handoff</code>"]:::otherClass
-17v1[\"(17v1) <code>identity()</code>"/]:::pullClass
-18v1["(18v1) <code>handoff</code>"]:::otherClass
-19v1[\"(19v1) <code>identity()</code>"/]:::pullClass
-20v1["(20v1) <code>handoff</code>"]:::otherClass
-21v1[\"(21v1) <code>identity()</code>"/]:::pullClass
-22v1["(22v1) <code>handoff</code>"]:::otherClass
 2v1-->13v1
 1v1-->2v1
 3v1-->9v1
@@ -42,15 +36,9 @@ linkStyle default stroke:#aaa
 11v1-->12v1
 10v1-->11v1
 13v1--x|1|10v1; linkStyle 11 stroke:red
-14v1-->17v1
-15v1-->19v1
-16v1-->21v1
-17v1-->18v1
-18v1--o5v1; linkStyle 16 stroke:red
-19v1-->20v1
-20v1--o8v1; linkStyle 18 stroke:red
-21v1-->22v1
-22v1--o7v1; linkStyle 20 stroke:red
+14v1--o5v1; linkStyle 12 stroke:red
+15v1--o8v1; linkStyle 13 stroke:red
+16v1--o7v1; linkStyle 14 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
     1v1
     2v1
@@ -76,13 +64,4 @@ subgraph sg_5v1 ["sg_5v1"]
     subgraph sg_5v1_var_unioner ["var <tt>unioner</tt>"]
         9v1
     end
-end
-subgraph sg_6v1 ["sg_6v1"]
-    17v1
-end
-subgraph sg_7v1 ["sg_7v1"]
-    19v1
-end
-subgraph sg_8v1 ["sg_8v1"]
-    21v1
 end

--- a/dfir_rs/tests/snapshots/surface_join_fused__static_tick_lhs_blocking_rhs_streaming@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_join_fused__static_tick_lhs_blocking_rhs_streaming@graphvis_dot.snap
@@ -20,12 +20,6 @@ digraph {
     n13v1 [label="(n13v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n14v1 [label="(n14v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n15v1 [label="(n15v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n16v1 [label="(n16v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n17v1 [label="(n17v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n18v1 [label="(n18v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n19v1 [label="(n19v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n20v1 [label="(n20v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n21v1 [label="(n21v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n2v1 -> n12v1
     n1v1 -> n2v1
     n3v1 -> n9v1
@@ -37,15 +31,9 @@ digraph {
     n9v1 -> n10v1 [label="1"]
     n10v1 -> n11v1
     n12v1 -> n10v1 [label="0", color=red]
-    n13v1 -> n16v1
-    n14v1 -> n18v1
-    n15v1 -> n20v1
-    n16v1 -> n17v1
-    n17v1 -> n5v1 [color=red]
-    n18v1 -> n19v1
-    n19v1 -> n8v1 [color=red]
-    n20v1 -> n21v1
-    n21v1 -> n7v1 [color=red]
+    n13v1 -> n5v1 [color=red]
+    n14v1 -> n8v1 [color=red]
+    n15v1 -> n7v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
@@ -94,26 +82,5 @@ digraph {
             label="var unioner"
             n9v1
         }
-    }
-    subgraph sg_6v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_6v1"
-        n16v1
-    }
-    subgraph sg_7v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_7v1"
-        n18v1
-    }
-    subgraph sg_8v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_8v1"
-        n20v1
     }
 }

--- a/dfir_rs/tests/snapshots/surface_join_fused__static_tick_lhs_blocking_rhs_streaming@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_join_fused__static_tick_lhs_blocking_rhs_streaming@graphvis_mermaid.snap
@@ -23,12 +23,6 @@ linkStyle default stroke:#aaa
 13v1["(13v1) <code>handoff</code>"]:::otherClass
 14v1["(14v1) <code>handoff</code>"]:::otherClass
 15v1["(15v1) <code>handoff</code>"]:::otherClass
-16v1[\"(16v1) <code>identity()</code>"/]:::pullClass
-17v1["(17v1) <code>handoff</code>"]:::otherClass
-18v1[\"(18v1) <code>identity()</code>"/]:::pullClass
-19v1["(19v1) <code>handoff</code>"]:::otherClass
-20v1[\"(20v1) <code>identity()</code>"/]:::pullClass
-21v1["(21v1) <code>handoff</code>"]:::otherClass
 2v1-->12v1
 1v1-->2v1
 3v1-->9v1
@@ -40,15 +34,9 @@ linkStyle default stroke:#aaa
 9v1-->|1|10v1
 10v1-->11v1
 12v1--x|0|10v1; linkStyle 10 stroke:red
-13v1-->16v1
-14v1-->18v1
-15v1-->20v1
-16v1-->17v1
-17v1--o5v1; linkStyle 15 stroke:red
-18v1-->19v1
-19v1--o8v1; linkStyle 17 stroke:red
-20v1-->21v1
-21v1--o7v1; linkStyle 19 stroke:red
+13v1--o5v1; linkStyle 11 stroke:red
+14v1--o8v1; linkStyle 12 stroke:red
+15v1--o7v1; linkStyle 13 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
     1v1
     2v1
@@ -73,13 +61,4 @@ subgraph sg_5v1 ["sg_5v1"]
     subgraph sg_5v1_var_unioner ["var <tt>unioner</tt>"]
         9v1
     end
-end
-subgraph sg_6v1 ["sg_6v1"]
-    16v1
-end
-subgraph sg_7v1 ["sg_7v1"]
-    18v1
-end
-subgraph sg_8v1 ["sg_8v1"]
-    20v1
 end

--- a/dfir_rs/tests/snapshots/surface_join_fused__static_tick_lhs_streaming_rhs_blocking@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_join_fused__static_tick_lhs_streaming_rhs_blocking@graphvis_dot.snap
@@ -20,12 +20,6 @@ digraph {
     n13v1 [label="(n13v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n14v1 [label="(n14v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n15v1 [label="(n15v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n16v1 [label="(n16v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n17v1 [label="(n17v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n18v1 [label="(n18v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n19v1 [label="(n19v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n20v1 [label="(n20v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n21v1 [label="(n21v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n2v1 -> n12v1
     n1v1 -> n2v1
     n3v1 -> n9v1
@@ -37,15 +31,9 @@ digraph {
     n9v1 -> n10v1 [label="0"]
     n10v1 -> n11v1
     n12v1 -> n10v1 [label="1", color=red]
-    n13v1 -> n16v1
-    n14v1 -> n18v1
-    n15v1 -> n20v1
-    n16v1 -> n17v1
-    n17v1 -> n5v1 [color=red]
-    n18v1 -> n19v1
-    n19v1 -> n8v1 [color=red]
-    n20v1 -> n21v1
-    n21v1 -> n7v1 [color=red]
+    n13v1 -> n5v1 [color=red]
+    n14v1 -> n8v1 [color=red]
+    n15v1 -> n7v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
@@ -94,26 +82,5 @@ digraph {
             label="var unioner"
             n9v1
         }
-    }
-    subgraph sg_6v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_6v1"
-        n16v1
-    }
-    subgraph sg_7v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_7v1"
-        n18v1
-    }
-    subgraph sg_8v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_8v1"
-        n20v1
     }
 }

--- a/dfir_rs/tests/snapshots/surface_join_fused__static_tick_lhs_streaming_rhs_blocking@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_join_fused__static_tick_lhs_streaming_rhs_blocking@graphvis_mermaid.snap
@@ -23,12 +23,6 @@ linkStyle default stroke:#aaa
 13v1["(13v1) <code>handoff</code>"]:::otherClass
 14v1["(14v1) <code>handoff</code>"]:::otherClass
 15v1["(15v1) <code>handoff</code>"]:::otherClass
-16v1[\"(16v1) <code>identity()</code>"/]:::pullClass
-17v1["(17v1) <code>handoff</code>"]:::otherClass
-18v1[\"(18v1) <code>identity()</code>"/]:::pullClass
-19v1["(19v1) <code>handoff</code>"]:::otherClass
-20v1[\"(20v1) <code>identity()</code>"/]:::pullClass
-21v1["(21v1) <code>handoff</code>"]:::otherClass
 2v1-->12v1
 1v1-->2v1
 3v1-->9v1
@@ -40,15 +34,9 @@ linkStyle default stroke:#aaa
 9v1-->|0|10v1
 10v1-->11v1
 12v1--x|1|10v1; linkStyle 10 stroke:red
-13v1-->16v1
-14v1-->18v1
-15v1-->20v1
-16v1-->17v1
-17v1--o5v1; linkStyle 15 stroke:red
-18v1-->19v1
-19v1--o8v1; linkStyle 17 stroke:red
-20v1-->21v1
-21v1--o7v1; linkStyle 19 stroke:red
+13v1--o5v1; linkStyle 11 stroke:red
+14v1--o8v1; linkStyle 12 stroke:red
+15v1--o7v1; linkStyle 13 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
     1v1
     2v1
@@ -73,13 +61,4 @@ subgraph sg_5v1 ["sg_5v1"]
     subgraph sg_5v1_var_unioner ["var <tt>unioner</tt>"]
         9v1
     end
-end
-subgraph sg_6v1 ["sg_6v1"]
-    16v1
-end
-subgraph sg_7v1 ["sg_7v1"]
-    18v1
-end
-subgraph sg_8v1 ["sg_8v1"]
-    20v1
 end

--- a/dfir_rs/tests/snapshots/surface_join_fused__tick_tick_lhs_blocking_rhs_streaming@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_join_fused__tick_tick_lhs_blocking_rhs_streaming@graphvis_dot.snap
@@ -20,12 +20,6 @@ digraph {
     n13v1 [label="(n13v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n14v1 [label="(n14v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n15v1 [label="(n15v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n16v1 [label="(n16v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n17v1 [label="(n17v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n18v1 [label="(n18v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n19v1 [label="(n19v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n20v1 [label="(n20v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n21v1 [label="(n21v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n2v1 -> n12v1
     n1v1 -> n2v1
     n3v1 -> n9v1
@@ -37,15 +31,9 @@ digraph {
     n9v1 -> n10v1 [label="1"]
     n10v1 -> n11v1
     n12v1 -> n10v1 [label="0", color=red]
-    n13v1 -> n16v1
-    n14v1 -> n18v1
-    n15v1 -> n20v1
-    n16v1 -> n17v1
-    n17v1 -> n5v1 [color=red]
-    n18v1 -> n19v1
-    n19v1 -> n8v1 [color=red]
-    n20v1 -> n21v1
-    n21v1 -> n7v1 [color=red]
+    n13v1 -> n5v1 [color=red]
+    n14v1 -> n8v1 [color=red]
+    n15v1 -> n7v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
@@ -94,26 +82,5 @@ digraph {
             label="var unioner"
             n9v1
         }
-    }
-    subgraph sg_6v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_6v1"
-        n16v1
-    }
-    subgraph sg_7v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_7v1"
-        n18v1
-    }
-    subgraph sg_8v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_8v1"
-        n20v1
     }
 }

--- a/dfir_rs/tests/snapshots/surface_join_fused__tick_tick_lhs_blocking_rhs_streaming@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_join_fused__tick_tick_lhs_blocking_rhs_streaming@graphvis_mermaid.snap
@@ -23,12 +23,6 @@ linkStyle default stroke:#aaa
 13v1["(13v1) <code>handoff</code>"]:::otherClass
 14v1["(14v1) <code>handoff</code>"]:::otherClass
 15v1["(15v1) <code>handoff</code>"]:::otherClass
-16v1[\"(16v1) <code>identity()</code>"/]:::pullClass
-17v1["(17v1) <code>handoff</code>"]:::otherClass
-18v1[\"(18v1) <code>identity()</code>"/]:::pullClass
-19v1["(19v1) <code>handoff</code>"]:::otherClass
-20v1[\"(20v1) <code>identity()</code>"/]:::pullClass
-21v1["(21v1) <code>handoff</code>"]:::otherClass
 2v1-->12v1
 1v1-->2v1
 3v1-->9v1
@@ -40,15 +34,9 @@ linkStyle default stroke:#aaa
 9v1-->|1|10v1
 10v1-->11v1
 12v1--x|0|10v1; linkStyle 10 stroke:red
-13v1-->16v1
-14v1-->18v1
-15v1-->20v1
-16v1-->17v1
-17v1--o5v1; linkStyle 15 stroke:red
-18v1-->19v1
-19v1--o8v1; linkStyle 17 stroke:red
-20v1-->21v1
-21v1--o7v1; linkStyle 19 stroke:red
+13v1--o5v1; linkStyle 11 stroke:red
+14v1--o8v1; linkStyle 12 stroke:red
+15v1--o7v1; linkStyle 13 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
     1v1
     2v1
@@ -73,13 +61,4 @@ subgraph sg_5v1 ["sg_5v1"]
     subgraph sg_5v1_var_unioner ["var <tt>unioner</tt>"]
         9v1
     end
-end
-subgraph sg_6v1 ["sg_6v1"]
-    16v1
-end
-subgraph sg_7v1 ["sg_7v1"]
-    18v1
-end
-subgraph sg_8v1 ["sg_8v1"]
-    20v1
 end

--- a/dfir_rs/tests/snapshots/surface_join_fused__tick_tick_lhs_fold_rhs_reduce@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_join_fused__tick_tick_lhs_fold_rhs_reduce@graphvis_dot.snap
@@ -21,12 +21,6 @@ digraph {
     n14v1 [label="(n14v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n15v1 [label="(n15v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n16v1 [label="(n16v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n17v1 [label="(n17v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n18v1 [label="(n18v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n19v1 [label="(n19v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n20v1 [label="(n20v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n21v1 [label="(n21v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n22v1 [label="(n22v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n2v1 -> n12v1
     n1v1 -> n2v1
     n3v1 -> n9v1
@@ -38,16 +32,10 @@ digraph {
     n9v1 -> n16v1
     n10v1 -> n11v1
     n12v1 -> n10v1 [label="0", color=red]
-    n13v1 -> n17v1
-    n14v1 -> n19v1
-    n15v1 -> n21v1
+    n13v1 -> n5v1 [color=red]
+    n14v1 -> n8v1 [color=red]
+    n15v1 -> n7v1 [color=red]
     n16v1 -> n10v1 [label="1", color=red]
-    n17v1 -> n18v1
-    n18v1 -> n5v1 [color=red]
-    n19v1 -> n20v1
-    n20v1 -> n8v1 [color=red]
-    n21v1 -> n22v1
-    n22v1 -> n7v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
@@ -102,26 +90,5 @@ digraph {
             n10v1
             n11v1
         }
-    }
-    subgraph sg_7v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_7v1"
-        n17v1
-    }
-    subgraph sg_8v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_8v1"
-        n19v1
-    }
-    subgraph sg_9v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_9v1"
-        n21v1
     }
 }

--- a/dfir_rs/tests/snapshots/surface_join_fused__tick_tick_lhs_fold_rhs_reduce@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_join_fused__tick_tick_lhs_fold_rhs_reduce@graphvis_mermaid.snap
@@ -24,12 +24,6 @@ linkStyle default stroke:#aaa
 14v1["(14v1) <code>handoff</code>"]:::otherClass
 15v1["(15v1) <code>handoff</code>"]:::otherClass
 16v1["(16v1) <code>handoff</code>"]:::otherClass
-17v1[\"(17v1) <code>identity()</code>"/]:::pullClass
-18v1["(18v1) <code>handoff</code>"]:::otherClass
-19v1[\"(19v1) <code>identity()</code>"/]:::pullClass
-20v1["(20v1) <code>handoff</code>"]:::otherClass
-21v1[\"(21v1) <code>identity()</code>"/]:::pullClass
-22v1["(22v1) <code>handoff</code>"]:::otherClass
 2v1-->12v1
 1v1-->2v1
 3v1-->9v1
@@ -41,16 +35,10 @@ linkStyle default stroke:#aaa
 9v1-->16v1
 10v1-->11v1
 12v1--x|0|10v1; linkStyle 10 stroke:red
-13v1-->17v1
-14v1-->19v1
-15v1-->21v1
+13v1--o5v1; linkStyle 11 stroke:red
+14v1--o8v1; linkStyle 12 stroke:red
+15v1--o7v1; linkStyle 13 stroke:red
 16v1--x|1|10v1; linkStyle 14 stroke:red
-17v1-->18v1
-18v1--o5v1; linkStyle 16 stroke:red
-19v1-->20v1
-20v1--o8v1; linkStyle 18 stroke:red
-21v1-->22v1
-22v1--o7v1; linkStyle 20 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
     1v1
     2v1
@@ -77,13 +65,4 @@ subgraph sg_6v1 ["sg_6v1"]
         10v1
         11v1
     end
-end
-subgraph sg_7v1 ["sg_7v1"]
-    17v1
-end
-subgraph sg_8v1 ["sg_8v1"]
-    19v1
-end
-subgraph sg_9v1 ["sg_9v1"]
-    21v1
 end

--- a/dfir_rs/tests/snapshots/surface_join_fused__tick_tick_lhs_streaming_rhs_blocking@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_join_fused__tick_tick_lhs_streaming_rhs_blocking@graphvis_dot.snap
@@ -20,12 +20,6 @@ digraph {
     n13v1 [label="(n13v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n14v1 [label="(n14v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n15v1 [label="(n15v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n16v1 [label="(n16v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n17v1 [label="(n17v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n18v1 [label="(n18v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n19v1 [label="(n19v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n20v1 [label="(n20v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n21v1 [label="(n21v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n2v1 -> n12v1
     n1v1 -> n2v1
     n3v1 -> n9v1
@@ -37,15 +31,9 @@ digraph {
     n9v1 -> n10v1 [label="0"]
     n10v1 -> n11v1
     n12v1 -> n10v1 [label="1", color=red]
-    n13v1 -> n16v1
-    n14v1 -> n18v1
-    n15v1 -> n20v1
-    n16v1 -> n17v1
-    n17v1 -> n5v1 [color=red]
-    n18v1 -> n19v1
-    n19v1 -> n8v1 [color=red]
-    n20v1 -> n21v1
-    n21v1 -> n7v1 [color=red]
+    n13v1 -> n5v1 [color=red]
+    n14v1 -> n8v1 [color=red]
+    n15v1 -> n7v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
@@ -94,26 +82,5 @@ digraph {
             label="var unioner"
             n9v1
         }
-    }
-    subgraph sg_6v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_6v1"
-        n16v1
-    }
-    subgraph sg_7v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_7v1"
-        n18v1
-    }
-    subgraph sg_8v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_8v1"
-        n20v1
     }
 }

--- a/dfir_rs/tests/snapshots/surface_join_fused__tick_tick_lhs_streaming_rhs_blocking@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_join_fused__tick_tick_lhs_streaming_rhs_blocking@graphvis_mermaid.snap
@@ -23,12 +23,6 @@ linkStyle default stroke:#aaa
 13v1["(13v1) <code>handoff</code>"]:::otherClass
 14v1["(14v1) <code>handoff</code>"]:::otherClass
 15v1["(15v1) <code>handoff</code>"]:::otherClass
-16v1[\"(16v1) <code>identity()</code>"/]:::pullClass
-17v1["(17v1) <code>handoff</code>"]:::otherClass
-18v1[\"(18v1) <code>identity()</code>"/]:::pullClass
-19v1["(19v1) <code>handoff</code>"]:::otherClass
-20v1[\"(20v1) <code>identity()</code>"/]:::pullClass
-21v1["(21v1) <code>handoff</code>"]:::otherClass
 2v1-->12v1
 1v1-->2v1
 3v1-->9v1
@@ -40,15 +34,9 @@ linkStyle default stroke:#aaa
 9v1-->|0|10v1
 10v1-->11v1
 12v1--x|1|10v1; linkStyle 10 stroke:red
-13v1-->16v1
-14v1-->18v1
-15v1-->20v1
-16v1-->17v1
-17v1--o5v1; linkStyle 15 stroke:red
-18v1-->19v1
-19v1--o8v1; linkStyle 17 stroke:red
-20v1-->21v1
-21v1--o7v1; linkStyle 19 stroke:red
+13v1--o5v1; linkStyle 11 stroke:red
+14v1--o8v1; linkStyle 12 stroke:red
+15v1--o7v1; linkStyle 13 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
     1v1
     2v1
@@ -73,13 +61,4 @@ subgraph sg_5v1 ["sg_5v1"]
     subgraph sg_5v1_var_unioner ["var <tt>unioner</tt>"]
         9v1
     end
-end
-subgraph sg_6v1 ["sg_6v1"]
-    16v1
-end
-subgraph sg_7v1 ["sg_7v1"]
-    18v1
-end
-subgraph sg_8v1 ["sg_8v1"]
-    20v1
 end

--- a/dfir_rs/tests/snapshots/surface_scheduling__nospin_issue_961@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_scheduling__nospin_issue_961@graphvis_dot.snap
@@ -10,14 +10,10 @@ digraph {
     n3v1 [label="(n3v1) defer_tick_lazy()", shape=invhouse, fillcolor="#88aaff"]
     n4v1 [label="(n4v1) null()", shape=house, fillcolor="#ffff88"]
     n5v1 [label="(n5v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n6v1 [label="(n6v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n7v1 [label="(n7v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n3v1 -> n4v1
     n2v1 -> n5v1
     n1v1 -> n2v1
-    n5v1 -> n6v1
-    n6v1 -> n7v1
-    n7v1 -> n3v1 [color=red]
+    n5v1 -> n3v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
@@ -33,12 +29,5 @@ digraph {
         label = "sg_2v1"
         n3v1
         n4v1
-    }
-    subgraph sg_3v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_3v1"
-        n6v1
     }
 }

--- a/dfir_rs/tests/snapshots/surface_scheduling__nospin_issue_961@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_scheduling__nospin_issue_961@graphvis_mermaid.snap
@@ -13,14 +13,10 @@ linkStyle default stroke:#aaa
 3v1[\"(3v1) <code>defer_tick_lazy()</code>"/]:::pullClass
 4v1[/"(4v1) <code>null()</code>"\]:::pushClass
 5v1["(5v1) <code>handoff</code>"]:::otherClass
-6v1[\"(6v1) <code>identity()</code>"/]:::pullClass
-7v1["(7v1) <code>handoff</code>"]:::otherClass
 3v1-->4v1
 2v1-->5v1
 1v1-->2v1
-5v1-->6v1
-6v1-->7v1
-7v1--o3v1; linkStyle 5 stroke:red
+5v1--o3v1; linkStyle 3 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
     1v1
     2v1
@@ -28,7 +24,4 @@ end
 subgraph sg_2v1 ["sg_2v1"]
     3v1
     4v1
-end
-subgraph sg_3v1 ["sg_3v1"]
-    6v1
 end

--- a/dfir_rs/tests/snapshots/surface_stratum__tick_loop_2@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_stratum__tick_loop_2@graphvis_dot.snap
@@ -14,8 +14,6 @@ digraph {
     n7v1 [label="(n7v1) for_each(|x| output_inner.borrow_mut().push(x))", shape=house, fillcolor="#ffff88"]
     n8v1 [label="(n8v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n9v1 [label="(n9v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n10v1 [label="(n10v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n11v1 [label="(n11v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n1v1 -> n2v1
     n3v1 -> n1v1 [label="0"]
     n6v1 -> n1v1 [label="1"]
@@ -23,10 +21,8 @@ digraph {
     n4v1 -> n8v1
     n2v1 -> n9v1 [label="0"]
     n2v1 -> n7v1 [label="1"]
-    n8v1 -> n10v1
+    n8v1 -> n5v1 [color=red]
     n9v1 -> n4v1 [color=red]
-    n10v1 -> n11v1
-    n11v1 -> n5v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
@@ -49,12 +45,5 @@ digraph {
             n1v1
             n2v1
         }
-    }
-    subgraph sg_3v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_3v1"
-        n10v1
     }
 }

--- a/dfir_rs/tests/snapshots/surface_stratum__tick_loop_2@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_stratum__tick_loop_2@graphvis_mermaid.snap
@@ -17,8 +17,6 @@ linkStyle default stroke:#aaa
 7v1[/"(7v1) <code>for_each(|x| output_inner.borrow_mut().push(x))</code>"\]:::pushClass
 8v1["(8v1) <code>handoff</code>"]:::otherClass
 9v1["(9v1) <code>handoff</code>"]:::otherClass
-10v1[\"(10v1) <code>identity()</code>"/]:::pullClass
-11v1["(11v1) <code>handoff</code>"]:::otherClass
 1v1-->2v1
 3v1-->|0|1v1
 6v1-->|1|1v1
@@ -26,10 +24,8 @@ linkStyle default stroke:#aaa
 4v1-->8v1
 2v1-->|0|9v1
 2v1-->|1|7v1
-8v1-->10v1
+8v1--o5v1; linkStyle 7 stroke:red
 9v1--o4v1; linkStyle 8 stroke:red
-10v1-->11v1
-11v1--o5v1; linkStyle 10 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
     4v1
 end
@@ -42,7 +38,4 @@ subgraph sg_2v1 ["sg_2v1"]
         1v1
         2v1
     end
-end
-subgraph sg_3v1 ["sg_3v1"]
-    10v1
 end

--- a/dfir_rs/tests/snapshots/surface_stratum__tick_loop_3@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_stratum__tick_loop_3@graphvis_dot.snap
@@ -16,10 +16,6 @@ digraph {
     n9v1 [label="(n9v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n10v1 [label="(n10v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n11v1 [label="(n11v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n12v1 [label="(n12v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n13v1 [label="(n13v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n14v1 [label="(n14v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n15v1 [label="(n15v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n1v1 -> n2v1
     n3v1 -> n1v1 [label="0"]
     n7v1 -> n1v1 [label="1"]
@@ -28,13 +24,9 @@ digraph {
     n4v1 -> n10v1
     n2v1 -> n11v1 [label="0"]
     n2v1 -> n8v1 [label="1"]
-    n9v1 -> n12v1
-    n10v1 -> n14v1
+    n9v1 -> n6v1 [color=red]
+    n10v1 -> n5v1 [color=red]
     n11v1 -> n4v1 [color=red]
-    n12v1 -> n13v1
-    n13v1 -> n6v1 [color=red]
-    n14v1 -> n15v1
-    n15v1 -> n5v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
@@ -64,19 +56,5 @@ digraph {
             n1v1
             n2v1
         }
-    }
-    subgraph sg_4v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_4v1"
-        n12v1
-    }
-    subgraph sg_5v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_5v1"
-        n14v1
     }
 }

--- a/dfir_rs/tests/snapshots/surface_stratum__tick_loop_3@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_stratum__tick_loop_3@graphvis_mermaid.snap
@@ -19,10 +19,6 @@ linkStyle default stroke:#aaa
 9v1["(9v1) <code>handoff</code>"]:::otherClass
 10v1["(10v1) <code>handoff</code>"]:::otherClass
 11v1["(11v1) <code>handoff</code>"]:::otherClass
-12v1[\"(12v1) <code>identity()</code>"/]:::pullClass
-13v1["(13v1) <code>handoff</code>"]:::otherClass
-14v1[\"(14v1) <code>identity()</code>"/]:::pullClass
-15v1["(15v1) <code>handoff</code>"]:::otherClass
 1v1-->2v1
 3v1-->|0|1v1
 7v1-->|1|1v1
@@ -31,13 +27,9 @@ linkStyle default stroke:#aaa
 4v1-->10v1
 2v1-->|0|11v1
 2v1-->|1|8v1
-9v1-->12v1
-10v1-->14v1
+9v1--o6v1; linkStyle 8 stroke:red
+10v1--o5v1; linkStyle 9 stroke:red
 11v1--o4v1; linkStyle 10 stroke:red
-12v1-->13v1
-13v1--o6v1; linkStyle 12 stroke:red
-14v1-->15v1
-15v1--o5v1; linkStyle 14 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
     4v1
 end
@@ -53,10 +45,4 @@ subgraph sg_3v1 ["sg_3v1"]
         1v1
         2v1
     end
-end
-subgraph sg_4v1 ["sg_4v1"]
-    12v1
-end
-subgraph sg_5v1 ["sg_5v1"]
-    14v1
 end

--- a/dfir_rs/tests/surface_inline.rs
+++ b/dfir_rs/tests/surface_inline.rs
@@ -518,3 +518,37 @@ pub async fn test_inline_defer_tick_run_available() {
     // Tick 5: [] (32 filtered out, no more data)
     assert_eq!(vec![1, 3, 2, 6, 4, 12, 8, 16], result);
 }
+
+/// Test: mutual defer_tick — two subgraphs each defer_tick to each other.
+/// This tests that the topo sort in as_code handles mutual back-edges without
+/// creating a cycle constraint.
+#[test]
+pub fn test_mutual_defer_tick() {
+    let (tx, mut rx) = dfir_rs::util::unbounded_channel::<(usize, usize)>();
+
+    let mut df = dfir_rs::dfir_syntax! {
+        a = union() -> tee();
+        b = union() -> tee();
+
+        source_iter([(1usize, 0usize)]) -> [0]a;
+        source_iter([(2usize, 0usize)]) -> [0]b;
+
+        a[0] -> defer_tick() -> map(|(id, gen): (usize, usize)| (id, gen + 1)) -> [1]b;
+        b[0] -> defer_tick() -> map(|(id, gen): (usize, usize)| (id, gen + 1)) -> [1]a;
+
+        a[1] -> for_each(|x| tx.send(x).unwrap());
+        b[1] -> for_each(|x| tx.send(x).unwrap());
+    };
+
+    df.run_tick_sync();
+    let mut r = dfir_rs::util::collect_ready::<Vec<_>, _>(&mut rx);
+    r.sort();
+    // Tick 0: a gets (1,0), b gets (2,0)
+    assert_eq!(r, vec![(1, 0), (2, 0)]);
+
+    df.run_tick_sync();
+    let mut r = dfir_rs::util::collect_ready::<Vec<_>, _>(&mut rx);
+    r.sort();
+    // Tick 1: a gets (2,1) from b's defer, b gets (1,1) from a's defer
+    assert_eq!(r, vec![(1, 1), (2, 1)]);
+}

--- a/dfir_rs/tests/surface_inline.rs
+++ b/dfir_rs/tests/surface_inline.rs
@@ -533,8 +533,8 @@ pub fn test_mutual_defer_tick() {
         source_iter([(1usize, 0usize)]) -> [0]a;
         source_iter([(2usize, 0usize)]) -> [0]b;
 
-        a[0] -> defer_tick() -> map(|(id, gen): (usize, usize)| (id, gen + 1)) -> [1]b;
-        b[0] -> defer_tick() -> map(|(id, gen): (usize, usize)| (id, gen + 1)) -> [1]a;
+        a[0] -> defer_tick() -> map(|(id, g): (usize, usize)| (id, g + 1)) -> [1]b;
+        b[0] -> defer_tick() -> map(|(id, g): (usize, usize)| (id, g + 1)) -> [1]a;
 
         a[1] -> for_each(|x| tx.send(x).unwrap());
         b[1] -> for_each(|x| tx.send(x).unwrap());

--- a/hydro_test/src/cluster/snapshots/paxos_ir@proposer_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir@proposer_mermaid.snap
@@ -273,8 +273,6 @@ linkStyle default stroke:#aaa
 263v1["<div style=text-align:center>(263v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
 264v1["<div style=text-align:center>(264v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
 265v1["<div style=text-align:center>(265v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-369v1["<div style=text-align:center>(369v1)</div> <code><br>identity()</code>"]:::otherClass
-371v1["<div style=text-align:center>(371v1)</div> <code><br>identity()</code>"]:::otherClass
 1v1-->2v1
 132v1--x|0|3v1; linkStyle 1 stroke:red
 250v1-->|1|3v1
@@ -424,7 +422,7 @@ linkStyle default stroke:#aaa
 136v1-->137v1
 128v1-->138v1
 138v1-->139v1
-139v1-->369v1
+139v1--o140v1; linkStyle 149 stroke:red
 140v1-->141v1
 141v1-->142v1
 143v1-->144v1
@@ -543,7 +541,7 @@ linkStyle default stroke:#aaa
 238v1--x|0|239v1; linkStyle 265 stroke:red
 216v1-->|1|239v1
 239v1-->240v1
-237v1-->371v1
+237v1--o241v1; linkStyle 268 stroke:red
 235v1-->|pos|242v1
 241v1--x|neg|242v1; linkStyle 270 stroke:red
 242v1-->243v1
@@ -572,8 +570,6 @@ linkStyle default stroke:#aaa
 262v1-->|1|263v1
 264v1-->265v1
 263v1-->264v1
-369v1--o140v1; linkStyle 297 stroke:red
-371v1--o241v1; linkStyle 298 stroke:red
 2v1
 44v1
 45v1
@@ -586,8 +582,6 @@ linkStyle default stroke:#aaa
 254v1
 264v1
 265v1
-369v1
-371v1
 subgraph var_cycle_10 ["var <tt>cycle_10</tt>"]
     style var_cycle_10 fill:transparent
     105v1


### PR DESCRIPTION
STACK #2797

Replace the intermediate identity subgraph injection for defer_tick edges
with double-buffering in the codegen. This eliminates unnecessary graph
nodes and simplifies the generated code.

Adds a test `test_mutual_defer_tick` where two subgraphs each have a
`defer_tick` edge to the other. This panics in `as_code`'s topo sort because
both back-edge handoffs create mutual ordering constraints (A after B, B after A).

This test demonstrates that removing the intermediate identity subgraph
injection from order_subgraphs is not sufficient — the as_code topo sort
needs to handle mutual back-edges without creating cycle constraints

For each back-edge (defer_tick/defer_tick_lazy) handoff, a second "back"
buffer is declared. At the start of each tick, the main buffer and back
buffer are swapped. The consumer drains from the back buffer (last tick's
data) while the producer writes to the main buffer (fresh). This makes
execution order irrelevant for tick-boundary edges, so no ordering
constraint is added to the topo sort — fixing the mutual defer_tick cycle
issue where two subgraphs each defer_tick to each other.

Changes:
- meta_graph.rs (as_code): Back-edge handoffs are excluded from the topo
  sort instead of adding reversed constraints. A second buffer and swap
  code are generated for each back-edge handoff. Recv codegen drains from
  the back buffer for back-edge handoffs.
- flat_to_partitioned.rs: Removed intermediate identity subgraph injection
  and topo sort position map (no longer needed).
- surface_inline.rs: Fixed test to avoid `gen` reserved keyword.
- ~30 snapshot files updated (intermediate subgraphs removed from graphs).