### PR TITLE
Remove DelayType::Stratum and DelayType::MonotoneAccum from operator input_delaytype_fn

### DIFF
--- a/dfir_lang/src/graph/flat_to_partitioned.rs
+++ b/dfir_lang/src/graph/flat_to_partitioned.rs
@@ -28,10 +28,7 @@ impl BarrierCrossers {
             .edge_barrier_crossers
             .iter()
             .map(|(edge_id, &_delay_type)| partitioned_graph.edge(edge_id));
-        let singleton_pairs_iter = self
-            .singleton_barrier_crossers
-            .iter()
-            .copied();
+        let singleton_pairs_iter = self.singleton_barrier_crossers.iter().copied();
         edge_pairs_iter.chain(singleton_pairs_iter)
     }
 

--- a/dfir_lang/src/graph/flat_to_partitioned.rs
+++ b/dfir_lang/src/graph/flat_to_partitioned.rs
@@ -15,26 +15,23 @@ use crate::union_find::UnionFind;
 struct BarrierCrossers {
     /// Edge barrier crossers, including what type.
     pub edge_barrier_crossers: SecondaryMap<GraphEdgeId, DelayType>,
-    /// Singleton reference barrier crossers, considered to be [`DelayType::Stratum`].
+    /// Singleton reference barrier crossers — force subgraph boundaries.
     pub singleton_barrier_crossers: Vec<(GraphNodeId, GraphNodeId)>,
 }
 impl BarrierCrossers {
-    /// Iterate pairs of nodes that are across a barrier. Excludes `DelayType::NextIteration` pairs.
+    /// Iterate pairs of nodes that are across a barrier (subgraph boundary or tick boundary).
     fn iter_node_pairs<'a>(
         &'a self,
         partitioned_graph: &'a DfirGraph,
-    ) -> impl 'a + Iterator<Item = ((GraphNodeId, GraphNodeId), DelayType)> {
+    ) -> impl 'a + Iterator<Item = (GraphNodeId, GraphNodeId)> {
         let edge_pairs_iter = self
             .edge_barrier_crossers
             .iter()
-            .map(|(edge_id, &delay_type)| {
-                let src_dst = partitioned_graph.edge(edge_id);
-                (src_dst, delay_type)
-            });
+            .map(|(edge_id, &_delay_type)| partitioned_graph.edge(edge_id));
         let singleton_pairs_iter = self
             .singleton_barrier_crossers
             .iter()
-            .map(|&src_dst| (src_dst, DelayType::Stratum));
+            .copied();
         edge_pairs_iter.chain(singleton_pairs_iter)
     }
 
@@ -122,7 +119,7 @@ fn find_subgraph_unionfind(
             // Do not connect stratum crossers (next edges).
             if barrier_crossers
                 .iter_node_pairs(partitioned_graph)
-                .any(|((x_src, x_dst), _)| {
+                .any(|(x_src, x_dst)| {
                     (subgraph_unionfind.same_set(x_src, src)
                         && subgraph_unionfind.same_set(x_dst, dst))
                         || (subgraph_unionfind.same_set(x_src, dst)

--- a/dfir_lang/src/graph/graph_write.rs
+++ b/dfir_lang/src/graph/graph_write.rs
@@ -181,8 +181,7 @@ where
             src = src_str.trim(),
             arrow_body = "--",
             arrow_head = match delay_type {
-                None | Some(DelayType::MonotoneAccum) => ">",
-                Some(DelayType::Stratum) => "x",
+                None => ">",
                 Some(DelayType::Tick | DelayType::TickLazy) => "o",
             },
             label = if let Some(label) = &label {
@@ -200,8 +199,7 @@ where
                 "; linkStyle {} stroke:{}",
                 self.link_count,
                 match delay_type {
-                    DelayType::Stratum | DelayType::Tick | DelayType::TickLazy => "red",
-                    DelayType::MonotoneAccum => "#060",
+                    DelayType::Tick | DelayType::TickLazy => "red",
                 }
             )?;
         }

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1802,7 +1802,7 @@ impl DfirGraph {
                     .copied()
                     .flatten()
                 {
-                    let delay_type = Some(DelayType::Stratum);
+                    let delay_type = None;
                     let label = None;
                     graph_write.write_edge(src_ref_id, dst_id, delay_type, label, true)?;
                 }

--- a/dfir_lang/src/graph/ops/_lattice_fold_batch.rs
+++ b/dfir_lang/src/graph/ops/_lattice_fold_batch.rs
@@ -2,7 +2,7 @@ use quote::{quote_spanned, ToTokens};
 use syn::parse_quote;
 
 use super::{
-    DelayType, OpInstGenerics, OperatorCategory, OperatorConstraints, OperatorInstance,
+    OpInstGenerics, OperatorCategory, OperatorConstraints, OperatorInstance,
     OperatorWriteOutput, PortListSpec, WriteContextArgs, RANGE_0, RANGE_1,
 };
 
@@ -46,7 +46,7 @@ pub const _LATTICE_FOLD_BATCH: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: Some(|| PortListSpec::Fixed(parse_quote! { input, signal })),
     ports_out: None,
-    input_delaytype_fn: |_| Some(DelayType::MonotoneAccum),
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    ident,
                    op_span,

--- a/dfir_lang/src/graph/ops/_lattice_join_fused_join.rs
+++ b/dfir_lang/src/graph/ops/_lattice_join_fused_join.rs
@@ -2,7 +2,7 @@ use quote::quote_spanned;
 use syn::{parse_quote, parse_quote_spanned};
 
 use super::{
-    DelayType, OpInstGenerics, OperatorCategory, OperatorConstraints, OperatorInstance,
+    OpInstGenerics, OperatorCategory, OperatorConstraints, OperatorInstance,
     OperatorWriteOutput, RANGE_1, WriteContextArgs,
 };
 
@@ -89,7 +89,7 @@ pub const _LATTICE_JOIN_FUSED_JOIN: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { 0, 1 })),
     ports_out: None,
-    input_delaytype_fn: |_| Some(DelayType::MonotoneAccum),
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
                    op_span,

--- a/dfir_lang/src/graph/ops/anti_join.rs
+++ b/dfir_lang/src/graph/ops/anti_join.rs
@@ -2,7 +2,7 @@ use quote::{ToTokens, quote_spanned};
 use syn::parse_quote;
 
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints, OperatorWriteOutput, PortIndexValue, RANGE_0,
+    OperatorCategory, OperatorConstraints, OperatorWriteOutput, PortIndexValue, RANGE_0,
     RANGE_1, WriteContextArgs,
 };
 use crate::graph::ops::Persistence;
@@ -40,7 +40,7 @@ pub const ANTI_JOIN: OperatorConstraints = OperatorConstraints {
     ports_out: None,
     input_delaytype_fn: |idx| match idx {
         PortIndexValue::Path(path) if "neg" == path.to_token_stream().to_string() => {
-            Some(DelayType::Stratum)
+            None
         }
         _else => None,
     },

--- a/dfir_lang/src/graph/ops/anti_join.rs
+++ b/dfir_lang/src/graph/ops/anti_join.rs
@@ -1,8 +1,8 @@
-use quote::{ToTokens, quote_spanned};
+use quote::quote_spanned;
 use syn::parse_quote;
 
 use super::{
-    OperatorCategory, OperatorConstraints, OperatorWriteOutput, PortIndexValue, RANGE_0,
+    OperatorCategory, OperatorConstraints, OperatorWriteOutput, RANGE_0,
     RANGE_1, WriteContextArgs,
 };
 use crate::graph::ops::Persistence;
@@ -38,12 +38,7 @@ pub const ANTI_JOIN: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { pos, neg })),
     ports_out: None,
-    input_delaytype_fn: |idx| match idx {
-        PortIndexValue::Path(path) if "neg" == path.to_token_stream().to_string() => {
-            None
-        }
-        _else => None,
-    },
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
                    op_span,

--- a/dfir_lang/src/graph/ops/chain.rs
+++ b/dfir_lang/src/graph/ops/chain.rs
@@ -1,5 +1,3 @@
-use crate::graph::PortIndexValue;
-
 use super::{
     OperatorCategory, OperatorConstraints, RANGE_0, RANGE_1
 };
@@ -34,11 +32,6 @@ pub const CHAIN: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: |idx| match idx {
-        PortIndexValue::Int(idx) if idx.value == 0 => {
-            None
-        }
-        _else => None,
-    },
+    input_delaytype_fn: |_| None,
     write_fn: super::union::UNION.write_fn,
 };

--- a/dfir_lang/src/graph/ops/chain.rs
+++ b/dfir_lang/src/graph/ops/chain.rs
@@ -1,7 +1,7 @@
 use crate::graph::PortIndexValue;
 
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints, RANGE_0, RANGE_1
+    OperatorCategory, OperatorConstraints, RANGE_0, RANGE_1
 };
 
 /// > 2 input streams of the same type, 1 output stream of the same type
@@ -36,7 +36,7 @@ pub const CHAIN: OperatorConstraints = OperatorConstraints {
     ports_out: None,
     input_delaytype_fn: |idx| match idx {
         PortIndexValue::Int(idx) if idx.value == 0 => {
-            Some(DelayType::Stratum)
+            None
         }
         _else => None,
     },

--- a/dfir_lang/src/graph/ops/chain_first_n.rs
+++ b/dfir_lang/src/graph/ops/chain_first_n.rs
@@ -5,7 +5,7 @@ use crate::graph::{
     ops::{OperatorWriteOutput, WriteContextArgs},
 };
 
-use super::{DelayType, OperatorCategory, OperatorConstraints, RANGE_0, RANGE_1};
+use super::{OperatorCategory, OperatorConstraints, RANGE_0, RANGE_1};
 
 /// > 2 input streams of the same type, 1 output stream of the same type
 ///
@@ -41,7 +41,7 @@ pub const CHAIN_FIRST_N: OperatorConstraints = OperatorConstraints {
     input_delaytype_fn: |idx| match idx {
         PortIndexValue::Int(idx) if idx.value == 0 => {
             // will no longer be needed once subgraphs are always DAGs (only run once per tick)
-            Some(DelayType::Stratum)
+            None
         }
         _else => None,
     },

--- a/dfir_lang/src/graph/ops/chain_first_n.rs
+++ b/dfir_lang/src/graph/ops/chain_first_n.rs
@@ -1,7 +1,6 @@
 use quote::quote_spanned;
 
 use crate::graph::{
-    PortIndexValue,
     ops::{OperatorWriteOutput, WriteContextArgs},
 };
 
@@ -38,13 +37,7 @@ pub const CHAIN_FIRST_N: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: |idx| match idx {
-        PortIndexValue::Int(idx) if idx.value == 0 => {
-            // will no longer be needed once subgraphs are always DAGs (only run once per tick)
-            None
-        }
-        _else => None,
-    },
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
                    op_span,

--- a/dfir_lang/src/graph/ops/cross_singleton.rs
+++ b/dfir_lang/src/graph/ops/cross_singleton.rs
@@ -2,7 +2,7 @@ use quote::{ToTokens, quote_spanned};
 use syn::parse_quote;
 
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints, OperatorWriteOutput, RANGE_0, RANGE_1,
+    OperatorCategory, OperatorConstraints, OperatorWriteOutput, RANGE_0, RANGE_1,
     WriteContextArgs,
 };
 use crate::graph::PortIndexValue;
@@ -45,7 +45,7 @@ pub const CROSS_SINGLETON: OperatorConstraints = OperatorConstraints {
     ports_out: None,
     input_delaytype_fn: |idx| match idx {
         PortIndexValue::Path(path) if "single" == path.to_token_stream().to_string() => {
-            Some(DelayType::Stratum)
+            None
         }
         _else => None,
     },

--- a/dfir_lang/src/graph/ops/cross_singleton.rs
+++ b/dfir_lang/src/graph/ops/cross_singleton.rs
@@ -1,11 +1,10 @@
-use quote::{ToTokens, quote_spanned};
+use quote::quote_spanned;
 use syn::parse_quote;
 
 use super::{
     OperatorCategory, OperatorConstraints, OperatorWriteOutput, RANGE_0, RANGE_1,
     WriteContextArgs,
 };
-use crate::graph::PortIndexValue;
 
 /// > 2 input streams, 1 output stream, no arguments.
 ///
@@ -43,12 +42,7 @@ pub const CROSS_SINGLETON: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { input, single })),
     ports_out: None,
