### PR TITLE
refactor(dfir_rs,dfir_lang): remove `schedule_subgraph`'s `SubgraphId` arg, no-op calls, and remove `current_subgraph`

### DIFF
--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1578,13 +1578,9 @@ impl DfirGraph {
                     #( #subgraph_blocks )*
 
                     // For non-lazy defer_tick: if any deferred buffer has data,
-                    // signal that another tick should run (sets can_start_tick).
-                    // Inline DFIR doesn't dynamically schedule subgraph IDs, so the
-                    // subgraph ID here is a meaningless placeholder.
+                    // signal that another tick should run.
                     if false #( || !#defer_tick_buf_idents.is_empty() )* {
-                        #df.schedule_subgraph(
-                            true,
-                        );
+                        #df.schedule_subgraph(true);
                     }
 
                     // End-of-tick state reset (e.g. 'tick persistence).

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1581,10 +1581,8 @@ impl DfirGraph {
                     // signal that another tick should run (sets can_start_tick).
                     // Inline DFIR doesn't dynamically schedule subgraph IDs, so the
                     // subgraph ID here is a meaningless placeholder.
-                    // TODO(cleanup): remove the subgraph ID parameter once scheduled DFIR is gone.
                     if false #( || !#defer_tick_buf_idents.is_empty() )* {
                         #df.schedule_subgraph(
-                            #root::scheduled::SubgraphId::from_raw(0),
                             true,
                         );
                     }

