### PR TITLE
fix(hydro_lang): sim scheduler no longer terminates on quiescence

### DIFF
--- a/hydro_lang/src/sim/compiled.rs
+++ b/hydro_lang/src/sim/compiled.rs
@@ -18,8 +18,8 @@ use libloading::Library;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use tempfile::TempPath;
-use tokio::sync::{Mutex, Notify};
 use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::{Mutex, Notify};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
 use super::runtime::{Hooks, InlineHooks};

--- a/hydro_lang/src/sim/compiled.rs
+++ b/hydro_lang/src/sim/compiled.rs
@@ -30,6 +30,41 @@ use crate::location::dynamic::LocationId;
 use crate::sim::graph::{SimExternalPort, SimExternalPortRegistry};
 use crate::sim::runtime::SimHook;
 
+struct QuiescenceState {
+    /// Set to true when the scheduler reaches quiescence; reset to false when new input is sent.
+    quiescent: Cell<bool>,
+    /// Notified when the scheduler reaches quiescence (wakes receivers waiting for data).
+    quiescence_notify: Notify,
+    /// Notified when new input is sent, signaling the scheduler to resume.
+    resume_notify: Notify,
+}
+
+impl QuiescenceState {
+    /// Signal that new input has been sent, waking the scheduler if it was quiescent.
+    fn resume(&self) {
+        self.quiescent.set(false);
+        self.resume_notify.notify_waiters();
+    }
+
+    /// Whether the scheduler is currently quiescent (no more progress possible without input).
+    fn is_quiescent(&self) -> bool {
+        self.quiescent.get()
+    }
+
+    /// Returns a future that completes when the scheduler next reaches quiescence.
+    fn notified(&self) -> tokio::sync::futures::Notified<'_> {
+        self.quiescence_notify.notified()
+    }
+
+    /// Enter quiescence and wait for new input before continuing.
+    async fn wait_for_resume(&self) {
+        self.quiescent.set(true);
+        self.quiescence_notify.notify_waiters();
+        self.resume_notify.notified().await;
+        self.quiescent.set(false);
+    }
+}
+
 struct SimConnections {
     input_senders: HashMap<SimExternalPort, Rc<UnboundedSender<Bytes>>>,
     output_receivers: HashMap<SimExternalPort, Rc<Mutex<UnboundedReceiverStream<Bytes>>>>,
@@ -37,9 +72,7 @@ struct SimConnections {
     cluster_output_receivers:
         HashMap<SimExternalPort, Vec<Rc<Mutex<UnboundedReceiverStream<Bytes>>>>>,
     external_registered: HashMap<ExternalPortId, SimExternalPort>,
-    quiescent: Rc<Cell<bool>>,
-    quiescence_notify: Rc<Notify>,
-    resume_notify: Rc<Notify>,
+    quiescence: Rc<QuiescenceState>,
 }
 
 tokio::task_local! {
@@ -392,9 +425,11 @@ impl<'a> CompiledSimInstance<'a> {
 
         let registered = &self.externals_port_registry.registered;
 
-        let quiescent = Rc::new(Cell::new(false));
-        let quiescence_notify = Rc::new(Notify::new());
-        let resume_notify = Rc::new(Notify::new());
+        let quiescence = Rc::new(QuiescenceState {
+            quiescent: Cell::new(false),
+            quiescence_notify: Notify::new(),
+            resume_notify: Notify::new(),
+        });
 
         let mut input_senders = HashMap::new();
         let mut output_receivers = HashMap::new();
@@ -438,9 +473,7 @@ impl<'a> CompiledSimInstance<'a> {
                     cluster_input_senders,
                     cluster_output_receivers,
                     external_registered: self.externals_port_registry.registered.clone(),
-                    quiescent: quiescent.clone(),
-                    quiescence_notify: quiescence_notify.clone(),
-                    resume_notify: resume_notify.clone(),
+                    quiescence: quiescence.clone(),
                 }),
                 async move {
                     thunk(self).await;
@@ -475,15 +508,10 @@ impl<'a> CompiledSimInstance<'a> {
             .map(|(lid, c_id, _)| (serde_json::from_str(lid).unwrap(), *c_id))
             .collect();
 
-        let (quiescent, quiescence_notify, resume_notify) =
-            CURRENT_SIM_CONNECTIONS.with(|connections| {
-                let connections = connections.borrow();
-                (
-                    connections.quiescent.clone(),
-                    connections.quiescence_notify.clone(),
-                    connections.resume_notify.clone(),
-                )
-            });
+        let quiescence = CURRENT_SIM_CONNECTIONS.with(|connections| {
+            let connections = connections.borrow();
+            connections.quiescence.clone()
+        });
 
         let mut launched = LaunchedSim {
             async_dfirs: async_dfirs
@@ -514,9 +542,7 @@ impl<'a> CompiledSimInstance<'a> {
             } else {
                 LogKind::Null
             },
-            quiescent,
-            quiescence_notify,
-            resume_notify,
+            quiescence,
         };
 
         async move { launched.scheduler().await }
@@ -536,19 +562,17 @@ impl<T: Serialize + DeserializeOwned, O: Ordering, R: Retries> SimReceiver<T, O,
         &self,
         thunk: impl AsyncFnOnce(&mut Pin<&mut dyn Stream<Item = T>>) -> Out,
     ) -> Out {
-        let (receiver, quiescent, quiescence_notify) =
-            CURRENT_SIM_CONNECTIONS.with(|connections| {
-                let connections = connections.borrow();
-                let port = connections.external_registered.get(&self.0).unwrap();
-                (
-                    connections.output_receivers.get(port).unwrap().clone(),
-                    connections.quiescent.clone(),
-                    connections.quiescence_notify.clone(),
-                )
-            });
+        let (receiver, quiescence) = CURRENT_SIM_CONNECTIONS.with(|connections| {
+            let connections = connections.borrow();
+            let port = connections.external_registered.get(&self.0).unwrap();
+            (
+                connections.output_receivers.get(port).unwrap().clone(),
+                connections.quiescence.clone(),
+            )
+        });
 
         let mut receiver_stream = receiver.lock().await;
-        let mut notified_fut = pin!(quiescence_notify.notified());
+        let mut notified_fut = pin!(quiescence.notified());
         let mut quiescence_aware = futures::stream::poll_fn(|cx| {
             use std::task::Poll;
             match receiver_stream.poll_next_unpin(cx) {
@@ -558,16 +582,12 @@ impl<T: Serialize + DeserializeOwned, O: Ordering, R: Retries> SimReceiver<T, O,
                 Poll::Ready(None) => return Poll::Ready(None),
                 Poll::Pending => {}
             }
-            if quiescent.get() {
+            if quiescence.is_quiescent() {
                 return Poll::Ready(None);
             }
-            match notified_fut.as_mut().poll(cx) {
-                Poll::Ready(()) => {
-                    notified_fut.set(quiescence_notify.notified());
-                    Poll::Ready(None)
-                }
-                Poll::Pending => Poll::Pending,
-            }
+            let () = ready!(notified_fut.as_mut().poll(cx));
+            notified_fut.set(quiescence.notified());
+            Poll::Ready(None)
         });
         thunk(&mut pin!(&mut quiescence_aware)).await
     }
@@ -798,7 +818,7 @@ impl<T: Serialize + DeserializeOwned, O: Ordering, R: Retries> SimSender<T, O, R
         &self,
         thunk: impl FnOnce(&dyn Fn(T) -> Result<(), tokio::sync::mpsc::error::SendError<Bytes>>) -> Out,
     ) -> Out {
-        let (sender, quiescent, resume_notify) = CURRENT_SIM_CONNECTIONS.with(|connections| {
+        let (sender, quiescence) = CURRENT_SIM_CONNECTIONS.with(|connections| {
             let connections = connections.borrow();
             (
                 connections
@@ -806,15 +826,13 @@ impl<T: Serialize + DeserializeOwned, O: Ordering, R: Retries> SimSender<T, O, R
                     .get(connections.external_registered.get(&self.0).unwrap())
                     .unwrap()
                     .clone(),
-                connections.quiescent.clone(),
-                connections.resume_notify.clone(),
+                connections.quiescence.clone(),
             )
         });
 
         thunk(&move |t| {
             let res = sender.send(bincode::serialize(&t).unwrap().into());
-            quiescent.set(false);
-            resume_notify.notify_waiters();
+            quiescence.resume();
             res
         })
     }
@@ -869,20 +887,18 @@ impl<T: Serialize + DeserializeOwned, O: Ordering, R: Retries> SimClusterReceive
         member_id: u32,
         thunk: impl AsyncFnOnce(&mut Pin<&mut dyn Stream<Item = T>>) -> Out,
     ) -> Out {
-        let (receiver, quiescent, quiescence_notify) =
-            CURRENT_SIM_CONNECTIONS.with(|connections| {
-                let connections = connections.borrow();
-                let port = connections.external_registered.get(&self.0).unwrap();
-                let receivers = connections.cluster_output_receivers.get(port).unwrap();
-                (
-                    receivers[member_id as usize].clone(),
-                    connections.quiescent.clone(),
-                    connections.quiescence_notify.clone(),
-                )
-            });
+        let (receiver, quiescence) = CURRENT_SIM_CONNECTIONS.with(|connections| {
+            let connections = connections.borrow();
+            let port = connections.external_registered.get(&self.0).unwrap();
+            let receivers = connections.cluster_output_receivers.get(port).unwrap();
+            (
+                receivers[member_id as usize].clone(),
+                connections.quiescence.clone(),
+            )
+        });
 
         let mut lock = receiver.lock().await;
-        let mut notified_fut = pin!(quiescence_notify.notified());
+        let mut notified_fut = pin!(quiescence.notified());
         let mut quiescence_aware = futures::stream::poll_fn(|cx| {
             use std::task::Poll;
             match lock.poll_next_unpin(cx) {
@@ -892,16 +908,12 @@ impl<T: Serialize + DeserializeOwned, O: Ordering, R: Retries> SimClusterReceive
                 Poll::Ready(None) => return Poll::Ready(None),
                 Poll::Pending => {}
             }
-            if quiescent.get() {
+            if quiescence.is_quiescent() {
                 return Poll::Ready(None);
             }
-            match notified_fut.as_mut().poll(cx) {
-                Poll::Ready(()) => {
-                    notified_fut.set(quiescence_notify.notified());
-                    Poll::Ready(None)
-                }
-                Poll::Pending => Poll::Pending,
-            }
+            let () = ready!(notified_fut.as_mut().poll(cx));
+            notified_fut.set(quiescence.notified());
+            Poll::Ready(None)
         });
         thunk(&mut pin!(&mut quiescence_aware)).await
     }
@@ -943,7 +955,7 @@ impl<T: Serialize + DeserializeOwned, O: Ordering, R: Retries> SimClusterSender<
             &dyn Fn(u32, T) -> Result<(), tokio::sync::mpsc::error::SendError<Bytes>>,
         ) -> Out,
     ) -> Out {
-        let (senders, quiescent, resume_notify) = CURRENT_SIM_CONNECTIONS.with(|connections| {
+        let (senders, quiescence) = CURRENT_SIM_CONNECTIONS.with(|connections| {
             let connections = connections.borrow();
             (
                 connections
@@ -951,16 +963,14 @@ impl<T: Serialize + DeserializeOwned, O: Ordering, R: Retries> SimClusterSender<
                     .get(connections.external_registered.get(&self.0).unwrap())
                     .unwrap()
                     .clone(),
-                connections.quiescent.clone(),
-                connections.resume_notify.clone(),
+                connections.quiescence.clone(),
             )
         });
 
         thunk(&move |member_id: u32, t: T| {
             let payload = bincode::serialize(&t).unwrap();
             let res = senders[member_id as usize].send(Bytes::from(payload));
-            quiescent.set(false);
-            resume_notify.notify_waiters();
+            quiescence.resume();
             res
         })
     }
@@ -1036,12 +1046,8 @@ struct LaunchedSim<W: std::io::Write> {
     /// a tick that block on ordering decisions while the tick DFIR is running.
     inline_hooks: InlineHooks<LocationId>,
     log: LogKind<W>,
-    /// Set to true when the scheduler reaches quiescence; reset to false when new input is sent.
-    quiescent: Rc<Cell<bool>>,
-    /// Notified when the scheduler reaches quiescence (wakes receivers waiting for data).
-    quiescence_notify: Rc<Notify>,
-    /// Notified when new input is sent, signaling the scheduler to resume.
-    resume_notify: Rc<Notify>,
+    /// Represents quiescence state of the simulation.
+    quiescence: Rc<QuiescenceState>,
 }
 
 impl<W: std::io::Write> LaunchedSim<W> {
@@ -1118,10 +1124,7 @@ impl<W: std::io::Write> LaunchedSim<W> {
                     && self.possibly_ready_observation.is_empty()
                 {
                     // Signal quiescence and wait for new input.
-                    self.quiescent.set(true);
-                    self.quiescence_notify.notify_waiters();
-                    self.resume_notify.notified().await;
-                    self.quiescent.set(false);
+                    self.quiescence.wait_for_resume().await;
                 } else {
                     let next_tick_or_obs = (0..(self.possibly_ready_ticks.len()
                         + self.possibly_ready_observation.len()))

--- a/hydro_lang/src/sim/compiled.rs
+++ b/hydro_lang/src/sim/compiled.rs
@@ -1,7 +1,7 @@
 //! Interfaces for compiled Hydro simulators and concrete simulation instances.
 
 use core::{fmt, panic};
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, VecDeque};
 use std::fmt::Debug;
 use std::panic::RefUnwindSafe;
@@ -18,7 +18,7 @@ use libloading::Library;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use tempfile::TempPath;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Notify};
 use tokio::sync::mpsc::UnboundedSender;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
@@ -37,6 +37,9 @@ struct SimConnections {
     cluster_output_receivers:
         HashMap<SimExternalPort, Vec<Rc<Mutex<UnboundedReceiverStream<Bytes>>>>>,
     external_registered: HashMap<ExternalPortId, SimExternalPort>,
+    quiescent: Rc<Cell<bool>>,
+    quiescence_notify: Rc<Notify>,
+    resume_notify: Rc<Notify>,
 }
 
 tokio::task_local! {
@@ -389,6 +392,10 @@ impl<'a> CompiledSimInstance<'a> {
 
         let registered = &self.externals_port_registry.registered;
 
+        let quiescent = Rc::new(Cell::new(false));
+        let quiescence_notify = Rc::new(Notify::new());
+        let resume_notify = Rc::new(Notify::new());
+
         let mut input_senders = HashMap::new();
         let mut output_receivers = HashMap::new();
         let mut cluster_input_senders = HashMap::new();
@@ -431,6 +438,9 @@ impl<'a> CompiledSimInstance<'a> {
                     cluster_input_senders,
                     cluster_output_receivers,
                     external_registered: self.externals_port_registry.registered.clone(),
+                    quiescent: quiescent.clone(),
+                    quiescence_notify: quiescence_notify.clone(),
+                    resume_notify: resume_notify.clone(),
                 }),
                 async move {
                     thunk(self).await;
@@ -465,6 +475,16 @@ impl<'a> CompiledSimInstance<'a> {
             .map(|(lid, c_id, _)| (serde_json::from_str(lid).unwrap(), *c_id))
             .collect();
 
+        let (quiescent, quiescence_notify, resume_notify) =
+            CURRENT_SIM_CONNECTIONS.with(|connections| {
+                let connections = connections.borrow();
+                (
+                    connections.quiescent.clone(),
+                    connections.quiescence_notify.clone(),
+                    connections.resume_notify.clone(),
+                )
+            });
+
         let mut launched = LaunchedSim {
             async_dfirs: async_dfirs
                 .into_iter()
@@ -494,6 +514,9 @@ impl<'a> CompiledSimInstance<'a> {
             } else {
                 LogKind::Null
             },
+            quiescent,
+            quiescence_notify,
+            resume_notify,
         };
 
         async move { launched.scheduler().await }
@@ -513,22 +536,40 @@ impl<T: Serialize + DeserializeOwned, O: Ordering, R: Retries> SimReceiver<T, O,
         &self,
         thunk: impl AsyncFnOnce(&mut Pin<&mut dyn Stream<Item = T>>) -> Out,
     ) -> Out {
-        let receiver = CURRENT_SIM_CONNECTIONS.with(|connections| {
-            let connections = &mut *connections.borrow_mut();
-            connections
-                .output_receivers
-                .get(connections.external_registered.get(&self.0).unwrap())
-                .unwrap()
-                .clone()
-        });
+        let (receiver, quiescent, quiescence_notify) =
+            CURRENT_SIM_CONNECTIONS.with(|connections| {
+                let connections = connections.borrow();
+                let port = connections.external_registered.get(&self.0).unwrap();
+                (
+                    connections.output_receivers.get(port).unwrap().clone(),
+                    connections.quiescent.clone(),
+                    connections.quiescence_notify.clone(),
+                )
+            });
 
         let mut receiver_stream = receiver.lock().await;
-        thunk(&mut pin!(
-            &mut receiver_stream
-                .by_ref()
-                .map(|b| bincode::deserialize(&b).unwrap())
-        ))
-        .await
+        let mut notified_fut = pin!(quiescence_notify.notified());
+        let mut quiescence_aware = futures::stream::poll_fn(|cx| {
+            use std::task::Poll;
+            match receiver_stream.poll_next_unpin(cx) {
+                Poll::Ready(Some(bytes)) => {
+                    return Poll::Ready(Some(bincode::deserialize(&bytes).unwrap()));
+                }
+                Poll::Ready(None) => return Poll::Ready(None),
+                Poll::Pending => {}
+            }
+            if quiescent.get() {
+                return Poll::Ready(None);
+            }
+            match notified_fut.as_mut().poll(cx) {
+                Poll::Ready(()) => {
+                    notified_fut.set(quiescence_notify.notified());
+                    Poll::Ready(None)
+                }
+                Poll::Pending => Poll::Pending,
+            }
+        });
+        thunk(&mut pin!(&mut quiescence_aware)).await
     }
 
     /// Asserts that the stream has ended and no more messages can possibly arrive.
@@ -757,16 +798,23 @@ impl<T: Serialize + DeserializeOwned, O: Ordering, R: Retries> SimSender<T, O, R
         &self,
         thunk: impl FnOnce(&dyn Fn(T) -> Result<(), tokio::sync::mpsc::error::SendError<Bytes>>) -> Out,
     ) -> Out {
-        let sender = CURRENT_SIM_CONNECTIONS.with(|connections| {
-            let connections = &mut *connections.borrow_mut();
-            connections
-                .input_senders
-                .get(connections.external_registered.get(&self.0).unwrap())
-                .unwrap()
-                .clone()
+        let (sender, quiescent, resume_notify) = CURRENT_SIM_CONNECTIONS.with(|connections| {
+            let connections = connections.borrow();
+            (
+                connections
+                    .input_senders
+                    .get(connections.external_registered.get(&self.0).unwrap())
+                    .unwrap()
+                    .clone(),
+                connections.quiescent.clone(),
+                connections.resume_notify.clone(),
+            )
         });
 
-        thunk(&move |t| sender.send(bincode::serialize(&t).unwrap().into()))
+        let result = thunk(&move |t| sender.send(bincode::serialize(&t).unwrap().into()));
+        quiescent.set(false);
+        resume_notify.notify_waiters();
+        result
     }
 }
 
@@ -819,20 +867,41 @@ impl<T: Serialize + DeserializeOwned, O: Ordering, R: Retries> SimClusterReceive
         member_id: u32,
         thunk: impl AsyncFnOnce(&mut Pin<&mut dyn Stream<Item = T>>) -> Out,
     ) -> Out {
-        let receiver = CURRENT_SIM_CONNECTIONS.with(|connections| {
-            let connections = &mut *connections.borrow_mut();
-            let receivers = connections
-                .cluster_output_receivers
-                .get(connections.external_registered.get(&self.0).unwrap())
-                .unwrap();
-            receivers[member_id as usize].clone()
-        });
+        let (receiver, quiescent, quiescence_notify) =
+            CURRENT_SIM_CONNECTIONS.with(|connections| {
+                let connections = connections.borrow();
+                let port = connections.external_registered.get(&self.0).unwrap();
+                let receivers = connections.cluster_output_receivers.get(port).unwrap();
+                (
+                    receivers[member_id as usize].clone(),
+                    connections.quiescent.clone(),
+                    connections.quiescence_notify.clone(),
+                )
+            });
 
         let mut lock = receiver.lock().await;
-        thunk(&mut pin!(
-            lock.by_ref().map(|b| bincode::deserialize(&b).unwrap())
-        ))
-        .await
+        let mut notified_fut = pin!(quiescence_notify.notified());
+        let mut quiescence_aware = futures::stream::poll_fn(|cx| {
+            use std::task::Poll;
+            match lock.poll_next_unpin(cx) {
+                Poll::Ready(Some(bytes)) => {
+                    return Poll::Ready(Some(bincode::deserialize(&bytes).unwrap()));
+                }
+                Poll::Ready(None) => return Poll::Ready(None),
+                Poll::Pending => {}
+            }
+            if quiescent.get() {
+                return Poll::Ready(None);
+            }
+            match notified_fut.as_mut().poll(cx) {
+                Poll::Ready(()) => {
+                    notified_fut.set(quiescence_notify.notified());
+                    Poll::Ready(None)
+                }
+                Poll::Pending => Poll::Pending,
+            }
+        });
+        thunk(&mut pin!(&mut quiescence_aware)).await
     }
 }
 
@@ -872,19 +941,26 @@ impl<T: Serialize + DeserializeOwned, O: Ordering, R: Retries> SimClusterSender<
             &dyn Fn(u32, T) -> Result<(), tokio::sync::mpsc::error::SendError<Bytes>>,
         ) -> Out,
     ) -> Out {
-        let senders = CURRENT_SIM_CONNECTIONS.with(|connections| {
-            let connections = &mut *connections.borrow_mut();
-            connections
-                .cluster_input_senders
-                .get(connections.external_registered.get(&self.0).unwrap())
-                .unwrap()
-                .clone()
+        let (senders, quiescent, resume_notify) = CURRENT_SIM_CONNECTIONS.with(|connections| {
+            let connections = connections.borrow();
+            (
+                connections
+                    .cluster_input_senders
+                    .get(connections.external_registered.get(&self.0).unwrap())
+                    .unwrap()
+                    .clone(),
+                connections.quiescent.clone(),
+                connections.resume_notify.clone(),
+            )
         });
 
-        thunk(&move |member_id: u32, t: T| {
+        let result = thunk(&move |member_id: u32, t: T| {
             let payload = bincode::serialize(&t).unwrap();
             senders[member_id as usize].send(Bytes::from(payload))
-        })
+        });
+        quiescent.set(false);
+        resume_notify.notify_waiters();
+        result
     }
 }
 
@@ -958,6 +1034,12 @@ struct LaunchedSim<W: std::io::Write> {
     /// a tick that block on ordering decisions while the tick DFIR is running.
     inline_hooks: InlineHooks<LocationId>,
     log: LogKind<W>,
+    /// Set to true when the scheduler reaches quiescence; reset to false when new input is sent.
+    quiescent: Rc<Cell<bool>>,
+    /// Notified when the scheduler reaches quiescence (wakes receivers waiting for data).
+    quiescence_notify: Rc<Notify>,
+    /// Notified when new input is sent, signaling the scheduler to resume.
+    resume_notify: Rc<Notify>,
 }
 
 impl<W: std::io::Write> LaunchedSim<W> {
@@ -1033,7 +1115,11 @@ impl<W: std::io::Write> LaunchedSim<W> {
                 if self.possibly_ready_ticks.is_empty()
                     && self.possibly_ready_observation.is_empty()
                 {
-                    break;
+                    // Signal quiescence and wait for new input.
+                    self.quiescent.set(true);
+                    self.quiescence_notify.notify_waiters();
+                    self.resume_notify.notified().await;
+                    self.quiescent.set(false);
                 } else {
                     let next_tick_or_obs = (0..(self.possibly_ready_ticks.len()
                         + self.possibly_ready_observation.len()))

--- a/hydro_lang/src/sim/compiled.rs
+++ b/hydro_lang/src/sim/compiled.rs
@@ -811,10 +811,12 @@ impl<T: Serialize + DeserializeOwned, O: Ordering, R: Retries> SimSender<T, O, R
             )
         });
 
-        let result = thunk(&move |t| sender.send(bincode::serialize(&t).unwrap().into()));
-        quiescent.set(false);
-        resume_notify.notify_waiters();
-        result
+        thunk(&move |t| {
+            let res = sender.send(bincode::serialize(&t).unwrap().into());
+            quiescent.set(false);
+            resume_notify.notify_waiters();
+            res
+        })
     }
 }
 
@@ -954,13 +956,13 @@ impl<T: Serialize + DeserializeOwned, O: Ordering, R: Retries> SimClusterSender<
             )
         });
 
