### PR TITLE
refactor(dfir_rs): use slotmap SecondaryMap for metrics

### DIFF
--- a/dfir_lang/Cargo.toml
+++ b/dfir_lang/Cargo.toml
@@ -12,26 +12,36 @@ license = { workspace = true }
 workspace = true
 
 [features]
-default = []
-debugging = [ "dep:data-encoding", "dep:webbrowser", "clap-derive" ]
-clap-derive = [ "dep:clap" ]
+default = ["codegen"]
+codegen = [
+    "dep:auto_impl",
+    "dep:documented",
+    "dep:itertools",
+    "dep:prettyplease",
+    "dep:proc-macro2",
+    "dep:quote",
+    "dep:serde_json",
+    "dep:syn",
+]
+debugging = [ "codegen", "dep:data-encoding", "dep:webbrowser", "clap-derive" ]
+clap-derive = [ "codegen", "dep:clap" ]
 
 [package.metadata.docs.rs]
 all-features = true
 
 [dependencies]
-auto_impl = "1.0.0"
+auto_impl = { version = "1.0.0", optional = true }
 clap = { version = "4.5.4", features = [ "derive" ], optional = true }
 data-encoding = { version = "2.0.0", optional = true }
-documented = "0.9.1"
-itertools = "0.14.0"
-prettyplease = { version = "0.2.0", features = [ "verbatim" ] }
-proc-macro2 = { version = "1.0.95", features = [ "span-locations" ] }
-quote = "1.0.35"
+documented = { version = "0.9.1", optional = true }
+itertools = { version = "0.14.0", optional = true }
+prettyplease = { version = "0.2.0", features = [ "verbatim" ], optional = true }
+proc-macro2 = { version = "1.0.95", features = [ "span-locations" ], optional = true }
+quote = { version = "1.0.35", optional = true }
 serde = "1.0.197"
-serde_json = "1.0.115"
+serde_json = { version = "1.0.115", optional = true }
 slotmap = { version = "1.1.0", features = ["serde"] }
