### PR TITLE
refactor(dfir_lang): remove `..` from OperatorWriteOutput destructures in delegating operators

### DIFF
--- a/dfir_lang/src/graph/ops/_lattice_join_fused_join.rs
+++ b/dfir_lang/src/graph/ops/_lattice_join_fused_join.rs
@@ -124,7 +124,6 @@ pub const _LATTICE_JOIN_FUSED_JOIN: OperatorConstraints = OperatorConstraints {
             write_iterator,
             write_iterator_after,
             write_tick_end,
-            ..
         } = (super::join_fused::JOIN_FUSED.write_fn)(&wc, diagnostics).unwrap();
 
         let write_iterator = quote_spanned! {op_span=>

--- a/dfir_lang/src/graph/ops/difference.rs
+++ b/dfir_lang/src/graph/ops/difference.rs
@@ -57,7 +57,6 @@ pub const DIFFERENCE: OperatorConstraints = OperatorConstraints {
             write_iterator,
             write_iterator_after,
             write_tick_end,
-            ..
         } = (super::anti_join::ANTI_JOIN.write_fn)(wc, diagnostics)?;
 
         let pos = &inputs[1];

--- a/dfir_lang/src/graph/ops/join_fused_rhs.rs
+++ b/dfir_lang/src/graph/ops/join_fused_rhs.rs
@@ -50,7 +50,6 @@ pub const JOIN_FUSED_RHS: OperatorConstraints = OperatorConstraints {
             write_iterator,
             write_iterator_after,
             write_tick_end,
-            ..
         } = (super::join_fused_lhs::JOIN_FUSED_LHS.write_fn)(&wc, diagnostics)?;
 
         let write_iterator = quote_spanned! {op_span=>

--- a/dfir_lang/src/graph/ops/source_interval.rs
+++ b/dfir_lang/src/graph/ops/source_interval.rs
@@ -77,11 +77,18 @@ pub const SOURCE_INTERVAL: OperatorConstraints = OperatorConstraints {
             arguments: &parse_quote_spanned!(op_span=> #ident_intervalstream),
             ..wc.clone()
         };
-        let write_output = (super::source_stream::SOURCE_STREAM.write_fn)(&wc, diagnostics)?;
-        write_prologue.extend(write_output.write_prologue);
+        let OperatorWriteOutput {
+            write_prologue: write_prologue_stream,
+            write_iterator,
+            write_iterator_after,
+            write_tick_end,
+        } = (super::source_stream::SOURCE_STREAM.write_fn)(&wc, diagnostics)?;
+        write_prologue.extend(write_prologue_stream);
         Ok(OperatorWriteOutput {
             write_prologue,
-            ..write_output
+            write_iterator,
+            write_iterator_after,
+            write_tick_end,
         })
     },
 };


### PR DESCRIPTION
Replaced `..` catch-all patterns with explicit field bindings in 4 delegating
operators (join_fused_rhs, difference, _lattice_join_fused_join, source_interval)
to ensure new fields added to OperatorWriteOutput are never silently dropped.

The remaining `..Default::default()` usages in non-delegating operators are
intentional — they only set the fields they need and default the rest to empty
TokenStreams.

Co-authored-by: Infinity 🤖 <infinity@hydro.run>