-    input_delaytype_fn: |idx| match idx {
-        PortIndexValue::Path(path) if "single" == path.to_token_stream().to_string() => {
-            None
-        }
-        _else => None,
-    },
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
                    ident,

--- a/dfir_lang/src/graph/ops/defer_signal.rs
+++ b/dfir_lang/src/graph/ops/defer_signal.rs
@@ -2,7 +2,7 @@ use quote::quote_spanned;
 use syn::parse_quote;
 
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints, OperatorWriteOutput, RANGE_0, RANGE_1,
+    OperatorCategory, OperatorConstraints, OperatorWriteOutput, RANGE_0, RANGE_1,
     WriteContextArgs,
 };
 
@@ -38,7 +38,7 @@ pub const DEFER_SIGNAL: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { input, signal })),
     ports_out: None,
-    input_delaytype_fn: |_| Some(DelayType::Stratum),
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
                    ident,

--- a/dfir_lang/src/graph/ops/difference.rs
+++ b/dfir_lang/src/graph/ops/difference.rs
@@ -1,9 +1,9 @@
-use quote::{ToTokens, quote_spanned};
+use quote::quote_spanned;
 use syn::parse_quote;
 
 use super::{
     OperatorCategory, OperatorConstraints, OperatorInstance, OperatorWriteOutput,
-    PortIndexValue, RANGE_0, RANGE_1, WriteContextArgs,
+    RANGE_0, RANGE_1, WriteContextArgs,
 };
 
 /// > 2 input streams of the same type T, 1 output stream of type T
@@ -38,12 +38,7 @@ pub const DIFFERENCE: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { pos, neg })),
     ports_out: None,
-    input_delaytype_fn: |idx| match idx {
-        PortIndexValue::Path(path) if "neg" == path.to_token_stream().to_string() => {
-            None
-        }
-        _else => None,
-    },
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
                    op_span,

--- a/dfir_lang/src/graph/ops/difference.rs
+++ b/dfir_lang/src/graph/ops/difference.rs
@@ -2,7 +2,7 @@ use quote::{ToTokens, quote_spanned};
 use syn::parse_quote;
 
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints, OperatorInstance, OperatorWriteOutput,
+    OperatorCategory, OperatorConstraints, OperatorInstance, OperatorWriteOutput,
     PortIndexValue, RANGE_0, RANGE_1, WriteContextArgs,
 };
 
@@ -40,7 +40,7 @@ pub const DIFFERENCE: OperatorConstraints = OperatorConstraints {
     ports_out: None,
     input_delaytype_fn: |idx| match idx {
         PortIndexValue::Path(path) if "neg" == path.to_token_stream().to_string() => {
-            Some(DelayType::Stratum)
+            None
         }
         _else => None,
     },

--- a/dfir_lang/src/graph/ops/fold.rs
+++ b/dfir_lang/src/graph/ops/fold.rs
@@ -1,7 +1,7 @@
 use quote::quote_spanned;
 
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints, OperatorWriteOutput, Persistence, RANGE_0,
+    OperatorCategory, OperatorConstraints, OperatorWriteOutput, Persistence, RANGE_0,
     RANGE_1, WriteContextArgs,
 };
 
@@ -48,7 +48,7 @@ pub const FOLD: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: |_| Some(DelayType::Stratum),
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
                    op_span,

--- a/dfir_lang/src/graph/ops/fold_no_replay.rs
+++ b/dfir_lang/src/graph/ops/fold_no_replay.rs
@@ -1,7 +1,7 @@
 use quote::quote_spanned;
 
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints, OperatorWriteOutput, Persistence, RANGE_0,
+    OperatorCategory, OperatorConstraints, OperatorWriteOutput, Persistence, RANGE_0,
     RANGE_1, WriteContextArgs,
 };
 
@@ -30,7 +30,7 @@ pub const FOLD_NO_REPLAY: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: |_| Some(DelayType::Stratum),
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
                    context,

--- a/dfir_lang/src/graph/ops/join_fused.rs
+++ b/dfir_lang/src/graph/ops/join_fused.rs
@@ -3,7 +3,7 @@ use quote::quote_spanned;
 use syn::{Ident, parse_quote};
 
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints, OperatorWriteOutput, Persistence, RANGE_0,
+    OperatorCategory, OperatorConstraints, OperatorWriteOutput, Persistence, RANGE_0,
     RANGE_1, WriteContextArgs,
 };
 use crate::diagnostic::Diagnostic;
@@ -111,7 +111,7 @@ pub const JOIN_FUSED: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { 0, 1 })),
     ports_out: None,
-    input_delaytype_fn: |_| Some(DelayType::Stratum),
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
                    op_span,

--- a/dfir_lang/src/graph/ops/join_fused_lhs.rs
+++ b/dfir_lang/src/graph/ops/join_fused_lhs.rs
@@ -1,10 +1,10 @@
-use quote::{ToTokens, quote_spanned};
+use quote::quote_spanned;
 use syn::parse_quote;
 
 use super::join_fused::make_joindata;
 use super::{
     OperatorCategory, OperatorConstraints, OperatorWriteOutput, Persistence,
-    PortIndexValue, RANGE_0, RANGE_1, WriteContextArgs,
+    RANGE_0, RANGE_1, WriteContextArgs,
 };
 
 /// See `join_fused`
@@ -38,12 +38,7 @@ pub const JOIN_FUSED_LHS: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { 0, 1 })),
     ports_out: None,
-    input_delaytype_fn: |idx| match idx {
-        PortIndexValue::Int(path) if "0" == path.to_token_stream().to_string() => {
-            None
-        }
-        _ => None,
-    },
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
                    op_span,

--- a/dfir_lang/src/graph/ops/join_fused_lhs.rs
+++ b/dfir_lang/src/graph/ops/join_fused_lhs.rs
@@ -3,7 +3,7 @@ use syn::parse_quote;
 
 use super::join_fused::make_joindata;
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints, OperatorWriteOutput, Persistence,
+    OperatorCategory, OperatorConstraints, OperatorWriteOutput, Persistence,
     PortIndexValue, RANGE_0, RANGE_1, WriteContextArgs,
 };
 
@@ -40,7 +40,7 @@ pub const JOIN_FUSED_LHS: OperatorConstraints = OperatorConstraints {
     ports_out: None,
     input_delaytype_fn: |idx| match idx {
         PortIndexValue::Int(path) if "0" == path.to_token_stream().to_string() => {
-            Some(DelayType::Stratum)
+            None
         }
         _ => None,
     },

--- a/dfir_lang/src/graph/ops/join_fused_rhs.rs
+++ b/dfir_lang/src/graph/ops/join_fused_rhs.rs
@@ -1,8 +1,8 @@
-use quote::{ToTokens, quote_spanned};
+use quote::quote_spanned;
 use syn::parse_quote;
 
 use super::{
-    OperatorCategory, OperatorConstraints, OperatorWriteOutput, PortIndexValue, RANGE_0,
+    OperatorCategory, OperatorConstraints, OperatorWriteOutput, RANGE_0,
     RANGE_1, WriteContextArgs,
 };
 
@@ -25,12 +25,7 @@ pub const JOIN_FUSED_RHS: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { 0, 1 })),
     ports_out: None,
-    input_delaytype_fn: |idx| match idx {
-        PortIndexValue::Int(path) if "1" == path.to_token_stream().to_string() => {
-            None
-        }
-        _ => None,
-    },
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
                    op_span,

--- a/dfir_lang/src/graph/ops/join_fused_rhs.rs
+++ b/dfir_lang/src/graph/ops/join_fused_rhs.rs
@@ -2,7 +2,7 @@ use quote::{ToTokens, quote_spanned};
 use syn::parse_quote;
 
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints, OperatorWriteOutput, PortIndexValue, RANGE_0,
+    OperatorCategory, OperatorConstraints, OperatorWriteOutput, PortIndexValue, RANGE_0,
     RANGE_1, WriteContextArgs,
 };
 
@@ -27,7 +27,7 @@ pub const JOIN_FUSED_RHS: OperatorConstraints = OperatorConstraints {
     ports_out: None,
     input_delaytype_fn: |idx| match idx {
         PortIndexValue::Int(path) if "1" == path.to_token_stream().to_string() => {
-            Some(DelayType::Stratum)
+            None
         }
         _ => None,
     },

--- a/dfir_lang/src/graph/ops/join_multiset_half.rs
+++ b/dfir_lang/src/graph/ops/join_multiset_half.rs
@@ -1,8 +1,8 @@
-use quote::{ToTokens, quote_spanned};
+use quote::quote_spanned;
 use syn::parse_quote;
 
 use super::{
-    OperatorCategory, OperatorConstraints, OperatorWriteOutput, PortIndexValue, RANGE_0,
+    OperatorCategory, OperatorConstraints, OperatorWriteOutput, RANGE_0,
     RANGE_1, WriteContextArgs,
 };
 use crate::graph::ops::Persistence;
@@ -36,12 +36,7 @@ pub const JOIN_MULTISET_HALF: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { build, probe })),
     ports_out: None,
-    input_delaytype_fn: |idx| match idx {
-        PortIndexValue::Path(path) if "build" == path.to_token_stream().to_string() => {
-            None
-        }
-        _else => None,
-    },
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                      root,
                      op_span,

--- a/dfir_lang/src/graph/ops/join_multiset_half.rs
+++ b/dfir_lang/src/graph/ops/join_multiset_half.rs
@@ -2,7 +2,7 @@ use quote::{ToTokens, quote_spanned};
 use syn::parse_quote;
 
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints, OperatorWriteOutput, PortIndexValue, RANGE_0,
+    OperatorCategory, OperatorConstraints, OperatorWriteOutput, PortIndexValue, RANGE_0,
     RANGE_1, WriteContextArgs,
 };
 use crate::graph::ops::Persistence;
