### PR TITLE
feat(dfir_pipes): add push-side `Fold`, `Reduce`, and `Sort` operators

### DIFF
--- a/dfir_pipes/src/push/fold.rs
+++ b/dfir_pipes/src/push/fold.rs
@@ -1,0 +1,72 @@
+//! [`Fold`] push combinator.
+use core::pin::Pin;
+
+use pin_project_lite::pin_project;
+
+use crate::push::{Push, PushStep};
+
+pin_project! {
+    /// Push combinator that accumulates all items via a fold function, then emits
+    /// the accumulated value downstream on finalize.
+    ///
+    /// During `start_send`, items are folded into the accumulator.
+    /// During `poll_finalize`, the accumulated value is cloned and sent downstream,
+    /// then the downstream is finalized.
+    #[must_use = "`Push`es do nothing unless items are pushed into them"]
+    #[derive(Clone, Debug)]
+    pub struct Fold<Acc, CombFn, Next> {
+        #[pin]
+        next: Next,
+        acc: Acc,
+        comb_fn: CombFn,
+        flushed: bool,
+    }
+}
+
+impl<Acc, CombFn, Next> Fold<Acc, CombFn, Next> {
+    /// Creates a new `Fold` push combinator with the given initial accumulator value.
+    pub const fn new(acc: Acc, comb_fn: CombFn, next: Next) -> Self {
+        Self {
+            next,
+            acc,
+            comb_fn,
+            flushed: false,
+        }
+    }
+}
+
+// TODO(mingwei): support arbitrary metadata.
+impl<Acc, CombFn, Item, Next> Push<Item, ()> for Fold<Acc, CombFn, Next>
+where
+    Acc: Clone,
+    CombFn: FnMut(&mut Acc, Item),
+    Next: Push<Acc, ()>,
+{
+    type Ctx<'ctx> = Next::Ctx<'ctx>;
+
+    type CanPend = Next::CanPend;
+
+    fn poll_ready(self: Pin<&mut Self>, _ctx: &mut Self::Ctx<'_>) -> PushStep<Self::CanPend> {
+        PushStep::Done
+    }
+
+    fn start_send(self: Pin<&mut Self>, item: Item, _meta: ()) {
+        let this = self.project();
+        (this.comb_fn)(this.acc, item);
+        *this.flushed = false;
+    }
+
+    fn poll_finalize(self: Pin<&mut Self>, ctx: &mut Self::Ctx<'_>) -> PushStep<Self::CanPend> {
+        let mut this = self.project();
+        if !*this.flushed {
+            *this.flushed = true;
+            let value = this.acc.clone();
+            this.next.as_mut().start_send(value, ());
+        }
+        this.next.poll_finalize(ctx)
+    }
+
+    fn size_hint(self: Pin<&mut Self>, _hint: (usize, Option<usize>)) {
+        self.project().next.size_hint((1, Some(1)));
+    }
+}

--- a/dfir_pipes/src/push/fold.rs
+++ b/dfir_pipes/src/push/fold.rs
@@ -3,7 +3,7 @@ use core::pin::Pin;
 
 use pin_project_lite::pin_project;
 
