### PR TITLE
fix(dfir_rs): defer `_counter` task spawning via `Context::request_task` buffer

### DIFF
--- a/dfir_lang/src/graph/ops/_counter.rs
+++ b/dfir_lang/src/graph/ops/_counter.rs
@@ -50,6 +50,7 @@ pub const _COUNTER: OperatorConstraints = OperatorConstraints {
     input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                      root,
+                     df_ident,
                      op_span,
                      ident,
                      inputs,
@@ -73,7 +74,7 @@ pub const _COUNTER: OperatorConstraints = OperatorConstraints {
             let #read_ident = ::std::rc::Rc::clone(&#write_ident);
             let #duration_ident = #duration_expr;
             let #tag_ident = #tag_expr;
-            #root::tokio::task::spawn_local(async move {
+            #df_ident.request_task(async move {
                 loop {
                     println!("{}: {}", #tag_ident, #read_ident.get());
                     #root::tokio::time::sleep(#duration_ident).await;

--- a/dfir_rs/src/scheduled/context.rs
+++ b/dfir_rs/src/scheduled/context.rs
@@ -88,7 +88,7 @@ pub struct Context {
     metrics: Rc<DfirMetrics>,
     /// Tasks buffered via [`Self::request_task`], spawned by [`Dfir::spawn_tasks`]
     /// once the runtime is running inside a tokio `LocalSet`.
-    pub(crate) tasks_to_spawn: Vec<Pin<Box<dyn Future<Output = ()> + 'static>>>,
+    tasks_to_spawn: Vec<Pin<Box<dyn Future<Output = ()> + 'static>>>,
 }
 
 impl Context {
@@ -144,9 +144,10 @@ impl Context {
     /// Buffers an async task to be spawned later by [`Dfir::spawn_tasks`].
     ///
     /// Tasks are deferred because `write_prologue` runs during graph construction,
-    /// which may occur before a tokio `LocalSet` is entered. The buffered tasks are
-    /// drained and spawned via `tokio::task::spawn_local` on the first call to
-    /// [`Dfir::run_tick`].
+    /// which may occur before a tokio `LocalSet` is entered. Buffered tasks are
+    /// drained and spawned via `tokio::task::spawn_local` at the start of
+    /// [`Dfir::run_tick`]. Tasks requested after that point remain buffered until
+    /// the next call to [`Dfir::run_tick`].
     pub fn request_task<Fut>(&mut self, future: Fut)
     where
         Fut: Future<Output = ()> + 'static,

--- a/dfir_rs/src/scheduled/context.rs
+++ b/dfir_rs/src/scheduled/context.rs
@@ -86,6 +86,9 @@ pub struct Context {
     wake_state: Arc<WakeState>,
     /// Live-updating DFIR runtime metrics via interior mutability.
     metrics: Rc<DfirMetrics>,
+    /// Tasks buffered via [`Self::request_task`], spawned by [`Dfir::spawn_tasks`]
+    /// once the runtime is running inside a tokio `LocalSet`.
+    pub(crate) tasks_to_spawn: Vec<Pin<Box<dyn Future<Output = ()> + 'static>>>,
 }
 
 impl Context {
@@ -96,6 +99,7 @@ impl Context {
             current_tick: TickInstant::default(),
             wake_state,
             metrics,
+            tasks_to_spawn: Vec::new(),
         }
     }
 
@@ -135,6 +139,19 @@ impl Context {
             (hook_fn)(state.downcast_mut::<T>().unwrap());
         }));
         state_data.lifespan = Some(_lifespan);
+    }
+
+    /// Buffers an async task to be spawned later by [`Dfir::spawn_tasks`].
+    ///
+    /// Tasks are deferred because `write_prologue` runs during graph construction,
+    /// which may occur before a tokio `LocalSet` is entered. The buffered tasks are
+    /// drained and spawned via `tokio::task::spawn_local` on the first call to
+    /// [`Dfir::run_tick`].
+    pub fn request_task<Fut>(&mut self, future: Fut)
+    where
+        Fut: Future<Output = ()> + 'static,
+    {
+        self.tasks_to_spawn.push(Box::pin(future));
     }
 
     // --- Methods called as `context.xxx()` in operator iterators ---
@@ -387,11 +404,21 @@ impl<Tick: TickClosure> Dfir<Tick> {
 }
 
 impl<Tick: TickClosure> Dfir<Tick> {
+    /// Spawns all tasks buffered via [`Context::request_task`].
+    ///
+    /// This drains the buffer, so subsequent calls are no-ops until new tasks are requested.
+    fn spawn_tasks(&mut self) {
+        for task in self.context.tasks_to_spawn.drain(..) {
+            tokio::task::spawn_local(task);
+        }
+    }
+
     /// Run a single tick. Returns `true` if any subgraph received input data.
     ///
     /// Checks both handoff buffers (via `work_done` flag set in generated recv port code)
     /// and external events (via `can_start_tick` set by wakers/schedule_subgraph).
     pub async fn run_tick(&mut self) -> bool {
+        self.spawn_tasks();
         let had_external = self
             .wake_state
             .can_start_tick


### PR DESCRIPTION
This is a temporary fix - we do not want to do things this way in the long run. Ideally, `_counter` (or equivalent) should report to the runtime metrics mechanism instead of hijacking stdout.

The `_counter` operator was calling `tokio::task::spawn_local` directly in `write_prologue`, which runs during graph construction — potentially before a tokio `LocalSet` is entered. This could panic with "spawn_local called from outside of a task::LocalSet".

Reintroduced the deferral buffer pattern from the old scheduled runtime:

- Added `tasks_to_spawn` buffer to `Context` and a `request_task` method that pushes futures into it (matching the old scheduled `Context` API).
- Added `Dfir::spawn_tasks()` which drains the buffer via `tokio::task::spawn_local`, called at the start of each `run_tick()` — guaranteeing tasks are only spawned once the runtime is actually running inside a `LocalSet`.
- Changed `_counter` codegen to use `df.request_task(...)` instead of `tokio::task::spawn_local(...)` directly.