-syn = { version = "2.0.46", features = [ "extra-traits", "full", "parsing", "visit-mut" ] }
+syn = { version = "2.0.46", features = [ "extra-traits", "full", "parsing", "visit-mut" ], optional = true }
 webbrowser = { version = "1.0.3", optional = true }
 
 # coax cargo-smart-release into publishing this crate.

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -850,12 +850,10 @@ impl DfirGraph {
         prefix: TokenStream,
         diagnostics: &mut Diagnostics,
     ) -> Result<TokenStream, Diagnostics> {
-        // Extract the slot index from a slotmap key for use as a runtime metrics key.
-        // Uses the low 32 bits of `KeyData::as_ffi()` (the idx, ignoring the version).
-        // TODO(cleanup): When scheduled Dfir is removed, DfirMetrics could use slotmap
-        // SecondaryMaps directly, eliminating this conversion.
-        fn slotmap_raw_idx(key: impl Key) -> usize {
-            (key.data().as_ffi() & 0xFFFF_FFFF) as usize
+        // Convert a slotmap key to its FFI representation for use in generated code.
+        // The FFI value can reconstruct the key at runtime via `KeyData::from_ffi`.
+        fn slotmap_key_ffi(key: impl Key) -> u64 {
+            key.data().as_ffi()
         }
 
         let df = Ident::new(GRAPH, Span::call_site());
@@ -998,7 +996,7 @@ impl DfirGraph {
         let mut subgraph_blocks = Vec::new();
         {
             for &(subgraph_id, subgraph_nodes) in all_subgraphs.iter() {
-                let sg_metrics_idx = slotmap_raw_idx(subgraph_id);
+                let sg_metrics_ffi = slotmap_key_ffi(subgraph_id);
                 let (recv_hoffs, send_hoffs) = &subgraph_handoffs[subgraph_id];
 
                 // Generate buffer ident helpers for this subgraph's handoffs.
@@ -1029,7 +1027,7 @@ impl DfirGraph {
                     .zip(recv_buf_idents.iter())
                     .zip(recv_hoffs.iter())
                     .map(|((port_ident, buf_ident), &hoff_id)| {
-                        let hoff_idx = slotmap_raw_idx(hoff_id);
+                        let hoff_ffi = slotmap_key_ffi(hoff_id);
                         // Use call_site span for internal identifiers to avoid
                         // hygiene issues when invoked through declarative macros
                         // (e.g. dfir_expect_warnings!). TODO(#2781): define these once.
@@ -1049,7 +1047,7 @@ impl DfirGraph {
                                     #work_done = true;
                                 }
                                 let hoff_metrics = &#metrics.handoffs[
-                                    #root::util::slot_vec::Key::<#root::scheduled::HandoffTag>::from_raw(#hoff_idx)
+                                    #root::slotmap::KeyData::from_ffi(#hoff_ffi).into()
                                 ];
                                 hoff_metrics.total_items_count.update(|x| x + hoff_len);
                                 hoff_metrics.curr_items_count.set(hoff_len);
@@ -1452,10 +1450,10 @@ impl DfirGraph {
                     .iter()
                     .zip(send_buf_idents.iter())
                     .map(|(&hoff_id, buf_ident)| {
-                        let hoff_idx = slotmap_raw_idx(hoff_id);
+                        let hoff_ffi = slotmap_key_ffi(hoff_id);
                         quote! {
                             __dfir_metrics.handoffs[
-                                #root::util::slot_vec::Key::<#root::scheduled::HandoffTag>::from_raw(#hoff_idx)
+                                #root::slotmap::KeyData::from_ffi(#hoff_ffi).into()
                             ].curr_items_count.set(#buf_ident.len());
                         }
                     })
@@ -1471,7 +1469,7 @@ impl DfirGraph {
                     };
                     {
                         let sg_metrics = &__dfir_metrics.subgraphs[
-                            #root::util::slot_vec::Key::<#root::scheduled::SubgraphTag>::from_raw(#sg_metrics_idx)
+                            #root::slotmap::KeyData::from_ffi(#sg_metrics_ffi).into()
                         ];
                         #root::scheduled::metrics::InstrumentSubgraph::new(
                             #sg_fut_ident, sg_metrics
@@ -1510,19 +1508,19 @@ impl DfirGraph {
         // Generate metrics initialization: one entry per handoff and per subgraph.
         let metrics_init_code = {
             let handoff_inits = handoff_nodes.iter().map(|&(node_id, _)| {
-                let idx = slotmap_raw_idx(node_id);
+                let ffi = slotmap_key_ffi(node_id);
                 quote! {
                     dfir_metrics.handoffs.insert(
-                        #root::util::slot_vec::Key::from_raw(#idx),
+                        #root::slotmap::KeyData::from_ffi(#ffi).into(),
                         ::std::default::Default::default(),
                     );
                 }
             });
             let subgraph_inits = all_subgraphs.iter().map(|&(sg_id, _)| {
-                let idx = slotmap_raw_idx(sg_id);
+                let ffi = slotmap_key_ffi(sg_id);
                 quote! {
                     dfir_metrics.subgraphs.insert(
-                        #root::util::slot_vec::Key::from_raw(#idx),
+                        #root::slotmap::KeyData::from_ffi(#ffi).into(),
                         ::std::default::Default::default(),
                     );
                 }

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1416,8 +1416,10 @@ impl DfirGraph {
                             .span()
                             .join(push_ident.span())
                             .unwrap_or_else(|| push_ident.span());
-                        let pivot_fn_ident =
-                            Ident::new(&format!("pivot_run_sg_{:?}", subgraph_id.0), pivot_span);
+                        let pivot_fn_ident = Ident::new(
+                            &format!("pivot_run_sg_{:?}", subgraph_id.data()),
+                            pivot_span,
+                        );
                         let root = change_spans(root.clone(), pivot_span);
                         subgraph_op_iter_code.push(quote_spanned! {pivot_span=>
                             #[inline(always)]

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -850,12 +850,6 @@ impl DfirGraph {
         prefix: TokenStream,
         diagnostics: &mut Diagnostics,
     ) -> Result<TokenStream, Diagnostics> {
-        // Convert a slotmap key to its FFI representation for use in generated code.
-        // The FFI value can reconstruct the key at runtime via `KeyData::from_ffi`.
-        fn slotmap_key_ffi(key: impl Key) -> u64 {
-            key.data().as_ffi()
-        }
-
         let df = Ident::new(GRAPH, Span::call_site());
         let context = Ident::new(CONTEXT, Span::call_site());
 
@@ -996,7 +990,7 @@ impl DfirGraph {
         let mut subgraph_blocks = Vec::new();
         {
             for &(subgraph_id, subgraph_nodes) in all_subgraphs.iter() {
-                let sg_metrics_ffi = slotmap_key_ffi(subgraph_id);
+                let sg_metrics_ffi = subgraph_id.data().as_ffi();
                 let (recv_hoffs, send_hoffs) = &subgraph_handoffs[subgraph_id];
 
                 // Generate buffer ident helpers for this subgraph's handoffs.
@@ -1027,7 +1021,7 @@ impl DfirGraph {
                     .zip(recv_buf_idents.iter())
                     .zip(recv_hoffs.iter())
                     .map(|((port_ident, buf_ident), &hoff_id)| {
-                        let hoff_ffi = slotmap_key_ffi(hoff_id);
+                        let hoff_ffi = hoff_id.data().as_ffi();
                         // Use call_site span for internal identifiers to avoid
                         // hygiene issues when invoked through declarative macros
                         // (e.g. dfir_expect_warnings!). TODO(#2781): define these once.
@@ -1450,7 +1444,7 @@ impl DfirGraph {
                     .iter()
                     .zip(send_buf_idents.iter())
                     .map(|(&hoff_id, buf_ident)| {
-                        let hoff_ffi = slotmap_key_ffi(hoff_id);
+                        let hoff_ffi = hoff_id.data().as_ffi();
                         quote! {
                             __dfir_metrics.handoffs[
                                 #root::slotmap::KeyData::from_ffi(#hoff_ffi).into()
@@ -1508,7 +1502,7 @@ impl DfirGraph {
         // Generate metrics initialization: one entry per handoff and per subgraph.
         let metrics_init_code = {
             let handoff_inits = handoff_nodes.iter().map(|&(node_id, _)| {
-                let ffi = slotmap_key_ffi(node_id);
+                let ffi = node_id.data().as_ffi();
                 quote! {
                     dfir_metrics.handoffs.insert(
                         #root::slotmap::KeyData::from_ffi(#ffi).into(),
@@ -1517,7 +1511,7 @@ impl DfirGraph {
                 }
             });
             let subgraph_inits = all_subgraphs.iter().map(|&(sg_id, _)| {
-                let ffi = slotmap_key_ffi(sg_id);
+                let ffi = sg_id.data().as_ffi();
                 quote! {
                     dfir_metrics.subgraphs.insert(
                         #root::slotmap::KeyData::from_ffi(#ffi).into(),

--- a/dfir_lang/src/graph/mod.rs
+++ b/dfir_lang/src/graph/mod.rs
@@ -6,7 +6,6 @@ use std::hash::Hash;
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::ToTokens;
 use serde::{Deserialize, Serialize};
-use slotmap::new_key_type;
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::{Expr, ExprPath, GenericArgument, Token, Type};
@@ -32,22 +31,10 @@ pub use flat_graph_builder::{FlatGraphBuilder, FlatGraphBuilderOutput};
 pub use flat_to_partitioned::partition_graph;
 pub use meta_graph::{DfirGraph, WriteConfig, WriteGraphType};
 
+pub use crate::graph_ids::{GraphEdgeId, GraphLoopId, GraphNodeId, GraphSubgraphId};
+
 pub mod graph_algorithms;
 pub mod ops;
-
-new_key_type! {
-    /// ID to identify a node (operator or handoff) in [`DfirGraph`].
-    pub struct GraphNodeId;
-
-    /// ID to identify an edge.
-    pub struct GraphEdgeId;
-
-    /// ID to identify a subgraph in [`DfirGraph`].
-    pub struct GraphSubgraphId;
-
-    /// ID to identify a loop block in [`DfirGraph`].
-    pub struct GraphLoopId;
-}
 
 impl GraphSubgraphId {
     /// Generate a deterministic `Ident` for the given subgraph ID.

--- a/dfir_lang/src/graph_ids.rs
+++ b/dfir_lang/src/graph_ids.rs
@@ -1,0 +1,20 @@
+//! Slotmap key types for graph nodes, edges, subgraphs, and loops.
+//!
+//! These are separated so they can be used without pulling in heavy codegen
+//! dependencies (syn, proc-macro2, quote, etc.).
+
+use slotmap::new_key_type;
+
+new_key_type! {
+    /// ID to identify a node (operator or handoff) in `DfirGraph`.
+    pub struct GraphNodeId;
+
+    /// ID to identify an edge.
+    pub struct GraphEdgeId;
+
+    /// ID to identify a subgraph in `DfirGraph`.
+    pub struct GraphSubgraphId;
+
+    /// ID to identify a loop block in `DfirGraph`.
+    pub struct GraphLoopId;
+}

--- a/dfir_lang/src/lib.rs
+++ b/dfir_lang/src/lib.rs
@@ -2,9 +2,18 @@
 
 #![warn(missing_docs)]
 #![cfg_attr(nightly, feature(proc_macro_diagnostic, proc_macro_span))]
+
+pub mod graph_ids;
+
+#[cfg(feature = "codegen")]
 pub mod diagnostic;
+#[cfg(feature = "codegen")]
 pub mod graph;
+#[cfg(feature = "codegen")]
 pub mod parse;
+#[cfg(feature = "codegen")]
 pub mod pretty_span;
+#[cfg(feature = "codegen")]
 pub mod process_singletons;
+#[cfg(feature = "codegen")]
 pub mod union_find;

--- a/dfir_rs/Cargo.toml
+++ b/dfir_rs/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 [features]
 default = [ "macros", "debugging", "meta" ]
 
-meta = [ ]
+meta = [ "dfir_lang/codegen" ]
 macros = [ "dfir_macro" ]
 dfir_macro = [ "dep:dfir_macro" ]
 debugging = [ "dfir_lang/debugging" ]
@@ -28,7 +28,7 @@ name = "kvs_bench"
 [dependencies]
 bincode = "1.3.1"
 bytes = "1.1.0"
-dfir_lang = { path = "../dfir_lang", version = "^0.16.0" }
+dfir_lang = { path = "../dfir_lang", version = "^0.16.0", default-features = false }
 dfir_macro = { optional = true, path = "../dfir_macro", version = "^0.16.0" }
 dfir_pipes = { path = "../dfir_pipes", version = "^0.0.1" }
 futures = "0.3.0"

--- a/dfir_rs/Cargo.toml
+++ b/dfir_rs/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 [features]
 default = [ "macros", "debugging", "meta" ]
 
-meta = [ "dep:dfir_lang" ]
+meta = [ ]
 macros = [ "dfir_macro" ]
 dfir_macro = [ "dep:dfir_macro" ]
 debugging = [ "dfir_lang/debugging" ]
@@ -28,7 +28,7 @@ name = "kvs_bench"
 [dependencies]
 bincode = "1.3.1"
 bytes = "1.1.0"
-dfir_lang = { path = "../dfir_lang", version = "^0.16.0", optional = true }
+dfir_lang = { path = "../dfir_lang", version = "^0.16.0" }
 dfir_macro = { optional = true, path = "../dfir_macro", version = "^0.16.0" }
 dfir_pipes = { path = "../dfir_pipes", version = "^0.0.1" }
 futures = "0.3.0"

--- a/dfir_rs/src/lib.rs
+++ b/dfir_rs/src/lib.rs
@@ -27,7 +27,9 @@ pub use ::{
 #[cfg(feature = "meta")]
 #[cfg_attr(docsrs, doc(cfg(feature = "meta")))]
 pub use dfir_lang as lang;
+pub use dfir_lang;
 pub use dfir_pipes::itertools;
+pub use slotmap;
 pub use variadics::{self, var_args, var_expr, var_type};
 
 /// `#[macro_use]` automagically brings the declarative macro export to the crate-level.

--- a/dfir_rs/src/scheduled/metrics.rs
+++ b/dfir_rs/src/scheduled/metrics.rs
@@ -5,11 +5,10 @@ use std::pin::Pin;
 use std::rc::Rc;
 use std::task::{Context, Poll};
 
+use dfir_lang::graph::{GraphNodeId, GraphSubgraphId};
 use pin_project_lite::pin_project;
+use slotmap::SecondaryMap;
 use web_time::{Duration, Instant};
-
-use super::{HandoffTag, SubgraphTag};
-use crate::util::slot_vec::SecondarySlotVec;
 
 /// Metrics for a [`Dfir`](super::context::Dfir) graph instance.
 ///
@@ -20,9 +19,9 @@ use crate::util::slot_vec::SecondarySlotVec;
 #[non_exhaustive]
 pub struct DfirMetrics {
     /// Per-subgraph metrics.
-    pub subgraphs: SecondarySlotVec<SubgraphTag, SubgraphMetrics>,
+    pub subgraphs: SecondaryMap<GraphSubgraphId, SubgraphMetrics>,
     /// Per-handoff metrics.
-    pub handoffs: SecondarySlotVec<HandoffTag, HandoffMetrics>,
+    pub handoffs: SecondaryMap<GraphNodeId, HandoffMetrics>,
 }
 
 impl DfirMetrics {
@@ -222,13 +221,18 @@ where
 
 #[cfg(test)]
 mod test {
+    use dfir_lang::graph::{GraphNodeId, GraphSubgraphId};
+    use slotmap::SlotMap;
+
     use super::*;
-    use crate::scheduled::{HandoffId, SubgraphId};
 
     #[test]
     fn test_dfir_metrics_intervals() {
-        let sg_id = SubgraphId::from_raw(0);
-        let handoff_id = HandoffId::from_raw(0);
+        // Create slotmaps to generate valid keys.
+        let mut sg_map: SlotMap<GraphSubgraphId, ()> = SlotMap::with_key();
+        let mut node_map: SlotMap<GraphNodeId, ()> = SlotMap::with_key();
+        let sg_id = sg_map.insert(());
+        let handoff_id = node_map.insert(());
 
         let mut metrics = DfirMetrics::default();
         metrics.subgraphs.insert(

--- a/dfir_rs/src/scheduled/metrics.rs
+++ b/dfir_rs/src/scheduled/metrics.rs
@@ -5,7 +5,7 @@ use std::pin::Pin;
 use std::rc::Rc;
 use std::task::{Context, Poll};
 
-use dfir_lang::graph::{GraphNodeId, GraphSubgraphId};
+use dfir_lang::graph_ids::{GraphNodeId, GraphSubgraphId};
 use pin_project_lite::pin_project;
 use slotmap::SecondaryMap;
 use web_time::{Duration, Instant};
@@ -221,7 +221,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use dfir_lang::graph::{GraphNodeId, GraphSubgraphId};
+    use dfir_lang::graph_ids::{GraphNodeId, GraphSubgraphId};
     use slotmap::SlotMap;
 
     use super::*;

--- a/dfir_rs/src/scheduled/mod.rs
+++ b/dfir_rs/src/scheduled/mod.rs
@@ -10,13 +10,8 @@ pub mod ticks;
 
 /// Tag for [`SubgraphId`].
 pub enum SubgraphTag {}
-/// A subgraph's ID. Used as a key for metrics tracking.
+/// A subgraph's ID.
 pub type SubgraphId = Key<SubgraphTag>;
-
-/// Tag for [`HandoffId`].
-pub enum HandoffTag {}
-/// A handoff's ID. Used as a key for metrics tracking.
-pub type HandoffId = Key<HandoffTag>;
 
 /// Tag for [`LoopId`].
 pub enum LoopTag {}

--- a/hydro_lang/src/telemetry/emf.rs
+++ b/hydro_lang/src/telemetry/emf.rs
@@ -184,7 +184,7 @@ where
                 ]
             },
             "LocationName": location_name,
-            "HandoffId": hoff_id.to_string(),
+            "HandoffId": format!("{:?}", hoff_id),
             "CurrItemsCount": hoff_metrics.curr_items_count(),
             "TotalItemsCount": hoff_metrics.total_items_count(),
         })
@@ -213,7 +213,7 @@ where
                 ]
             },
             "LocationName": location_name,
-            "SubgraphId": sg_id.to_string(),
+            "SubgraphId": format!("{:?}", sg_id),
             "TotalRunCount": sg_metrics.total_run_count(),
             "TotalPollDuration": sg_metrics.total_poll_duration().as_micros(),
             "TotalPollCount": sg_metrics.total_poll_count(),


### PR DESCRIPTION
STACK #2801

Replace custom `SecondarySlotVec<SubgraphTag, _>` and
`SecondarySlotVec<HandoffTag, _>` in DfirMetrics with
`slotmap::SecondaryMap<GraphSubgraphId, _>` and
`SecondaryMap<GraphNodeId, _>` from dfir_lang.

This eliminates the `slotmap_raw_idx` conversion hack in codegen —
keys are now reconstructed via `slotmap::KeyData::from_ffi()` which
preserves the full key (including version), not just the raw index.

Make `dfir_lang` a non-optional dependency of `dfir_rs` (it was already
always compiled via `dfir_macro`). Re-export `dfir_lang` and `slotmap`
from `dfir_rs` for use in generated code.

Update `hydro_lang/src/telemetry/emf.rs` to use `Debug` formatting for
slotmap keys instead of `Display`.