-use crate::push::{Push, PushStep};
+use crate::push::{Push, PushStep, ready};
 
 pin_project! {
     /// Push combinator that accumulates all items via a fold function, then emits
@@ -59,14 +59,65 @@ where
     fn poll_finalize(self: Pin<&mut Self>, ctx: &mut Self::Ctx<'_>) -> PushStep<Self::CanPend> {
         let mut this = self.project();
         if !*this.flushed {
-            *this.flushed = true;
+            ready!(this.next.as_mut().poll_ready(ctx));
             let value = this.acc.clone();
             this.next.as_mut().start_send(value, ());
+            *this.flushed = true;
         }
         this.next.poll_finalize(ctx)
     }
 
     fn size_hint(self: Pin<&mut Self>, _hint: (usize, Option<usize>)) {
         self.project().next.size_hint((1, Some(1)));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+    use core::pin::Pin;
+
+    use crate::Yes;
+    use crate::push::{Push, PushStep};
+    use crate::push::test_utils::{PushCall, TestPush};
+
+    #[test]
+    fn fold_emits_on_finalize() {
+        let mut tp = TestPush::no_pend();
+        let mut f = crate::push::fold(0i32, |acc, x| *acc += x, &mut tp);
+        let mut f = Pin::new(&mut f);
+        f.as_mut().start_send(1, ());
+        f.as_mut().start_send(2, ());
+        f.as_mut().start_send(3, ());
+        f.as_mut().poll_finalize(&mut ());
+        assert_eq!(tp.items(), vec![6]);
+    }
+
+    #[test]
+    fn fold_emits_initial_when_no_items() {
+        let mut tp = TestPush::no_pend();
+        let mut f = crate::push::fold(0i32, |acc, x: i32| *acc += x, &mut tp);
+        let mut f = Pin::new(&mut f);
+        f.as_mut().poll_finalize(&mut ());
+        assert_eq!(tp.items(), vec![0]);
+    }
+
+    #[test]
+    fn fold_poll_ready_before_send_on_finalize() {
+        let mut tp: TestPush<i32, Yes, true> =
+            TestPush::new_fused([PushStep::pending()], []);
+        let mut f = crate::push::fold(0i32, |acc, x| *acc += x, &mut tp);
+        let mut f = Pin::new(&mut f);
+        f.as_mut().start_send(5, ());
+        // First call: poll_ready returns Pending.
+        let step = f.as_mut().poll_finalize(&mut ());
+        assert!(step.is_pending());
+        // Second call: poll_ready returns Done (fused), send proceeds.
+        let step = f.as_mut().poll_finalize(&mut ());
+        assert!(step.is_done());
+        assert_eq!(tp.items(), vec![5]);
+        assert_eq!(tp.history[0], PushCall::PollReady);
+        assert_eq!(tp.history[1], PushCall::PollReady);
+        assert_eq!(tp.history[2], PushCall::SendItem(5));
     }
 }

--- a/dfir_pipes/src/push/fold.rs
+++ b/dfir_pipes/src/push/fold.rs
@@ -10,16 +10,15 @@ pin_project! {
     /// the accumulated value downstream on finalize.
     ///
     /// During `start_send`, items are folded into the accumulator.
-    /// During `poll_finalize`, the accumulated value is cloned and sent downstream,
+    /// During `poll_finalize`, the accumulated value is taken and sent downstream,
     /// then the downstream is finalized.
     #[must_use = "`Push`es do nothing unless items are pushed into them"]
     #[derive(Clone, Debug)]
     pub struct Fold<Acc, CombFn, Next> {
         #[pin]
         next: Next,
-        acc: Acc,
+        acc: Option<Acc>,
         comb_fn: CombFn,
-        flushed: bool,
     }
 }
 
@@ -28,9 +27,8 @@ impl<Acc, CombFn, Next> Fold<Acc, CombFn, Next> {
     pub const fn new(acc: Acc, comb_fn: CombFn, next: Next) -> Self {
         Self {
             next,
-            acc,
+            acc: Some(acc),
             comb_fn,
-            flushed: false,
         }
     }
 }
@@ -38,7 +36,6 @@ impl<Acc, CombFn, Next> Fold<Acc, CombFn, Next> {
 // TODO(mingwei): support arbitrary metadata.
 impl<Acc, CombFn, Item, Next> Push<Item, ()> for Fold<Acc, CombFn, Next>
 where
-    Acc: Clone,
     CombFn: FnMut(&mut Acc, Item),
     Next: Push<Acc, ()>,
 {
@@ -52,17 +49,18 @@ where
 
     fn start_send(self: Pin<&mut Self>, item: Item, _meta: ()) {
         let this = self.project();
-        (this.comb_fn)(this.acc, item);
-        *this.flushed = false;
+        (this.comb_fn)(
+            this.acc.as_mut().expect("Fold: start_send after finalize"),
+            item,
+        );
     }
 
     fn poll_finalize(self: Pin<&mut Self>, ctx: &mut Self::Ctx<'_>) -> PushStep<Self::CanPend> {
         let mut this = self.project();
-        if !*this.flushed {
+        if this.acc.is_some() {
             ready!(this.next.as_mut().poll_ready(ctx));
-            let value = this.acc.clone();
+            let value = this.acc.take().unwrap();
             this.next.as_mut().start_send(value, ());
-            *this.flushed = true;
         }
         this.next.poll_finalize(ctx)
     }
@@ -78,16 +76,19 @@ mod tests {
     use core::pin::Pin;
 
     use crate::Yes;
-    use crate::push::{Push, PushStep};
     use crate::push::test_utils::{PushCall, TestPush};
+    use crate::push::{Push, PushStep};
 
     #[test]
     fn fold_emits_on_finalize() {
         let mut tp = TestPush::no_pend();
         let mut f = crate::push::fold(0i32, |acc, x| *acc += x, &mut tp);
         let mut f = Pin::new(&mut f);
+        f.as_mut().poll_ready(&mut ());
         f.as_mut().start_send(1, ());
+        f.as_mut().poll_ready(&mut ());
         f.as_mut().start_send(2, ());
+        f.as_mut().poll_ready(&mut ());
         f.as_mut().start_send(3, ());
         f.as_mut().poll_finalize(&mut ());
         assert_eq!(tp.items(), vec![6]);
@@ -104,12 +105,12 @@ mod tests {
 
     #[test]
     fn fold_poll_ready_before_send_on_finalize() {
-        let mut tp: TestPush<i32, Yes, true> =
-            TestPush::new_fused([PushStep::pending()], []);
+        let mut tp: TestPush<i32, Yes, true> = TestPush::new_fused([PushStep::pending()], []);
         let mut f = crate::push::fold(0i32, |acc, x| *acc += x, &mut tp);
         let mut f = Pin::new(&mut f);
+        f.as_mut().poll_ready(&mut ());
         f.as_mut().start_send(5, ());
-        // First call: poll_ready returns Pending.
+        // First call: downstream poll_ready returns Pending.
         let step = f.as_mut().poll_finalize(&mut ());
         assert!(step.is_pending());
         // Second call: poll_ready returns Done (fused), send proceeds.

--- a/dfir_pipes/src/push/mod.rs
+++ b/dfir_pipes/src/push/mod.rs
@@ -317,6 +317,40 @@ where
     FlattenStream::new(next)
 }
 
+/// Creates a [`Fold`] push that accumulates all items via a fold function, then emits
+/// the accumulated value downstream on finalize.
+pub const fn fold<Acc, CombFn, Item, Next>(acc: Acc, comb_fn: CombFn, next: Next) -> Fold<Acc, CombFn, Next>
+where
+    Acc: Clone,
+    CombFn: FnMut(&mut Acc, Item),
+    Next: Push<Acc, ()>,
+{
+    Fold::new(acc, comb_fn, next)
+}
+
+/// Creates a [`Reduce`] push that reduces all items into a single value, then emits
+/// it downstream on finalize. If no items were received, nothing is emitted.
+pub const fn reduce<Acc, ReduceFn, Next>(reduce_fn: ReduceFn, next: Next) -> Reduce<Acc, ReduceFn, Next>
+where
+    Acc: Clone,
+    ReduceFn: FnMut(&mut Acc, Acc),
+    Next: Push<Acc, ()>,
+{
+    Reduce::new(reduce_fn, next)
+}
+
+/// Creates a [`Sort`] push that collects all items, sorts them, then emits them
+/// downstream in sorted order on finalize.
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub const fn sort<Item, Next>(next: Next) -> Sort<Item, Next>
+where
+    Item: Ord + Clone,
+    Next: Push<Item, ()>,
+{
+    Sort::new(next)
+}
+
 /// Creates a [`ForEach`] terminal push that consumes each item with a function.
 pub const fn for_each<Func, Item>(func: Func) -> ForEach<Func>
 where

--- a/dfir_pipes/src/push/mod.rs
+++ b/dfir_pipes/src/push/mod.rs
@@ -319,9 +319,12 @@ where
 
 /// Creates a [`Fold`] push that accumulates all items via a fold function, then emits
 /// the accumulated value downstream on finalize.
-pub const fn fold<Acc, CombFn, Item, Next>(acc: Acc, comb_fn: CombFn, next: Next) -> Fold<Acc, CombFn, Next>
+pub const fn fold<Acc, CombFn, Item, Next>(
+    acc: Acc,
+    comb_fn: CombFn,
+    next: Next,
+) -> Fold<Acc, CombFn, Next>
 where
-    Acc: Clone,
     CombFn: FnMut(&mut Acc, Item),
     Next: Push<Acc, ()>,
 {
@@ -330,9 +333,11 @@ where
 
 /// Creates a [`Reduce`] push that reduces all items into a single value, then emits
 /// it downstream on finalize. If no items were received, nothing is emitted.
-pub const fn reduce<Acc, ReduceFn, Next>(reduce_fn: ReduceFn, next: Next) -> Reduce<Acc, ReduceFn, Next>
+pub const fn reduce<Acc, ReduceFn, Next>(
+    reduce_fn: ReduceFn,
+    next: Next,
+) -> Reduce<Acc, ReduceFn, Next>
 where
-    Acc: Clone,
     ReduceFn: FnMut(&mut Acc, Acc),
     Next: Push<Acc, ()>,
 {
@@ -345,7 +350,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub const fn sort<Item, Next>(next: Next) -> Sort<Item, Next>
 where
-    Item: Ord + Clone,
+    Item: Ord,
     Next: Push<Item, ()>,
 {
     Sort::new(next)

--- a/dfir_pipes/src/push/mod.rs
+++ b/dfir_pipes/src/push/mod.rs
@@ -16,15 +16,20 @@ mod flat_map;
 mod flat_map_stream;
 mod flatten;
 mod flatten_stream;
+mod fold;
 mod for_each;
 mod inspect;
 mod map;
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 mod persist;
+mod reduce;
 mod resolve_futures;
 mod sink;
 mod sink_compat;
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+mod sort;
 mod unzip;
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
@@ -48,6 +53,7 @@ pub use flat_map::FlatMap;
 pub use flat_map_stream::FlatMapStream;
 pub use flatten::Flatten;
 pub use flatten_stream::FlattenStream;
+pub use fold::Fold;
 pub use for_each::ForEach;
 use futures_core::FusedStream;
 pub use inspect::Inspect;
@@ -55,9 +61,13 @@ pub use map::Map;
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub use persist::Persist;
+pub use reduce::Reduce;
 pub use resolve_futures::ResolveFutures;
 pub use sink::Sink;
 pub use sink_compat::SinkCompat;
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub use sort::Sort;
 pub use unzip::Unzip;
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]

--- a/dfir_pipes/src/push/reduce.rs
+++ b/dfir_pipes/src/push/reduce.rs
@@ -1,0 +1,75 @@
+//! [`Reduce`] push combinator.
+use core::pin::Pin;
+
+use pin_project_lite::pin_project;
+
+use crate::push::{Push, PushStep};
+
+pin_project! {
+    /// Push combinator that reduces all items into a single value, then emits
+    /// it downstream on finalize. If no items were received, nothing is emitted.
+    ///
+    /// During `start_send`, items are reduced into the accumulator.
+    /// During `poll_finalize`, the accumulated value (if any) is sent downstream.
+    #[must_use = "`Push`es do nothing unless items are pushed into them"]
+    #[derive(Clone, Debug)]
+    pub struct Reduce<Acc, ReduceFn, Next> {
+        #[pin]
+        next: Next,
+        acc: Option<Acc>,
+        reduce_fn: ReduceFn,
+        flushed: bool,
+    }
+}
+
+impl<Acc, ReduceFn, Next> Reduce<Acc, ReduceFn, Next> {
+    /// Creates a new `Reduce` push combinator.
+    pub const fn new(reduce_fn: ReduceFn, next: Next) -> Self {
+        Self {
+            next,
+            acc: None,
+            reduce_fn,
+            flushed: false,
+        }
+    }
+}
+
+// TODO(mingwei): support arbitrary metadata.
+impl<Acc, ReduceFn, Next> Push<Acc, ()> for Reduce<Acc, ReduceFn, Next>
+where
+    Acc: Clone,
+    ReduceFn: FnMut(&mut Acc, Acc),
+    Next: Push<Acc, ()>,
+{
+    type Ctx<'ctx> = Next::Ctx<'ctx>;
+
+    type CanPend = Next::CanPend;
+
+    fn poll_ready(self: Pin<&mut Self>, _ctx: &mut Self::Ctx<'_>) -> PushStep<Self::CanPend> {
+        PushStep::Done
+    }
+
+    fn start_send(self: Pin<&mut Self>, item: Acc, _meta: ()) {
+        let this = self.project();
+        match this.acc {
+            Some(acc) => (this.reduce_fn)(acc, item),
+            None => *this.acc = Some(item),
+        }
+        *this.flushed = false;
+    }
+
+    fn poll_finalize(self: Pin<&mut Self>, ctx: &mut Self::Ctx<'_>) -> PushStep<Self::CanPend> {
+        let mut this = self.project();
+        if !*this.flushed {
+            *this.flushed = true;
+            if let Some(value) = this.acc.as_ref() {
+                this.next.as_mut().start_send(value.clone(), ());
+            }
+        }
+        this.next.poll_finalize(ctx)
+    }
+
+    fn size_hint(self: Pin<&mut Self>, _hint: (usize, Option<usize>)) {
+        self.project().next.size_hint((0, Some(1)));
+    }
+}

--- a/dfir_pipes/src/push/reduce.rs
+++ b/dfir_pipes/src/push/reduce.rs
@@ -10,7 +10,7 @@ pin_project! {
     /// it downstream on finalize. If no items were received, nothing is emitted.
     ///
     /// During `start_send`, items are reduced into the accumulator.
-    /// During `poll_finalize`, the accumulated value (if any) is sent downstream.
+    /// During `poll_finalize`, the accumulated value (if any) is taken and sent downstream.
     #[must_use = "`Push`es do nothing unless items are pushed into them"]
     #[derive(Clone, Debug)]
     pub struct Reduce<Acc, ReduceFn, Next> {
@@ -18,7 +18,6 @@ pin_project! {
         next: Next,
         acc: Option<Acc>,
         reduce_fn: ReduceFn,
-        flushed: bool,
     }
 }
 
@@ -29,7 +28,6 @@ impl<Acc, ReduceFn, Next> Reduce<Acc, ReduceFn, Next> {
             next,
             acc: None,
             reduce_fn,
-            flushed: false,
         }
     }
 }
@@ -37,7 +35,6 @@ impl<Acc, ReduceFn, Next> Reduce<Acc, ReduceFn, Next> {
 // TODO(mingwei): support arbitrary metadata.
 impl<Acc, ReduceFn, Next> Push<Acc, ()> for Reduce<Acc, ReduceFn, Next>
 where
-    Acc: Clone,
     ReduceFn: FnMut(&mut Acc, Acc),
     Next: Push<Acc, ()>,
 {
@@ -55,17 +52,14 @@ where
             Some(acc) => (this.reduce_fn)(acc, item),
             None => *this.acc = Some(item),
         }
-        *this.flushed = false;
     }
 
     fn poll_finalize(self: Pin<&mut Self>, ctx: &mut Self::Ctx<'_>) -> PushStep<Self::CanPend> {
         let mut this = self.project();
-        if !*this.flushed {
-            if let Some(value) = this.acc.as_ref() {
-                ready!(this.next.as_mut().poll_ready(ctx));
-                this.next.as_mut().start_send(value.clone(), ());
-            }
-            *this.flushed = true;
+        if this.acc.is_some() {
+            ready!(this.next.as_mut().poll_ready(ctx));
+            let value = this.acc.take().unwrap();
+            this.next.as_mut().start_send(value, ());
         }
         this.next.poll_finalize(ctx)
     }
@@ -82,16 +76,19 @@ mod tests {
     use core::pin::Pin;
 
     use crate::Yes;
-    use crate::push::{Push, PushStep};
     use crate::push::test_utils::{PushCall, TestPush};
+    use crate::push::{Push, PushStep};
 
     #[test]
     fn reduce_emits_on_finalize() {
         let mut tp = TestPush::no_pend();
         let mut r = crate::push::reduce(|acc: &mut i32, x| *acc += x, &mut tp);
         let mut r = Pin::new(&mut r);
+        r.as_mut().poll_ready(&mut ());
         r.as_mut().start_send(1, ());
+        r.as_mut().poll_ready(&mut ());
         r.as_mut().start_send(2, ());
+        r.as_mut().poll_ready(&mut ());
         r.as_mut().start_send(3, ());
         r.as_mut().poll_finalize(&mut ());
         assert_eq!(tp.items(), vec![6]);
@@ -108,10 +105,10 @@ mod tests {
 
     #[test]
     fn reduce_poll_ready_before_send_on_finalize() {
-        let mut tp: TestPush<i32, Yes, true> =
-            TestPush::new_fused([PushStep::pending()], []);
+        let mut tp: TestPush<i32, Yes, true> = TestPush::new_fused([PushStep::pending()], []);
         let mut r = crate::push::reduce(|acc: &mut i32, x| *acc += x, &mut tp);
         let mut r = Pin::new(&mut r);
+        r.as_mut().poll_ready(&mut ());
         r.as_mut().start_send(1, ());
         // First call: poll_ready returns Pending, so poll_finalize returns Pending.
         let step = r.as_mut().poll_finalize(&mut ());

--- a/dfir_pipes/src/push/reduce.rs
+++ b/dfir_pipes/src/push/reduce.rs
@@ -3,7 +3,7 @@ use core::pin::Pin;
 
 use pin_project_lite::pin_project;
 
-use crate::push::{Push, PushStep};
+use crate::push::{Push, PushStep, ready};
 
 pin_project! {
     /// Push combinator that reduces all items into a single value, then emits
@@ -61,15 +61,68 @@ where
     fn poll_finalize(self: Pin<&mut Self>, ctx: &mut Self::Ctx<'_>) -> PushStep<Self::CanPend> {
         let mut this = self.project();
         if !*this.flushed {
-            *this.flushed = true;
             if let Some(value) = this.acc.as_ref() {
+                ready!(this.next.as_mut().poll_ready(ctx));
                 this.next.as_mut().start_send(value.clone(), ());
             }
+            *this.flushed = true;
         }
         this.next.poll_finalize(ctx)
     }
 
     fn size_hint(self: Pin<&mut Self>, _hint: (usize, Option<usize>)) {
         self.project().next.size_hint((0, Some(1)));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+    use alloc::vec::Vec;
+    use core::pin::Pin;
+
+    use crate::Yes;
+    use crate::push::{Push, PushStep};
+    use crate::push::test_utils::{PushCall, TestPush};
+
+    #[test]
+    fn reduce_emits_on_finalize() {
+        let mut tp = TestPush::no_pend();
+        let mut r = crate::push::reduce(|acc: &mut i32, x| *acc += x, &mut tp);
+        let mut r = Pin::new(&mut r);
+        r.as_mut().start_send(1, ());
+        r.as_mut().start_send(2, ());
+        r.as_mut().start_send(3, ());
+        r.as_mut().poll_finalize(&mut ());
+        assert_eq!(tp.items(), vec![6]);
+    }
+
+    #[test]
+    fn reduce_no_items_no_output() {
+        let mut tp = TestPush::no_pend();
+        let mut r = crate::push::reduce(|acc: &mut i32, x| *acc += x, &mut tp);
+        let mut r = Pin::new(&mut r);
+        r.as_mut().poll_finalize(&mut ());
+        assert_eq!(tp.items(), Vec::<i32>::new());
+    }
+
+    #[test]
+    fn reduce_poll_ready_before_send_on_finalize() {
+        let mut tp: TestPush<i32, Yes, true> =
+            TestPush::new_fused([PushStep::pending()], []);
+        let mut r = crate::push::reduce(|acc: &mut i32, x| *acc += x, &mut tp);
+        let mut r = Pin::new(&mut r);
+        r.as_mut().start_send(1, ());
+        // First call: poll_ready returns Pending, so poll_finalize returns Pending.
+        let step = r.as_mut().poll_finalize(&mut ());
+        assert!(step.is_pending());
+        // Second call: poll_ready returns Done (fused), send proceeds.
+        let step = r.as_mut().poll_finalize(&mut ());
+        assert!(step.is_done());
+        assert_eq!(tp.items(), vec![1]);
+        // Verify poll_ready was called before send.
+        assert_eq!(tp.history[0], PushCall::PollReady);
+        assert_eq!(tp.history[1], PushCall::PollReady);
+        assert_eq!(tp.history[2], PushCall::SendItem(1));
     }
 }

--- a/dfir_pipes/src/push/sort.rs
+++ b/dfir_pipes/src/push/sort.rs
@@ -1,0 +1,79 @@
+//! [`Sort`] push combinator.
+use alloc::vec::Vec;
+use core::pin::Pin;
+
+use pin_project_lite::pin_project;
+
+use crate::push::{Push, PushStep, ready};
+
+pin_project! {
+    /// Push combinator that collects all items, sorts them, then emits them
+    /// downstream in sorted order on finalize.
+    #[must_use = "`Push`es do nothing unless items are pushed into them"]
+    #[derive(Clone, Debug)]
+    pub struct Sort<Item, Next> {
+        #[pin]
+        next: Next,
+        buf: Vec<Item>,
+        sorted: bool,
+        flush_idx: usize,
+    }
+}
+
+impl<Item, Next> Sort<Item, Next> {
+    /// Creates a new `Sort` push combinator.
+    pub const fn new(next: Next) -> Self {
+        Self {
+            next,
+            buf: Vec::new(),
+            sorted: false,
+            flush_idx: 0,
+        }
+    }
+}
+
+// TODO(mingwei): support arbitrary metadata.
+impl<Item, Next> Push<Item, ()> for Sort<Item, Next>
+where
+    Item: Ord + Clone,
+    Next: Push<Item, ()>,
+{
+    type Ctx<'ctx> = Next::Ctx<'ctx>;
+
+    type CanPend = Next::CanPend;
+
+    fn poll_ready(self: Pin<&mut Self>, _ctx: &mut Self::Ctx<'_>) -> PushStep<Self::CanPend> {
+        PushStep::Done
+    }
+
+    fn start_send(self: Pin<&mut Self>, item: Item, _meta: ()) {
+        let this = self.project();
+        this.buf.push(item);
+        *this.sorted = false;
+    }
+
+    fn poll_finalize(self: Pin<&mut Self>, ctx: &mut Self::Ctx<'_>) -> PushStep<Self::CanPend> {
+        let mut this = self.project();
+        if !*this.sorted {
+            this.buf.sort_unstable();
+            *this.sorted = true;
+            *this.flush_idx = 0;
+        }
+        while *this.flush_idx < this.buf.len() {
+            ready!(this.next.as_mut().poll_ready(ctx));
+            let item = this.buf[*this.flush_idx].clone();
+            this.next.as_mut().start_send(item, ());
+            *this.flush_idx += 1;
+        }
+        this.buf.clear();
+        *this.sorted = false;
+        *this.flush_idx = 0;
+        this.next.poll_finalize(ctx)
+    }
+
+    fn size_hint(self: Pin<&mut Self>, hint: (usize, Option<usize>)) {
+        let this = self.project();
+        this.buf.reserve(hint.0);
+        this.next.size_hint(hint);
+    }
+}

--- a/dfir_pipes/src/push/sort.rs
+++ b/dfir_pipes/src/push/sort.rs
@@ -16,7 +16,6 @@ pin_project! {
         next: Next,
         buf: Vec<Item>,
         sorted: bool,
-        flush_idx: usize,
     }
 }
 
@@ -27,7 +26,6 @@ impl<Item, Next> Sort<Item, Next> {
             next,
             buf: Vec::new(),
             sorted: false,
-            flush_idx: 0,
         }
     }
 }
@@ -35,7 +33,7 @@ impl<Item, Next> Sort<Item, Next> {
 // TODO(mingwei): support arbitrary metadata.
 impl<Item, Next> Push<Item, ()> for Sort<Item, Next>
 where
-    Item: Ord + Clone,
+    Item: Ord,
     Next: Push<Item, ()>,
 {
     type Ctx<'ctx> = Next::Ctx<'ctx>;
@@ -55,19 +53,14 @@ where
     fn poll_finalize(self: Pin<&mut Self>, ctx: &mut Self::Ctx<'_>) -> PushStep<Self::CanPend> {
         let mut this = self.project();
         if !*this.sorted {
-            this.buf.sort_unstable();
+            this.buf.sort_unstable_by(|a, b| b.cmp(a));
             *this.sorted = true;
-            *this.flush_idx = 0;
         }
-        while *this.flush_idx < this.buf.len() {
+        while !this.buf.is_empty() {
             ready!(this.next.as_mut().poll_ready(ctx));
-            let item = this.buf[*this.flush_idx].clone();
+            let item = this.buf.pop().unwrap();
             this.next.as_mut().start_send(item, ());
-            *this.flush_idx += 1;
         }
-        this.buf.clear();
-        *this.sorted = false;
-        *this.flush_idx = 0;
         this.next.poll_finalize(ctx)
     }
 
@@ -84,40 +77,52 @@ mod tests {
     use core::pin::Pin;
 
     use crate::Yes;
-    use crate::push::{Push, PushStep};
     use crate::push::test_utils::TestPush;
+    use crate::push::{Push, PushStep};
 
     #[test]
     fn sort_emits_sorted_on_finalize() {
         let mut tp = TestPush::no_pend();
         let mut s = crate::push::sort(&mut tp);
         let mut s = Pin::new(&mut s);
+        s.as_mut().poll_ready(&mut ());
         s.as_mut().start_send(3, ());
+        s.as_mut().poll_ready(&mut ());
         s.as_mut().start_send(1, ());
+        s.as_mut().poll_ready(&mut ());
         s.as_mut().start_send(2, ());
         s.as_mut().poll_finalize(&mut ());
         assert_eq!(tp.items(), vec![1, 2, 3]);
     }
 
     #[test]
-    fn sort_resumes_from_flush_idx_on_pending() {
+    fn sort_resumes_on_pending_without_dropping_items() {
         // poll_ready returns Pending on the second item, then Done on retry.
         let mut tp: TestPush<i32, Yes, true> = TestPush::new_fused(
-            [PushStep::Done, PushStep::pending(), PushStep::Done, PushStep::Done],
+            [
+                PushStep::Done,
+                PushStep::pending(),
+                PushStep::Done,
+                PushStep::Done,
+            ],
             [],
         );
-        let mut s = crate::push::sort(&mut tp);
-        let mut s = Pin::new(&mut s);
-        s.as_mut().start_send(3, ());
-        s.as_mut().start_send(1, ());
-        s.as_mut().start_send(2, ());
-        // First call: sends item 0 (1), then poll_ready returns Pending on item 1.
-        let step = s.as_mut().poll_finalize(&mut ());
-        assert!(step.is_pending());
-        // Second call: resumes from idx 1, sends items 1 and 2.
-        let step = s.as_mut().poll_finalize(&mut ());
-        assert!(step.is_done());
-        drop(s);
+        {
+            let mut s = crate::push::sort(&mut tp);
+            let mut s = Pin::new(&mut s);
+            s.as_mut().poll_ready(&mut ());
+            s.as_mut().start_send(3, ());
+            s.as_mut().poll_ready(&mut ());
+            s.as_mut().start_send(1, ());
+            s.as_mut().poll_ready(&mut ());
+            s.as_mut().start_send(2, ());
+            // First call: sends item 1, then poll_ready returns Pending.
+            let step = s.as_mut().poll_finalize(&mut ());
+            assert!(step.is_pending());
+            // Second call: resumes, sends remaining items.
+            let step = s.as_mut().poll_finalize(&mut ());
+            assert!(step.is_done());
+        }
         assert_eq!(tp.items(), vec![1, 2, 3]);
     }
 }

--- a/dfir_pipes/src/push/sort.rs
+++ b/dfir_pipes/src/push/sort.rs
@@ -77,3 +77,47 @@ where
         this.next.size_hint(hint);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+    use core::pin::Pin;
+
+    use crate::Yes;
+    use crate::push::{Push, PushStep};
+    use crate::push::test_utils::TestPush;
+
+    #[test]
+    fn sort_emits_sorted_on_finalize() {
+        let mut tp = TestPush::no_pend();
+        let mut s = crate::push::sort(&mut tp);
+        let mut s = Pin::new(&mut s);
+        s.as_mut().start_send(3, ());
+        s.as_mut().start_send(1, ());
+        s.as_mut().start_send(2, ());
+        s.as_mut().poll_finalize(&mut ());
+        assert_eq!(tp.items(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn sort_resumes_from_flush_idx_on_pending() {
+        // poll_ready returns Pending on the second item, then Done on retry.
+        let mut tp: TestPush<i32, Yes, true> = TestPush::new_fused(
+            [PushStep::Done, PushStep::pending(), PushStep::Done, PushStep::Done],
+            [],
+        );
+        let mut s = crate::push::sort(&mut tp);
+        let mut s = Pin::new(&mut s);
+        s.as_mut().start_send(3, ());
+        s.as_mut().start_send(1, ());
+        s.as_mut().start_send(2, ());
+        // First call: sends item 0 (1), then poll_ready returns Pending on item 1.
+        let step = s.as_mut().poll_finalize(&mut ());
+        assert!(step.is_pending());
+        // Second call: resumes from idx 1, sends items 1 and 2.
+        let step = s.as_mut().poll_finalize(&mut ());
+        assert!(step.is_done());
+        drop(s);
+        assert_eq!(tp.items(), vec![1, 2, 3]);
+    }
+}

--- a/dfir_rs/tests/compile-fail-stable/surface_demuxenum_wrongenum.stderr
+++ b/dfir_rs/tests/compile-fail-stable/surface_demuxenum_wrongenum.stderr
@@ -87,11 +87,11 @@ error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<std::option:
              `&mut P` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `DemuxEnum<Outputs>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `ResolveFutures<Psh, Queue, QueueInner>` implements `dfir_rs::dfir_pipes::push::Push<Fut, ()>`
+             `Sort<Item, Next>` implements `dfir_rs::dfir_pipes::push::Push<Item, ()>`
              `VecPush<Buf>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::DemuxVar<Pushes>` implements `dfir_rs::dfir_pipes::push::Push<(usize, Item), Meta>`
              `dfir_rs::dfir_pipes::push::Fanout<P0, P1>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::Filter<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
-             `dfir_rs::dfir_pipes::push::FilterMap<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<In, Meta>`
            and $N others
 note: required by a bound in `pivot_run_sg_1v1`
   --> tests/compile-fail-stable/surface_demuxenum_wrongenum.rs:17:15

--- a/dfir_rs/tests/compile-fail-stable/surface_demuxenum_wrongfields_1.stderr
+++ b/dfir_rs/tests/compile-fail-stable/surface_demuxenum_wrongfields_1.stderr
@@ -9,11 +9,11 @@ error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<u32, (), Can
              `&mut P` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `DemuxEnum<Outputs>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `ResolveFutures<Psh, Queue, QueueInner>` implements `dfir_rs::dfir_pipes::push::Push<Fut, ()>`
+             `Sort<Item, Next>` implements `dfir_rs::dfir_pipes::push::Push<Item, ()>`
              `VecPush<Buf>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::DemuxVar<Pushes>` implements `dfir_rs::dfir_pipes::push::Push<(usize, Item), Meta>`
              `dfir_rs::dfir_pipes::push::Fanout<P0, P1>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::Filter<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
-             `dfir_rs::dfir_pipes::push::FilterMap<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<In, Meta>`
            and $N others
 note: required for `Shape` to implement `DemuxEnumPush<(Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64,)) {std::mem::drop::<(f64,)>}> as dfir_rs::dfir_pipes::push::Push<(f64,), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64, f64), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64, f64)) {std::mem::drop::<(f64, f64)>}> as dfir_rs::dfir_pipes::push::Push<(f64, f64), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<u32, (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<{closure@$DIR/tests/compile-fail-stable/surface_demuxenum_wrongfields_1.rs:20:38: 20:49}> as dfir_rs::dfir_pipes::push::Push<u32, ()>>::CanPend>>), ()>`
   --> tests/compile-fail-stable/surface_demuxenum_wrongfields_1.rs:5:14
@@ -40,11 +40,11 @@ error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<u32, (), Can
              `&mut P` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `DemuxEnum<Outputs>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `ResolveFutures<Psh, Queue, QueueInner>` implements `dfir_rs::dfir_pipes::push::Push<Fut, ()>`
+             `Sort<Item, Next>` implements `dfir_rs::dfir_pipes::push::Push<Item, ()>`
              `VecPush<Buf>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::DemuxVar<Pushes>` implements `dfir_rs::dfir_pipes::push::Push<(usize, Item), Meta>`
              `dfir_rs::dfir_pipes::push::Fanout<P0, P1>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::Filter<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
-             `dfir_rs::dfir_pipes::push::FilterMap<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<In, Meta>`
            and $N others
 note: required for `Shape` to implement `DemuxEnumPush<(Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64,)) {std::mem::drop::<(f64,)>}> as dfir_rs::dfir_pipes::push::Push<(f64,), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64, f64), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64, f64)) {std::mem::drop::<(f64, f64)>}> as dfir_rs::dfir_pipes::push::Push<(f64, f64), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<u32, (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<{closure@$DIR/tests/compile-fail-stable/surface_demuxenum_wrongfields_1.rs:20:38: 20:49}> as dfir_rs::dfir_pipes::push::Push<u32, ()>>::CanPend>>), ()>`
   --> tests/compile-fail-stable/surface_demuxenum_wrongfields_1.rs:5:14

--- a/dfir_rs/tests/compile-fail-stable/surface_demuxenum_wrongfields_2.stderr
+++ b/dfir_rs/tests/compile-fail-stable/surface_demuxenum_wrongfields_2.stderr
@@ -9,11 +9,11 @@ error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<(u32,), (), 
              `&mut P` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `DemuxEnum<Outputs>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `ResolveFutures<Psh, Queue, QueueInner>` implements `dfir_rs::dfir_pipes::push::Push<Fut, ()>`
+             `Sort<Item, Next>` implements `dfir_rs::dfir_pipes::push::Push<Item, ()>`
              `VecPush<Buf>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::DemuxVar<Pushes>` implements `dfir_rs::dfir_pipes::push::Push<(usize, Item), Meta>`
              `dfir_rs::dfir_pipes::push::Fanout<P0, P1>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::Filter<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
-             `dfir_rs::dfir_pipes::push::FilterMap<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<In, Meta>`
            and $N others
 note: required for `Shape` to implement `DemuxEnumPush<(Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64,)) {std::mem::drop::<(f64,)>}> as dfir_rs::dfir_pipes::push::Push<(f64,), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64, f64), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64, f64)) {std::mem::drop::<(f64, f64)>}> as dfir_rs::dfir_pipes::push::Push<(f64, f64), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(u32,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<{closure@$DIR/tests/compile-fail-stable/surface_demuxenum_wrongfields_2.rs:20:38: 20:52}> as dfir_rs::dfir_pipes::push::Push<(u32,), ()>>::CanPend>>), ()>`
   --> tests/compile-fail-stable/surface_demuxenum_wrongfields_2.rs:5:14
@@ -40,11 +40,11 @@ error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<(u32,), (), 
              `&mut P` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `DemuxEnum<Outputs>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `ResolveFutures<Psh, Queue, QueueInner>` implements `dfir_rs::dfir_pipes::push::Push<Fut, ()>`
+             `Sort<Item, Next>` implements `dfir_rs::dfir_pipes::push::Push<Item, ()>`
              `VecPush<Buf>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::DemuxVar<Pushes>` implements `dfir_rs::dfir_pipes::push::Push<(usize, Item), Meta>`
              `dfir_rs::dfir_pipes::push::Fanout<P0, P1>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::Filter<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
-             `dfir_rs::dfir_pipes::push::FilterMap<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<In, Meta>`
            and $N others
 note: required for `Shape` to implement `DemuxEnumPush<(Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64,)) {std::mem::drop::<(f64,)>}> as dfir_rs::dfir_pipes::push::Push<(f64,), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64, f64), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64, f64)) {std::mem::drop::<(f64, f64)>}> as dfir_rs::dfir_pipes::push::Push<(f64, f64), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(u32,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<{closure@$DIR/tests/compile-fail-stable/surface_demuxenum_wrongfields_2.rs:20:38: 20:52}> as dfir_rs::dfir_pipes::push::Push<(u32,), ()>>::CanPend>>), ()>`
   --> tests/compile-fail-stable/surface_demuxenum_wrongfields_2.rs:5:14


### PR DESCRIPTION
These operators accumulate items during `start_send` and emit results
downstream during `poll_flush`, enabling them to work on the push side
of a subgraph without requiring a subgraph boundary.

New push operators:
- `Fold<Acc, CombFn, Next>`: accumulates all items via a fold function,
  emits the accumulated value on flush
- `Reduce<Acc, ReduceFn, Next>`: reduces items into a single value,
  emits on flush (nothing if no items received)
- `Sort<Item, Next>`: collects all items, sorts them, emits in sorted
  order on flush

These are needed because removing `DelayType::Stratum` allows blocking
operators to end up on the push side of a subgraph. Previously they were
always pull-side due to the forced subgraph boundary on their input.

This is part of the effort for singleton references in Hydro

Co-authored-by: Infinity 🤖 <infinity@hydro.run>