@@ -38,7 +38,7 @@ pub const JOIN_MULTISET_HALF: OperatorConstraints = OperatorConstraints {
     ports_out: None,
     input_delaytype_fn: |idx| match idx {
         PortIndexValue::Path(path) if "build" == path.to_token_stream().to_string() => {
-            Some(DelayType::Stratum)
+            None
         }
         _else => None,
     },

--- a/dfir_lang/src/graph/ops/lattice_fold.rs
+++ b/dfir_lang/src/graph/ops/lattice_fold.rs
@@ -1,7 +1,7 @@
 use syn::parse_quote_spanned;
 
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints, WriteContextArgs,
+    OperatorCategory, OperatorConstraints, WriteContextArgs,
     RANGE_0, RANGE_1,
 };
 
@@ -43,7 +43,7 @@ pub const LATTICE_FOLD: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: |_| Some(DelayType::MonotoneAccum),
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
                    is_pull,

--- a/dfir_lang/src/graph/ops/lattice_reduce.rs
+++ b/dfir_lang/src/graph/ops/lattice_reduce.rs
@@ -2,7 +2,7 @@ use quote::quote_spanned;
 use syn::parse_quote_spanned;
 
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints, OperatorWriteOutput, RANGE_0, RANGE_1,
+    OperatorCategory, OperatorConstraints, OperatorWriteOutput, RANGE_0, RANGE_1,
     WriteContextArgs,
 };
 
@@ -44,7 +44,7 @@ pub const LATTICE_REDUCE: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: |_| Some(DelayType::MonotoneAccum),
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
                    inputs,

--- a/dfir_lang/src/graph/ops/mod.rs
+++ b/dfir_lang/src/graph/ops/mod.rs
@@ -23,10 +23,6 @@ use crate::parse::{Operator, PortIndex};
 /// The delay (soft barrier) type, for each input to an operator if needed.
 #[derive(Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub enum DelayType {
-    /// Input must be collected over the preceding stratum.
-    Stratum,
-    /// Monotone accumulation: can delay to reduce flow rate, but also correct to emit "early"
-    MonotoneAccum,
     /// Input must be collected over the previous tick.
     Tick,
     /// Input must be collected over the previous tick but also not cause a new tick to occur.

--- a/dfir_lang/src/graph/ops/reduce.rs
+++ b/dfir_lang/src/graph/ops/reduce.rs
@@ -1,7 +1,7 @@
 use quote::quote_spanned;
 
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints, OperatorWriteOutput, Persistence, RANGE_0,
+    OperatorCategory, OperatorConstraints, OperatorWriteOutput, Persistence, RANGE_0,
     RANGE_1, WriteContextArgs,
 };
 
@@ -46,7 +46,7 @@ pub const REDUCE: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: |_| Some(DelayType::Stratum),
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
                    op_span,

--- a/dfir_lang/src/graph/ops/reduce_no_replay.rs
+++ b/dfir_lang/src/graph/ops/reduce_no_replay.rs
@@ -1,7 +1,7 @@
 use quote::quote_spanned;
 
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints, OperatorWriteOutput, Persistence, RANGE_0,
+    OperatorCategory, OperatorConstraints, OperatorWriteOutput, Persistence, RANGE_0,
     RANGE_1, WriteContextArgs,
 };
 
@@ -29,7 +29,7 @@ pub const REDUCE_NO_REPLAY: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: |_| Some(DelayType::Stratum),
+    input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
                    root,
                    context,

--- a/dfir_lang/src/graph/ops/sort.rs
+++ b/dfir_lang/src/graph/ops/sort.rs
@@ -1,7 +1,7 @@
 use quote::quote_spanned;
 
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints, OperatorWriteOutput, RANGE_0, RANGE_1,
+    OperatorCategory, OperatorConstraints, OperatorWriteOutput, RANGE_0, RANGE_1,
     WriteContextArgs,
 };
 
@@ -31,7 +31,7 @@ pub const SORT: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: |_| Some(DelayType::Stratum),
+    input_delaytype_fn: |_| None,
     write_fn: |&WriteContextArgs {
                    root,
                    op_span,

--- a/dfir_lang/src/graph/ops/sort_by_key.rs
+++ b/dfir_lang/src/graph/ops/sort_by_key.rs
@@ -1,7 +1,7 @@
 use quote::quote_spanned;
 
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints, OperatorWriteOutput, RANGE_0, RANGE_1,
+    OperatorCategory, OperatorConstraints, OperatorWriteOutput, RANGE_0, RANGE_1,
     WriteContextArgs,
 };
 
@@ -31,7 +31,7 @@ pub const SORT_BY_KEY: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: |_| Some(DelayType::Stratum),
+    input_delaytype_fn: |_| None,
     write_fn: |&WriteContextArgs {
                    root,
                    op_span,

--- a/dfir_lang/src/graph/ops/zip_longest.rs
+++ b/dfir_lang/src/graph/ops/zip_longest.rs
@@ -2,7 +2,7 @@ use quote::quote_spanned;
 use syn::parse_quote;
 
 use super::{
-    DelayType, OpInstGenerics, OperatorCategory, OperatorConstraints, OperatorInstance,
+    OpInstGenerics, OperatorCategory, OperatorConstraints, OperatorInstance,
     OperatorWriteOutput, Persistence, RANGE_0, RANGE_1, WriteContextArgs,
 };
 use crate::diagnostic::{Diagnostic, Level};
@@ -41,7 +41,7 @@ pub const ZIP_LONGEST: OperatorConstraints = OperatorConstraints {
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { 0, 1 })),
     ports_out: None,
