### PR TITLE
refactor(dfir_lang): DFIR singleton references, convert singleton state to plain local variables

### DIFF
--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1567,7 +1567,7 @@ impl DfirGraph {
                 // start false (from take()) and are set true by recv port code
                 // if any handoff buffer has data.
                 let mut __dfir_work_done = true;
-                #[allow(unused_qualifications, unused_mut, unused_variables, clippy::await_holding_refcell_ref)]
+                #[allow(unused_qualifications, unused_mut, unused_variables, clippy::await_holding_refcell_ref, clippy::deref_addrof)]
                 let __dfir_inline_tick = async move |#df: &mut #root::scheduled::context::Context| {
                     let __dfir_metrics = #df.metrics();
                     // Double-buffer swap for defer_tick handoffs: move last tick's

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -816,10 +816,9 @@ impl DfirGraph {
     /// instead of runtime handoffs. Each call to the closure runs one tick.
     ///
     /// The generated code block evaluates to a `Dfir` instance wrapping the
-    /// closure. Operator prologues (`add_state`, `set_state_lifespan_hook`)
-    /// run at construction time on the `Context` before it is moved into
-    /// `Dfir::new`. `Dfir` provides the `Context` to the closure on
-    /// each tick run.
+    /// closure. Operator prologues run at construction time before the `Context`
+    /// is moved into `Dfir::new`. `Dfir` provides the `Context` to the closure
+    /// on each tick run.
     ///
     /// # Errors
     ///
@@ -1163,7 +1162,6 @@ impl DfirGraph {
                             let arguments = &process_singletons::postprocess_singletons(
                                 op_inst.arguments_raw.clone(),
                                 singletons_resolved.clone(),
-                                context,
                             );
                             let arguments_handles =
                                 &process_singletons::postprocess_singletons_handles(

--- a/dfir_lang/src/graph/ops/fold.rs
+++ b/dfir_lang/src/graph/ops/fold.rs
@@ -82,20 +82,20 @@ pub const FOLD: OperatorConstraints = OperatorConstraints {
             let mut #initializer_func_ident = #init_fn;
 
             #[allow(clippy::redundant_closure_call)]
-            let #singleton_output_ident = ::std::cell::RefCell::new(#init);
+            let mut #singleton_output_ident = #init;
         };
 
         let write_tick_end = match persistence {
             Persistence::Tick => quote_spanned! {op_span=>
                 #[allow(clippy::redundant_closure_call)]
-                #singleton_output_ident.replace(#init);
+                { #singleton_output_ident = #init; }
             },
             _ => Default::default(),
         };
 
         let assign_accum_ident = quote_spanned! {op_span=>
             #[allow(unused_mut)]
-            let mut #accumulator_ident = #singleton_output_ident.borrow_mut();
+            let mut #accumulator_ident = &mut #singleton_output_ident;
         };
         let foreach_body = quote_spanned! {op_span=>
             #[inline(always)]

--- a/dfir_lang/src/graph/ops/fold_keyed.rs
+++ b/dfir_lang/src/graph/ops/fold_keyed.rs
@@ -131,18 +131,18 @@ pub const FOLD_KEYED: OperatorConstraints = OperatorConstraints {
         let hashtable_ident = wc.make_ident("hashtable");
 
         let write_prologue = quote_spanned! {op_span=>
-            let #singleton_output_ident = ::std::cell::RefCell::new(#root::rustc_hash::FxHashMap::<#( #generic_type_args ),*>::default());
+            let mut #singleton_output_ident = #root::rustc_hash::FxHashMap::<#( #generic_type_args ),*>::default();
         };
 
         let write_tick_end = match persistence {
             Persistence::Tick => quote_spanned! {op_span=>
-                #singleton_output_ident.borrow_mut().clear();
+                #singleton_output_ident.clear();
             },
             _ => Default::default(),
         };
 
         let assign_hashtable_ident = quote_spanned! {op_span=>
-            let mut #hashtable_ident = #singleton_output_ident.borrow_mut();
+            let mut #hashtable_ident = &mut #singleton_output_ident;
         };
 
         let write_iterator = if Persistence::Mutable == persistence {

--- a/dfir_lang/src/graph/ops/fold_no_replay.rs
+++ b/dfir_lang/src/graph/ops/fold_no_replay.rs
@@ -64,20 +64,20 @@ pub const FOLD_NO_REPLAY: OperatorConstraints = OperatorConstraints {
             let mut #initializer_func_ident = #init_fn;
 
             #[allow(clippy::redundant_closure_call)]
-            let #singleton_output_ident = ::std::cell::RefCell::new(#init);
+            let mut #singleton_output_ident = #init;
         };
 
         let write_tick_end = match persistence {
             Persistence::Tick => quote_spanned! {op_span=>
                 #[allow(clippy::redundant_closure_call)]
-                #singleton_output_ident.replace(#init);
+                { #singleton_output_ident = #init; }
             },
             _ => Default::default(),
         };
 
         let assign_accum_ident = quote_spanned! {op_span=>
             #[allow(unused_mut)]
-            let mut #accumulator_ident = #singleton_output_ident.borrow_mut();
+            let mut #accumulator_ident = &mut #singleton_output_ident;
         };
         let foreach_body = quote_spanned! {op_span=>
             #[inline(always)]

--- a/dfir_lang/src/graph/ops/lattice_bimorphism.rs
+++ b/dfir_lang/src/graph/ops/lattice_bimorphism.rs
@@ -86,8 +86,8 @@ pub const LATTICE_BIMORPHISM: OperatorConstraints = OperatorConstraints {
                     lhs_pull: LhsPull,
                     rhs_pull: RhsPull,
                     func: Func,
-                    lhs_state: &'a ::std::cell::RefCell<LhsState>,
-                    rhs_state: &'a ::std::cell::RefCell<RhsState>,
+                    lhs_state: &'a LhsState,
+                    rhs_state: &'a RhsState,
                 ) -> impl #root::dfir_pipes::pull::Pull<
                     Item = Output,
                     Meta = (),

--- a/dfir_lang/src/graph/ops/persist.rs
+++ b/dfir_lang/src/graph/ops/persist.rs
@@ -90,15 +90,13 @@ pub const PERSIST: OperatorConstraints = OperatorConstraints {
         let persistdata_ident = singleton_output_ident;
         let vec_ident = wc.make_ident("persistvec");
         let write_prologue = quote_spanned! {op_span=>
-            let #persistdata_ident = ::std::cell::RefCell::new(
-                ::std::vec::Vec::<#generic_type>::new(),
-            );
+            let mut #persistdata_ident = ::std::vec::Vec::<#generic_type>::new();
         };
 
         let write_iterator = if is_pull {
             let input = &inputs[0];
             quote_spanned! {op_span=>
-                let mut #vec_ident = #persistdata_ident.borrow_mut();
+                let #vec_ident = &mut #persistdata_ident;
 
                 let #ident = {
                     let replay_idx = if #context.is_first_run_this_tick() {
@@ -119,7 +117,7 @@ pub const PERSIST: OperatorConstraints = OperatorConstraints {
         } else {
             let output = &outputs[0];
             quote_spanned! {op_span=>
-                let mut #vec_ident = #persistdata_ident.borrow_mut();
+                let #vec_ident = &mut #persistdata_ident;
 
                 let #ident = {
                     fn constrain_types<'ctx, Psh, Item>(vec: &'ctx mut Vec<Item>, output: Psh, is_new_tick: bool) -> impl 'ctx + #root::dfir_pipes::push::Push<Item, ()>

--- a/dfir_lang/src/graph/ops/prefix.rs
+++ b/dfir_lang/src/graph/ops/prefix.rs
@@ -40,14 +40,14 @@ pub const PREFIX: OperatorConstraints = OperatorConstraints {
 
         let write_prologue = quote_spanned! {op_span=>
             #[allow(clippy::redundant_closure_call)]
-            let #singleton_output_ident = ::std::cell::RefCell::new(::std::vec::Vec::new());
+            let mut #singleton_output_ident = ::std::vec::Vec::new();
         };
 
         let vec_ident = wc.make_ident("vec");
 
         let input = &inputs[0];
         let write_iterator = quote_spanned! {op_span=>
-            let mut #vec_ident = #singleton_output_ident.borrow_mut();
+            let #vec_ident = &mut #singleton_output_ident;
 
             let #ident = {
                 let fut = #root::dfir_pipes::pull::Pull::for_each(#input, |item| {

--- a/dfir_lang/src/graph/ops/reduce.rs
+++ b/dfir_lang/src/graph/ops/reduce.rs
@@ -63,12 +63,12 @@ pub const REDUCE: OperatorConstraints = OperatorConstraints {
         let [persistence] = wc.persistence_args_disallow_mutable(diagnostics);
 
         let write_prologue = quote_spanned! {op_span=>
-            let #singleton_output_ident = ::std::cell::RefCell::new(::std::option::Option::None);
+            let mut #singleton_output_ident = ::std::option::Option::None;
         };
 
         let write_tick_end = match persistence {
             Persistence::Tick => quote_spanned! {op_span=>
-                #singleton_output_ident.replace(::std::option::Option::None);
+                #singleton_output_ident = ::std::option::Option::None;
             },
             _ => Default::default(),
         };
@@ -95,7 +95,7 @@ pub const REDUCE: OperatorConstraints = OperatorConstraints {
 
         let assign_accum_ident = quote_spanned! {op_span=>
             #[allow(unused_mut)]
-            let mut #accumulator_ident = #singleton_output_ident.borrow_mut();
+            let mut #accumulator_ident = &mut #singleton_output_ident;
         };
 
         let write_iterator = if is_pull {

--- a/dfir_lang/src/graph/ops/reduce_keyed.rs
+++ b/dfir_lang/src/graph/ops/reduce_keyed.rs
@@ -110,12 +110,12 @@ pub const REDUCE_KEYED: OperatorConstraints = OperatorConstraints {
         let hashtable_ident = wc.make_ident("hashtable");
 
         let write_prologue = quote_spanned! {op_span=>
-            let #singleton_output_ident = ::std::cell::RefCell::new(#root::rustc_hash::FxHashMap::<#( #generic_type_args ),*>::default());
+            let mut #singleton_output_ident = #root::rustc_hash::FxHashMap::<#( #generic_type_args ),*>::default();
         };
 
         let write_tick_end = match persistence {
             Persistence::Tick => quote_spanned! {op_span=>
-                #singleton_output_ident.borrow_mut().clear();
+                #singleton_output_ident.clear();
             },
             _ => Default::default(),
         };
@@ -154,7 +154,7 @@ pub const REDUCE_KEYED: OperatorConstraints = OperatorConstraints {
             };
 
             quote_spanned! {op_span=>
-                let mut #hashtable_ident = #singleton_output_ident.borrow_mut();
+                let mut #hashtable_ident = &mut #singleton_output_ident;
 
                 {
                     #[inline(always)]

--- a/dfir_lang/src/graph/ops/reduce_no_replay.rs
+++ b/dfir_lang/src/graph/ops/reduce_no_replay.rs
@@ -46,12 +46,12 @@ pub const REDUCE_NO_REPLAY: OperatorConstraints = OperatorConstraints {
         let [persistence] = wc.persistence_args_disallow_mutable(diagnostics);
 
         let write_prologue = quote_spanned! {op_span=>
-            let #singleton_output_ident = ::std::cell::RefCell::new(::std::option::Option::None);
+            let mut #singleton_output_ident = ::std::option::Option::None;
         };
 
         let write_tick_end = match persistence {
             Persistence::Tick => quote_spanned! {op_span=>
-                #singleton_output_ident.replace(::std::option::Option::None);
+                #singleton_output_ident = ::std::option::Option::None;
             },
             _ => Default::default(),
         };
@@ -78,7 +78,7 @@ pub const REDUCE_NO_REPLAY: OperatorConstraints = OperatorConstraints {
 
         let assign_accum_ident = quote_spanned! {op_span=>
             #[allow(unused_mut)]
-            let mut #accumulator_ident = #singleton_output_ident.borrow_mut();
+            let mut #accumulator_ident = &mut #singleton_output_ident;
         };
 
         let write_iterator = if is_pull {

--- a/dfir_lang/src/graph/ops/repeat_n.rs
+++ b/dfir_lang/src/graph/ops/repeat_n.rs
@@ -41,14 +41,14 @@ pub const REPEAT_N: OperatorConstraints = OperatorConstraints {
 
         let write_prologue = quote_spanned! {op_span=>
             #[allow(clippy::redundant_closure_call)]
-            let #singleton_output_ident = ::std::cell::RefCell::new(::std::vec::Vec::new());
+            let mut #singleton_output_ident = ::std::vec::Vec::new();
         };
 
         let vec_ident = wc.make_ident("vec");
 
         let input = &inputs[0];
         let write_iterator = quote_spanned! {op_span=>
-            let mut #vec_ident = #singleton_output_ident.borrow_mut();
+            let #vec_ident = &mut #singleton_output_ident;
 
             if 0 == #context.loop_iter_count() {
                 *#vec_ident = #work_fn_async(

--- a/dfir_lang/src/graph/ops/scan.rs
+++ b/dfir_lang/src/graph/ops/scan.rs
@@ -93,21 +93,19 @@ pub const SCAN: OperatorConstraints = OperatorConstraints {
             let mut #initializer_func_ident = #init_fn;
 
             #[allow(clippy::redundant_closure_call)]
-            let #singleton_output_ident = ::std::cell::RefCell::new(
-                Some(#init)
-            );
+            let mut #singleton_output_ident = Some(#init);
         };
 
         let write_tick_end = match persistence {
             super::Persistence::Tick => quote_spanned! {op_span=>
                 #[allow(clippy::redundant_closure_call)]
-                #singleton_output_ident.replace(Some(#init));
+                { #singleton_output_ident = Some(#init); }
             },
             _ => Default::default(),
         };
 
         let assign_accum_ident = quote_spanned! {op_span=>
-            let mut #state_ident = #singleton_output_ident.borrow_mut();
+            let #state_ident = &mut #singleton_output_ident;
 
             if #state_ident.is_none() {
                 return None;

--- a/dfir_lang/src/graph/ops/scan_async_blocking.rs
+++ b/dfir_lang/src/graph/ops/scan_async_blocking.rs
@@ -81,15 +81,13 @@ pub const SCAN_ASYNC_BLOCKING: OperatorConstraints = OperatorConstraints {
             let mut #initializer_func_ident = #init_fn;
 
             #[allow(clippy::redundant_closure_call)]
-            let #singleton_output_ident = ::std::cell::RefCell::new(
-                Some(#init)
-            );
+            let mut #singleton_output_ident = Some(#init);
         };
 
         let write_tick_end = match persistence {
             super::Persistence::Tick => quote_spanned! {op_span=>
                 #[allow(clippy::redundant_closure_call)]
-                #singleton_output_ident.replace(Some(#init));
+                { #singleton_output_ident = Some(#init); }
             },
             _ => Default::default(),
         };
@@ -107,7 +105,7 @@ pub const SCAN_ASYNC_BLOCKING: OperatorConstraints = OperatorConstraints {
                 (func)(accum, item)
             }
 
-            let mut #state_ident = #singleton_output_ident.borrow_mut();
+            let #state_ident = &mut #singleton_output_ident;
 
             #[allow(clippy::redundant_closure_call)]
             call_scan_async_blocking_fn(#state_ident.as_mut().unwrap(), #iterator_item_ident, #func)

--- a/dfir_lang/src/graph/ops/state_by.rs
+++ b/dfir_lang/src/graph/ops/state_by.rs
@@ -101,15 +101,15 @@ pub const STATE_BY: OperatorConstraints = OperatorConstraints {
         let factory_fn = &arguments[1];
 
         let write_prologue = quote_spanned! {op_span=>
-            let #state_ident = {
-                let data_struct: #lattice_type = (#factory_fn)();
+            let mut #state_ident: #lattice_type = {
+                let data_struct = (#factory_fn)();
                 ::std::debug_assert!(#root::lattices::IsBot::is_bot(&data_struct));
-                ::std::cell::RefCell::new(data_struct)
+                data_struct
             };
         };
         let write_tick_end = match persistence {
             Persistence::Tick => quote_spanned! {op_span=>
-                ::std::cell::RefCell::take(&#state_ident);
+                #state_ident = ::std::default::Default::default();
             },
             _ => Default::default(),
         };
@@ -124,7 +124,7 @@ pub const STATE_BY: OperatorConstraints = OperatorConstraints {
                     fn check_input<'a, Item, MappingFn, MappedItem, Prev, Lat>(
                         prev: Prev,
                         mapfn: MappingFn,
-                        state_ref: &'a ::std::cell::RefCell<Lat>,
+                        state_ref: &'a mut Lat,
                     ) -> impl 'a + #root::dfir_pipes::pull::Pull<Item = Item, Meta = Prev::Meta>
                     where
                         Item: ::std::clone::Clone,
@@ -135,12 +135,11 @@ pub const STATE_BY: OperatorConstraints = OperatorConstraints {
                         #root::dfir_pipes::pull::Pull::filter(
                             prev,
                             move |item| {
-                                let mut state = state_ref.borrow_mut();
-                                #root::lattices::Merge::merge(&mut *state, (mapfn)(::std::clone::Clone::clone(item)))
+                                #root::lattices::Merge::merge(state_ref, (mapfn)(::std::clone::Clone::clone(item)))
                             },
                         )
                     }
-                    check_input::<_, _, _, _, #lattice_type>(#input, #by_fn, &#state_ident)
+                    check_input::<_, _, _, _, #lattice_type>(#input, #by_fn, &mut #state_ident)
                 };
             }
         } else if let Some(output) = outputs.first() {
@@ -149,7 +148,7 @@ pub const STATE_BY: OperatorConstraints = OperatorConstraints {
                     fn check_output<'a, Item, MappingFn, MappedItem, Psh, Lat>(
                         push: Psh,
                         mapfn: MappingFn,
-                        state_ref: &'a ::std::cell::RefCell<Lat>,
+                        state_ref: &'a mut Lat,
                     ) -> impl 'a + #root::dfir_pipes::push::Push<Item, ()>
                     where
                         Item: 'a + ::std::clone::Clone,
@@ -158,18 +157,17 @@ pub const STATE_BY: OperatorConstraints = OperatorConstraints {
                         Lat: 'static + #root::lattices::Merge<MappedItem>,
                     {
                         #root::dfir_pipes::push::filter(move |item| {
-                            let mut state = state_ref.borrow_mut();
-                            #root::lattices::Merge::merge(&mut *state, (mapfn)(::std::clone::Clone::clone(item)))
+                            #root::lattices::Merge::merge(state_ref, (mapfn)(::std::clone::Clone::clone(item)))
                         }, push)
                     }
-                    check_output::<_, _, _, _, #lattice_type>(#output, #by_fn, &#state_ident)
+                    check_output::<_, _, _, _, #lattice_type>(#output, #by_fn, &mut #state_ident)
                 };
             }
         } else {
             quote_spanned! {op_span=>
                 let #ident = {
                     fn check_output<'a, Item, MappingFn, MappedItem, Lat>(
-                        state_ref: &'a ::std::cell::RefCell<Lat>,
+                        state_ref: &'a mut Lat,
                         mapfn: MappingFn,
                     ) -> impl 'a + #root::dfir_pipes::push::Push<Item, ()>
                     where
@@ -179,11 +177,10 @@ pub const STATE_BY: OperatorConstraints = OperatorConstraints {
                         Lat: 'static + #root::lattices::Merge<MappedItem>,
                     {
                         #root::dfir_pipes::push::for_each(move |item| {
-                            let mut state = state_ref.borrow_mut();
-                            #root::lattices::Merge::merge(&mut *state, (mapfn)(item));
+                            #root::lattices::Merge::merge(state_ref, (mapfn)(item));
                         })
                     }
-                    check_output::<_, _, _, #lattice_type>(&#state_ident, #by_fn)
+                    check_output::<_, _, _, #lattice_type>(&mut #state_ident, #by_fn)
                 };
             }
         };

--- a/dfir_lang/src/process_singletons.rs
+++ b/dfir_lang/src/process_singletons.rs
@@ -26,8 +26,8 @@ pub fn preprocess_singletons(tokens: TokenStream, found_idents: &mut Vec<Ident>)
 /// * `resolved_idents` - The local variable idents that correspond 1:1 and in the same
 ///   order as the singleton references within `tokens` (found in-order via [`preprocess_singletons`]).
 ///
-/// Generates a direct reference to the local variable. Use [`postprocess_singletons_handles`] for
-/// just the raw idents.
+/// Generates `(*&ident)` — an immutable place expression that prevents consumer mutation.
+/// Use [`postprocess_singletons_handles`] for just the raw idents.
 pub fn postprocess_singletons(
     tokens: TokenStream,
     resolved_idents: impl IntoIterator<Item = Ident>,
@@ -37,7 +37,19 @@ pub fn postprocess_singletons(
         let span = singleton_ident.span();
         let mut resolved_ident = resolved_idents_iter.next().unwrap();
         resolved_ident.set_span(span);
-        TokenTree::Ident(resolved_ident)
+        // Emit `(*&ident)` so consumers get an immutable place expression.
+        // The `&` prevents mutation (can't assign through a shared reference),
+        // and the `*` dereferences back to the original type for ergonomic use.
+        let deref_ref_tokens: TokenStream = [
+            TokenTree::Punct(proc_macro2::Punct::new('*', proc_macro2::Spacing::Alone)),
+            TokenTree::Punct(proc_macro2::Punct::new('&', proc_macro2::Spacing::Alone)),
+            TokenTree::Ident(resolved_ident),
+        ]
+        .into_iter()
+        .collect();
+        let mut group = Group::new(proc_macro2::Delimiter::Parenthesis, deref_ref_tokens);
+        group.set_span(span);
+        TokenTree::Group(group)
     });
     parse_terminated(processed).unwrap()
 }

--- a/dfir_lang/src/process_singletons.rs
+++ b/dfir_lang/src/process_singletons.rs
@@ -2,7 +2,6 @@
 
 use itertools::Itertools;
 use proc_macro2::{Group, Ident, TokenStream, TokenTree};
-use quote::quote_spanned;
 use syn::punctuated::Punctuated;
 use syn::{Expr, Token};
 
@@ -24,29 +23,21 @@ pub fn preprocess_singletons(tokens: TokenStream, found_idents: &mut Vec<Ident>)
 /// Replaces singleton references `#my_var` with the code needed to actually get the value inside.
 ///
 /// * `tokens` - The tokens to update singleton references within.
-/// * `resolved_idents` - The `RefCell<_>` local variable idents that correspond 1:1 and in the same
+/// * `resolved_idents` - The local variable idents that correspond 1:1 and in the same
 ///   order as the singleton references within `tokens` (found in-order via [`preprocess_singletons`]).
 ///
-/// Generates borrowing code ([`std::cell::RefCell::borrow`]). Use
-/// [`postprocess_singletons_handles`] for just the raw idents.
+/// Generates a direct reference to the local variable. Use [`postprocess_singletons_handles`] for
+/// just the raw idents.
 pub fn postprocess_singletons(
     tokens: TokenStream,
     resolved_idents: impl IntoIterator<Item = Ident>,
-    _context: &Ident,
 ) -> Punctuated<Expr, Token![,]> {
     let mut resolved_idents_iter = resolved_idents.into_iter();
     let processed = process_singletons(tokens, &mut |singleton_ident| {
         let span = singleton_ident.span();
         let mut resolved_ident = resolved_idents_iter.next().unwrap();
         resolved_ident.set_span(span);
-        let mut group = Group::new(
-            proc_macro2::Delimiter::Parenthesis,
-            quote_spanned! {span=>
-                *#resolved_ident.borrow()
-            },
-        );
-        group.set_span(singleton_ident.span());
-        TokenTree::Group(group)
+        TokenTree::Ident(resolved_ident)
     });
     parse_terminated(processed).unwrap()
 }

--- a/dfir_rs/src/compiled/pull/lattice_bimorphism.rs
+++ b/dfir_rs/src/compiled/pull/lattice_bimorphism.rs
@@ -1,4 +1,3 @@
-use std::cell::RefCell;
 use std::pin::Pin;
 
 use dfir_pipes::pull::{FusedPull, Pull, PullStep};
@@ -17,8 +16,8 @@ pin_project! {
 
         func: Func,
 
-        lhs_state: &'a RefCell<LhsState>,
-        rhs_state: &'a RefCell<RhsState>,
+        lhs_state: &'a LhsState,
+        rhs_state: &'a RhsState,
 
         output: Option<Output>,
     }
@@ -41,8 +40,8 @@ where
         lhs_prev: LhsPrev,
         rhs_prev: RhsPrev,
         func: Func,
-        lhs_state: &'a RefCell<LhsState>,
-        rhs_state: &'a RefCell<RhsState>,
+        lhs_state: &'a LhsState,
+        rhs_state: &'a RhsState,
     ) -> Self {
         Self {
             lhs_prev,
@@ -91,7 +90,7 @@ where
             let lhs_pending = matches!(lhs_step, PullStep::Pending(_));
             if let PullStep::Ready(lhs_item, _meta) = lhs_step {
                 progress = true;
-                let delta = this.func.call(lhs_item, this.rhs_state.borrow().clone());
+                let delta = this.func.call(lhs_item, this.rhs_state.clone());
                 if let Some(output) = this.output.as_mut() {
                     output.merge(delta);
                 } else {
@@ -106,7 +105,7 @@ where
             let rhs_pending = matches!(rhs_step, PullStep::Pending(_));
             if let PullStep::Ready(rhs_item, _meta) = rhs_step {
                 progress = true;
-                let delta = this.func.call(this.lhs_state.borrow().clone(), rhs_item);
+                let delta = this.func.call(this.lhs_state.clone(), rhs_item);
                 if let Some(output) = this.output.as_mut() {
                     output.merge(delta);
                 } else {

--- a/dfir_rs/tests/compile-fail-stable/surface_singleton_mutation.rs
+++ b/dfir_rs/tests/compile-fail-stable/surface_singleton_mutation.rs
@@ -1,0 +1,1 @@
+../compile-fail/surface_singleton_mutation.rs

--- a/dfir_rs/tests/compile-fail-stable/surface_singleton_mutation.stderr
+++ b/dfir_rs/tests/compile-fail-stable/surface_singleton_mutation.stderr
@@ -1,0 +1,5 @@
+error[E0594]: cannot assign to data in a `&` reference
+ --> tests/compile-fail-stable/surface_singleton_mutation.rs:9:18
+  |
+9 |                 #max_of_stream2 = 999;
+  |                  ^^^^^^^^^^^^^^^^^^^^ cannot assign

--- a/dfir_rs/tests/compile-fail/surface_singleton_mutation.rs
+++ b/dfir_rs/tests/compile-fail/surface_singleton_mutation.rs
@@ -1,0 +1,15 @@
+/// Consumers should not be able to mutate singleton state.
+fn main() {
+    let mut df = dfir_rs::dfir_syntax! {
+        stream2 = source_iter(3..=5);
+        max_of_stream2 = stream2 -> fold(|| 0usize, |a, b| *a = std::cmp::max(*a, b));
+
+        source_iter(1..=3)
+            -> map(|x| {
+                #max_of_stream2 = 999;
+                x
+            })
+            -> for_each(|x| println!("{}", x));
+    };
+    df.run_available_sync();
+}

--- a/dfir_rs/tests/compile-fail/surface_singleton_mutation.stderr
+++ b/dfir_rs/tests/compile-fail/surface_singleton_mutation.stderr
@@ -1,0 +1,5 @@
+error[E0594]: cannot assign to data in a `&` reference
+ --> tests/compile-fail-stable/surface_singleton_mutation.rs:9:18
+  |
+9 |                 #max_of_stream2 = 999;
+  |                  ^^^^^^^^^^^^^^^^^^^^ cannot assign


### PR DESCRIPTION
Uses `*&var` pattern to prevent mutation