-        let result = thunk(&move |member_id: u32, t: T| {
+        thunk(&move |member_id: u32, t: T| {
             let payload = bincode::serialize(&t).unwrap();
-            senders[member_id as usize].send(Bytes::from(payload))
-        });
-        quiescent.set(false);
-        resume_notify.notify_waiters();
-        result
+            let res = senders[member_id as usize].send(Bytes::from(payload));
+            quiescent.set(false);
+            resume_notify.notify_waiters();
+            res
+        })
     }
 }
 

--- a/hydro_lang/src/sim/tests/mod.rs
+++ b/hydro_lang/src/sim/tests/mod.rs
@@ -360,4 +360,3 @@ fn sim_collect_waits_for_all_ticks() {
         assert_eq!(all, vec![1, 2, 3]);
     });
 }
-

--- a/hydro_lang/src/sim/tests/mod.rs
+++ b/hydro_lang/src/sim/tests/mod.rs
@@ -304,3 +304,60 @@ fn sim_cluster_e2m_m2e() {
             assert_eq!(out_recv.next(2).await, Some(30));
         });
 }
+
+#[test]
+fn sim_send_after_assert_yields_only() {
+    let mut flow = FlowBuilder::new();
+    let process = flow.process::<()>();
+
+    let (send_port, input) = process.sim_input();
+    let output = input.atomic().end_atomic();
+    let out_port = output.sim_output();
+
+    flow.sim().exhaustive(async || {
+        send_port.send(1u32);
+        out_port.assert_yields_only([1u32]).await;
+
+        // This previously panicked with SendError because the scheduler terminated on quiescence.
+        send_port.send(2u32);
+        out_port.assert_yields_only([2u32]).await;
+    });
+}
+
+#[test]
+#[should_panic(expected = "unexpected message")]
+fn assert_yields_only_catches_extra_value() {
+    let mut flow = FlowBuilder::new();
+    let process = flow.process::<()>();
+
+    let (send_port, input) = process.sim_input();
+    let out_port = input.atomic().end_atomic().sim_output();
+
+    flow.sim().exhaustive(async || {
+        send_port.send(1u32);
+        send_port.send(2u32);
+        // Expects only [1], but stream also produces 2 → should panic
+        out_port.assert_yields_only([1u32]).await;
+    });
+}
+
+#[test]
+fn sim_collect_waits_for_all_ticks() {
+    let mut flow = FlowBuilder::new();
+    let node = flow.process::<()>();
+    let tick = node.tick();
+    let (in_send, input) = node.sim_input();
+    let out_recv = input
+        .batch(&tick, nondet!(/** test */))
+        .all_ticks()
+        .sim_output();
+
+    flow.sim().exhaustive(async || {
+        in_send.send(1);
+        in_send.send(2);
+        in_send.send(3);
+        let all: Vec<i32> = out_recv.collect().await;
+        assert_eq!(all, vec![1, 2, 3]);
+    });
+}
+


### PR DESCRIPTION
Resolves #2816

The scheduler previously broke out of its loop on quiescence, dropping all DFIRs and input receivers. This caused subsequent send() calls to panic with SendError after assert_yields_only.

Fix: signal quiescence via Notify and pend, resuming when new input arrives. Receivers detect quiescence via a shared flag + Notify and yield None instead of blocking forever. Senders reset the flag and notify the scheduler.

Adds regression test: sim_send_after_assert_yields_only.