### PR TITLE
refactor(dfir_lang): remove `DelayType::Stratum`/`MonotoneAccum` from operator `input_delaytype_fn`

### DIFF
--- a/dfir_lang/src/graph/flat_to_partitioned.rs
+++ b/dfir_lang/src/graph/flat_to_partitioned.rs
@@ -28,10 +28,7 @@ impl BarrierCrossers {
             .edge_barrier_crossers
             .iter()
             .map(|(edge_id, &_delay_type)| partitioned_graph.edge(edge_id));
-        let singleton_pairs_iter = self
-            .singleton_barrier_crossers
-            .iter()
-            .copied();
+        let singleton_pairs_iter = self.singleton_barrier_crossers.iter().copied();
         edge_pairs_iter.chain(singleton_pairs_iter)
     }
 

--- a/dfir_lang/src/graph/flat_to_partitioned.rs
+++ b/dfir_lang/src/graph/flat_to_partitioned.rs
@@ -15,26 +15,23 @@ use crate::union_find::UnionFind;
 struct BarrierCrossers {
     /// Edge barrier crossers, including what type.
     pub edge_barrier_crossers: SecondaryMap<GraphEdgeId, DelayType>,
-    /// Singleton reference barrier crossers, considered to be [`DelayType::Stratum`].
+    /// Singleton reference barrier crossers — force subgraph boundaries.
     pub singleton_barrier_crossers: Vec<(GraphNodeId, GraphNodeId)>,
 }
 impl BarrierCrossers {
-    /// Iterate pairs of nodes that are across a barrier. Excludes `DelayType::NextIteration` pairs.
+    /// Iterate pairs of nodes that are across a barrier (subgraph boundary or tick boundary).
     fn iter_node_pairs<'a>(
         &'a self,
         partitioned_graph: &'a DfirGraph,
-    ) -> impl 'a + Iterator<Item = ((GraphNodeId, GraphNodeId), DelayType)> {
+    ) -> impl 'a + Iterator<Item = (GraphNodeId, GraphNodeId)> {
         let edge_pairs_iter = self
             .edge_barrier_crossers
             .iter()
-            .map(|(edge_id, &delay_type)| {
-                let src_dst = partitioned_graph.edge(edge_id);
-                (src_dst, delay_type)
-            });
+            .map(|(edge_id, &_delay_type)| partitioned_graph.edge(edge_id));
         let singleton_pairs_iter = self
             .singleton_barrier_crossers
             .iter()
-            .map(|&src_dst| (src_dst, DelayType::Stratum));
+            .copied();
         edge_pairs_iter.chain(singleton_pairs_iter)
     }
 
