### PR TITLE
refactor!: remove `is_first_run_this_tick()` — always true in inline DAG mode

### DIFF
--- a/dfir_lang/src/graph/ops/anti_join.rs
+++ b/dfir_lang/src/graph/ops/anti_join.rs
@@ -124,8 +124,7 @@ pub const ANTI_JOIN: OperatorConstraints = OperatorConstraints {
                     let () = #work_fn_async(fut).await;
 
                     // Replay out of pos vec
-                    let iter = #pos_ident[..].iter();
-                    let iter = ::std::iter::Iterator::filter(iter, |(k, _)| {
+                    let iter = ::std::iter::Iterator::filter(#pos_ident.iter(), |(k, _)| {
                         !#neg_ident.contains(k)
                     });
                     let iter = ::std::iter::Iterator::cloned(iter);

--- a/dfir_lang/src/graph/ops/anti_join.rs
+++ b/dfir_lang/src/graph/ops/anti_join.rs
@@ -45,7 +45,6 @@ pub const ANTI_JOIN: OperatorConstraints = OperatorConstraints {
     },
     write_fn: |wc @ &WriteContextArgs {
                    root,
-                   context,
                    op_span,
                    work_fn_async,
                    ident,
@@ -118,12 +117,6 @@ pub const ANTI_JOIN: OperatorConstraints = OperatorConstraints {
                 let #ident = {
                     #accum_neg
 
-                    let replay_idx = if #context.is_first_run_this_tick() {
-                        0
-                    } else {
-                        #pos_ident.len()
-                    };
-
                     // Accum into pos vec
                     let fut = #root::dfir_pipes::pull::Pull::for_each(#input_pos, |kv| {
                         #pos_ident.push(kv);
@@ -131,7 +124,7 @@ pub const ANTI_JOIN: OperatorConstraints = OperatorConstraints {
                     let () = #work_fn_async(fut).await;
 
                     // Replay out of pos vec
-                    let iter = #pos_ident[replay_idx..].iter();
+                    let iter = #pos_ident[..].iter();
                     let iter = ::std::iter::Iterator::filter(iter, |(k, _)| {
                         !#neg_ident.contains(k)
                     });

--- a/dfir_lang/src/graph/ops/cross_join_multiset.rs
+++ b/dfir_lang/src/graph/ops/cross_join_multiset.rs
@@ -81,9 +81,9 @@ pub const CROSS_JOIN_MULTISET: OperatorConstraints = OperatorConstraints {
                 #lhs_state
                     .iter()
                     .flat_map(|lhs| {
-                        #rhs_state[..]
-                            .iter()
-                            .map(move |rhs| (::std::clone::Clone::clone(lhs), ::std::clone::Clone::clone(rhs)))
+                #rhs_state
+                    .iter()
+                    .map(move |rhs| (::std::clone::Clone::clone(lhs), ::std::clone::Clone::clone(rhs)))
                     })
             );
         };

--- a/dfir_lang/src/graph/ops/cross_join_multiset.rs
+++ b/dfir_lang/src/graph/ops/cross_join_multiset.rs
@@ -41,7 +41,6 @@ pub const CROSS_JOIN_MULTISET: OperatorConstraints = OperatorConstraints {
     input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
-                   context,
                    op_span,
                    work_fn_async,
                    ident,
@@ -74,31 +73,15 @@ pub const CROSS_JOIN_MULTISET: OperatorConstraints = OperatorConstraints {
             _ => Default::default(),
         };
 
-        let lhs_i = wc.make_ident("lhs_i");
-        let rhs_i = wc.make_ident("rhs_i");
         let write_iterator = quote_spanned! {op_span=>
-            let (#lhs_i, #rhs_i) = if #context.is_first_run_this_tick() {
-                (0, 0)
-            } else {
-                (#lhs_state.len(), #rhs_state.len())
-            };
-
             #work_fn_async(#root::dfir_pipes::pull::Pull::for_each(#lhs, |x| #lhs_state.push(x))).await;
             #work_fn_async(#root::dfir_pipes::pull::Pull::for_each(#rhs, |x| #rhs_state.push(x))).await;
 
-            //       RHS
-            //   +-----+-----+
-            // L | Old | New |
-            // H +-----+-----+
-            // S | New | New |
-            //   +-----+-----+
             let #ident = #root::dfir_pipes::pull::iter(
                 #lhs_state
                     .iter()
-                    .enumerate()
-                    .flat_map(|(i, lhs)| {
-                        let j = if i < #lhs_i { #rhs_i } else { 0 };
-                        #rhs_state[j..]
+                    .flat_map(|lhs| {
+                        #rhs_state[..]
                             .iter()
                             .map(move |rhs| (::std::clone::Clone::clone(lhs), ::std::clone::Clone::clone(rhs)))
                     })

--- a/dfir_lang/src/graph/ops/fold_keyed.rs
+++ b/dfir_lang/src/graph/ops/fold_keyed.rs
@@ -82,7 +82,6 @@ pub const FOLD_KEYED: OperatorConstraints = OperatorConstraints {
     ports_out: None,
     input_delaytype_fn: |_| Some(DelayType::Stratum),
     write_fn: |wc @ &WriteContextArgs {
-                   context,
                    op_span,
                    work_fn_async,
                    ident,
@@ -202,13 +201,8 @@ pub const FOLD_KEYED: OperatorConstraints = OperatorConstraints {
                     )
                 },
                 Persistence::Static => quote_spanned! {op_span=>
-                    // Play everything but only on the first run of this tick/stratum.
-                    // (We know we won't have any more inputs, so it is fine to only play once.
-                    // Because of the `DelayType::Stratum` or `DelayType::MonotoneAccum`).
-                    #context.is_first_run_this_tick()
-                        .then_some(#hashtable_ident.iter())
-                        .into_iter()
-                        .flatten()
+                    // Play everything (each subgraph runs exactly once per tick).
+                    #hashtable_ident.iter()
                         .map(
                             #[allow(suspicious_double_ref_op, clippy::clone_on_copy)]
                             |(k, v)| (

--- a/dfir_lang/src/graph/ops/fold_no_replay.rs
+++ b/dfir_lang/src/graph/ops/fold_no_replay.rs
@@ -106,7 +106,7 @@ pub const FOLD_NO_REPLAY: OperatorConstraints = OperatorConstraints {
                     let () = #work_fn_async(__fut).await;
                 }
 
-                let #ident = if __was_updated || (#context.current_tick().0 == 0 && #context.is_first_run_this_tick()) {
+                let #ident = if __was_updated || #context.current_tick().0 == 0 {
                     #work_fn(
                         || #root::dfir_pipes::pull::iter(
                             ::std::option::Option::Some(::std::clone::Clone::clone(&*#accumulator_ident))

--- a/dfir_lang/src/graph/ops/join.rs
+++ b/dfir_lang/src/graph/ops/join.rs
@@ -96,7 +96,6 @@ pub const JOIN: OperatorConstraints = OperatorConstraints {
     input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
-                   context,
                    loop_id,
                    op_span,
                    work_fn,
@@ -205,7 +204,7 @@ pub const JOIN: OperatorConstraints = OperatorConstraints {
                     ).await
                 }
 
-                let fut = check_inputs(#lhs, #rhs, &mut #lhs_joindata_ident, &mut #rhs_joindata_ident, #context.is_first_run_this_tick());
+                let fut = check_inputs(#lhs, #rhs, &mut #lhs_joindata_ident, &mut #rhs_joindata_ident, true);
                 #work_fn_async(fut).await
             };
         };

--- a/dfir_lang/src/graph/ops/join_fused_lhs.rs
+++ b/dfir_lang/src/graph/ops/join_fused_lhs.rs
@@ -110,9 +110,9 @@ pub const JOIN_FUSED_LHS: OperatorConstraints = OperatorConstraints {
 
                     #[allow(clippy::clone_on_copy)]
                     #[allow(suspicious_double_ref_op)]
-                    let iter = #rhs_borrow_ident[..]
-                        .iter()
-                        .filter_map(|(k, v2)| #lhs_borrow.get(k).map(|v1| (k.clone(), (v1.clone(), v2.clone()))));
+                let iter = #rhs_borrow_ident
+                    .iter()
+                    .filter_map(|(k, v2)| #lhs_borrow.get(k).map(|v1| (k.clone(), (v1.clone(), v2.clone()))));
                     #root::dfir_pipes::pull::iter(iter)
                 };
             },

--- a/dfir_lang/src/graph/ops/join_fused_lhs.rs
+++ b/dfir_lang/src/graph/ops/join_fused_lhs.rs
@@ -45,7 +45,6 @@ pub const JOIN_FUSED_LHS: OperatorConstraints = OperatorConstraints {
     },
     write_fn: |wc @ &WriteContextArgs {
                    root,
-                   context,
                    op_span,
                    work_fn_async,
                    ident,
@@ -101,13 +100,6 @@ pub const JOIN_FUSED_LHS: OperatorConstraints = OperatorConstraints {
                         #root::dfir_pipes::pull::accumulate_all(&mut #lhs_accum, &mut *#lhs_borrow, #lhs),
                     ).await;
 
-                    // RHS replay index.
-                    let replay_idx = if #context.is_first_run_this_tick() {
-                        0
-                    } else {
-                        #rhs_borrow_ident.len()
-                    };
-
                     // Accumulate RHS.
                     let () = #work_fn_async(
                         #root::dfir_pipes::pull::Pull::for_each(#rhs, |kv| {
@@ -118,7 +110,7 @@ pub const JOIN_FUSED_LHS: OperatorConstraints = OperatorConstraints {
 
                     #[allow(clippy::clone_on_copy)]
                     #[allow(suspicious_double_ref_op)]
-                    let iter = #rhs_borrow_ident[replay_idx..]
+                    let iter = #rhs_borrow_ident[..]
                         .iter()
                         .filter_map(|(k, v2)| #lhs_borrow.get(k).map(|v1| (k.clone(), (v1.clone(), v2.clone()))));
                     #root::dfir_pipes::pull::iter(iter)

--- a/dfir_lang/src/graph/ops/join_multiset_half.rs
+++ b/dfir_lang/src/graph/ops/join_multiset_half.rs
@@ -43,7 +43,6 @@ pub const JOIN_MULTISET_HALF: OperatorConstraints = OperatorConstraints {
     },
     write_fn: |wc @ &WriteContextArgs {
                      root,
-                     context,
                      op_span,
                      work_fn_async,
                      ident,
@@ -137,12 +136,6 @@ pub const JOIN_MULTISET_HALF: OperatorConstraints = OperatorConstraints {
                 let #ident = {
                     #accum_build
 
-                    let replay_idx = if #context.is_first_run_this_tick() {
-                        0
-                    } else {
-                        #probe_ident.len()
-                    };
-
                     // Accum into probe vec
                     let fut = #root::dfir_pipes::pull::Pull::for_each(#input_probe, |kv| {
                         #probe_ident.push(kv);
@@ -151,7 +144,7 @@ pub const JOIN_MULTISET_HALF: OperatorConstraints = OperatorConstraints {
 
                     // Replay out of probe vec
                     #[allow(clippy::clone_on_copy, noop_method_call)]
-                    let iter = #probe_ident[replay_idx..].iter().flat_map(|(k, v_probe)| {
+                    let iter = #probe_ident[..].iter().flat_map(|(k, v_probe)| {
                         #build_ident
                             .get(k)
                             .map(|vals: &::std::vec::Vec<_>| {

--- a/dfir_lang/src/graph/ops/join_multiset_half.rs
+++ b/dfir_lang/src/graph/ops/join_multiset_half.rs
@@ -144,7 +144,7 @@ pub const JOIN_MULTISET_HALF: OperatorConstraints = OperatorConstraints {
 
                     // Replay out of probe vec
                     #[allow(clippy::clone_on_copy, noop_method_call)]
-                    let iter = #probe_ident[..].iter().flat_map(|(k, v_probe)| {
+                    let iter = #probe_ident.iter().flat_map(|(k, v_probe)| {
                         #build_ident
                             .get(k)
                             .map(|vals: &::std::vec::Vec<_>| {

--- a/dfir_lang/src/graph/ops/multiset_delta.rs
+++ b/dfir_lang/src/graph/ops/multiset_delta.rs
@@ -52,7 +52,6 @@ pub const MULTISET_DELTA: OperatorConstraints = OperatorConstraints {
     write_fn: |wc @ &WriteContextArgs {
                    root,
                    op_span,
-                   context,
                    ident,
                    inputs,
                    outputs,
@@ -74,14 +73,12 @@ pub const MULTISET_DELTA: OperatorConstraints = OperatorConstraints {
 
         let tick_swap = quote_spanned! {op_span=>
             {
-                if #context.is_first_run_this_tick() {
-                    let (mut prev_map, mut curr_map) = (
-                        #prev_data.borrow_mut(),
-                        #curr_data.borrow_mut(),
-                    );
-                    ::std::mem::swap(::std::ops::DerefMut::deref_mut(&mut prev_map), ::std::ops::DerefMut::deref_mut(&mut curr_map));
-                    curr_map.clear();
-                }
+                let (mut prev_map, mut curr_map) = (
+                    #prev_data.borrow_mut(),
+                    #curr_data.borrow_mut(),
+                );
+                ::std::mem::swap(::std::ops::DerefMut::deref_mut(&mut prev_map), ::std::ops::DerefMut::deref_mut(&mut curr_map));
+                curr_map.clear();
             }
         };
 

--- a/dfir_lang/src/graph/ops/persist.rs
+++ b/dfir_lang/src/graph/ops/persist.rs
@@ -103,7 +103,7 @@ pub const PERSIST: OperatorConstraints = OperatorConstraints {
                     });
                     let () = #work_fn_async(fut).await;
 
-                    let iter = #vec_ident[..].iter().cloned();
+                    let iter = #vec_ident.iter().cloned();
                     #root::dfir_pipes::pull::iter(iter)
                 };
             }

--- a/dfir_lang/src/graph/ops/persist.rs
+++ b/dfir_lang/src/graph/ops/persist.rs
@@ -53,7 +53,6 @@ pub const PERSIST: OperatorConstraints = OperatorConstraints {
     input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
-                   context,
                    op_span,
                    ident,
                    is_pull,
@@ -99,18 +98,12 @@ pub const PERSIST: OperatorConstraints = OperatorConstraints {
                 let #vec_ident = &mut #persistdata_ident;
 
                 let #ident = {
-                    let replay_idx = if #context.is_first_run_this_tick() {
-                        0
-                    } else {
-                        #vec_ident.len()
-                    };
-
                     let fut = #root::dfir_pipes::pull::Pull::for_each(#input, |item| {
                         #vec_ident.push(item);
                     });
                     let () = #work_fn_async(fut).await;
 
-                    let iter = #vec_ident[replay_idx..].iter().cloned();
+                    let iter = #vec_ident[..].iter().cloned();
                     #root::dfir_pipes::pull::iter(iter)
                 };
             }
@@ -127,7 +120,7 @@ pub const PERSIST: OperatorConstraints = OperatorConstraints {
                     {
                         #root::dfir_pipes::push::persist_state(vec, is_new_tick, output)
                     }
-                    constrain_types(&mut *#vec_ident, #output, #context.is_first_run_this_tick())
+                    constrain_types(&mut *#vec_ident, #output, true)
                 };
             }
         };

--- a/dfir_lang/src/graph/ops/persist_mut.rs
+++ b/dfir_lang/src/graph/ops/persist_mut.rs
@@ -45,7 +45,6 @@ pub const PERSIST_MUT: OperatorConstraints = OperatorConstraints {
     input_delaytype_fn: |_| Some(DelayType::Stratum),
     write_fn: |wc @ &WriteContextArgs {
                    root,
-                   context,
                    op_span,
                    work_fn_async,
                    ident,
@@ -95,7 +94,7 @@ pub const PERSIST_MUT: OperatorConstraints = OperatorConstraints {
                         prev
                     }
 
-                    let iter = if #context.is_first_run_this_tick() {
+                    let iter = {
                         let fut = #root::dfir_pipes::pull::Pull::for_each(check_pull(#input), |item| {
                             match item {
                                 #root::util::Persistence::Persist(v) => #persistdata_ident.push(v),
@@ -104,9 +103,7 @@ pub const PERSIST_MUT: OperatorConstraints = OperatorConstraints {
                         });
                         let () = #work_fn_async(fut).await;
 
-                        Some(#persistdata_ident.iter().cloned()).into_iter().flatten()
-                    } else {
-                        None.into_iter().flatten()
+                        #persistdata_ident.iter().cloned()
                     };
                     #root::dfir_pipes::pull::iter(iter)
                 };

--- a/dfir_lang/src/graph/ops/persist_mut_keyed.rs
+++ b/dfir_lang/src/graph/ops/persist_mut_keyed.rs
@@ -45,7 +45,6 @@ pub const PERSIST_MUT_KEYED: OperatorConstraints = OperatorConstraints {
     input_delaytype_fn: |_| Some(DelayType::Stratum),
     write_fn: |wc @ &WriteContextArgs {
                    root,
-                   context,
                    op_span,
                    work_fn_async,
                    ident,
@@ -96,7 +95,7 @@ pub const PERSIST_MUT_KEYED: OperatorConstraints = OperatorConstraints {
                         prev
                     }
 
-                    let iter = if #context.is_first_run_this_tick() {
+                    let iter = {
                         let fut = #root::dfir_pipes::pull::Pull::for_each(check_pull(#input), |item| {
                             match item {
                                 #root::util::PersistenceKeyed::Persist(k, v) => {
@@ -111,15 +110,9 @@ pub const PERSIST_MUT_KEYED: OperatorConstraints = OperatorConstraints {
 
                         #[allow(clippy::clone_on_copy)]
                         #[allow(clippy::disallowed_methods, reason = "FxHasher is deterministic")]
-                        Some(
-                            #persistdata_ident
-                                .iter()
-                                .flat_map(|(k, v)| v.iter().map(move |v| (k.clone(), v.clone())))
-                        )
-                        .into_iter()
-                        .flatten()
-                    } else {
-                        None.into_iter().flatten()
+                        #persistdata_ident
+                            .iter()
+                            .flat_map(|(k, v)| v.iter().map(move |v| (k.clone(), v.clone())))
                     };
                     #root::dfir_pipes::pull::iter(iter)
                 };

--- a/dfir_lang/src/graph/ops/reduce_keyed.rs
+++ b/dfir_lang/src/graph/ops/reduce_keyed.rs
@@ -71,7 +71,6 @@ pub const REDUCE_KEYED: OperatorConstraints = OperatorConstraints {
     ports_out: None,
     input_delaytype_fn: |_| Some(DelayType::Stratum),
     write_fn: |wc @ &WriteContextArgs {
-                   context,
                    op_span,
                    ident,
                    inputs,
@@ -135,13 +134,8 @@ pub const REDUCE_KEYED: OperatorConstraints = OperatorConstraints {
                     )
                 },
                 Persistence::Static => quote_spanned! {op_span=>
-                    // Play everything but only on the first run of this tick/stratum.
-                    // (We know we won't have any more inputs, so it is fine to only play once.
-                    // Because of the `DelayType::Stratum` or `DelayType::MonotoneAccum`).
-                    #context.is_first_run_this_tick()
-                        .then_some(#hashtable_ident.iter())
-                        .into_iter()
-                        .flatten()
+                    // Play everything (each subgraph runs exactly once per tick).
+                    #hashtable_ident.iter()
                         .map(
                             #[allow(suspicious_double_ref_op, clippy::clone_on_copy)]
                             |(k, v)| (

--- a/dfir_lang/src/graph/ops/reduce_no_replay.rs
+++ b/dfir_lang/src/graph/ops/reduce_no_replay.rs
@@ -96,7 +96,7 @@ pub const REDUCE_NO_REPLAY: OperatorConstraints = OperatorConstraints {
                     let () = #work_fn_async(__fut).await;
                 }
 
-                let #ident = if __was_updated || (#context.current_tick().0 == 0 && #context.is_first_run_this_tick()) {
+                let #ident = if __was_updated || #context.current_tick().0 == 0 {
                     #work_fn(
                         || #root::dfir_pipes::pull::iter(
                             ::std::clone::Clone::clone(&*#accumulator_ident)

--- a/dfir_rs/src/scheduled/context.rs
+++ b/dfir_rs/src/scheduled/context.rs
@@ -54,11 +54,11 @@ impl Wake for WakeState {
 }
 
 /// A lightweight context for inline codegen that avoids the overhead of the full
-/// [`Context`] (no tokio channels, no scheduler queues, no loop machinery).
+/// scheduled graph (no tokio channels, no scheduler queues, no loop machinery).
 ///
-/// Exposes the same method names that operator-generated code calls on both
-/// `df` (for prologues: `add_state`, `set_state_lifespan_hook`) and
-/// `context` (for iterators: `state_ref_unchecked`, etc.).
+/// Exposes methods that operator-generated code calls on both
+/// `df` (for prologues: `request_task`) and
+/// `context` (for iterators: `current_tick`, `schedule_subgraph`, etc.).
 #[doc(hidden)]
 #[derive(Default)]
 pub struct Context {

--- a/dfir_rs/src/scheduled/context.rs
+++ b/dfir_rs/src/scheduled/context.rs
@@ -56,8 +56,9 @@ impl Wake for WakeState {
 /// A lightweight context for inline codegen that avoids the overhead of the full
 /// [`Context`] (no tokio channels, no scheduler queues, no loop machinery).
 ///
-/// Exposes method names that operator-generated code calls on
-/// `context` (for iterators: `is_first_run_this_tick`, `current_tick`, etc.).
+/// Exposes the same method names that operator-generated code calls on both
+/// `df` (for prologues: `add_state`, `set_state_lifespan_hook`) and
+/// `context` (for iterators: `state_ref_unchecked`, etc.).
 #[doc(hidden)]
 #[derive(Default)]
 pub struct Context {
@@ -101,13 +102,6 @@ impl Context {
     }
 
     // --- Methods called as `context.xxx()` in operator iterators ---
-
-    /// Always returns `true` in inline mode. The inline codegen runs the entire DAG
-    /// once per tick with no re-execution, so every subgraph is always on its first
-    /// (and only) run within each tick.
-    pub fn is_first_run_this_tick(&self) -> bool {
-        true
-    }
 
     /// Gets the current tick count.
     pub fn current_tick(&self) -> TickInstant {


### PR DESCRIPTION
With the inline DAG codegen, each subgraph runs exactly once per tick.
The `is_first_run_this_tick()` method always returned `true` and was dead
code. This removes it and simplifies all operator codegen that depended on it.

Changes:
- Removed `Context::is_first_run_this_tick()` method from dfir_rs
- Simplified `reduce_keyed` and `fold_keyed`: removed `.then_some().into_iter().flatten()`
  wrapping, now directly iterates the hashtable
- Simplified `fold_no_replay` and `reduce_no_replay`: condition simplified from
  `__was_updated || (tick == 0 && is_first_run_this_tick())` to
  `__was_updated || tick == 0`
- Simplified `persist`: removed replay_idx logic, always replays from start
- Simplified `persist_mut` and `persist_mut_keyed`: removed if/else branch,
  always processes input and replays
- Simplified `anti_join`, `join_multiset_half`, `join_fused_lhs`: removed
  replay_idx, always replays from start of accumulated vec
- Simplified `cross_join_multiset`: removed lhs_i/rhs_i tracking, always
  produces full cross product
- Simplified `join`: passes `true` directly instead of calling the method
- Simplified `multiset_delta`: removed conditional, always swaps maps
- Removed unused `context` destructuring from `anti_join` and `multiset_delta`

BREAKING CHANGE: `Context::is_first_run_this_tick` removed

Co-authored-by: Infinity 🤖 <infinity@hydro.run>