### PR TITLE
feat(hydro_lang): Pr/ir export

### DIFF
--- a/hydro_lang/src/compile/built.rs
+++ b/hydro_lang/src/compile/built.rs
@@ -50,7 +50,7 @@ impl<'a> BuiltFlow<'a> {
     }
 
     /// Serialize the IR as JSON.
-    #[cfg(feature = "runtime_support")]
+    #[cfg(feature = "viz")]
     pub fn ir_json(&self) -> Result<String, serde_json::Error> {
         super::ir::serialize_dedup_shared(|| serde_json::to_string_pretty(&self.ir))
     }
@@ -98,6 +98,12 @@ impl<'a> BuiltFlow<'a> {
         &self,
         config: &crate::viz::config::GraphConfig,
     ) -> Result<Option<String>, Box<dyn std::error::Error>> {
+        if let Some(crate::viz::config::GraphType::Ir) = config.graph {
+            let filename = config.output.clone().unwrap_or_else(|| "hydro_ir.json".to_string());
+            let json = self.ir_json()?;
+            std::fs::write(&filename, &json)?;
+            return Ok(Some(filename));
+        }
         self.graph_api().generate_graph(config)
     }
 

--- a/hydro_lang/src/compile/built.rs
+++ b/hydro_lang/src/compile/built.rs
@@ -98,12 +98,6 @@ impl<'a> BuiltFlow<'a> {
         &self,
         config: &crate::viz::config::GraphConfig,
     ) -> Result<Option<String>, Box<dyn std::error::Error>> {
-        if let Some(crate::viz::config::GraphType::Ir) = config.graph {
-            let filename = config.output.clone().unwrap_or_else(|| "hydro_ir.json".to_string());
-            let json = self.ir_json()?;
-            std::fs::write(&filename, &json)?;
-            return Ok(Some(filename));
-        }
         self.graph_api().generate_graph(config)
     }
 

--- a/hydro_lang/src/viz/api.rs
+++ b/hydro_lang/src/viz/api.rs
@@ -40,7 +40,11 @@ impl<'a> GraphApi<'a> {
             crate::viz::config::GraphType::Mermaid => render_hydro_ir_mermaid(self.ir, config),
             crate::viz::config::GraphType::Dot => render_hydro_ir_dot(self.ir, config),
             crate::viz::config::GraphType::Json => render_hydro_ir_json(self.ir, config),
-            crate::viz::config::GraphType::Ir => panic!("Ir format handled by BuiltFlow::generate_graph"),
+            crate::viz::config::GraphType::Ir => {
+                crate::compile::ir::serialize_dedup_shared(|| {
+                    serde_json::to_string_pretty(self.ir).expect("failed to serialize IR")
+                })
+            }
         }
     }
 

--- a/hydro_lang/src/viz/api.rs
+++ b/hydro_lang/src/viz/api.rs
@@ -40,6 +40,7 @@ impl<'a> GraphApi<'a> {
             crate::viz::config::GraphType::Mermaid => render_hydro_ir_mermaid(self.ir, config),
             crate::viz::config::GraphType::Dot => render_hydro_ir_dot(self.ir, config),
             crate::viz::config::GraphType::Json => render_hydro_ir_json(self.ir, config),
+            crate::viz::config::GraphType::Ir => panic!("Ir format handled by BuiltFlow::generate_graph"),
         }
     }
 

--- a/hydro_lang/src/viz/config.rs
+++ b/hydro_lang/src/viz/config.rs
@@ -9,6 +9,8 @@ pub enum GraphType {
     Dot,
     /// JSON format for Hydroscope interactive viewer.
     Json,
+    /// Serialized IR JSON for standalone coordination analysis.
+    Ir,
 }
 
 impl GraphType {
@@ -18,6 +20,7 @@ impl GraphType {
             GraphType::Mermaid => "mmd",
             GraphType::Dot => "dot",
             GraphType::Json => "json",
+            GraphType::Ir => "json",
         }
     }
 }

--- a/hydro_lang/src/viz/config.rs
+++ b/hydro_lang/src/viz/config.rs
@@ -20,7 +20,7 @@ impl GraphType {
             GraphType::Mermaid => "mmd",
             GraphType::Dot => "dot",
             GraphType::Json => "json",
-            GraphType::Ir => "json",
+            GraphType::Ir => "ir.json",
         }
     }
 }


### PR DESCRIPTION
Adds a new `--graph ir` option that exports the serialized Hydro IR as JSON, for use by standalone analysis tools (e.g. `hydro-coord`).

## Changes

- New `GraphType::Ir` variant in `viz/config.rs`
- IR serialization handled in `GraphApi::render` using `serialize_dedup_shared` for cycle-safe output
- Uses `.ir.json` file extension to distinguish from the Hydroscope viewer format (`.json`)
- `ir_json()` feature gate changed from `runtime_support` to `viz` (it only needs `serde_json`, not `dfir_rs`)

## Usage

```
cargo run --example my_flow -- --graph ir
cargo run --example my_flow -- --graph ir -o my_flow.ir.json
```

The output can be piped directly into `hydro-coord`:

```
hydro-coord my_flow.ir.json
```