@@ -122,7 +119,7 @@ fn find_subgraph_unionfind(
             // Do not connect stratum crossers (next edges).
             if barrier_crossers
                 .iter_node_pairs(partitioned_graph)
-                .any(|((x_src, x_dst), _)| {
+                .any(|(x_src, x_dst)| {
                     (subgraph_unionfind.same_set(x_src, src)
                         && subgraph_unionfind.same_set(x_dst, dst))
                         || (subgraph_unionfind.same_set(x_src, dst)

--- a/dfir_lang/src/graph/graph_write.rs
+++ b/dfir_lang/src/graph/graph_write.rs
@@ -181,8 +181,7 @@ where
             src = src_str.trim(),
             arrow_body = "--",
             arrow_head = match delay_type {
-                None | Some(DelayType::MonotoneAccum) => ">",
-                Some(DelayType::Stratum) => "x",
+                None => ">",
                 Some(DelayType::Tick | DelayType::TickLazy) => "o",
             },
             label = if let Some(label) = &label {
@@ -200,8 +199,7 @@ where
                 "; linkStyle {} stroke:{}",
                 self.link_count,
                 match delay_type {
-                    DelayType::Stratum | DelayType::Tick | DelayType::TickLazy => "red",
-                    DelayType::MonotoneAccum => "#060",
+                    DelayType::Tick | DelayType::TickLazy => "red",
                 }
             )?;
         }

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1769,7 +1769,7 @@ impl DfirGraph {
                     .copied()
                     .flatten()
                 {
-                    let delay_type = Some(DelayType::Stratum);
+                    let delay_type = None;
                     let label = None;
                     graph_write.write_edge(src_ref_id, dst_id, delay_type, label, true)?;
                 }

--- a/dfir_lang/src/graph/ops/_lattice_fold_batch.rs
+++ b/dfir_lang/src/graph/ops/_lattice_fold_batch.rs
@@ -2,7 +2,7 @@ use quote::{quote_spanned, ToTokens};
 use syn::parse_quote;
 
 use super::{
-    DelayType, OpInstGenerics, OperatorCategory, OperatorConstraints, OperatorInstance,
+    OpInstGenerics, OperatorCategory, OperatorConstraints, OperatorInstance,
     OperatorWriteOutput, PortListSpec, WriteContextArgs, RANGE_0, RANGE_1,
 };
 
@@ -45,7 +45,7 @@ pub const _LATTICE_FOLD_BATCH: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: Some(|| PortListSpec::Fixed(parse_quote! { input, signal })),
     ports_out: None,
-    input_delaytype_fn: |_| Some(DelayType::MonotoneAccum),
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    ident,
                    op_span,

--- a/dfir_lang/src/graph/ops/_lattice_join_fused_join.rs
+++ b/dfir_lang/src/graph/ops/_lattice_join_fused_join.rs
@@ -2,7 +2,7 @@ use quote::quote_spanned;
 use syn::{parse_quote, parse_quote_spanned};
 
 use super::{
-    DelayType, OpInstGenerics, OperatorCategory, OperatorConstraints, OperatorInstance,
+    OpInstGenerics, OperatorCategory, OperatorConstraints, OperatorInstance,
     OperatorWriteOutput, RANGE_1, WriteContextArgs,
 };
 
@@ -88,7 +88,7 @@ pub const _LATTICE_JOIN_FUSED_JOIN: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { 0, 1 })),
     ports_out: None,
-    input_delaytype_fn: |_| Some(DelayType::MonotoneAccum),
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
                    op_span,

--- a/dfir_lang/src/graph/ops/anti_join.rs
+++ b/dfir_lang/src/graph/ops/anti_join.rs
@@ -2,7 +2,7 @@ use quote::{ToTokens, quote_spanned};
 use syn::parse_quote;
 
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints, OperatorWriteOutput, PortIndexValue, RANGE_0,
+    OperatorCategory, OperatorConstraints, OperatorWriteOutput, PortIndexValue, RANGE_0,
     RANGE_1, WriteContextArgs,
 };
 use crate::graph::ops::Persistence;
@@ -39,13 +39,12 @@ pub const ANTI_JOIN: OperatorConstraints = OperatorConstraints {
     ports_out: None,
     input_delaytype_fn: |idx| match idx {
         PortIndexValue::Path(path) if "neg" == path.to_token_stream().to_string() => {
-            Some(DelayType::Stratum)
+            None
         }
         _else => None,
     },
     write_fn: |wc @ &WriteContextArgs {
                    root,
-                   context,
                    op_span,
                    work_fn_async,
                    ident,
@@ -118,12 +117,6 @@ pub const ANTI_JOIN: OperatorConstraints = OperatorConstraints {
                 let #ident = {
                     #accum_neg
 
-                    let replay_idx = if #context.is_first_run_this_tick() {
-                        0
-                    } else {
-                        #pos_ident.len()
-                    };
-
                     // Accum into pos vec
                     let fut = #root::dfir_pipes::pull::Pull::for_each(#input_pos, |kv| {
                         #pos_ident.push(kv);
@@ -131,7 +124,7 @@ pub const ANTI_JOIN: OperatorConstraints = OperatorConstraints {
                     let () = #work_fn_async(fut).await;
 
                     // Replay out of pos vec
-                    let iter = #pos_ident[replay_idx..].iter();
+                    let iter = #pos_ident[..].iter();
                     let iter = ::std::iter::Iterator::filter(iter, |(k, _)| {
                         !#neg_ident.contains(k)
                     });

--- a/dfir_lang/src/graph/ops/anti_join.rs
+++ b/dfir_lang/src/graph/ops/anti_join.rs
@@ -1,8 +1,8 @@
-use quote::{ToTokens, quote_spanned};
+use quote::quote_spanned;
 use syn::parse_quote;
 
 use super::{
-    OperatorCategory, OperatorConstraints, OperatorWriteOutput, PortIndexValue, RANGE_0,
+    OperatorCategory, OperatorConstraints, OperatorWriteOutput, RANGE_0,
     RANGE_1, WriteContextArgs,
 };
 use crate::graph::ops::Persistence;
@@ -37,12 +37,7 @@ pub const ANTI_JOIN: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { pos, neg })),
     ports_out: None,
-    input_delaytype_fn: |idx| match idx {
-        PortIndexValue::Path(path) if "neg" == path.to_token_stream().to_string() => {
-            None
-        }
-        _else => None,
-    },
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
                    op_span,

--- a/dfir_lang/src/graph/ops/anti_join.rs
+++ b/dfir_lang/src/graph/ops/anti_join.rs
@@ -45,7 +45,6 @@ pub const ANTI_JOIN: OperatorConstraints = OperatorConstraints {
     },
     write_fn: |wc @ &WriteContextArgs {
                    root,
-                   context,
                    op_span,
                    work_fn_async,
                    ident,
@@ -118,12 +117,6 @@ pub const ANTI_JOIN: OperatorConstraints = OperatorConstraints {
                 let #ident = {
                     #accum_neg
 
-                    let replay_idx = if #context.is_first_run_this_tick() {
-                        0
-                    } else {
-                        #pos_ident.len()
-                    };
-
                     // Accum into pos vec
                     let fut = #root::dfir_pipes::pull::Pull::for_each(#input_pos, |kv| {
                         #pos_ident.push(kv);
@@ -131,7 +124,7 @@ pub const ANTI_JOIN: OperatorConstraints = OperatorConstraints {
                     let () = #work_fn_async(fut).await;
 
                     // Replay out of pos vec
-                    let iter = #pos_ident[replay_idx..].iter();
+                    let iter = #pos_ident[..].iter();
                     let iter = ::std::iter::Iterator::filter(iter, |(k, _)| {
                         !#neg_ident.contains(k)
                     });

--- a/dfir_lang/src/graph/ops/chain.rs
+++ b/dfir_lang/src/graph/ops/chain.rs
@@ -1,7 +1,7 @@
 use crate::graph::PortIndexValue;
 
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints, RANGE_0, RANGE_1
+    OperatorCategory, OperatorConstraints, RANGE_0, RANGE_1
 };
 
 /// > 2 input streams of the same type, 1 output stream of the same type
@@ -35,7 +35,7 @@ pub const CHAIN: OperatorConstraints = OperatorConstraints {
     ports_out: None,
     input_delaytype_fn: |idx| match idx {
         PortIndexValue::Int(idx) if idx.value == 0 => {
-            Some(DelayType::Stratum)
+            None
         }
         _else => None,
     },

--- a/dfir_lang/src/graph/ops/chain.rs
+++ b/dfir_lang/src/graph/ops/chain.rs
@@ -1,5 +1,3 @@
-use crate::graph::PortIndexValue;
-
 use super::{
     OperatorCategory, OperatorConstraints, RANGE_0, RANGE_1
 };
@@ -33,11 +31,6 @@ pub const CHAIN: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: |idx| match idx {
-        PortIndexValue::Int(idx) if idx.value == 0 => {
-            None
-        }
-        _else => None,
-    },
+    input_delaytype_fn: |_| None,
     write_fn: super::union::UNION.write_fn,
 };

--- a/dfir_lang/src/graph/ops/chain_first_n.rs
+++ b/dfir_lang/src/graph/ops/chain_first_n.rs
@@ -1,7 +1,6 @@
 use quote::quote_spanned;
 
 use crate::graph::{
-    PortIndexValue,
     ops::{OperatorWriteOutput, WriteContextArgs},
 };
 
@@ -37,13 +36,7 @@ pub const CHAIN_FIRST_N: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: |idx| match idx {
-        PortIndexValue::Int(idx) if idx.value == 0 => {
-            // will no longer be needed once subgraphs are always DAGs (only run once per tick)
-            None
-        }
-        _else => None,
-    },
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
                    op_span,

--- a/dfir_lang/src/graph/ops/chain_first_n.rs
+++ b/dfir_lang/src/graph/ops/chain_first_n.rs
@@ -5,7 +5,7 @@ use crate::graph::{
     ops::{OperatorWriteOutput, WriteContextArgs},
 };
 
-use super::{DelayType, OperatorCategory, OperatorConstraints, RANGE_0, RANGE_1};
+use super::{OperatorCategory, OperatorConstraints, RANGE_0, RANGE_1};
 
 /// > 2 input streams of the same type, 1 output stream of the same type
 ///
@@ -40,7 +40,7 @@ pub const CHAIN_FIRST_N: OperatorConstraints = OperatorConstraints {
     input_delaytype_fn: |idx| match idx {
         PortIndexValue::Int(idx) if idx.value == 0 => {
             // will no longer be needed once subgraphs are always DAGs (only run once per tick)
-            Some(DelayType::Stratum)
+            None
         }
         _else => None,
     },

--- a/dfir_lang/src/graph/ops/cross_join_multiset.rs
+++ b/dfir_lang/src/graph/ops/cross_join_multiset.rs
@@ -41,7 +41,6 @@ pub const CROSS_JOIN_MULTISET: OperatorConstraints = OperatorConstraints {
     input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
-                   context,
                    op_span,
                    work_fn_async,
                    ident,
@@ -74,31 +73,15 @@ pub const CROSS_JOIN_MULTISET: OperatorConstraints = OperatorConstraints {
             _ => Default::default(),
         };
 
-        let lhs_i = wc.make_ident("lhs_i");
-        let rhs_i = wc.make_ident("rhs_i");
         let write_iterator = quote_spanned! {op_span=>
-            let (#lhs_i, #rhs_i) = if #context.is_first_run_this_tick() {
-                (0, 0)
-            } else {
-                (#lhs_state.len(), #rhs_state.len())
-            };
-
             #work_fn_async(#root::dfir_pipes::pull::Pull::for_each(#lhs, |x| #lhs_state.push(x))).await;
             #work_fn_async(#root::dfir_pipes::pull::Pull::for_each(#rhs, |x| #rhs_state.push(x))).await;
 
-            //       RHS
-            //   +-----+-----+
-            // L | Old | New |
-            // H +-----+-----+
-            // S | New | New |
-            //   +-----+-----+
             let #ident = #root::dfir_pipes::pull::iter(
                 #lhs_state
                     .iter()
-                    .enumerate()
-                    .flat_map(|(i, lhs)| {
-                        let j = if i < #lhs_i { #rhs_i } else { 0 };
-                        #rhs_state[j..]
+                    .flat_map(|lhs| {
+                        #rhs_state[..]
                             .iter()
                             .map(move |rhs| (::std::clone::Clone::clone(lhs), ::std::clone::Clone::clone(rhs)))
                     })

--- a/dfir_lang/src/graph/ops/cross_singleton.rs
+++ b/dfir_lang/src/graph/ops/cross_singleton.rs
@@ -2,7 +2,7 @@ use quote::{ToTokens, quote_spanned};
 use syn::parse_quote;
 
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints, OperatorWriteOutput, RANGE_0, RANGE_1,
+    OperatorCategory, OperatorConstraints, OperatorWriteOutput, RANGE_0, RANGE_1,
     WriteContextArgs,
 };
 use crate::graph::PortIndexValue;
@@ -44,7 +44,7 @@ pub const CROSS_SINGLETON: OperatorConstraints = OperatorConstraints {
     ports_out: None,
     input_delaytype_fn: |idx| match idx {
         PortIndexValue::Path(path) if "single" == path.to_token_stream().to_string() => {
-            Some(DelayType::Stratum)
+            None
         }
         _else => None,
     },

--- a/dfir_lang/src/graph/ops/cross_singleton.rs
+++ b/dfir_lang/src/graph/ops/cross_singleton.rs
@@ -1,11 +1,10 @@
-use quote::{ToTokens, quote_spanned};
+use quote::quote_spanned;
 use syn::parse_quote;
 
 use super::{
     OperatorCategory, OperatorConstraints, OperatorWriteOutput, RANGE_0, RANGE_1,
     WriteContextArgs,
 };
-use crate::graph::PortIndexValue;
 
 /// > 2 input streams, 1 output stream, no arguments.
 ///
@@ -42,12 +41,7 @@ pub const CROSS_SINGLETON: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { input, single })),
     ports_out: None,
-    input_delaytype_fn: |idx| match idx {
-        PortIndexValue::Path(path) if "single" == path.to_token_stream().to_string() => {
-            None
-        }
-        _else => None,
-    },
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
                    ident,

--- a/dfir_lang/src/graph/ops/defer_signal.rs
+++ b/dfir_lang/src/graph/ops/defer_signal.rs
@@ -2,7 +2,7 @@ use quote::quote_spanned;
 use syn::parse_quote;
 
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints, OperatorWriteOutput, RANGE_0, RANGE_1,
+    OperatorCategory, OperatorConstraints, OperatorWriteOutput, RANGE_0, RANGE_1,
     WriteContextArgs,
 };
 
@@ -37,7 +37,7 @@ pub const DEFER_SIGNAL: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { input, signal })),
     ports_out: None,
-    input_delaytype_fn: |_| Some(DelayType::Stratum),
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
                    ident,

--- a/dfir_lang/src/graph/ops/difference.rs
+++ b/dfir_lang/src/graph/ops/difference.rs
@@ -2,7 +2,7 @@ use quote::{ToTokens, quote_spanned};
 use syn::parse_quote;
 
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints, OperatorInstance, OperatorWriteOutput,
+    OperatorCategory, OperatorConstraints, OperatorInstance, OperatorWriteOutput,
     PortIndexValue, RANGE_0, RANGE_1, WriteContextArgs,
 };
 
@@ -39,7 +39,7 @@ pub const DIFFERENCE: OperatorConstraints = OperatorConstraints {
     ports_out: None,
     input_delaytype_fn: |idx| match idx {
         PortIndexValue::Path(path) if "neg" == path.to_token_stream().to_string() => {
-            Some(DelayType::Stratum)
+            None
         }
         _else => None,
     },

--- a/dfir_lang/src/graph/ops/difference.rs
+++ b/dfir_lang/src/graph/ops/difference.rs
@@ -1,9 +1,9 @@
-use quote::{ToTokens, quote_spanned};
+use quote::quote_spanned;
 use syn::parse_quote;
 
 use super::{
     OperatorCategory, OperatorConstraints, OperatorInstance, OperatorWriteOutput,
-    PortIndexValue, RANGE_0, RANGE_1, WriteContextArgs,
+    RANGE_0, RANGE_1, WriteContextArgs,
 };
 
 /// > 2 input streams of the same type T, 1 output stream of type T
@@ -37,12 +37,7 @@ pub const DIFFERENCE: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { pos, neg })),
     ports_out: None,
-    input_delaytype_fn: |idx| match idx {
-        PortIndexValue::Path(path) if "neg" == path.to_token_stream().to_string() => {
-            None
-        }
-        _else => None,
-    },
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
                    op_span,

--- a/dfir_lang/src/graph/ops/fold.rs
+++ b/dfir_lang/src/graph/ops/fold.rs
@@ -1,7 +1,7 @@
 use quote::quote_spanned;
 
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints, OperatorWriteOutput, Persistence, RANGE_0,
+    OperatorCategory, OperatorConstraints, OperatorWriteOutput, Persistence, RANGE_0,
     RANGE_1, WriteContextArgs,
 };
 
@@ -47,7 +47,7 @@ pub const FOLD: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: |_| Some(DelayType::Stratum),
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
                    op_span,

--- a/dfir_lang/src/graph/ops/fold_keyed.rs
+++ b/dfir_lang/src/graph/ops/fold_keyed.rs
@@ -1,7 +1,7 @@
 use quote::{ToTokens, quote_spanned};
 
 use super::{
-    DelayType, OpInstGenerics, OperatorCategory, OperatorConstraints, OperatorInstance,
+    OpInstGenerics, OperatorCategory, OperatorConstraints, OperatorInstance,
     OperatorWriteOutput, Persistence, RANGE_1, WriteContextArgs,
 };
 
@@ -80,9 +80,8 @@ pub const FOLD_KEYED: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: |_| Some(DelayType::Stratum),
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
-                   context,
                    op_span,
                    work_fn_async,
                    ident,
@@ -202,13 +201,8 @@ pub const FOLD_KEYED: OperatorConstraints = OperatorConstraints {
                     )
                 },
                 Persistence::Static => quote_spanned! {op_span=>
-                    // Play everything but only on the first run of this tick/stratum.
-                    // (We know we won't have any more inputs, so it is fine to only play once.
-                    // Because of the `DelayType::Stratum` or `DelayType::MonotoneAccum`).
-                    #context.is_first_run_this_tick()
-                        .then_some(#hashtable_ident.iter())
-                        .into_iter()
-                        .flatten()
+                    // Play everything (each subgraph runs exactly once per tick).
+                    #hashtable_ident.iter()
                         .map(
                             #[allow(suspicious_double_ref_op, clippy::clone_on_copy)]
                             |(k, v)| (

--- a/dfir_lang/src/graph/ops/fold_keyed.rs
+++ b/dfir_lang/src/graph/ops/fold_keyed.rs
@@ -82,7 +82,6 @@ pub const FOLD_KEYED: OperatorConstraints = OperatorConstraints {
     ports_out: None,
     input_delaytype_fn: |_| Some(DelayType::Stratum),
     write_fn: |wc @ &WriteContextArgs {
-                   context,
                    op_span,
                    work_fn_async,
                    ident,
@@ -202,13 +201,8 @@ pub const FOLD_KEYED: OperatorConstraints = OperatorConstraints {
                     )
                 },
                 Persistence::Static => quote_spanned! {op_span=>
-                    // Play everything but only on the first run of this tick/stratum.
-                    // (We know we won't have any more inputs, so it is fine to only play once.
-                    // Because of the `DelayType::Stratum` or `DelayType::MonotoneAccum`).
-                    #context.is_first_run_this_tick()
-                        .then_some(#hashtable_ident.iter())
-                        .into_iter()
-                        .flatten()
+                    // Play everything (each subgraph runs exactly once per tick).
+                    #hashtable_ident.iter()
                         .map(
                             #[allow(suspicious_double_ref_op, clippy::clone_on_copy)]
                             |(k, v)| (

--- a/dfir_lang/src/graph/ops/fold_no_replay.rs
+++ b/dfir_lang/src/graph/ops/fold_no_replay.rs
@@ -1,7 +1,7 @@
 use quote::quote_spanned;
 
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints, OperatorWriteOutput, Persistence, RANGE_0,
+    OperatorCategory, OperatorConstraints, OperatorWriteOutput, Persistence, RANGE_0,
     RANGE_1, WriteContextArgs,
 };
 
@@ -29,7 +29,7 @@ pub const FOLD_NO_REPLAY: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: |_| Some(DelayType::Stratum),
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
                    context,
@@ -106,7 +106,7 @@ pub const FOLD_NO_REPLAY: OperatorConstraints = OperatorConstraints {
                     let () = #work_fn_async(__fut).await;
                 }
 
-                let #ident = if __was_updated || (#context.current_tick().0 == 0 && #context.is_first_run_this_tick()) {
+                let #ident = if __was_updated || #context.current_tick().0 == 0 {
                     #work_fn(
                         || #root::dfir_pipes::pull::iter(
                             ::std::option::Option::Some(::std::clone::Clone::clone(&*#accumulator_ident))

--- a/dfir_lang/src/graph/ops/fold_no_replay.rs
+++ b/dfir_lang/src/graph/ops/fold_no_replay.rs
@@ -106,7 +106,7 @@ pub const FOLD_NO_REPLAY: OperatorConstraints = OperatorConstraints {
                     let () = #work_fn_async(__fut).await;
                 }
 
-                let #ident = if __was_updated || (#context.current_tick().0 == 0 && #context.is_first_run_this_tick()) {
+                let #ident = if __was_updated || #context.current_tick().0 == 0 {
                     #work_fn(
                         || #root::dfir_pipes::pull::iter(
                             ::std::option::Option::Some(::std::clone::Clone::clone(&*#accumulator_ident))

--- a/dfir_lang/src/graph/ops/join.rs
+++ b/dfir_lang/src/graph/ops/join.rs
@@ -96,7 +96,6 @@ pub const JOIN: OperatorConstraints = OperatorConstraints {
     input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
-                   context,
                    loop_id,
                    op_span,
                    work_fn,
@@ -205,7 +204,7 @@ pub const JOIN: OperatorConstraints = OperatorConstraints {
                     ).await
                 }
 
-                let fut = check_inputs(#lhs, #rhs, &mut #lhs_joindata_ident, &mut #rhs_joindata_ident, #context.is_first_run_this_tick());
+                let fut = check_inputs(#lhs, #rhs, &mut #lhs_joindata_ident, &mut #rhs_joindata_ident, true);
                 #work_fn_async(fut).await
             };
         };

--- a/dfir_lang/src/graph/ops/join_fused.rs
+++ b/dfir_lang/src/graph/ops/join_fused.rs
@@ -3,7 +3,7 @@ use quote::quote_spanned;
 use syn::{Ident, parse_quote};
 
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints, OperatorWriteOutput, Persistence, RANGE_0,
+    OperatorCategory, OperatorConstraints, OperatorWriteOutput, Persistence, RANGE_0,
     RANGE_1, WriteContextArgs,
 };
 use crate::diagnostic::Diagnostic;
@@ -110,7 +110,7 @@ pub const JOIN_FUSED: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { 0, 1 })),
     ports_out: None,
-    input_delaytype_fn: |_| Some(DelayType::Stratum),
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
                    op_span,

--- a/dfir_lang/src/graph/ops/join_fused_lhs.rs
+++ b/dfir_lang/src/graph/ops/join_fused_lhs.rs
@@ -1,10 +1,10 @@
-use quote::{ToTokens, quote_spanned};
+use quote::quote_spanned;
 use syn::parse_quote;
 
 use super::join_fused::make_joindata;
 use super::{
     OperatorCategory, OperatorConstraints, OperatorWriteOutput, Persistence,
-    PortIndexValue, RANGE_0, RANGE_1, WriteContextArgs,
+    RANGE_0, RANGE_1, WriteContextArgs,
 };
 
 /// See `join_fused`
@@ -37,12 +37,7 @@ pub const JOIN_FUSED_LHS: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { 0, 1 })),
     ports_out: None,
-    input_delaytype_fn: |idx| match idx {
-        PortIndexValue::Int(path) if "0" == path.to_token_stream().to_string() => {
-            None
-        }
-        _ => None,
-    },
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
                    op_span,

--- a/dfir_lang/src/graph/ops/join_fused_lhs.rs
+++ b/dfir_lang/src/graph/ops/join_fused_lhs.rs
@@ -45,7 +45,6 @@ pub const JOIN_FUSED_LHS: OperatorConstraints = OperatorConstraints {
     },
     write_fn: |wc @ &WriteContextArgs {
                    root,
-                   context,
                    op_span,
                    work_fn_async,
                    ident,
@@ -101,13 +100,6 @@ pub const JOIN_FUSED_LHS: OperatorConstraints = OperatorConstraints {
                         #root::dfir_pipes::pull::accumulate_all(&mut #lhs_accum, &mut *#lhs_borrow, #lhs),
                     ).await;
 
-                    // RHS replay index.
-                    let replay_idx = if #context.is_first_run_this_tick() {
-                        0
-                    } else {
-                        #rhs_borrow_ident.len()
-                    };
-
                     // Accumulate RHS.
                     let () = #work_fn_async(
                         #root::dfir_pipes::pull::Pull::for_each(#rhs, |kv| {
@@ -118,7 +110,7 @@ pub const JOIN_FUSED_LHS: OperatorConstraints = OperatorConstraints {
 
                     #[allow(clippy::clone_on_copy)]
                     #[allow(suspicious_double_ref_op)]
-                    let iter = #rhs_borrow_ident[replay_idx..]
+                    let iter = #rhs_borrow_ident[..]
                         .iter()
                         .filter_map(|(k, v2)| #lhs_borrow.get(k).map(|v1| (k.clone(), (v1.clone(), v2.clone()))));
                     #root::dfir_pipes::pull::iter(iter)

--- a/dfir_lang/src/graph/ops/join_fused_lhs.rs
+++ b/dfir_lang/src/graph/ops/join_fused_lhs.rs
@@ -3,7 +3,7 @@ use syn::parse_quote;
 
 use super::join_fused::make_joindata;
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints, OperatorWriteOutput, Persistence,
+    OperatorCategory, OperatorConstraints, OperatorWriteOutput, Persistence,
     PortIndexValue, RANGE_0, RANGE_1, WriteContextArgs,
 };
 
@@ -39,13 +39,12 @@ pub const JOIN_FUSED_LHS: OperatorConstraints = OperatorConstraints {
     ports_out: None,
     input_delaytype_fn: |idx| match idx {
         PortIndexValue::Int(path) if "0" == path.to_token_stream().to_string() => {
-            Some(DelayType::Stratum)
+            None
         }
         _ => None,
     },
     write_fn: |wc @ &WriteContextArgs {
                    root,
-                   context,
                    op_span,
                    work_fn_async,
                    ident,
@@ -101,13 +100,6 @@ pub const JOIN_FUSED_LHS: OperatorConstraints = OperatorConstraints {
                         #root::dfir_pipes::pull::accumulate_all(&mut #lhs_accum, &mut *#lhs_borrow, #lhs),
                     ).await;
 
-                    // RHS replay index.
-                    let replay_idx = if #context.is_first_run_this_tick() {
-                        0
-                    } else {
-                        #rhs_borrow_ident.len()
-                    };
-
                     // Accumulate RHS.
                     let () = #work_fn_async(
                         #root::dfir_pipes::pull::Pull::for_each(#rhs, |kv| {
@@ -118,7 +110,7 @@ pub const JOIN_FUSED_LHS: OperatorConstraints = OperatorConstraints {
 
                     #[allow(clippy::clone_on_copy)]
                     #[allow(suspicious_double_ref_op)]
-                    let iter = #rhs_borrow_ident[replay_idx..]
+                    let iter = #rhs_borrow_ident[..]
                         .iter()
                         .filter_map(|(k, v2)| #lhs_borrow.get(k).map(|v1| (k.clone(), (v1.clone(), v2.clone()))));
                     #root::dfir_pipes::pull::iter(iter)

--- a/dfir_lang/src/graph/ops/join_fused_rhs.rs
+++ b/dfir_lang/src/graph/ops/join_fused_rhs.rs
@@ -1,8 +1,8 @@
-use quote::{ToTokens, quote_spanned};
+use quote::quote_spanned;
 use syn::parse_quote;
 
 use super::{
-    OperatorCategory, OperatorConstraints, OperatorWriteOutput, PortIndexValue, RANGE_0,
+    OperatorCategory, OperatorConstraints, OperatorWriteOutput, RANGE_0,
     RANGE_1, WriteContextArgs,
 };
 
@@ -24,12 +24,7 @@ pub const JOIN_FUSED_RHS: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { 0, 1 })),
     ports_out: None,
-    input_delaytype_fn: |idx| match idx {
-        PortIndexValue::Int(path) if "1" == path.to_token_stream().to_string() => {
-            None
-        }
-        _ => None,
-    },
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
                    op_span,

--- a/dfir_lang/src/graph/ops/join_fused_rhs.rs
+++ b/dfir_lang/src/graph/ops/join_fused_rhs.rs
@@ -2,7 +2,7 @@ use quote::{ToTokens, quote_spanned};
 use syn::parse_quote;
 
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints, OperatorWriteOutput, PortIndexValue, RANGE_0,
+    OperatorCategory, OperatorConstraints, OperatorWriteOutput, PortIndexValue, RANGE_0,
     RANGE_1, WriteContextArgs,
 };
 
@@ -26,7 +26,7 @@ pub const JOIN_FUSED_RHS: OperatorConstraints = OperatorConstraints {
     ports_out: None,
     input_delaytype_fn: |idx| match idx {
         PortIndexValue::Int(path) if "1" == path.to_token_stream().to_string() => {
-            Some(DelayType::Stratum)
+            None
         }
         _ => None,
     },

--- a/dfir_lang/src/graph/ops/join_multiset_half.rs
+++ b/dfir_lang/src/graph/ops/join_multiset_half.rs
@@ -43,7 +43,6 @@ pub const JOIN_MULTISET_HALF: OperatorConstraints = OperatorConstraints {
     },
     write_fn: |wc @ &WriteContextArgs {
                      root,
-                     context,
                      op_span,
                      work_fn_async,
                      ident,
@@ -137,12 +136,6 @@ pub const JOIN_MULTISET_HALF: OperatorConstraints = OperatorConstraints {
                 let #ident = {
                     #accum_build
 
-                    let replay_idx = if #context.is_first_run_this_tick() {
-                        0
-                    } else {
-                        #probe_ident.len()
-                    };
-
                     // Accum into probe vec
                     let fut = #root::dfir_pipes::pull::Pull::for_each(#input_probe, |kv| {
                         #probe_ident.push(kv);
@@ -151,7 +144,7 @@ pub const JOIN_MULTISET_HALF: OperatorConstraints = OperatorConstraints {
 
                     // Replay out of probe vec
                     #[allow(clippy::clone_on_copy, noop_method_call)]
-                    let iter = #probe_ident[replay_idx..].iter().flat_map(|(k, v_probe)| {
+                    let iter = #probe_ident[..].iter().flat_map(|(k, v_probe)| {
                         #build_ident
                             .get(k)
                             .map(|vals: &::std::vec::Vec<_>| {

--- a/dfir_lang/src/graph/ops/join_multiset_half.rs
+++ b/dfir_lang/src/graph/ops/join_multiset_half.rs
@@ -2,7 +2,7 @@ use quote::{ToTokens, quote_spanned};
 use syn::parse_quote;
 
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints, OperatorWriteOutput, PortIndexValue, RANGE_0,
+    OperatorCategory, OperatorConstraints, OperatorWriteOutput, PortIndexValue, RANGE_0,
     RANGE_1, WriteContextArgs,
 };
 use crate::graph::ops::Persistence;
@@ -37,13 +37,12 @@ pub const JOIN_MULTISET_HALF: OperatorConstraints = OperatorConstraints {
     ports_out: None,
     input_delaytype_fn: |idx| match idx {
         PortIndexValue::Path(path) if "build" == path.to_token_stream().to_string() => {
-            Some(DelayType::Stratum)
+            None
         }
         _else => None,
     },
     write_fn: |wc @ &WriteContextArgs {
                      root,
-                     context,
                      op_span,
                      work_fn_async,
                      ident,
@@ -137,12 +136,6 @@ pub const JOIN_MULTISET_HALF: OperatorConstraints = OperatorConstraints {
                 let #ident = {
                     #accum_build
 
-                    let replay_idx = if #context.is_first_run_this_tick() {
-                        0
-                    } else {
-                        #probe_ident.len()
-                    };
-
                     // Accum into probe vec
                     let fut = #root::dfir_pipes::pull::Pull::for_each(#input_probe, |kv| {
                         #probe_ident.push(kv);
@@ -151,7 +144,7 @@ pub const JOIN_MULTISET_HALF: OperatorConstraints = OperatorConstraints {
 
                     // Replay out of probe vec
                     #[allow(clippy::clone_on_copy, noop_method_call)]
-                    let iter = #probe_ident[replay_idx..].iter().flat_map(|(k, v_probe)| {
+                    let iter = #probe_ident[..].iter().flat_map(|(k, v_probe)| {
                         #build_ident
                             .get(k)
                             .map(|vals: &::std::vec::Vec<_>| {

--- a/dfir_lang/src/graph/ops/join_multiset_half.rs
+++ b/dfir_lang/src/graph/ops/join_multiset_half.rs
@@ -1,8 +1,8 @@
-use quote::{ToTokens, quote_spanned};
+use quote::quote_spanned;
 use syn::parse_quote;
 
 use super::{
-    OperatorCategory, OperatorConstraints, OperatorWriteOutput, PortIndexValue, RANGE_0,
+    OperatorCategory, OperatorConstraints, OperatorWriteOutput, RANGE_0,
     RANGE_1, WriteContextArgs,
 };
 use crate::graph::ops::Persistence;
@@ -35,12 +35,7 @@ pub const JOIN_MULTISET_HALF: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { build, probe })),
     ports_out: None,
-    input_delaytype_fn: |idx| match idx {
-        PortIndexValue::Path(path) if "build" == path.to_token_stream().to_string() => {
-            None
-        }
-        _else => None,
-    },
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                      root,
                      op_span,

--- a/dfir_lang/src/graph/ops/lattice_fold.rs
+++ b/dfir_lang/src/graph/ops/lattice_fold.rs
@@ -1,7 +1,7 @@
 use syn::parse_quote_spanned;
 
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints, WriteContextArgs,
+    OperatorCategory, OperatorConstraints, WriteContextArgs,
     RANGE_0, RANGE_1,
 };
 
@@ -42,7 +42,7 @@ pub const LATTICE_FOLD: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: |_| Some(DelayType::MonotoneAccum),
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
                    is_pull,

--- a/dfir_lang/src/graph/ops/lattice_reduce.rs
+++ b/dfir_lang/src/graph/ops/lattice_reduce.rs
@@ -2,7 +2,7 @@ use quote::quote_spanned;
 use syn::parse_quote_spanned;
 
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints, OperatorWriteOutput, RANGE_0, RANGE_1,
+    OperatorCategory, OperatorConstraints, OperatorWriteOutput, RANGE_0, RANGE_1,
     WriteContextArgs,
 };
 
@@ -43,7 +43,7 @@ pub const LATTICE_REDUCE: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: |_| Some(DelayType::MonotoneAccum),
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
                    inputs,

--- a/dfir_lang/src/graph/ops/mod.rs
+++ b/dfir_lang/src/graph/ops/mod.rs
@@ -23,10 +23,6 @@ use crate::parse::{Operator, PortIndex};
 /// The delay (soft barrier) type, for each input to an operator if needed.
 #[derive(Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub enum DelayType {
-    /// Input must be collected over the preceding stratum.
-    Stratum,
-    /// Monotone accumulation: can delay to reduce flow rate, but also correct to emit "early"
-    MonotoneAccum,
     /// Input must be collected over the previous tick.
     Tick,
     /// Input must be collected over the previous tick but also not cause a new tick to occur.

--- a/dfir_lang/src/graph/ops/multiset_delta.rs
+++ b/dfir_lang/src/graph/ops/multiset_delta.rs
@@ -52,7 +52,6 @@ pub const MULTISET_DELTA: OperatorConstraints = OperatorConstraints {
     write_fn: |wc @ &WriteContextArgs {
                    root,
                    op_span,
-                   context,
                    ident,
                    inputs,
                    outputs,
@@ -74,14 +73,12 @@ pub const MULTISET_DELTA: OperatorConstraints = OperatorConstraints {
 
         let tick_swap = quote_spanned! {op_span=>
             {
-                if #context.is_first_run_this_tick() {
-                    let (mut prev_map, mut curr_map) = (
-                        #prev_data.borrow_mut(),
-                        #curr_data.borrow_mut(),
-                    );
-                    ::std::mem::swap(::std::ops::DerefMut::deref_mut(&mut prev_map), ::std::ops::DerefMut::deref_mut(&mut curr_map));
-                    curr_map.clear();
-                }
+                let (mut prev_map, mut curr_map) = (
+                    #prev_data.borrow_mut(),
+                    #curr_data.borrow_mut(),
+                );
+                ::std::mem::swap(::std::ops::DerefMut::deref_mut(&mut prev_map), ::std::ops::DerefMut::deref_mut(&mut curr_map));
+                curr_map.clear();
             }
         };
 

--- a/dfir_lang/src/graph/ops/persist.rs
+++ b/dfir_lang/src/graph/ops/persist.rs
@@ -53,7 +53,6 @@ pub const PERSIST: OperatorConstraints = OperatorConstraints {
     input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
-                   context,
                    op_span,
                    ident,
                    is_pull,
@@ -99,18 +98,12 @@ pub const PERSIST: OperatorConstraints = OperatorConstraints {
                 let #vec_ident = &mut #persistdata_ident;
 
                 let #ident = {
-                    let replay_idx = if #context.is_first_run_this_tick() {
-                        0
-                    } else {
-                        #vec_ident.len()
-                    };
-
                     let fut = #root::dfir_pipes::pull::Pull::for_each(#input, |item| {
                         #vec_ident.push(item);
                     });
                     let () = #work_fn_async(fut).await;
 
-                    let iter = #vec_ident[replay_idx..].iter().cloned();
+                    let iter = #vec_ident[..].iter().cloned();
                     #root::dfir_pipes::pull::iter(iter)
                 };
             }
@@ -127,7 +120,7 @@ pub const PERSIST: OperatorConstraints = OperatorConstraints {
                     {
                         #root::dfir_pipes::push::persist_state(vec, is_new_tick, output)
                     }
-                    constrain_types(&mut *#vec_ident, #output, #context.is_first_run_this_tick())
+                    constrain_types(&mut *#vec_ident, #output, true)
                 };
             }
         };

--- a/dfir_lang/src/graph/ops/persist_mut.rs
+++ b/dfir_lang/src/graph/ops/persist_mut.rs
@@ -45,7 +45,6 @@ pub const PERSIST_MUT: OperatorConstraints = OperatorConstraints {
     input_delaytype_fn: |_| Some(DelayType::Stratum),
     write_fn: |wc @ &WriteContextArgs {
                    root,
-                   context,
                    op_span,
                    work_fn_async,
                    ident,
@@ -95,7 +94,7 @@ pub const PERSIST_MUT: OperatorConstraints = OperatorConstraints {
                         prev
                     }
 
-                    let iter = if #context.is_first_run_this_tick() {
+                    let iter = {
                         let fut = #root::dfir_pipes::pull::Pull::for_each(check_pull(#input), |item| {
                             match item {
                                 #root::util::Persistence::Persist(v) => #persistdata_ident.push(v),
@@ -104,9 +103,7 @@ pub const PERSIST_MUT: OperatorConstraints = OperatorConstraints {
                         });
                         let () = #work_fn_async(fut).await;
 
-                        Some(#persistdata_ident.iter().cloned()).into_iter().flatten()
-                    } else {
-                        None.into_iter().flatten()
+                        #persistdata_ident.iter().cloned()
                     };
                     #root::dfir_pipes::pull::iter(iter)
                 };

--- a/dfir_lang/src/graph/ops/persist_mut.rs
+++ b/dfir_lang/src/graph/ops/persist_mut.rs
@@ -1,7 +1,7 @@
 use quote::quote_spanned;
 
 use super::{
-    DelayType, OpInstGenerics, OperatorCategory, OperatorConstraints, OperatorInstance,
+    OpInstGenerics, OperatorCategory, OperatorConstraints, OperatorInstance,
     OperatorWriteOutput, Persistence, RANGE_0, RANGE_1, WriteContextArgs,
 };
 use crate::diagnostic::{Diagnostic, Level};
@@ -42,10 +42,9 @@ pub const PERSIST_MUT: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: |_| Some(DelayType::Stratum),
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
-                   context,
                    op_span,
                    work_fn_async,
                    ident,
@@ -95,7 +94,7 @@ pub const PERSIST_MUT: OperatorConstraints = OperatorConstraints {
                         prev
                     }
 
-                    let iter = if #context.is_first_run_this_tick() {
+                    let iter = {
                         let fut = #root::dfir_pipes::pull::Pull::for_each(check_pull(#input), |item| {
                             match item {
                                 #root::util::Persistence::Persist(v) => #persistdata_ident.push(v),
@@ -104,9 +103,7 @@ pub const PERSIST_MUT: OperatorConstraints = OperatorConstraints {
                         });
                         let () = #work_fn_async(fut).await;
 
-                        Some(#persistdata_ident.iter().cloned()).into_iter().flatten()
-                    } else {
-                        None.into_iter().flatten()
+                        #persistdata_ident.iter().cloned()
                     };
                     #root::dfir_pipes::pull::iter(iter)
                 };

--- a/dfir_lang/src/graph/ops/persist_mut_keyed.rs
+++ b/dfir_lang/src/graph/ops/persist_mut_keyed.rs
@@ -1,7 +1,7 @@
 use quote::quote_spanned;
 
 use super::{
-    DelayType, OpInstGenerics, OperatorCategory, OperatorConstraints, OperatorInstance,
+    OpInstGenerics, OperatorCategory, OperatorConstraints, OperatorInstance,
     OperatorWriteOutput, Persistence, RANGE_0, RANGE_1, WriteContextArgs,
 };
 use crate::diagnostic::{Diagnostic, Level};
@@ -42,10 +42,9 @@ pub const PERSIST_MUT_KEYED: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: |_| Some(DelayType::Stratum),
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
-                   context,
                    op_span,
                    work_fn_async,
                    ident,
@@ -96,7 +95,7 @@ pub const PERSIST_MUT_KEYED: OperatorConstraints = OperatorConstraints {
                         prev
                     }
 
-                    let iter = if #context.is_first_run_this_tick() {
+                    let iter = {
                         let fut = #root::dfir_pipes::pull::Pull::for_each(check_pull(#input), |item| {
                             match item {
                                 #root::util::PersistenceKeyed::Persist(k, v) => {
@@ -111,15 +110,9 @@ pub const PERSIST_MUT_KEYED: OperatorConstraints = OperatorConstraints {
 
                         #[allow(clippy::clone_on_copy)]
                         #[allow(clippy::disallowed_methods, reason = "FxHasher is deterministic")]
-                        Some(
-                            #persistdata_ident
-                                .iter()
-                                .flat_map(|(k, v)| v.iter().map(move |v| (k.clone(), v.clone())))
-                        )
-                        .into_iter()
-                        .flatten()
-                    } else {
-                        None.into_iter().flatten()
+                        #persistdata_ident
+                            .iter()
+                            .flat_map(|(k, v)| v.iter().map(move |v| (k.clone(), v.clone())))
                     };
                     #root::dfir_pipes::pull::iter(iter)
                 };

--- a/dfir_lang/src/graph/ops/persist_mut_keyed.rs
+++ b/dfir_lang/src/graph/ops/persist_mut_keyed.rs
@@ -45,7 +45,6 @@ pub const PERSIST_MUT_KEYED: OperatorConstraints = OperatorConstraints {
     input_delaytype_fn: |_| Some(DelayType::Stratum),
     write_fn: |wc @ &WriteContextArgs {
                    root,
-                   context,
                    op_span,
                    work_fn_async,
                    ident,
@@ -96,7 +95,7 @@ pub const PERSIST_MUT_KEYED: OperatorConstraints = OperatorConstraints {
                         prev
                     }
 
-                    let iter = if #context.is_first_run_this_tick() {
+                    let iter = {
                         let fut = #root::dfir_pipes::pull::Pull::for_each(check_pull(#input), |item| {
                             match item {
                                 #root::util::PersistenceKeyed::Persist(k, v) => {
@@ -111,15 +110,9 @@ pub const PERSIST_MUT_KEYED: OperatorConstraints = OperatorConstraints {
 
                         #[allow(clippy::clone_on_copy)]
                         #[allow(clippy::disallowed_methods, reason = "FxHasher is deterministic")]
-                        Some(
-                            #persistdata_ident
-                                .iter()
-                                .flat_map(|(k, v)| v.iter().map(move |v| (k.clone(), v.clone())))
-                        )
-                        .into_iter()
-                        .flatten()
-                    } else {
-                        None.into_iter().flatten()
+                        #persistdata_ident
+                            .iter()
+                            .flat_map(|(k, v)| v.iter().map(move |v| (k.clone(), v.clone())))
                     };
                     #root::dfir_pipes::pull::iter(iter)
                 };

--- a/dfir_lang/src/graph/ops/reduce.rs
+++ b/dfir_lang/src/graph/ops/reduce.rs
@@ -1,7 +1,7 @@
 use quote::quote_spanned;
 
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints, OperatorWriteOutput, Persistence, RANGE_0,
+    OperatorCategory, OperatorConstraints, OperatorWriteOutput, Persistence, RANGE_0,
     RANGE_1, WriteContextArgs,
 };
 
@@ -45,7 +45,7 @@ pub const REDUCE: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: |_| Some(DelayType::Stratum),
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
                    op_span,

--- a/dfir_lang/src/graph/ops/reduce_keyed.rs
+++ b/dfir_lang/src/graph/ops/reduce_keyed.rs
@@ -71,7 +71,6 @@ pub const REDUCE_KEYED: OperatorConstraints = OperatorConstraints {
     ports_out: None,
     input_delaytype_fn: |_| Some(DelayType::Stratum),
     write_fn: |wc @ &WriteContextArgs {
-                   context,
                    op_span,
                    ident,
                    inputs,
@@ -135,13 +134,8 @@ pub const REDUCE_KEYED: OperatorConstraints = OperatorConstraints {
                     )
                 },
                 Persistence::Static => quote_spanned! {op_span=>
-                    // Play everything but only on the first run of this tick/stratum.
-                    // (We know we won't have any more inputs, so it is fine to only play once.
-                    // Because of the `DelayType::Stratum` or `DelayType::MonotoneAccum`).
-                    #context.is_first_run_this_tick()
-                        .then_some(#hashtable_ident.iter())
-                        .into_iter()
-                        .flatten()
+                    // Play everything (each subgraph runs exactly once per tick).
+                    #hashtable_ident.iter()
                         .map(
                             #[allow(suspicious_double_ref_op, clippy::clone_on_copy)]
                             |(k, v)| (

--- a/dfir_lang/src/graph/ops/reduce_keyed.rs
+++ b/dfir_lang/src/graph/ops/reduce_keyed.rs
@@ -1,7 +1,7 @@
 use quote::{ToTokens, quote_spanned};
 
 use super::{
-    DelayType, OpInstGenerics, OperatorCategory, OperatorConstraints, OperatorInstance,
+    OpInstGenerics, OperatorCategory, OperatorConstraints, OperatorInstance,
     OperatorWriteOutput, Persistence, RANGE_1, WriteContextArgs,
 };
 
@@ -69,9 +69,8 @@ pub const REDUCE_KEYED: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: |_| Some(DelayType::Stratum),
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
-                   context,
                    op_span,
                    ident,
                    inputs,
@@ -135,13 +134,8 @@ pub const REDUCE_KEYED: OperatorConstraints = OperatorConstraints {
                     )
                 },
                 Persistence::Static => quote_spanned! {op_span=>
-                    // Play everything but only on the first run of this tick/stratum.
-                    // (We know we won't have any more inputs, so it is fine to only play once.
-                    // Because of the `DelayType::Stratum` or `DelayType::MonotoneAccum`).
-                    #context.is_first_run_this_tick()
-                        .then_some(#hashtable_ident.iter())
-                        .into_iter()
-                        .flatten()
+                    // Play everything (each subgraph runs exactly once per tick).
+                    #hashtable_ident.iter()
                         .map(
                             #[allow(suspicious_double_ref_op, clippy::clone_on_copy)]
                             |(k, v)| (

--- a/dfir_lang/src/graph/ops/reduce_no_replay.rs
+++ b/dfir_lang/src/graph/ops/reduce_no_replay.rs
@@ -1,7 +1,7 @@
 use quote::quote_spanned;
 
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints, OperatorWriteOutput, Persistence, RANGE_0,
+    OperatorCategory, OperatorConstraints, OperatorWriteOutput, Persistence, RANGE_0,
     RANGE_1, WriteContextArgs,
 };
 
@@ -28,7 +28,7 @@ pub const REDUCE_NO_REPLAY: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: |_| Some(DelayType::Stratum),
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
                    context,
@@ -96,7 +96,7 @@ pub const REDUCE_NO_REPLAY: OperatorConstraints = OperatorConstraints {
                     let () = #work_fn_async(__fut).await;
                 }
 
-                let #ident = if __was_updated || (#context.current_tick().0 == 0 && #context.is_first_run_this_tick()) {
+                let #ident = if __was_updated || #context.current_tick().0 == 0 {
                     #work_fn(
                         || #root::dfir_pipes::pull::iter(
                             ::std::clone::Clone::clone(&*#accumulator_ident)

--- a/dfir_lang/src/graph/ops/reduce_no_replay.rs
+++ b/dfir_lang/src/graph/ops/reduce_no_replay.rs
@@ -96,7 +96,7 @@ pub const REDUCE_NO_REPLAY: OperatorConstraints = OperatorConstraints {
                     let () = #work_fn_async(__fut).await;
                 }
 
-                let #ident = if __was_updated || (#context.current_tick().0 == 0 && #context.is_first_run_this_tick()) {
+                let #ident = if __was_updated || #context.current_tick().0 == 0 {
                     #work_fn(
                         || #root::dfir_pipes::pull::iter(
                             ::std::clone::Clone::clone(&*#accumulator_ident)

--- a/dfir_lang/src/graph/ops/sort.rs
+++ b/dfir_lang/src/graph/ops/sort.rs
@@ -1,7 +1,7 @@
 use quote::quote_spanned;
 
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints, OperatorWriteOutput, RANGE_0, RANGE_1,
+    OperatorCategory, OperatorConstraints, OperatorWriteOutput, RANGE_0, RANGE_1,
     WriteContextArgs,
 };
 
@@ -30,7 +30,7 @@ pub const SORT: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: |_| Some(DelayType::Stratum),
+    input_delaytype_fn: |_| None,
     write_fn: |&WriteContextArgs {
                    root,
                    op_span,

--- a/dfir_lang/src/graph/ops/sort_by_key.rs
+++ b/dfir_lang/src/graph/ops/sort_by_key.rs
@@ -1,7 +1,7 @@
 use quote::quote_spanned;
 
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints, OperatorWriteOutput, RANGE_0, RANGE_1,
+    OperatorCategory, OperatorConstraints, OperatorWriteOutput, RANGE_0, RANGE_1,
     WriteContextArgs,
 };
 
@@ -30,7 +30,7 @@ pub const SORT_BY_KEY: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: |_| Some(DelayType::Stratum),
+    input_delaytype_fn: |_| None,
     write_fn: |&WriteContextArgs {
                    root,
                    op_span,

--- a/dfir_lang/src/graph/ops/zip_longest.rs
+++ b/dfir_lang/src/graph/ops/zip_longest.rs
@@ -2,7 +2,7 @@ use quote::quote_spanned;
 use syn::parse_quote;
 
 use super::{
-    DelayType, OpInstGenerics, OperatorCategory, OperatorConstraints, OperatorInstance,
+    OpInstGenerics, OperatorCategory, OperatorConstraints, OperatorInstance,
     OperatorWriteOutput, Persistence, RANGE_0, RANGE_1, WriteContextArgs,
 };
 use crate::diagnostic::{Diagnostic, Level};
@@ -40,7 +40,7 @@ pub const ZIP_LONGEST: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { 0, 1 })),
     ports_out: None,
-    input_delaytype_fn: |_| Some(DelayType::Stratum),
+    input_delaytype_fn: |_| None,
     write_fn: |&WriteContextArgs {
                    root,
                    op_span,

--- a/dfir_pipes/src/push/fold.rs
+++ b/dfir_pipes/src/push/fold.rs
@@ -1,0 +1,72 @@
+//! [`Fold`] push combinator.
+use core::pin::Pin;
+
+use pin_project_lite::pin_project;
+
+use crate::push::{Push, PushStep};
+
+pin_project! {
+    /// Push combinator that accumulates all items via a fold function, then emits
+    /// the accumulated value downstream on flush.
+    ///
+    /// During `start_send`, items are folded into the accumulator.
+    /// During `poll_flush`, the accumulated value is cloned and sent downstream,
+    /// then the downstream is flushed.
+    #[must_use = "`Push`es do nothing unless items are pushed into them"]
+    #[derive(Clone, Debug)]
+    pub struct Fold<Acc, CombFn, Next> {
+        #[pin]
+        next: Next,
+        acc: Acc,
+        comb_fn: CombFn,
+        flushed: bool,
+    }
+}
+
+impl<Acc, CombFn, Next> Fold<Acc, CombFn, Next> {
+    /// Creates a new `Fold` push combinator with the given initial accumulator value.
+    pub const fn new(acc: Acc, comb_fn: CombFn, next: Next) -> Self {
+        Self {
+            next,
+            acc,
+            comb_fn,
+            flushed: false,
+        }
+    }
+}
+
+// TODO(mingwei): support arbitrary metadata.
+impl<Acc, CombFn, Item, Next> Push<Item, ()> for Fold<Acc, CombFn, Next>
+where
+    Acc: Clone,
+    CombFn: FnMut(&mut Acc, Item),
+    Next: Push<Acc, ()>,
+{
+    type Ctx<'ctx> = Next::Ctx<'ctx>;
+
+    type CanPend = Next::CanPend;
+
+    fn poll_ready(self: Pin<&mut Self>, _ctx: &mut Self::Ctx<'_>) -> PushStep<Self::CanPend> {
+        PushStep::Done
+    }
+
+    fn start_send(self: Pin<&mut Self>, item: Item, _meta: ()) {
+        let this = self.project();
+        (this.comb_fn)(this.acc, item);
+        *this.flushed = false;
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, ctx: &mut Self::Ctx<'_>) -> PushStep<Self::CanPend> {
+        let mut this = self.project();
+        if !*this.flushed {
+            *this.flushed = true;
+            let value = this.acc.clone();
+            this.next.as_mut().start_send(value, ());
+        }
+        this.next.poll_flush(ctx)
+    }
+
+    fn size_hint(self: Pin<&mut Self>, _hint: (usize, Option<usize>)) {
+        self.project().next.size_hint((1, Some(1)));
+    }
+}

--- a/dfir_pipes/src/push/mod.rs
+++ b/dfir_pipes/src/push/mod.rs
@@ -16,15 +16,20 @@ mod flat_map;
 mod flat_map_stream;
 mod flatten;
 mod flatten_stream;
+mod fold;
 mod for_each;
 mod inspect;
 mod map;
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 mod persist;
+mod reduce;
 mod resolve_futures;
 mod sink;
 mod sink_compat;
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+mod sort;
 mod unzip;
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
@@ -48,6 +53,7 @@ pub use flat_map::FlatMap;
 pub use flat_map_stream::FlatMapStream;
 pub use flatten::Flatten;
 pub use flatten_stream::FlattenStream;
+pub use fold::Fold;
 pub use for_each::ForEach;
 use futures_core::FusedStream;
 pub use inspect::Inspect;
@@ -55,9 +61,13 @@ pub use map::Map;
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub use persist::Persist;
+pub use reduce::Reduce;
 pub use resolve_futures::ResolveFutures;
 pub use sink::Sink;
 pub use sink_compat::SinkCompat;
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub use sort::Sort;
 pub use unzip::Unzip;
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]

--- a/dfir_pipes/src/push/reduce.rs
+++ b/dfir_pipes/src/push/reduce.rs
@@ -1,0 +1,75 @@
+//! [`Reduce`] push combinator.
+use core::pin::Pin;
+
+use pin_project_lite::pin_project;
+
+use crate::push::{Push, PushStep};
+
+pin_project! {
+    /// Push combinator that reduces all items into a single value, then emits
+    /// it downstream on flush. If no items were received, nothing is emitted.
+    ///
+    /// During `start_send`, items are reduced into the accumulator.
+    /// During `poll_flush`, the accumulated value (if any) is sent downstream.
+    #[must_use = "`Push`es do nothing unless items are pushed into them"]
+    #[derive(Clone, Debug)]
+    pub struct Reduce<Acc, ReduceFn, Next> {
+        #[pin]
+        next: Next,
+        acc: Option<Acc>,
+        reduce_fn: ReduceFn,
+        flushed: bool,
+    }
+}
+
+impl<Acc, ReduceFn, Next> Reduce<Acc, ReduceFn, Next> {
+    /// Creates a new `Reduce` push combinator.
+    pub const fn new(reduce_fn: ReduceFn, next: Next) -> Self {
+        Self {
+            next,
+            acc: None,
+            reduce_fn,
+            flushed: false,
+        }
+    }
+}
+
+// TODO(mingwei): support arbitrary metadata.
+impl<Acc, ReduceFn, Next> Push<Acc, ()> for Reduce<Acc, ReduceFn, Next>
+where
+    Acc: Clone,
+    ReduceFn: FnMut(&mut Acc, Acc),
+    Next: Push<Acc, ()>,
+{
+    type Ctx<'ctx> = Next::Ctx<'ctx>;
+
+    type CanPend = Next::CanPend;
+
+    fn poll_ready(self: Pin<&mut Self>, _ctx: &mut Self::Ctx<'_>) -> PushStep<Self::CanPend> {
+        PushStep::Done
+    }
+
+    fn start_send(self: Pin<&mut Self>, item: Acc, _meta: ()) {
+        let this = self.project();
+        match this.acc {
+            Some(acc) => (this.reduce_fn)(acc, item),
+            None => *this.acc = Some(item),
+        }
+        *this.flushed = false;
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, ctx: &mut Self::Ctx<'_>) -> PushStep<Self::CanPend> {
+        let mut this = self.project();
+        if !*this.flushed {
+            *this.flushed = true;
+            if let Some(value) = this.acc.as_ref() {
+                this.next.as_mut().start_send(value.clone(), ());
+            }
+        }
+        this.next.poll_flush(ctx)
+    }
+
+    fn size_hint(self: Pin<&mut Self>, _hint: (usize, Option<usize>)) {
+        self.project().next.size_hint((0, Some(1)));
+    }
+}

--- a/dfir_pipes/src/push/sort.rs
+++ b/dfir_pipes/src/push/sort.rs
@@ -1,0 +1,79 @@
+//! [`Sort`] push combinator.
+use alloc::vec::Vec;
+use core::pin::Pin;
+
+use pin_project_lite::pin_project;
+
+use crate::push::{Push, PushStep, ready};
+
+pin_project! {
+    /// Push combinator that collects all items, sorts them, then emits them
+    /// downstream in sorted order on flush.
+    #[must_use = "`Push`es do nothing unless items are pushed into them"]
+    #[derive(Clone, Debug)]
+    pub struct Sort<Item, Next> {
+        #[pin]
+        next: Next,
+        buf: Vec<Item>,
+        sorted: bool,
+        flush_idx: usize,
+    }
+}
+
+impl<Item, Next> Sort<Item, Next> {
+    /// Creates a new `Sort` push combinator.
+    pub const fn new(next: Next) -> Self {
+        Self {
+            next,
+            buf: Vec::new(),
+            sorted: false,
+            flush_idx: 0,
+        }
+    }
+}
+
+// TODO(mingwei): support arbitrary metadata.
+impl<Item, Next> Push<Item, ()> for Sort<Item, Next>
+where
+    Item: Ord + Clone,
+    Next: Push<Item, ()>,
+{
+    type Ctx<'ctx> = Next::Ctx<'ctx>;
+
+    type CanPend = Next::CanPend;
+
+    fn poll_ready(self: Pin<&mut Self>, _ctx: &mut Self::Ctx<'_>) -> PushStep<Self::CanPend> {
+        PushStep::Done
+    }
+
+    fn start_send(self: Pin<&mut Self>, item: Item, _meta: ()) {
+        let this = self.project();
+        this.buf.push(item);
+        *this.sorted = false;
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, ctx: &mut Self::Ctx<'_>) -> PushStep<Self::CanPend> {
+        let mut this = self.project();
+        if !*this.sorted {
+            this.buf.sort_unstable();
+            *this.sorted = true;
+            *this.flush_idx = 0;
+        }
+        while *this.flush_idx < this.buf.len() {
+            ready!(this.next.as_mut().poll_ready(ctx));
+            let item = this.buf[*this.flush_idx].clone();
+            this.next.as_mut().start_send(item, ());
+            *this.flush_idx += 1;
+        }
+        this.buf.clear();
+        *this.sorted = false;
+        *this.flush_idx = 0;
+        this.next.poll_flush(ctx)
+    }
+
+    fn size_hint(self: Pin<&mut Self>, hint: (usize, Option<usize>)) {
+        let this = self.project();
+        this.buf.reserve(hint.0);
+        this.next.size_hint(hint);
+    }
+}

--- a/dfir_rs/src/scheduled/context.rs
+++ b/dfir_rs/src/scheduled/context.rs
@@ -56,8 +56,9 @@ impl Wake for WakeState {
 /// A lightweight context for inline codegen that avoids the overhead of the full
 /// [`Context`] (no tokio channels, no scheduler queues, no loop machinery).
 ///
-/// Exposes method names that operator-generated code calls on
-/// `context` (for iterators: `is_first_run_this_tick`, `current_tick`, etc.).
+/// Exposes the same method names that operator-generated code calls on both
+/// `df` (for prologues: `add_state`, `set_state_lifespan_hook`) and
+/// `context` (for iterators: `state_ref_unchecked`, etc.).
 #[doc(hidden)]
 #[derive(Default)]
 pub struct Context {
@@ -101,13 +102,6 @@ impl Context {
     }
 
     // --- Methods called as `context.xxx()` in operator iterators ---
-
-    /// Always returns `true` in inline mode. The inline codegen runs the entire DAG
-    /// once per tick with no re-execution, so every subgraph is always on its first
-    /// (and only) run within each tick.
-    pub fn is_first_run_this_tick(&self) -> bool {
-        true
-    }
 
     /// Gets the current tick count.
     pub fn current_tick(&self) -> TickInstant {

--- a/dfir_rs/tests/compile-fail-stable/surface_demuxenum_wrongenum.stderr
+++ b/dfir_rs/tests/compile-fail-stable/surface_demuxenum_wrongenum.stderr
@@ -87,11 +87,11 @@ error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<std::option:
              `&mut P` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `DemuxEnum<Outputs>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `ResolveFutures<Psh, Queue, QueueInner>` implements `dfir_rs::dfir_pipes::push::Push<Fut, ()>`
+             `Sort<Item, Next>` implements `dfir_rs::dfir_pipes::push::Push<Item, ()>`
              `VecPush<Buf>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::DemuxVar<Pushes>` implements `dfir_rs::dfir_pipes::push::Push<(usize, Item), Meta>`
              `dfir_rs::dfir_pipes::push::Fanout<P0, P1>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::Filter<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
-             `dfir_rs::dfir_pipes::push::FilterMap<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<In, Meta>`
            and $N others
 note: required by a bound in `pivot_run_sg_1v1`
   --> tests/compile-fail-stable/surface_demuxenum_wrongenum.rs:17:15

--- a/dfir_rs/tests/compile-fail-stable/surface_demuxenum_wrongfields_1.stderr
+++ b/dfir_rs/tests/compile-fail-stable/surface_demuxenum_wrongfields_1.stderr
@@ -9,11 +9,11 @@ error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<u32, (), Can
              `&mut P` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `DemuxEnum<Outputs>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `ResolveFutures<Psh, Queue, QueueInner>` implements `dfir_rs::dfir_pipes::push::Push<Fut, ()>`
+             `Sort<Item, Next>` implements `dfir_rs::dfir_pipes::push::Push<Item, ()>`
              `VecPush<Buf>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::DemuxVar<Pushes>` implements `dfir_rs::dfir_pipes::push::Push<(usize, Item), Meta>`
              `dfir_rs::dfir_pipes::push::Fanout<P0, P1>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::Filter<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
-             `dfir_rs::dfir_pipes::push::FilterMap<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<In, Meta>`
            and $N others
 note: required for `Shape` to implement `DemuxEnumPush<(Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64,)) {std::mem::drop::<(f64,)>}> as dfir_rs::dfir_pipes::push::Push<(f64,), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64, f64), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64, f64)) {std::mem::drop::<(f64, f64)>}> as dfir_rs::dfir_pipes::push::Push<(f64, f64), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<u32, (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<{closure@$DIR/tests/compile-fail-stable/surface_demuxenum_wrongfields_1.rs:20:38: 20:49}> as dfir_rs::dfir_pipes::push::Push<u32, ()>>::CanPend>>), ()>`
   --> tests/compile-fail-stable/surface_demuxenum_wrongfields_1.rs:5:14
@@ -40,11 +40,11 @@ error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<u32, (), Can
              `&mut P` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `DemuxEnum<Outputs>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `ResolveFutures<Psh, Queue, QueueInner>` implements `dfir_rs::dfir_pipes::push::Push<Fut, ()>`
+             `Sort<Item, Next>` implements `dfir_rs::dfir_pipes::push::Push<Item, ()>`
              `VecPush<Buf>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::DemuxVar<Pushes>` implements `dfir_rs::dfir_pipes::push::Push<(usize, Item), Meta>`
              `dfir_rs::dfir_pipes::push::Fanout<P0, P1>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::Filter<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
-             `dfir_rs::dfir_pipes::push::FilterMap<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<In, Meta>`
            and $N others
 note: required for `Shape` to implement `DemuxEnumPush<(Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64,)) {std::mem::drop::<(f64,)>}> as dfir_rs::dfir_pipes::push::Push<(f64,), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64, f64), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64, f64)) {std::mem::drop::<(f64, f64)>}> as dfir_rs::dfir_pipes::push::Push<(f64, f64), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<u32, (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<{closure@$DIR/tests/compile-fail-stable/surface_demuxenum_wrongfields_1.rs:20:38: 20:49}> as dfir_rs::dfir_pipes::push::Push<u32, ()>>::CanPend>>), ()>`
   --> tests/compile-fail-stable/surface_demuxenum_wrongfields_1.rs:5:14

--- a/dfir_rs/tests/compile-fail-stable/surface_demuxenum_wrongfields_2.stderr
+++ b/dfir_rs/tests/compile-fail-stable/surface_demuxenum_wrongfields_2.stderr
@@ -9,11 +9,11 @@ error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<(u32,), (), 
              `&mut P` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `DemuxEnum<Outputs>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `ResolveFutures<Psh, Queue, QueueInner>` implements `dfir_rs::dfir_pipes::push::Push<Fut, ()>`
+             `Sort<Item, Next>` implements `dfir_rs::dfir_pipes::push::Push<Item, ()>`
              `VecPush<Buf>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::DemuxVar<Pushes>` implements `dfir_rs::dfir_pipes::push::Push<(usize, Item), Meta>`
              `dfir_rs::dfir_pipes::push::Fanout<P0, P1>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::Filter<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
-             `dfir_rs::dfir_pipes::push::FilterMap<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<In, Meta>`
            and $N others
 note: required for `Shape` to implement `DemuxEnumPush<(Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64,)) {std::mem::drop::<(f64,)>}> as dfir_rs::dfir_pipes::push::Push<(f64,), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64, f64), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64, f64)) {std::mem::drop::<(f64, f64)>}> as dfir_rs::dfir_pipes::push::Push<(f64, f64), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(u32,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<{closure@$DIR/tests/compile-fail-stable/surface_demuxenum_wrongfields_2.rs:20:38: 20:52}> as dfir_rs::dfir_pipes::push::Push<(u32,), ()>>::CanPend>>), ()>`
   --> tests/compile-fail-stable/surface_demuxenum_wrongfields_2.rs:5:14
@@ -40,11 +40,11 @@ error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<(u32,), (), 
              `&mut P` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `DemuxEnum<Outputs>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `ResolveFutures<Psh, Queue, QueueInner>` implements `dfir_rs::dfir_pipes::push::Push<Fut, ()>`
+             `Sort<Item, Next>` implements `dfir_rs::dfir_pipes::push::Push<Item, ()>`
              `VecPush<Buf>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::DemuxVar<Pushes>` implements `dfir_rs::dfir_pipes::push::Push<(usize, Item), Meta>`
              `dfir_rs::dfir_pipes::push::Fanout<P0, P1>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::Filter<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
-             `dfir_rs::dfir_pipes::push::FilterMap<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<In, Meta>`
            and $N others
 note: required for `Shape` to implement `DemuxEnumPush<(Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64,)) {std::mem::drop::<(f64,)>}> as dfir_rs::dfir_pipes::push::Push<(f64,), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64, f64), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64, f64)) {std::mem::drop::<(f64, f64)>}> as dfir_rs::dfir_pipes::push::Push<(f64, f64), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(u32,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<{closure@$DIR/tests/compile-fail-stable/surface_demuxenum_wrongfields_2.rs:20:38: 20:52}> as dfir_rs::dfir_pipes::push::Push<(u32,), ()>>::CanPend>>), ()>`
   --> tests/compile-fail-stable/surface_demuxenum_wrongfields_2.rs:5:14


### PR DESCRIPTION
All operator files that returned Some(DelayType::Stratum) or
Some(DelayType::MonotoneAccum) from their input_delaytype_fn now return None.
This includes fold, reduce, sort, join, anti_join, difference, cross_singleton,
and all other operators that previously used these variants.

Also cleaned up unused imports (DelayType, PortIndexValue, ToTokens) from
the affected operator files.

The dfir_lang crate compiles cleanly with no warnings.

Co-authored-by: Infinity 🤖 <infinity@hydro.run>