--- a/dfir_lang/src/graph/ops/cross_join_multiset.rs
+++ b/dfir_lang/src/graph/ops/cross_join_multiset.rs
@@ -112,7 +112,7 @@ pub const CROSS_JOIN_MULTISET: OperatorConstraints = OperatorConstraints {
         .then(|| {
             quote_spanned! {op_span=>
                 // Reschedule the subgraph lazily to ensure replay on later ticks.
-                #context.schedule_subgraph(#context.current_subgraph(), false);
+                #context.schedule_subgraph(false);
             }
         });
         let write_iterator_after = quote_spanned! {op_span=>

--- a/dfir_lang/src/graph/ops/cross_join_multiset.rs
+++ b/dfir_lang/src/graph/ops/cross_join_multiset.rs
@@ -112,7 +112,7 @@ pub const CROSS_JOIN_MULTISET: OperatorConstraints = OperatorConstraints {
         .then(|| {
             quote_spanned! {op_span=>
                 // Reschedule the subgraph lazily to ensure replay on later ticks.
-                #context.schedule_subgraph(false);
+                
             }
         });
         let write_iterator_after = quote_spanned! {op_span=>

--- a/dfir_lang/src/graph/ops/fold.rs
+++ b/dfir_lang/src/graph/ops/fold.rs
@@ -141,7 +141,7 @@ pub const FOLD: OperatorConstraints = OperatorConstraints {
 
         let write_iterator_after = if let Persistence::Static | Persistence::Tick = persistence {
             quote_spanned! {op_span=>
-                #context.schedule_subgraph(#context.current_subgraph(), false);
+                #context.schedule_subgraph(false);
             }
         } else {
             Default::default()

--- a/dfir_lang/src/graph/ops/fold.rs
+++ b/dfir_lang/src/graph/ops/fold.rs
@@ -50,7 +50,6 @@ pub const FOLD: OperatorConstraints = OperatorConstraints {
     input_delaytype_fn: |_| Some(DelayType::Stratum),
     write_fn: |wc @ &WriteContextArgs {
                    root,
-                   context,
                    op_span,
                    work_fn,
                    work_fn_async,
@@ -139,18 +138,9 @@ pub const FOLD: OperatorConstraints = OperatorConstraints {
             }
         };
 
-        let write_iterator_after = if let Persistence::Static | Persistence::Tick = persistence {
-            quote_spanned! {op_span=>
-                
-            }
-        } else {
-            Default::default()
-        };
-
         Ok(OperatorWriteOutput {
             write_prologue,
             write_iterator,
-            write_iterator_after,
             write_tick_end,
             ..Default::default()
         })

--- a/dfir_lang/src/graph/ops/fold.rs
+++ b/dfir_lang/src/graph/ops/fold.rs
@@ -141,7 +141,7 @@ pub const FOLD: OperatorConstraints = OperatorConstraints {
 
         let write_iterator_after = if let Persistence::Static | Persistence::Tick = persistence {
             quote_spanned! {op_span=>
-                #context.schedule_subgraph(false);
+                
             }
         } else {
             Default::default()

--- a/dfir_lang/src/graph/ops/fold_keyed.rs
+++ b/dfir_lang/src/graph/ops/fold_keyed.rs
@@ -262,7 +262,7 @@ pub const FOLD_KEYED: OperatorConstraints = OperatorConstraints {
             Persistence::None | Persistence::Tick | Persistence::Loop => Default::default(),
             Persistence::Static | Persistence::Mutable => quote_spanned! {op_span=>
                 // Reschedule the subgraph lazily to ensure replay on later ticks.
-                #context.schedule_subgraph(#context.current_subgraph(), false);
+                #context.schedule_subgraph(false);
             },
         };
 

--- a/dfir_lang/src/graph/ops/fold_keyed.rs
+++ b/dfir_lang/src/graph/ops/fold_keyed.rs
@@ -258,18 +258,9 @@ pub const FOLD_KEYED: OperatorConstraints = OperatorConstraints {
             }
         };
 
-        let write_iterator_after = match persistence {
-            Persistence::None | Persistence::Tick | Persistence::Loop => Default::default(),
-            Persistence::Static | Persistence::Mutable => quote_spanned! {op_span=>
-                // Reschedule the subgraph lazily to ensure replay on later ticks.
-                
-            },
-        };
-
         Ok(OperatorWriteOutput {
             write_prologue,
             write_iterator,
-            write_iterator_after,
             write_tick_end,
             ..Default::default()
         })

--- a/dfir_lang/src/graph/ops/fold_keyed.rs
+++ b/dfir_lang/src/graph/ops/fold_keyed.rs
@@ -262,7 +262,7 @@ pub const FOLD_KEYED: OperatorConstraints = OperatorConstraints {
             Persistence::None | Persistence::Tick | Persistence::Loop => Default::default(),
             Persistence::Static | Persistence::Mutable => quote_spanned! {op_span=>
                 // Reschedule the subgraph lazily to ensure replay on later ticks.
-                #context.schedule_subgraph(false);
+                
             },
         };
 

--- a/dfir_lang/src/graph/ops/join.rs
+++ b/dfir_lang/src/graph/ops/join.rs
@@ -214,7 +214,7 @@ pub const JOIN: OperatorConstraints = OperatorConstraints {
             if persistences[0] == Persistence::Static || persistences[1] == Persistence::Static {
                 quote_spanned! {op_span=>
                     // TODO: Probably only need to schedule if #*_borrow.len() > 0?
-                    #context.schedule_subgraph(#context.current_subgraph(), false);
+                    #context.schedule_subgraph(false);
                 }
             } else {
                 quote_spanned! {op_span=>}

--- a/dfir_lang/src/graph/ops/join.rs
+++ b/dfir_lang/src/graph/ops/join.rs
@@ -214,7 +214,7 @@ pub const JOIN: OperatorConstraints = OperatorConstraints {
             if persistences[0] == Persistence::Static || persistences[1] == Persistence::Static {
                 quote_spanned! {op_span=>
                     // TODO: Probably only need to schedule if #*_borrow.len() > 0?
-                    #context.schedule_subgraph(false);
+                    
                 }
             } else {
                 quote_spanned! {op_span=>}

--- a/dfir_lang/src/graph/ops/join.rs
+++ b/dfir_lang/src/graph/ops/join.rs
@@ -210,23 +210,12 @@ pub const JOIN: OperatorConstraints = OperatorConstraints {
             };
         };
 
-        let write_iterator_after =
-            if persistences[0] == Persistence::Static || persistences[1] == Persistence::Static {
-                quote_spanned! {op_span=>
-                    // TODO: Probably only need to schedule if #*_borrow.len() > 0?
-                    
-                }
-            } else {
-                quote_spanned! {op_span=>}
-            };
-
         Ok(OperatorWriteOutput {
             write_prologue: quote_spanned! {op_span=>
                 #lhs_prologue
                 #rhs_prologue
             },
             write_iterator,
-            write_iterator_after,
             write_tick_end: quote_spanned! {op_span=>
                 #lhs_tick_end
                 #rhs_tick_end

--- a/dfir_lang/src/graph/ops/join_fused.rs
+++ b/dfir_lang/src/graph/ops/join_fused.rs
@@ -174,7 +174,7 @@ pub const JOIN_FUSED: OperatorConstraints = OperatorConstraints {
             if persistences[0] == Persistence::Static || persistences[1] == Persistence::Static {
                 quote_spanned! {op_span=>
                     // TODO: Probably only need to schedule if #*_borrow.len() > 0?
-                    #context.schedule_subgraph(false);
+                    
                 }
             } else {
                 quote_spanned! {op_span=>}

--- a/dfir_lang/src/graph/ops/join_fused.rs
+++ b/dfir_lang/src/graph/ops/join_fused.rs
@@ -113,7 +113,6 @@ pub const JOIN_FUSED: OperatorConstraints = OperatorConstraints {
     input_delaytype_fn: |_| Some(DelayType::Stratum),
     write_fn: |wc @ &WriteContextArgs {
                    root,
-                   context,
                    op_span,
                    work_fn_async,
                    ident,
@@ -170,23 +169,12 @@ pub const JOIN_FUSED: OperatorConstraints = OperatorConstraints {
             };
         };
 
-        let write_iterator_after =
-            if persistences[0] == Persistence::Static || persistences[1] == Persistence::Static {
-                quote_spanned! {op_span=>
-                    // TODO: Probably only need to schedule if #*_borrow.len() > 0?
-                    
-                }
-            } else {
-                quote_spanned! {op_span=>}
-            };
-
         Ok(OperatorWriteOutput {
             write_prologue: quote_spanned! {op_span=>
                 #lhs_prologue
                 #rhs_prologue
             },
             write_iterator,
-            write_iterator_after,
             write_tick_end: quote_spanned! {op_span=>
                 #lhs_tick_end
                 #rhs_tick_end

--- a/dfir_lang/src/graph/ops/join_fused.rs
+++ b/dfir_lang/src/graph/ops/join_fused.rs
@@ -174,7 +174,7 @@ pub const JOIN_FUSED: OperatorConstraints = OperatorConstraints {
             if persistences[0] == Persistence::Static || persistences[1] == Persistence::Static {
                 quote_spanned! {op_span=>
                     // TODO: Probably only need to schedule if #*_borrow.len() > 0?
-                    #context.schedule_subgraph(#context.current_subgraph(), false);
+                    #context.schedule_subgraph(false);
                 }
             } else {
                 quote_spanned! {op_span=>}

--- a/dfir_lang/src/graph/ops/join_fused_lhs.rs
+++ b/dfir_lang/src/graph/ops/join_fused_lhs.rs
@@ -131,7 +131,7 @@ pub const JOIN_FUSED_LHS: OperatorConstraints = OperatorConstraints {
             if persistences[0] == Persistence::Static || persistences[1] == Persistence::Static {
                 quote_spanned! {op_span=>
                     // TODO: Probably only need to schedule if #*_borrow.len() > 0?
-                    #context.schedule_subgraph(#context.current_subgraph(), false);
+                    #context.schedule_subgraph(false);
                 }
             } else {
                 quote_spanned! {op_span=>}

--- a/dfir_lang/src/graph/ops/join_fused_lhs.rs
+++ b/dfir_lang/src/graph/ops/join_fused_lhs.rs
@@ -127,23 +127,12 @@ pub const JOIN_FUSED_LHS: OperatorConstraints = OperatorConstraints {
             Persistence::Mutable => unreachable!(),
         };
 
-        let write_iterator_after =
-            if persistences[0] == Persistence::Static || persistences[1] == Persistence::Static {
-                quote_spanned! {op_span=>
-                    // TODO: Probably only need to schedule if #*_borrow.len() > 0?
-                    
-                }
-            } else {
-                quote_spanned! {op_span=>}
-            };
-
         Ok(OperatorWriteOutput {
             write_prologue: quote_spanned! {op_span=>
                 #lhs_prologue
                 #rhs_prologue
             },
             write_iterator,
-            write_iterator_after,
             write_tick_end: lhs_tick_end,
             ..Default::default()
         })

--- a/dfir_lang/src/graph/ops/join_fused_lhs.rs
+++ b/dfir_lang/src/graph/ops/join_fused_lhs.rs
@@ -131,7 +131,7 @@ pub const JOIN_FUSED_LHS: OperatorConstraints = OperatorConstraints {
             if persistences[0] == Persistence::Static || persistences[1] == Persistence::Static {
                 quote_spanned! {op_span=>
                     // TODO: Probably only need to schedule if #*_borrow.len() > 0?
-                    #context.schedule_subgraph(false);
+                    
                 }
             } else {
                 quote_spanned! {op_span=>}

--- a/dfir_lang/src/graph/ops/persist.rs
+++ b/dfir_lang/src/graph/ops/persist.rs
@@ -135,7 +135,7 @@ pub const PERSIST: OperatorConstraints = OperatorConstraints {
         };
 
         let write_iterator_after = quote_spanned! {op_span=>
-            #context.schedule_subgraph(false);
+            
         };
 
         Ok(OperatorWriteOutput {

--- a/dfir_lang/src/graph/ops/persist.rs
+++ b/dfir_lang/src/graph/ops/persist.rs
@@ -135,7 +135,7 @@ pub const PERSIST: OperatorConstraints = OperatorConstraints {
         };
 
         let write_iterator_after = quote_spanned! {op_span=>
-            #context.schedule_subgraph(#context.current_subgraph(), false);
+            #context.schedule_subgraph(false);
         };
 
         Ok(OperatorWriteOutput {

--- a/dfir_lang/src/graph/ops/persist.rs
+++ b/dfir_lang/src/graph/ops/persist.rs
@@ -134,14 +134,9 @@ pub const PERSIST: OperatorConstraints = OperatorConstraints {
             }
         };
 
-        let write_iterator_after = quote_spanned! {op_span=>
-            
-        };
-
         Ok(OperatorWriteOutput {
             write_prologue,
             write_iterator,
-            write_iterator_after,
             ..Default::default()
         })
     },

--- a/dfir_lang/src/graph/ops/persist_mut.rs
+++ b/dfir_lang/src/graph/ops/persist_mut.rs
@@ -114,7 +114,7 @@ pub const PERSIST_MUT: OperatorConstraints = OperatorConstraints {
         };
 
         let write_iterator_after = quote_spanned! {op_span=>
-            #context.schedule_subgraph(#context.current_subgraph(), false);
+            #context.schedule_subgraph(false);
         };
 
         Ok(OperatorWriteOutput {

--- a/dfir_lang/src/graph/ops/persist_mut.rs
+++ b/dfir_lang/src/graph/ops/persist_mut.rs
@@ -114,7 +114,7 @@ pub const PERSIST_MUT: OperatorConstraints = OperatorConstraints {
         };
 
         let write_iterator_after = quote_spanned! {op_span=>
-            #context.schedule_subgraph(false);
+            
         };
 
         Ok(OperatorWriteOutput {

--- a/dfir_lang/src/graph/ops/persist_mut.rs
+++ b/dfir_lang/src/graph/ops/persist_mut.rs
@@ -113,14 +113,9 @@ pub const PERSIST_MUT: OperatorConstraints = OperatorConstraints {
             }
         };
 
-        let write_iterator_after = quote_spanned! {op_span=>
-            
-        };
-
         Ok(OperatorWriteOutput {
             write_prologue,
             write_iterator,
-            write_iterator_after,
             ..Default::default()
         })
     },

--- a/dfir_lang/src/graph/ops/persist_mut_keyed.rs
+++ b/dfir_lang/src/graph/ops/persist_mut_keyed.rs
@@ -127,7 +127,7 @@ pub const PERSIST_MUT_KEYED: OperatorConstraints = OperatorConstraints {
         };
 
         let write_iterator_after = quote_spanned! {op_span=>
-            #context.schedule_subgraph(false);
+            
         };
 
         Ok(OperatorWriteOutput {

--- a/dfir_lang/src/graph/ops/persist_mut_keyed.rs
+++ b/dfir_lang/src/graph/ops/persist_mut_keyed.rs
@@ -127,7 +127,7 @@ pub const PERSIST_MUT_KEYED: OperatorConstraints = OperatorConstraints {
         };
 
         let write_iterator_after = quote_spanned! {op_span=>
-            #context.schedule_subgraph(#context.current_subgraph(), false);
+            #context.schedule_subgraph(false);
         };
 
         Ok(OperatorWriteOutput {

--- a/dfir_lang/src/graph/ops/persist_mut_keyed.rs
+++ b/dfir_lang/src/graph/ops/persist_mut_keyed.rs
@@ -126,14 +126,9 @@ pub const PERSIST_MUT_KEYED: OperatorConstraints = OperatorConstraints {
             }
         };
 
-        let write_iterator_after = quote_spanned! {op_span=>
-            
-        };
-
         Ok(OperatorWriteOutput {
             write_prologue,
             write_iterator,
-            write_iterator_after,
             ..Default::default()
         })
     },

--- a/dfir_lang/src/graph/ops/reduce.rs
+++ b/dfir_lang/src/graph/ops/reduce.rs
@@ -131,7 +131,7 @@ pub const REDUCE: OperatorConstraints = OperatorConstraints {
 
         let write_iterator_after = if Persistence::Static == persistence {
             quote_spanned! {op_span=>
-                #context.schedule_subgraph(false);
+                
             }
         } else {
             Default::default()

--- a/dfir_lang/src/graph/ops/reduce.rs
+++ b/dfir_lang/src/graph/ops/reduce.rs
@@ -48,7 +48,6 @@ pub const REDUCE: OperatorConstraints = OperatorConstraints {
     input_delaytype_fn: |_| Some(DelayType::Stratum),
     write_fn: |wc @ &WriteContextArgs {
                    root,
-                   context,
                    op_span,
                    work_fn,
                    work_fn_async,
@@ -129,18 +128,9 @@ pub const REDUCE: OperatorConstraints = OperatorConstraints {
             }
         };
 
-        let write_iterator_after = if Persistence::Static == persistence {
-            quote_spanned! {op_span=>
-                
-            }
-        } else {
-            Default::default()
-        };
-
         Ok(OperatorWriteOutput {
             write_prologue,
             write_iterator,
-            write_iterator_after,
             write_tick_end,
             ..Default::default()
         })

--- a/dfir_lang/src/graph/ops/reduce.rs
+++ b/dfir_lang/src/graph/ops/reduce.rs
@@ -131,7 +131,7 @@ pub const REDUCE: OperatorConstraints = OperatorConstraints {
 
         let write_iterator_after = if Persistence::Static == persistence {
             quote_spanned! {op_span=>
-                #context.schedule_subgraph(#context.current_subgraph(), false);
+                #context.schedule_subgraph(false);
             }
         } else {
             Default::default()

--- a/dfir_lang/src/graph/ops/reduce_keyed.rs
+++ b/dfir_lang/src/graph/ops/reduce_keyed.rs
@@ -193,18 +193,9 @@ pub const REDUCE_KEYED: OperatorConstraints = OperatorConstraints {
             }
         };
 
-        let write_iterator_after = match persistence {
-            Persistence::None | Persistence::Tick | Persistence::Loop => Default::default(),
-            Persistence::Static | Persistence::Mutable => quote_spanned! {op_span=>
-                // Reschedule the subgraph lazily to ensure replay on later ticks.
-                
-            },
-        };
-
         Ok(OperatorWriteOutput {
             write_prologue,
             write_iterator,
-            write_iterator_after,
             write_tick_end,
             ..Default::default()
         })

--- a/dfir_lang/src/graph/ops/reduce_keyed.rs
+++ b/dfir_lang/src/graph/ops/reduce_keyed.rs
@@ -197,7 +197,7 @@ pub const REDUCE_KEYED: OperatorConstraints = OperatorConstraints {
             Persistence::None | Persistence::Tick | Persistence::Loop => Default::default(),
             Persistence::Static | Persistence::Mutable => quote_spanned! {op_span=>
                 // Reschedule the subgraph lazily to ensure replay on later ticks.
-                #context.schedule_subgraph(#context.current_subgraph(), false);
+                #context.schedule_subgraph(false);
             },
         };
 

--- a/dfir_lang/src/graph/ops/reduce_keyed.rs
+++ b/dfir_lang/src/graph/ops/reduce_keyed.rs
@@ -197,7 +197,7 @@ pub const REDUCE_KEYED: OperatorConstraints = OperatorConstraints {
             Persistence::None | Persistence::Tick | Persistence::Loop => Default::default(),
             Persistence::Static | Persistence::Mutable => quote_spanned! {op_span=>
                 // Reschedule the subgraph lazily to ensure replay on later ticks.
-                #context.schedule_subgraph(false);
+                
             },
         };
 

--- a/dfir_lang/src/graph/ops/spin.rs
+++ b/dfir_lang/src/graph/ops/spin.rs
@@ -46,7 +46,7 @@ pub const SPIN: OperatorConstraints = OperatorConstraints {
             let #ident = #root::dfir_pipes::pull::once(());
         };
         let write_iterator_after = quote_spanned! {op_span=>
-            #context.schedule_subgraph(#context.current_subgraph(), true);
+            #context.schedule_subgraph(true);
         };
         Ok(OperatorWriteOutput {
             write_iterator,

--- a/dfir_rs/src/scheduled/context.rs
+++ b/dfir_rs/src/scheduled/context.rs
@@ -20,7 +20,7 @@ use dfir_lang::graph::DfirGraph;
 
 use super::metrics::{DfirMetrics, DfirMetricsIntervals};
 use super::state::StateHandle;
-use super::{StateLifespan, StateTag, SubgraphId};
+use super::{StateLifespan, StateTag};
 use crate::scheduled::ticks::TickInstant;
 use crate::util::slot_vec::SlotVec;
 
@@ -192,15 +192,8 @@ impl Context {
         &self.metrics
     }
 
-    /// No-op: inline mode has no subgraph scheduling.
-    pub fn current_subgraph(&self) -> SubgraphId {
-        SubgraphId::from_raw(0)
-    }
-
-    /// In inline mode, every subgraph runs unconditionally each tick, so the `sg_id`
-    /// parameter is ignored. Only `is_external` matters: when `true`, it signals that
-    /// external data has arrived and a new tick should be started.
-    pub fn schedule_subgraph(&self, _sg_id: SubgraphId, is_external: bool) {
+    /// Signals that external data has arrived and a new tick should be started.
+    pub fn schedule_subgraph(&self, is_external: bool) {
         if is_external {
             self.wake_state.wake_by_ref();
         }


### PR DESCRIPTION
STACK: #2801

Remove the unused `sg_id: SubgraphId` parameter from
`Context::schedule_subgraph` — inline mode ignores it. Remove
`Context::current_subgraph` which always returned a dummy value.

Update all operator codegen call sites to drop the
`#context.current_subgraph()` argument.