-    input_delaytype_fn: |_| Some(DelayType::Stratum),
+    input_delaytype_fn: |_| None,
     write_fn: |&WriteContextArgs {
                    root,
                    op_span,

--- a/dfir_pipes/src/push/fold_keyed.rs
+++ b/dfir_pipes/src/push/fold_keyed.rs
@@ -26,7 +26,7 @@ pin_project! {
 
 impl<MapRef, InitFn, CombFn, Next, K, V> FoldKeyed<MapRef, InitFn, CombFn, Next, K, V> {
     /// Creates a new `FoldKeyed` push combinator.
-    pub const fn new(map: MapRef, init_fn: InitFn, comb_fn: CombFn, next: Next) -> Self {
+    pub fn new(map: MapRef, init_fn: InitFn, comb_fn: CombFn, next: Next) -> Self {
         Self {
             next,
             map,
@@ -67,14 +67,8 @@ where
     fn poll_flush(self: Pin<&mut Self>, ctx: &mut Self::Ctx<'_>) -> PushStep<Self::CanPend> {
         let mut this = self.project();
         if this.flush_items.is_empty() && *this.flush_idx == 0 {
-            #[expect(
-                clippy::disallowed_methods,
-                reason = "collected into a Vec; key order is irrelevant"
-            )]
-            {
-                this.flush_items
-                    .extend(this.map.iter().map(|(k, v)| (k.clone(), v.clone())));
-            }
+            this.flush_items
+                .extend(this.map.iter().map(|(k, v)| (k.clone(), v.clone())));
         }
         while *this.flush_idx < this.flush_items.len() {
             ready!(this.next.as_mut().poll_ready(ctx));

--- a/dfir_pipes/src/push/reduce_keyed.rs
+++ b/dfir_pipes/src/push/reduce_keyed.rs
@@ -26,7 +26,7 @@ pin_project! {
 
 impl<MapRef, ReduceFn, Next, K, V> ReduceKeyed<MapRef, ReduceFn, Next, K, V> {
     /// Creates a new `ReduceKeyed` push combinator.
-    pub const fn new(map: MapRef, reduce_fn: ReduceFn, next: Next) -> Self {
+    pub fn new(map: MapRef, reduce_fn: ReduceFn, next: Next) -> Self {
         Self {
             next,
             map,
@@ -70,14 +70,8 @@ where
     fn poll_flush(self: Pin<&mut Self>, ctx: &mut Self::Ctx<'_>) -> PushStep<Self::CanPend> {
         let mut this = self.project();
         if this.flush_items.is_empty() && *this.flush_idx == 0 {
-            #[expect(
-                clippy::disallowed_methods,
-                reason = "collected into a Vec; key order is irrelevant"
-            )]
-            {
-                this.flush_items
-                    .extend(this.map.iter().map(|(k, v)| (k.clone(), v.clone())));
-            }
+            this.flush_items
+                .extend(this.map.iter().map(|(k, v)| (k.clone(), v.clone())));
         }
         while *this.flush_idx < this.flush_items.len() {
             ready!(this.next.as_mut().poll_ready(ctx));

--- a/dfir_rs/tests/compile-fail-stable/surface_demuxenum_wrongenum.stderr
+++ b/dfir_rs/tests/compile-fail-stable/surface_demuxenum_wrongenum.stderr
@@ -86,18 +86,15 @@ error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<std::option:
    = help: the following other types implement trait `dfir_rs::dfir_pipes::push::Push<Item, Meta>`:
              `&mut P` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `DemuxEnum<Outputs>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
-             `FoldKeyed<&mut HashMap<K, V, S>, InitFn, CombFn, Next, K, V>` implements `dfir_rs::dfir_pipes::push::Push<(K, V), ()>`
-             `ReduceKeyed<&mut HashMap<K, V, S>, ReduceFn, Next, K, V>` implements `dfir_rs::dfir_pipes::push::Push<(K, V), ()>`
              `ResolveFutures<Psh, Queue, QueueInner>` implements `dfir_rs::dfir_pipes::push::Push<Fut, ()>`
              `Sort<Item, Next>` implements `dfir_rs::dfir_pipes::push::Push<Item, ()>`
              `VecPush<Buf>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::DemuxVar<Pushes>` implements `dfir_rs::dfir_pipes::push::Push<(usize, Item), Meta>`
+             `dfir_rs::dfir_pipes::push::Fanout<P0, P1>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
+             `dfir_rs::dfir_pipes::push::Filter<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
            and $N others
-note: required by a bound in `send_push`
-  --> $WORKSPACE/dfir_pipes/src/pull/mod.rs
+note: required by a bound in `pivot_run_sg_1v1`
+  --> tests/compile-fail-stable/surface_demuxenum_wrongenum.rs:17:15
    |
-   |     fn send_push<Psh>(self, push: Psh) -> SendPush<Self, Psh>
-   |        --------- required by a bound in this associated function
-...
-   |         Psh: crate::push::Push<Self::Item, Self::Meta>,
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Pull::send_push`
+17 |         ]) -> demux_enum::<Option<()>>();
+   |               ^^^^^^^^^^ required by this bound in `pivot_run_sg_1v1`

--- a/dfir_rs/tests/compile-fail-stable/surface_demuxenum_wrongfields_1.stderr
+++ b/dfir_rs/tests/compile-fail-stable/surface_demuxenum_wrongfields_1.stderr
@@ -8,12 +8,12 @@ error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<u32, (), Can
    = help: the following other types implement trait `dfir_rs::dfir_pipes::push::Push<Item, Meta>`:
              `&mut P` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `DemuxEnum<Outputs>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
-             `FoldKeyed<&mut HashMap<K, V, S>, InitFn, CombFn, Next, K, V>` implements `dfir_rs::dfir_pipes::push::Push<(K, V), ()>`
-             `ReduceKeyed<&mut HashMap<K, V, S>, ReduceFn, Next, K, V>` implements `dfir_rs::dfir_pipes::push::Push<(K, V), ()>`
              `ResolveFutures<Psh, Queue, QueueInner>` implements `dfir_rs::dfir_pipes::push::Push<Fut, ()>`
              `Sort<Item, Next>` implements `dfir_rs::dfir_pipes::push::Push<Item, ()>`
              `VecPush<Buf>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::DemuxVar<Pushes>` implements `dfir_rs::dfir_pipes::push::Push<(usize, Item), Meta>`
+             `dfir_rs::dfir_pipes::push::Fanout<P0, P1>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
+             `dfir_rs::dfir_pipes::push::Filter<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
            and $N others
 note: required for `Shape` to implement `DemuxEnumPush<(Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64,)) {std::mem::drop::<(f64,)>}> as dfir_rs::dfir_pipes::push::Push<(f64,), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64, f64), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64, f64)) {std::mem::drop::<(f64, f64)>}> as dfir_rs::dfir_pipes::push::Push<(f64, f64), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<u32, (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<{closure@$DIR/tests/compile-fail-stable/surface_demuxenum_wrongfields_1.rs:20:38: 20:49}> as dfir_rs::dfir_pipes::push::Push<u32, ()>>::CanPend>>), ()>`
   --> tests/compile-fail-stable/surface_demuxenum_wrongfields_1.rs:5:14
@@ -39,12 +39,12 @@ error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<u32, (), Can
    = help: the following other types implement trait `dfir_rs::dfir_pipes::push::Push<Item, Meta>`:
              `&mut P` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `DemuxEnum<Outputs>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
-             `FoldKeyed<&mut HashMap<K, V, S>, InitFn, CombFn, Next, K, V>` implements `dfir_rs::dfir_pipes::push::Push<(K, V), ()>`
-             `ReduceKeyed<&mut HashMap<K, V, S>, ReduceFn, Next, K, V>` implements `dfir_rs::dfir_pipes::push::Push<(K, V), ()>`
              `ResolveFutures<Psh, Queue, QueueInner>` implements `dfir_rs::dfir_pipes::push::Push<Fut, ()>`
              `Sort<Item, Next>` implements `dfir_rs::dfir_pipes::push::Push<Item, ()>`
              `VecPush<Buf>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::DemuxVar<Pushes>` implements `dfir_rs::dfir_pipes::push::Push<(usize, Item), Meta>`
+             `dfir_rs::dfir_pipes::push::Fanout<P0, P1>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
+             `dfir_rs::dfir_pipes::push::Filter<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
            and $N others
 note: required for `Shape` to implement `DemuxEnumPush<(Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64,)) {std::mem::drop::<(f64,)>}> as dfir_rs::dfir_pipes::push::Push<(f64,), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64, f64), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64, f64)) {std::mem::drop::<(f64, f64)>}> as dfir_rs::dfir_pipes::push::Push<(f64, f64), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<u32, (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<{closure@$DIR/tests/compile-fail-stable/surface_demuxenum_wrongfields_1.rs:20:38: 20:49}> as dfir_rs::dfir_pipes::push::Push<u32, ()>>::CanPend>>), ()>`
   --> tests/compile-fail-stable/surface_demuxenum_wrongfields_1.rs:5:14

--- a/dfir_rs/tests/compile-fail-stable/surface_demuxenum_wrongfields_2.stderr
+++ b/dfir_rs/tests/compile-fail-stable/surface_demuxenum_wrongfields_2.stderr
@@ -8,12 +8,12 @@ error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<(u32,), (), 
    = help: the following other types implement trait `dfir_rs::dfir_pipes::push::Push<Item, Meta>`:
              `&mut P` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `DemuxEnum<Outputs>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
-             `FoldKeyed<&mut HashMap<K, V, S>, InitFn, CombFn, Next, K, V>` implements `dfir_rs::dfir_pipes::push::Push<(K, V), ()>`
-             `ReduceKeyed<&mut HashMap<K, V, S>, ReduceFn, Next, K, V>` implements `dfir_rs::dfir_pipes::push::Push<(K, V), ()>`
              `ResolveFutures<Psh, Queue, QueueInner>` implements `dfir_rs::dfir_pipes::push::Push<Fut, ()>`
              `Sort<Item, Next>` implements `dfir_rs::dfir_pipes::push::Push<Item, ()>`
              `VecPush<Buf>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::DemuxVar<Pushes>` implements `dfir_rs::dfir_pipes::push::Push<(usize, Item), Meta>`
+             `dfir_rs::dfir_pipes::push::Fanout<P0, P1>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
+             `dfir_rs::dfir_pipes::push::Filter<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
            and $N others
 note: required for `Shape` to implement `DemuxEnumPush<(Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64,)) {std::mem::drop::<(f64,)>}> as dfir_rs::dfir_pipes::push::Push<(f64,), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64, f64), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64, f64)) {std::mem::drop::<(f64, f64)>}> as dfir_rs::dfir_pipes::push::Push<(f64, f64), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(u32,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<{closure@$DIR/tests/compile-fail-stable/surface_demuxenum_wrongfields_2.rs:20:38: 20:52}> as dfir_rs::dfir_pipes::push::Push<(u32,), ()>>::CanPend>>), ()>`
   --> tests/compile-fail-stable/surface_demuxenum_wrongfields_2.rs:5:14
@@ -39,12 +39,12 @@ error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<(u32,), (), 
    = help: the following other types implement trait `dfir_rs::dfir_pipes::push::Push<Item, Meta>`:
              `&mut P` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `DemuxEnum<Outputs>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
-             `FoldKeyed<&mut HashMap<K, V, S>, InitFn, CombFn, Next, K, V>` implements `dfir_rs::dfir_pipes::push::Push<(K, V), ()>`
-             `ReduceKeyed<&mut HashMap<K, V, S>, ReduceFn, Next, K, V>` implements `dfir_rs::dfir_pipes::push::Push<(K, V), ()>`
              `ResolveFutures<Psh, Queue, QueueInner>` implements `dfir_rs::dfir_pipes::push::Push<Fut, ()>`
              `Sort<Item, Next>` implements `dfir_rs::dfir_pipes::push::Push<Item, ()>`
              `VecPush<Buf>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::DemuxVar<Pushes>` implements `dfir_rs::dfir_pipes::push::Push<(usize, Item), Meta>`
+             `dfir_rs::dfir_pipes::push::Fanout<P0, P1>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
+             `dfir_rs::dfir_pipes::push::Filter<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
            and $N others
 note: required for `Shape` to implement `DemuxEnumPush<(Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64,)) {std::mem::drop::<(f64,)>}> as dfir_rs::dfir_pipes::push::Push<(f64,), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64, f64), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64, f64)) {std::mem::drop::<(f64, f64)>}> as dfir_rs::dfir_pipes::push::Push<(f64, f64), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(u32,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<{closure@$DIR/tests/compile-fail-stable/surface_demuxenum_wrongfields_2.rs:20:38: 20:52}> as dfir_rs::dfir_pipes::push::Push<(u32,), ()>>::CanPend>>), ()>`
   --> tests/compile-fail-stable/surface_demuxenum_wrongfields_2.rs:5:14

--- a/dfir_rs/tests/compile-fail-stable/surface_fold_keyed_badtype_int.stderr
+++ b/dfir_rs/tests/compile-fail-stable/surface_fold_keyed_badtype_int.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<impl Pull<Item = {integer}, Meta = (), CanPend = <Iter<&mut impl Iterator<Item = {integer}>> as Pull>::CanPend, CanEnd = <Iter<&mut impl Iterator<Item = {integer}>> as Pull>::CanEnd> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, {integer}>> as Pull>::Item == (_, _)`
  --> tests/compile-fail-stable/surface_fold_keyed_badtype_int.rs:3:9
   |
 3 |         source_iter(0..1)
@@ -14,7 +14,7 @@ note: required by a bound in `check_input`
 4 |             -> reduce_keyed(|old: &mut u32, val: u32| { *old += val; })
   |                ^^^^^^^^^^^^ required by this bound in `check_input`
 
-error[E0271]: type mismatch resolving `<impl Pull<Item = {integer}, Meta = (), CanPend = <Iter<&mut impl Iterator<Item = {integer}>> as Pull>::CanPend, CanEnd = <Iter<&mut impl Iterator<Item = {integer}>> as Pull>::CanEnd> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, {integer}>> as Pull>::Item == (_, _)`
  --> tests/compile-fail-stable/surface_fold_keyed_badtype_int.rs:4:16
   |
 4 |             -> reduce_keyed(|old: &mut u32, val: u32| { *old += val; })

--- a/dfir_rs/tests/compile-fail-stable/surface_fold_keyed_badtype_option.stderr
+++ b/dfir_rs/tests/compile-fail-stable/surface_fold_keyed_badtype_option.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<impl Pull<Item = Option<{integer}>, Meta = (), CanPend = <Iter<&mut impl Iterator<Item = Option<{integer}>>> as Pull>::CanPend, CanEnd = <Iter<&mut impl Iterator<Item = Option<{integer}>>> as Pull>::CanEnd> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, Option<{integer}>>> as Pull>::Item == (_, _)`
  --> tests/compile-fail-stable/surface_fold_keyed_badtype_option.rs:3:9
   |
 3 |         source_iter([ Some(5), None, Some(12) ])
@@ -14,7 +14,7 @@ note: required by a bound in `check_input`
 4 |             -> reduce_keyed(|old: &mut u32, val: u32| { *old += val; })
   |                ^^^^^^^^^^^^ required by this bound in `check_input`
 
-error[E0271]: type mismatch resolving `<impl Pull<Item = Option<{integer}>, Meta = (), CanPend = <Iter<&mut impl Iterator<Item = Option<{integer}>>> as Pull>::CanPend, CanEnd = <Iter<&mut impl Iterator<Item = Option<{integer}>>> as Pull>::CanEnd> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, Option<{integer}>>> as Pull>::Item == (_, _)`
  --> tests/compile-fail-stable/surface_fold_keyed_badtype_option.rs:4:16
   |
 4 |             -> reduce_keyed(|old: &mut u32, val: u32| { *old += val; })

--- a/dfir_rs/tests/compile-fail-stable/surface_fold_keyed_generics_bad.stderr
+++ b/dfir_rs/tests/compile-fail-stable/surface_fold_keyed_generics_bad.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<impl Pull<Item = &str, Meta = (), CanPend = <Iter<&mut impl Iterator<Item = &str>> as Pull>::CanPend, CanEnd = <Iter<&mut impl Iterator<Item = &str>> as Pull>::CanEnd> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, &str>> as Pull>::Item == (_, _)`
  --> tests/compile-fail-stable/surface_fold_keyed_generics_bad.rs:3:9
   |
 3 |         source_iter(["hello", "world"])
@@ -14,7 +14,7 @@ note: required by a bound in `check_input`
 4 |             -> fold_keyed::<'tick, &str, usize>(String::new, |old: &mut _, val| {
   |                ^^^^^^^^^^ required by this bound in `check_input`
 
-error[E0271]: type mismatch resolving `<impl Pull<Item = &str, Meta = (), CanPend = <Iter<&mut impl Iterator<Item = &str>> as Pull>::CanPend, CanEnd = <Iter<&mut impl Iterator<Item = &str>> as Pull>::CanEnd> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, &str>> as Pull>::Item == (_, _)`
  --> tests/compile-fail-stable/surface_fold_keyed_generics_bad.rs:4:16
   |
 4 |             -> fold_keyed::<'tick, &str, usize>(String::new, |old: &mut _, val| {

--- a/dfir_rs/tests/compile-fail-stable/surface_reduce_keyed_badtype_int.stderr
+++ b/dfir_rs/tests/compile-fail-stable/surface_reduce_keyed_badtype_int.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<impl Pull<Item = {integer}, Meta = (), CanPend = <Iter<&mut impl Iterator<Item = {integer}>> as Pull>::CanPend, CanEnd = <Iter<&mut impl Iterator<Item = {integer}>> as Pull>::CanEnd> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, {integer}>> as Pull>::Item == (_, _)`
  --> tests/compile-fail-stable/surface_reduce_keyed_badtype_int.rs:3:9
   |
 3 |         source_iter(0..1)
@@ -14,7 +14,7 @@ note: required by a bound in `check_input`
 4 |             -> fold_keyed(|| 0, |old: &mut u32, val: u32| { *old += val; })
   |                ^^^^^^^^^^ required by this bound in `check_input`
 
-error[E0271]: type mismatch resolving `<impl Pull<Item = {integer}, Meta = (), CanPend = <Iter<&mut impl Iterator<Item = {integer}>> as Pull>::CanPend, CanEnd = <Iter<&mut impl Iterator<Item = {integer}>> as Pull>::CanEnd> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, {integer}>> as Pull>::Item == (_, _)`
  --> tests/compile-fail-stable/surface_reduce_keyed_badtype_int.rs:4:16
   |
 4 |             -> fold_keyed(|| 0, |old: &mut u32, val: u32| { *old += val; })

--- a/dfir_rs/tests/compile-fail-stable/surface_reduce_keyed_badtype_option.stderr
+++ b/dfir_rs/tests/compile-fail-stable/surface_reduce_keyed_badtype_option.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<impl Pull<Item = Option<{integer}>, Meta = (), CanPend = <Iter<&mut impl Iterator<Item = Option<{integer}>>> as Pull>::CanPend, CanEnd = <Iter<&mut impl Iterator<Item = Option<{integer}>>> as Pull>::CanEnd> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, Option<{integer}>>> as Pull>::Item == (_, _)`
  --> tests/compile-fail-stable/surface_reduce_keyed_badtype_option.rs:3:9
   |
 3 |         source_iter([ Some(5), None, Some(12) ])
@@ -14,7 +14,7 @@ note: required by a bound in `check_input`
 4 |             -> fold_keyed(|| 0, |old: &mut u32, val: u32| { *old += val; })
   |                ^^^^^^^^^^ required by this bound in `check_input`
 
-error[E0271]: type mismatch resolving `<impl Pull<Item = Option<{integer}>, Meta = (), CanPend = <Iter<&mut impl Iterator<Item = Option<{integer}>>> as Pull>::CanPend, CanEnd = <Iter<&mut impl Iterator<Item = Option<{integer}>>> as Pull>::CanEnd> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, Option<{integer}>>> as Pull>::Item == (_, _)`
  --> tests/compile-fail-stable/surface_reduce_keyed_badtype_option.rs:4:16
   |
 4 |             -> fold_keyed(|| 0, |old: &mut u32, val: u32| { *old += val; })

--- a/dfir_rs/tests/snapshots/surface_fold__fold_sort@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_fold__fold_sort@graphvis_dot.snap
@@ -9,23 +9,15 @@ digraph {
     n2v1 [label="(n2v1) fold::<'tick>(Vec::new, Vec::push)", shape=invhouse, fillcolor="#88aaff"]
     n3v1 [label="(n3v1) flat_map(|mut vec| {\l    vec.sort();\l    vec\l})\l", shape=invhouse, fillcolor="#88aaff"]
     n4v1 [label="(n4v1) for_each(|v| print!(\"{:?}, \", v))", shape=house, fillcolor="#ffff88"]
-    n5v1 [label="(n5v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n3v1 -> n4v1
     n2v1 -> n3v1
-    n1v1 -> n5v1
-    n5v1 -> n2v1 [color=red]
+    n1v1 -> n2v1
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
         style=filled
         label = "sg_1v1"
         n1v1
-    }
-    subgraph sg_2v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_2v1"
         n2v1
         n3v1
         n4v1

--- a/dfir_rs/tests/snapshots/surface_fold__fold_sort@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_fold__fold_sort@graphvis_mermaid.snap
@@ -12,15 +12,11 @@ linkStyle default stroke:#aaa
 2v1[\"(2v1) <code>fold::&lt;'tick&gt;(Vec::new, Vec::push)</code>"/]:::pullClass
 3v1[\"<div style=text-align:center>(3v1)</div> <code>flat_map(|mut vec| {<br>    vec.sort();<br>    vec<br>})</code>"/]:::pullClass
 4v1[/"(4v1) <code>for_each(|v| print!(&quot;{:?}, &quot;, v))</code>"\]:::pushClass
-5v1["(5v1) <code>handoff</code>"]:::otherClass
 3v1-->4v1
 2v1-->3v1
-1v1-->5v1
-5v1--x2v1; linkStyle 3 stroke:red
+1v1-->2v1
 subgraph sg_1v1 ["sg_1v1"]
     1v1
-end
-subgraph sg_2v1 ["sg_2v1"]
     2v1
     3v1
     4v1

--- a/dfir_rs/tests/snapshots/surface_fold__fold_static@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_fold__fold_static@graphvis_dot.snap
@@ -8,22 +8,14 @@ digraph {
     n1v1 [label="(n1v1) source_stream(items_recv)", shape=invhouse, fillcolor="#88aaff"]
     n2v1 [label="(n2v1) fold::<\l    'static,\l>(\l    Vec::new,\l    |old: &mut Vec<u32>, mut x: Vec<u32>| {\l        old.append(&mut x);\l    },\l)\l", shape=invhouse, fillcolor="#88aaff"]
     n3v1 [label="(n3v1) for_each(|v| result_send.send(v).unwrap())", shape=house, fillcolor="#ffff88"]
-    n4v1 [label="(n4v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n2v1 -> n3v1
-    n1v1 -> n4v1
-    n4v1 -> n2v1 [color=red]
+    n1v1 -> n2v1
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
         style=filled
         label = "sg_1v1"
         n1v1
-    }
-    subgraph sg_2v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_2v1"
         n2v1
         n3v1
     }

--- a/dfir_rs/tests/snapshots/surface_fold__fold_static@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_fold__fold_static@graphvis_mermaid.snap
@@ -11,14 +11,10 @@ linkStyle default stroke:#aaa
 1v1[\"(1v1) <code>source_stream(items_recv)</code>"/]:::pullClass
 2v1[\"<div style=text-align:center>(2v1)</div> <code>fold::&lt;<br>    'static,<br>&gt;(<br>    Vec::new,<br>    |old: &amp;mut Vec&lt;u32&gt;, mut x: Vec&lt;u32&gt;| {<br>        old.append(&amp;mut x);<br>    },<br>)</code>"/]:::pullClass
 3v1[/"(3v1) <code>for_each(|v| result_send.send(v).unwrap())</code>"\]:::pushClass
-4v1["(4v1) <code>handoff</code>"]:::otherClass
 2v1-->3v1
-1v1-->4v1
-4v1--x2v1; linkStyle 2 stroke:red
+1v1-->2v1
 subgraph sg_1v1 ["sg_1v1"]
     1v1
-end
-subgraph sg_2v1 ["sg_2v1"]
     2v1
     3v1
 end

--- a/dfir_rs/tests/snapshots/surface_fold__fold_static_join@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_fold__fold_static_join@graphvis_dot.snap
@@ -13,24 +13,25 @@ digraph {
     n6v1 [label="(n6v1) cross_join_multiset()", shape=invhouse, fillcolor="#88aaff"]
     n7v1 [label="(n7v1) for_each(|v| result_send.send(v).unwrap())", shape=house, fillcolor="#ffff88"]
     n8v1 [label="(n8v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n9v1 [label="(n9v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n2v1 -> n3v1
-    n1v1 -> n8v1
+    n1v1 -> n2v1
     n3v1 -> n4v1
-    n3v1 -> n9v1
+    n3v1 -> n8v1
     n5v1 -> n6v1 [label="0"]
     n6v1 -> n7v1
-    n8v1 -> n2v1 [color=red]
-    n9v1 -> n6v1 [label="1"]
+    n8v1 -> n6v1 [label="1"]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
         style=filled
         label = "sg_1v1"
+        n4v1
         subgraph sg_1v1_var_teed_fold {
             cluster=true
             label="var teed_fold"
             n1v1
+            n2v1
+            n3v1
         }
     }
     subgraph sg_2v1 {
@@ -38,22 +39,9 @@ digraph {
         fillcolor="#dddddd"
         style=filled
         label = "sg_2v1"
-        n4v1
-        subgraph sg_2v1_var_teed_fold {
-            cluster=true
-            label="var teed_fold"
-            n2v1
-            n3v1
-        }
-    }
-    subgraph sg_3v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_3v1"
         n5v1
         n7v1
-        subgraph sg_3v1_var_join_node {
+        subgraph sg_2v1_var_join_node {
             cluster=true
             label="var join_node"
             n6v1

--- a/dfir_rs/tests/snapshots/surface_fold__fold_static_join@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_fold__fold_static_join@graphvis_mermaid.snap
@@ -16,31 +16,25 @@ linkStyle default stroke:#aaa
 6v1[\"(6v1) <code>cross_join_multiset()</code>"/]:::pullClass
 7v1[/"(7v1) <code>for_each(|v| result_send.send(v).unwrap())</code>"\]:::pushClass
 8v1["(8v1) <code>handoff</code>"]:::otherClass
-9v1["(9v1) <code>handoff</code>"]:::otherClass
 2v1-->3v1
-1v1-->8v1
+1v1-->2v1
 3v1-->4v1
-3v1-->9v1
+3v1-->8v1
 5v1-->|0|6v1
 6v1-->7v1
-8v1--x2v1; linkStyle 6 stroke:red
-9v1-->|1|6v1
+8v1-->|1|6v1
 subgraph sg_1v1 ["sg_1v1"]
+    4v1
     subgraph sg_1v1_var_teed_fold ["var <tt>teed_fold</tt>"]
         1v1
-    end
-end
-subgraph sg_2v1 ["sg_2v1"]
-    4v1
-    subgraph sg_2v1_var_teed_fold ["var <tt>teed_fold</tt>"]
         2v1
         3v1
     end
 end
-subgraph sg_3v1 ["sg_3v1"]
+subgraph sg_2v1 ["sg_2v1"]
     5v1
     7v1
-    subgraph sg_3v1_var_join_node ["var <tt>join_node</tt>"]
+    subgraph sg_2v1_var_join_node ["var <tt>join_node</tt>"]
         6v1
     end
 end

--- a/dfir_rs/tests/snapshots/surface_fold__fold_tick@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_fold__fold_tick@graphvis_dot.snap
@@ -8,22 +8,14 @@ digraph {
     n1v1 [label="(n1v1) source_stream(items_recv)", shape=invhouse, fillcolor="#88aaff"]
     n2v1 [label="(n2v1) fold::<\l    'tick,\l>(\l    Vec::new,\l    |old: &mut Vec<u32>, mut x: Vec<u32>| {\l        old.append(&mut x);\l    },\l)\l", shape=invhouse, fillcolor="#88aaff"]
     n3v1 [label="(n3v1) for_each(|v| result_send.send(v).unwrap())", shape=house, fillcolor="#ffff88"]
-    n4v1 [label="(n4v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n2v1 -> n3v1
-    n1v1 -> n4v1
-    n4v1 -> n2v1 [color=red]
+    n1v1 -> n2v1
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
         style=filled
         label = "sg_1v1"
         n1v1
-    }
-    subgraph sg_2v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_2v1"
         n2v1
         n3v1
     }

--- a/dfir_rs/tests/snapshots/surface_fold__fold_tick@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_fold__fold_tick@graphvis_mermaid.snap
@@ -11,14 +11,10 @@ linkStyle default stroke:#aaa
 1v1[\"(1v1) <code>source_stream(items_recv)</code>"/]:::pullClass
 2v1[\"<div style=text-align:center>(2v1)</div> <code>fold::&lt;<br>    'tick,<br>&gt;(<br>    Vec::new,<br>    |old: &amp;mut Vec&lt;u32&gt;, mut x: Vec&lt;u32&gt;| {<br>        old.append(&amp;mut x);<br>    },<br>)</code>"/]:::pullClass
 3v1[/"(3v1) <code>for_each(|v| result_send.send(v).unwrap())</code>"\]:::pushClass
-4v1["(4v1) <code>handoff</code>"]:::otherClass
 2v1-->3v1
-1v1-->4v1
-4v1--x2v1; linkStyle 2 stroke:red
+1v1-->2v1
 subgraph sg_1v1 ["sg_1v1"]
     1v1
-end
-subgraph sg_2v1 ["sg_2v1"]
     2v1
     3v1
 end

--- a/dfir_rs/tests/snapshots/surface_fold_keyed__fold_keyed_infer_basic@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_fold_keyed__fold_keyed_infer_basic@graphvis_dot.snap
@@ -9,9 +9,11 @@ digraph {
     n2v1 [label="(n2v1) map(|m: SubordResponse| (m.xid, m.mtype))", shape=invhouse, fillcolor="#88aaff"]
     n3v1 [label="(n3v1) fold_keyed::<'static>(|| 0, |old: &mut u32, val: u32| *old += val)", shape=invhouse, fillcolor="#88aaff"]
     n4v1 [label="(n4v1) for_each(|kv| result_send.send(kv).unwrap())", shape=house, fillcolor="#ffff88"]
+    n5v1 [label="(n5v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n3v1 -> n4v1
-    n2v1 -> n3v1
+    n2v1 -> n5v1
     n1v1 -> n2v1
+    n5v1 -> n3v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
@@ -19,6 +21,12 @@ digraph {
         label = "sg_1v1"
         n1v1
         n2v1
+    }
+    subgraph sg_2v1 {
+        cluster=true
+        fillcolor="#dddddd"
+        style=filled
+        label = "sg_2v1"
         n3v1
         n4v1
     }

--- a/dfir_rs/tests/snapshots/surface_fold_keyed__fold_keyed_infer_basic@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_fold_keyed__fold_keyed_infer_basic@graphvis_mermaid.snap
@@ -12,12 +12,16 @@ linkStyle default stroke:#aaa
 2v1[\"(2v1) <code>map(|m: SubordResponse| (m.xid, m.mtype))</code>"/]:::pullClass
 3v1[\"(3v1) <code>fold_keyed::&lt;'static&gt;(|| 0, |old: &amp;mut u32, val: u32| *old += val)</code>"/]:::pullClass
 4v1[/"(4v1) <code>for_each(|kv| result_send.send(kv).unwrap())</code>"\]:::pushClass
+5v1["(5v1) <code>handoff</code>"]:::otherClass
 3v1-->4v1
-2v1-->3v1
+2v1-->5v1
 1v1-->2v1
+5v1--x3v1; linkStyle 3 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
     1v1
     2v1
+end
+subgraph sg_2v1 ["sg_2v1"]
     3v1
     4v1
 end

--- a/dfir_rs/tests/snapshots/surface_fold_keyed__fold_keyed_static@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_fold_keyed__fold_keyed_static@graphvis_dot.snap
@@ -8,14 +8,22 @@ digraph {
     n1v1 [label="(n1v1) source_stream(items_recv)", shape=invhouse, fillcolor="#88aaff"]
     n2v1 [label="(n2v1) fold_keyed::<\l    'static,\l>(Vec::new, |old: &mut Vec<u32>, mut x: Vec<u32>| old.append(&mut x))\l", shape=invhouse, fillcolor="#88aaff"]
     n3v1 [label="(n3v1) for_each(|v| result_send.send(v).unwrap())", shape=house, fillcolor="#ffff88"]
+    n4v1 [label="(n4v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n2v1 -> n3v1
-    n1v1 -> n2v1
+    n1v1 -> n4v1
+    n4v1 -> n2v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
         style=filled
         label = "sg_1v1"
         n1v1
+    }
+    subgraph sg_2v1 {
+        cluster=true
+        fillcolor="#dddddd"
+        style=filled
+        label = "sg_2v1"
         n2v1
         n3v1
     }

--- a/dfir_rs/tests/snapshots/surface_fold_keyed__fold_keyed_static@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_fold_keyed__fold_keyed_static@graphvis_mermaid.snap
@@ -11,10 +11,14 @@ linkStyle default stroke:#aaa
 1v1[\"(1v1) <code>source_stream(items_recv)</code>"/]:::pullClass
 2v1[\"<div style=text-align:center>(2v1)</div> <code>fold_keyed::&lt;<br>    'static,<br>&gt;(Vec::new, |old: &amp;mut Vec&lt;u32&gt;, mut x: Vec&lt;u32&gt;| old.append(&amp;mut x))</code>"/]:::pullClass
 3v1[/"(3v1) <code>for_each(|v| result_send.send(v).unwrap())</code>"\]:::pushClass
+4v1["(4v1) <code>handoff</code>"]:::otherClass
 2v1-->3v1
-1v1-->2v1
+1v1-->4v1
+4v1--x2v1; linkStyle 2 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
     1v1
+end
+subgraph sg_2v1 ["sg_2v1"]
     2v1
     3v1
 end

--- a/dfir_rs/tests/snapshots/surface_fold_keyed__fold_keyed_tick@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_fold_keyed__fold_keyed_tick@graphvis_dot.snap
@@ -8,14 +8,22 @@ digraph {
     n1v1 [label="(n1v1) source_stream(items_recv)", shape=invhouse, fillcolor="#88aaff"]
     n2v1 [label="(n2v1) fold_keyed::<\l    'tick,\l>(Vec::new, |old: &mut Vec<u32>, mut x: Vec<u32>| old.append(&mut x))\l", shape=invhouse, fillcolor="#88aaff"]
     n3v1 [label="(n3v1) for_each(|v| result_send.send(v).unwrap())", shape=house, fillcolor="#ffff88"]
+    n4v1 [label="(n4v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n2v1 -> n3v1
-    n1v1 -> n2v1
+    n1v1 -> n4v1
+    n4v1 -> n2v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
         style=filled
         label = "sg_1v1"
         n1v1
+    }
+    subgraph sg_2v1 {
+        cluster=true
+        fillcolor="#dddddd"
+        style=filled
+        label = "sg_2v1"
         n2v1
         n3v1
     }

--- a/dfir_rs/tests/snapshots/surface_fold_keyed__fold_keyed_tick@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_fold_keyed__fold_keyed_tick@graphvis_mermaid.snap
@@ -11,10 +11,14 @@ linkStyle default stroke:#aaa
 1v1[\"(1v1) <code>source_stream(items_recv)</code>"/]:::pullClass
 2v1[\"<div style=text-align:center>(2v1)</div> <code>fold_keyed::&lt;<br>    'tick,<br>&gt;(Vec::new, |old: &amp;mut Vec&lt;u32&gt;, mut x: Vec&lt;u32&gt;| old.append(&amp;mut x))</code>"/]:::pullClass
 3v1[/"(3v1) <code>for_each(|v| result_send.send(v).unwrap())</code>"\]:::pushClass
+4v1["(4v1) <code>handoff</code>"]:::otherClass
 2v1-->3v1
-1v1-->2v1
+1v1-->4v1
+4v1--x2v1; linkStyle 2 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
     1v1
+end
+subgraph sg_2v1 ["sg_2v1"]
     2v1
     3v1
 end

--- a/dfir_rs/tests/snapshots/surface_fold_keyed__fold_keyed_typed_basic@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_fold_keyed__fold_keyed_typed_basic@graphvis_dot.snap
@@ -9,9 +9,11 @@ digraph {
     n2v1 [label="(n2v1) map(|m: SubordResponse| (m.xid, m.mtype))", shape=invhouse, fillcolor="#88aaff"]
     n3v1 [label="(n3v1) fold_keyed::<'static, &'static str, u32>(|| 0, |old: &mut u32, val: u32| *old += val)", shape=invhouse, fillcolor="#88aaff"]
     n4v1 [label="(n4v1) for_each(|kv| result_send.send(kv).unwrap())", shape=house, fillcolor="#ffff88"]
+    n5v1 [label="(n5v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n3v1 -> n4v1
-    n2v1 -> n3v1
+    n2v1 -> n5v1
     n1v1 -> n2v1
+    n5v1 -> n3v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
@@ -19,6 +21,12 @@ digraph {
         label = "sg_1v1"
         n1v1
         n2v1
+    }
+    subgraph sg_2v1 {
+        cluster=true
+        fillcolor="#dddddd"
+        style=filled
+        label = "sg_2v1"
         n3v1
         n4v1
     }

--- a/dfir_rs/tests/snapshots/surface_fold_keyed__fold_keyed_typed_basic@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_fold_keyed__fold_keyed_typed_basic@graphvis_mermaid.snap
@@ -12,12 +12,16 @@ linkStyle default stroke:#aaa
 2v1[\"(2v1) <code>map(|m: SubordResponse| (m.xid, m.mtype))</code>"/]:::pullClass
 3v1[\"(3v1) <code>fold_keyed::&lt;'static, &amp;'static str, u32&gt;(|| 0, |old: &amp;mut u32, val: u32| *old += val)</code>"/]:::pullClass
 4v1[/"(4v1) <code>for_each(|kv| result_send.send(kv).unwrap())</code>"\]:::pushClass
+5v1["(5v1) <code>handoff</code>"]:::otherClass
 3v1-->4v1
-2v1-->3v1
+2v1-->5v1
 1v1-->2v1
+5v1--x3v1; linkStyle 3 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
     1v1
     2v1
+end
+subgraph sg_2v1 ["sg_2v1"]
     3v1
     4v1
 end

--- a/dfir_rs/tests/snapshots/surface_persist__persist_basic@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_persist__persist_basic@graphvis_dot.snap
@@ -10,12 +10,10 @@ digraph {
     n3v1 [label="(n3v1) persist::<'static>()", shape=invhouse, fillcolor="#88aaff"]
     n4v1 [label="(n4v1) fold(|| 0, |a: &mut _, b| *a += b)", shape=invhouse, fillcolor="#88aaff"]
     n5v1 [label="(n5v1) for_each(|x| result_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
-    n6v1 [label="(n6v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n4v1 -> n5v1
-    n3v1 -> n6v1
+    n3v1 -> n4v1
     n2v1 -> n3v1
     n1v1 -> n2v1
-    n6v1 -> n4v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
@@ -24,12 +22,6 @@ digraph {
         n1v1
         n2v1
         n3v1
-    }
-    subgraph sg_2v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_2v1"
         n4v1
         n5v1
     }

--- a/dfir_rs/tests/snapshots/surface_persist__persist_basic@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_persist__persist_basic@graphvis_mermaid.snap
@@ -13,18 +13,14 @@ linkStyle default stroke:#aaa
 3v1[\"(3v1) <code>persist::&lt;'static&gt;()</code>"/]:::pullClass
 4v1[\"(4v1) <code>fold(|| 0, |a: &amp;mut _, b| *a += b)</code>"/]:::pullClass
 5v1[/"(5v1) <code>for_each(|x| result_send.send(x).unwrap())</code>"\]:::pushClass
-6v1["(6v1) <code>handoff</code>"]:::otherClass
 4v1-->5v1
-3v1-->6v1
+3v1-->4v1
 2v1-->3v1
 1v1-->2v1
-6v1--x4v1; linkStyle 4 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
     1v1
     2v1
     3v1
-end
-subgraph sg_2v1 ["sg_2v1"]
     4v1
     5v1
 end

--- a/dfir_rs/tests/snapshots/surface_persist__persist_pull@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_persist__persist_pull@graphvis_dot.snap
@@ -14,7 +14,6 @@ digraph {
     n7v1 [label="(n7v1) union()", shape=invhouse, fillcolor="#88aaff"]
     n8v1 [label="(n8v1) fold(|| 0, |a: &mut _, b| *a += b)", shape=invhouse, fillcolor="#88aaff"]
     n9v1 [label="(n9v1) for_each(|x| result_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
-    n10v1 [label="(n10v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n2v1 -> n4v1
     n1v1 -> n2v1
     n3v1 -> n4v1
@@ -22,8 +21,7 @@ digraph {
     n4v1 -> n5v1
     n6v1 -> n7v1
     n8v1 -> n9v1
-    n7v1 -> n10v1
-    n10v1 -> n8v1 [color=red]
+    n7v1 -> n8v1
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
@@ -43,16 +41,6 @@ digraph {
             cluster=true
             label="var m1"
             n7v1
-        }
-    }
-    subgraph sg_2v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_2v1"
-        subgraph sg_2v1_var_m1 {
-            cluster=true
-            label="var m1"
             n8v1
             n9v1
         }

--- a/dfir_rs/tests/snapshots/surface_persist__persist_pull@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_persist__persist_pull@graphvis_mermaid.snap
@@ -17,7 +17,6 @@ linkStyle default stroke:#aaa
 7v1[\"(7v1) <code>union()</code>"/]:::pullClass
 8v1[\"(8v1) <code>fold(|| 0, |a: &amp;mut _, b| *a += b)</code>"/]:::pullClass
 9v1[/"(9v1) <code>for_each(|x| result_send.send(x).unwrap())</code>"\]:::pushClass
-10v1["(10v1) <code>handoff</code>"]:::otherClass
 2v1-->4v1
 1v1-->2v1
 3v1-->4v1
@@ -25,8 +24,7 @@ linkStyle default stroke:#aaa
 4v1-->5v1
 6v1-->7v1
 8v1-->9v1
-7v1-->10v1
-10v1--x8v1; linkStyle 8 stroke:red
+7v1-->8v1
 subgraph sg_1v1 ["sg_1v1"]
     1v1
     2v1
@@ -38,10 +36,6 @@ subgraph sg_1v1 ["sg_1v1"]
     end
     subgraph sg_1v1_var_m1 ["var <tt>m1</tt>"]
         7v1
-    end
-end
-subgraph sg_2v1 ["sg_2v1"]
-    subgraph sg_2v1_var_m1 ["var <tt>m1</tt>"]
         8v1
         9v1
     end

--- a/dfir_rs/tests/snapshots/surface_persist__persist_push@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_persist__persist_push@graphvis_dot.snap
@@ -12,9 +12,8 @@ digraph {
     n5v1 [label="(n5v1) persist::<'static>()", shape=house, fillcolor="#ffff88"]
     n6v1 [label="(n6v1) tee()", shape=house, fillcolor="#ffff88"]
     n7v1 [label="(n7v1) null()", shape=house, fillcolor="#ffff88"]
-    n8v1 [label="(n8v1) fold(|| 0, |a: &mut _, b| *a += b)", shape=invhouse, fillcolor="#88aaff"]
+    n8v1 [label="(n8v1) fold(|| 0, |a: &mut _, b| *a += b)", shape=house, fillcolor="#ffff88"]
     n9v1 [label="(n9v1) for_each(|x| result_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
-    n10v1 [label="(n10v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n2v1 -> n3v1
     n1v1 -> n2v1
     n3v1 -> n4v1
@@ -22,8 +21,7 @@ digraph {
     n3v1 -> n5v1
     n6v1 -> n7v1
     n8v1 -> n9v1
-    n6v1 -> n10v1
-    n10v1 -> n8v1 [color=red]
+    n6v1 -> n8v1
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
@@ -31,6 +29,8 @@ digraph {
         label = "sg_1v1"
         n4v1
         n7v1
+        n8v1
+        n9v1
         subgraph sg_1v1_var_t0 {
             cluster=true
             label="var t0"
@@ -44,13 +44,5 @@ digraph {
             n5v1
             n6v1
         }
-    }
-    subgraph sg_2v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_2v1"
-        n8v1
-        n9v1
     }
 }

--- a/dfir_rs/tests/snapshots/surface_persist__persist_push@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_persist__persist_push@graphvis_mermaid.snap
@@ -15,9 +15,8 @@ linkStyle default stroke:#aaa
 5v1[/"(5v1) <code>persist::&lt;'static&gt;()</code>"\]:::pushClass
 6v1[/"(6v1) <code>tee()</code>"\]:::pushClass
 7v1[/"(7v1) <code>null()</code>"\]:::pushClass
-8v1[\"(8v1) <code>fold(|| 0, |a: &amp;mut _, b| *a += b)</code>"/]:::pullClass
+8v1[/"(8v1) <code>fold(|| 0, |a: &amp;mut _, b| *a += b)</code>"\]:::pushClass
 9v1[/"(9v1) <code>for_each(|x| result_send.send(x).unwrap())</code>"\]:::pushClass
-10v1["(10v1) <code>handoff</code>"]:::otherClass
 2v1-->3v1
 1v1-->2v1
 3v1-->4v1
@@ -25,11 +24,12 @@ linkStyle default stroke:#aaa
 3v1-->5v1
 6v1-->7v1
 8v1-->9v1
-6v1-->10v1
-10v1--x8v1; linkStyle 8 stroke:red
+6v1-->8v1
 subgraph sg_1v1 ["sg_1v1"]
     4v1
     7v1
+    8v1
+    9v1
     subgraph sg_1v1_var_t0 ["var <tt>t0</tt>"]
         1v1
         2v1
@@ -39,8 +39,4 @@ subgraph sg_1v1 ["sg_1v1"]
         5v1
         6v1
     end
-end
-subgraph sg_2v1 ["sg_2v1"]
-    8v1
-    9v1
 end

--- a/dfir_rs/tests/snapshots/surface_reduce_keyed__reduce_keyed_infer_basic@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_reduce_keyed__reduce_keyed_infer_basic@graphvis_dot.snap
@@ -9,9 +9,11 @@ digraph {
     n2v1 [label="(n2v1) map(|m: SubordResponse| (m.xid, m.mtype))", shape=invhouse, fillcolor="#88aaff"]
     n3v1 [label="(n3v1) reduce_keyed::<'static>(|old: &mut u32, val: u32| *old += val)", shape=invhouse, fillcolor="#88aaff"]
     n4v1 [label="(n4v1) for_each(|kv| result_send.send(kv).unwrap())", shape=house, fillcolor="#ffff88"]
+    n5v1 [label="(n5v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n3v1 -> n4v1
-    n2v1 -> n3v1
+    n2v1 -> n5v1
     n1v1 -> n2v1
+    n5v1 -> n3v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
@@ -19,6 +21,12 @@ digraph {
         label = "sg_1v1"
         n1v1
         n2v1
+    }
+    subgraph sg_2v1 {
+        cluster=true
+        fillcolor="#dddddd"
+        style=filled
+        label = "sg_2v1"
         n3v1
         n4v1
     }

--- a/dfir_rs/tests/snapshots/surface_reduce_keyed__reduce_keyed_infer_basic@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_reduce_keyed__reduce_keyed_infer_basic@graphvis_mermaid.snap
@@ -12,12 +12,16 @@ linkStyle default stroke:#aaa
 2v1[\"(2v1) <code>map(|m: SubordResponse| (m.xid, m.mtype))</code>"/]:::pullClass
 3v1[\"(3v1) <code>reduce_keyed::&lt;'static&gt;(|old: &amp;mut u32, val: u32| *old += val)</code>"/]:::pullClass
 4v1[/"(4v1) <code>for_each(|kv| result_send.send(kv).unwrap())</code>"\]:::pushClass
+5v1["(5v1) <code>handoff</code>"]:::otherClass
 3v1-->4v1
-2v1-->3v1
+2v1-->5v1
 1v1-->2v1
+5v1--x3v1; linkStyle 3 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
     1v1
     2v1
+end
+subgraph sg_2v1 ["sg_2v1"]
     3v1
     4v1
 end

--- a/dfir_rs/tests/snapshots/surface_reduce_keyed__reduce_keyed_static@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_reduce_keyed__reduce_keyed_static@graphvis_dot.snap
@@ -8,14 +8,22 @@ digraph {
     n1v1 [label="(n1v1) source_stream(items_recv)", shape=invhouse, fillcolor="#88aaff"]
     n2v1 [label="(n2v1) reduce_keyed::<'static>(|old: &mut Vec<u32>, mut x: Vec<u32>| old.append(&mut x))", shape=invhouse, fillcolor="#88aaff"]
     n3v1 [label="(n3v1) for_each(|v| result_send.send(v).unwrap())", shape=house, fillcolor="#ffff88"]
+    n4v1 [label="(n4v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n2v1 -> n3v1
-    n1v1 -> n2v1
+    n1v1 -> n4v1
+    n4v1 -> n2v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
         style=filled
         label = "sg_1v1"
         n1v1
+    }
+    subgraph sg_2v1 {
+        cluster=true
+        fillcolor="#dddddd"
+        style=filled
+        label = "sg_2v1"
         n2v1
         n3v1
     }

--- a/dfir_rs/tests/snapshots/surface_reduce_keyed__reduce_keyed_static@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_reduce_keyed__reduce_keyed_static@graphvis_mermaid.snap
@@ -11,10 +11,14 @@ linkStyle default stroke:#aaa
 1v1[\"(1v1) <code>source_stream(items_recv)</code>"/]:::pullClass
 2v1[\"(2v1) <code>reduce_keyed::&lt;'static&gt;(|old: &amp;mut Vec&lt;u32&gt;, mut x: Vec&lt;u32&gt;| old.append(&amp;mut x))</code>"/]:::pullClass
 3v1[/"(3v1) <code>for_each(|v| result_send.send(v).unwrap())</code>"\]:::pushClass
+4v1["(4v1) <code>handoff</code>"]:::otherClass
 2v1-->3v1
-1v1-->2v1
+1v1-->4v1
+4v1--x2v1; linkStyle 2 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
     1v1
+end
+subgraph sg_2v1 ["sg_2v1"]
     2v1
     3v1
 end

--- a/dfir_rs/tests/snapshots/surface_reduce_keyed__reduce_keyed_tick@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_reduce_keyed__reduce_keyed_tick@graphvis_dot.snap
@@ -8,14 +8,22 @@ digraph {
     n1v1 [label="(n1v1) source_stream(items_recv)", shape=invhouse, fillcolor="#88aaff"]
     n2v1 [label="(n2v1) reduce_keyed::<'tick>(|old: &mut Vec<u32>, mut x: Vec<u32>| old.append(&mut x))", shape=invhouse, fillcolor="#88aaff"]
     n3v1 [label="(n3v1) for_each(|v| result_send.send(v).unwrap())", shape=house, fillcolor="#ffff88"]
+    n4v1 [label="(n4v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n2v1 -> n3v1
-    n1v1 -> n2v1
+    n1v1 -> n4v1
+    n4v1 -> n2v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
         style=filled
         label = "sg_1v1"
         n1v1
+    }
+    subgraph sg_2v1 {
+        cluster=true
+        fillcolor="#dddddd"
+        style=filled
+        label = "sg_2v1"
         n2v1
         n3v1
     }

--- a/dfir_rs/tests/snapshots/surface_reduce_keyed__reduce_keyed_tick@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_reduce_keyed__reduce_keyed_tick@graphvis_mermaid.snap
@@ -11,10 +11,14 @@ linkStyle default stroke:#aaa
 1v1[\"(1v1) <code>source_stream(items_recv)</code>"/]:::pullClass
 2v1[\"(2v1) <code>reduce_keyed::&lt;'tick&gt;(|old: &amp;mut Vec&lt;u32&gt;, mut x: Vec&lt;u32&gt;| old.append(&amp;mut x))</code>"/]:::pullClass
 3v1[/"(3v1) <code>for_each(|v| result_send.send(v).unwrap())</code>"\]:::pushClass
+4v1["(4v1) <code>handoff</code>"]:::otherClass
 2v1-->3v1
-1v1-->2v1
+1v1-->4v1
+4v1--x2v1; linkStyle 2 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
     1v1
+end
+subgraph sg_2v1 ["sg_2v1"]
     2v1
     3v1
 end

--- a/dfir_rs/tests/snapshots/surface_sort__sort@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_sort__sort@graphvis_dot.snap
@@ -8,22 +8,14 @@ digraph {
     n1v1 [label="(n1v1) source_stream(items_recv)", shape=invhouse, fillcolor="#88aaff"]
     n2v1 [label="(n2v1) sort()", shape=invhouse, fillcolor="#88aaff"]
     n3v1 [label="(n3v1) for_each(|v| print!(\"{:?}, \", v))", shape=house, fillcolor="#ffff88"]
-    n4v1 [label="(n4v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n2v1 -> n3v1
-    n1v1 -> n4v1
-    n4v1 -> n2v1 [color=red]
+    n1v1 -> n2v1
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
         style=filled
         label = "sg_1v1"
         n1v1
-    }
-    subgraph sg_2v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_2v1"
         n2v1
         n3v1
     }

--- a/dfir_rs/tests/snapshots/surface_sort__sort@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_sort__sort@graphvis_mermaid.snap
@@ -11,14 +11,10 @@ linkStyle default stroke:#aaa
 1v1[\"(1v1) <code>source_stream(items_recv)</code>"/]:::pullClass
 2v1[\"(2v1) <code>sort()</code>"/]:::pullClass
 3v1[/"(3v1) <code>for_each(|v| print!(&quot;{:?}, &quot;, v))</code>"\]:::pushClass
-4v1["(4v1) <code>handoff</code>"]:::otherClass
 2v1-->3v1
-1v1-->4v1
-4v1--x2v1; linkStyle 2 stroke:red
+1v1-->2v1
 subgraph sg_1v1 ["sg_1v1"]
     1v1
-end
-subgraph sg_2v1 ["sg_2v1"]
     2v1
     3v1
 end

--- a/dfir_rs/tests/snapshots/surface_sort__sort_by_key@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_sort__sort_by_key@graphvis_dot.snap
@@ -8,22 +8,14 @@ digraph {
     n1v1 [label="(n1v1) source_iter(vec![(2, 'y'), (3, 'x'), (1, 'z')])", shape=invhouse, fillcolor="#88aaff"]
     n2v1 [label="(n2v1) sort_by_key(|(k, _v)| k)", shape=invhouse, fillcolor="#88aaff"]
     n3v1 [label="(n3v1) for_each(|v| println!(\"{:?}\", v))", shape=house, fillcolor="#ffff88"]
-    n4v1 [label="(n4v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n2v1 -> n3v1
-    n1v1 -> n4v1
-    n4v1 -> n2v1 [color=red]
+    n1v1 -> n2v1
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
         style=filled
         label = "sg_1v1"
         n1v1
-    }
-    subgraph sg_2v1 {
-        cluster=true
-        fillcolor="#dddddd"
-        style=filled
-        label = "sg_2v1"
         n2v1
         n3v1
     }

--- a/dfir_rs/tests/snapshots/surface_sort__sort_by_key@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_sort__sort_by_key@graphvis_mermaid.snap
@@ -11,14 +11,10 @@ linkStyle default stroke:#aaa
 1v1[\"(1v1) <code>source_iter(vec![(2, 'y'), (3, 'x'), (1, 'z')])</code>"/]:::pullClass
 2v1[\"(2v1) <code>sort_by_key(|(k, _v)| k)</code>"/]:::pullClass
 3v1[/"(3v1) <code>for_each(|v| println!(&quot;{:?}&quot;, v))</code>"\]:::pushClass
-4v1["(4v1) <code>handoff</code>"]:::otherClass
 2v1-->3v1
-1v1-->4v1
-4v1--x2v1; linkStyle 2 stroke:red
+1v1-->2v1
 subgraph sg_1v1 ["sg_1v1"]
     1v1
-end
-subgraph sg_2v1 ["sg_2v1"]
     2v1
     3v1
 end

--- a/dfir_rs/tests/surface_persist_mut_push.rs
+++ b/dfir_rs/tests/surface_persist_mut_push.rs
@@ -1,12 +1,13 @@
 //! Isolated test for persist_mut push-side borrow conflict.
 use dfir_rs::dfir_syntax;
 use dfir_rs::util::Persistence::*;
+use dfir_rs::util::collect_ready;
 use multiplatform_test::multiplatform_test;
 
 #[multiplatform_test]
 pub fn test_persist_mut_push() {
-    let (pull_tx, _pull_rx) = dfir_rs::util::unbounded_channel::<usize>();
-    let (push_tx, _push_rx) = dfir_rs::util::unbounded_channel::<usize>();
+    let (pull_tx, mut pull_rx) = dfir_rs::util::unbounded_channel::<usize>();
+    let (push_tx, mut push_rx) = dfir_rs::util::unbounded_channel::<usize>();
 
     let mut df = dfir_syntax! {
         my_tee = source_iter([Persist(1), Persist(2), Persist(3), Persist(4), Delete(2)])

--- a/dfir_rs/tests/surface_persist_mut_push_expanded.rs
+++ b/dfir_rs/tests/surface_persist_mut_push_expanded.rs
@@ -7,10 +7,7 @@
 //! remaining items. But Rust can't prove the first borrow is dead because `op_2v1`
 //! is an opaque `impl Pull` type.
 
-#![expect(
-    unused,
-    reason = "expanded macro reproduction, not all bindings are used"
-)]
+#![allow(unused)]
 
 use dfir_rs::dfir_pipes;
 use dfir_rs::util::Persistence::{self, *};
@@ -19,14 +16,13 @@ use dfir_rs::util::sparse_vec::SparseVec;
 async fn repro() {
     // Prologue (outer scope, persists across ticks)
     let mut sg_1v1_node_1v1_iter = {
-        [
+        std::iter::IntoIterator::into_iter([
             Persist(1usize),
             Persist(2),
             Persist(3),
             Persist(4),
             Delete(2),
-        ]
-        .into_iter()
+        ])
     };
     let mut sg_1v1_node_2v1_persistdata: SparseVec<usize> = SparseVec::default();
     let mut sg_1v1_node_6v1_persistdata: SparseVec<usize> = SparseVec::default();
@@ -94,6 +90,6 @@ async fn repro() {
         // After the block, the &mut borrow of sg_1v1_node_1v1_iter is provably dead.
 
         // Cleanup: drain remaining items from source_iter
-        (&mut sg_1v1_node_1v1_iter).for_each(drop);
+        std::iter::Iterator::for_each(&mut sg_1v1_node_1v1_iter, std::mem::drop);
     }
 }


### PR DESCRIPTION
All operator files that returned Some(DelayType::Stratum) or
Some(DelayType::MonotoneAccum) from their input_delaytype_fn now return None.
This includes fold, reduce, sort, join, anti_join, difference, cross_singleton,
and all other operators that previously used these variants.

Also cleaned up unused imports (DelayType, PortIndexValue, ToTokens) from
the affected operator files.

The dfir_lang crate compiles cleanly with no warnings.

Co-authored-by: Infinity 🤖 <infinity@hydro.run>
PR: #2841