### PR TITLE
perf(hydro_lang/sim): create dedicated fold hook

### DIFF
--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -483,6 +483,21 @@ pub trait DfirBuilder {
         serialize: Option<&DebugExpr>,
         tag_id: usize,
     );
+
+    /// Optionally emit a fold hook that buffers and permutes inputs before the fold.
+    /// Returns the new input ident to use for the fold if a hook was emitted.
+    /// The default implementation does nothing (no hook needed outside simulation).
+    #[expect(unused_variables, reason = "default impl ignores all params")]
+    fn emit_fold_hook(
+        &mut self,
+        location: &LocationId,
+        in_ident: &syn::Ident,
+        in_kind: &CollectionKind,
+        commutativity_proven: bool,
+        op_meta: &HydroIrOpMetadata,
+    ) -> Option<syn::Ident> {
+        None
+    }
 }
 
 #[cfg(feature = "build")]
@@ -2187,6 +2202,11 @@ pub enum HydroNode {
         init: DebugExpr,
         acc: DebugExpr,
         input: Box<HydroNode>,
+        /// If true, the fold function has a user-provided commutativity proof,
+        /// so the simulator can skip exploring different input orderings.
+        /// This is set when the input stream is `NoOrder` (which requires the
+        /// user to prove commutativity via the type system).
+        commutativity_proven: bool,
         metadata: HydroIrMetadata,
     },
 
@@ -2206,6 +2226,9 @@ pub enum HydroNode {
         init: DebugExpr,
         acc: DebugExpr,
         input: Box<HydroNode>,
+        /// If true, the fold function has a user-provided commutativity proof,
+        /// so the simulator can skip exploring different input orderings.
+        commutativity_proven: bool,
         metadata: HydroIrMetadata,
     },
 
@@ -2641,11 +2664,13 @@ impl HydroNode {
                 init,
                 acc,
                 input,
+                commutativity_proven,
                 metadata,
             } => HydroNode::Fold {
                 init: init.clone(),
                 acc: acc.clone(),
                 input: Box::new(input.deep_clone(seen_tees)),
+                commutativity_proven: *commutativity_proven,
                 metadata: metadata.clone(),
             },
             HydroNode::Scan {
@@ -2674,11 +2699,13 @@ impl HydroNode {
                 init,
                 acc,
                 input,
+                commutativity_proven,
                 metadata,
             } => HydroNode::FoldKeyed {
                 init: init.clone(),
                 acc: acc.clone(),
                 input: Box::new(input.deep_clone(seen_tees)),
+                commutativity_proven: *commutativity_proven,
                 metadata: metadata.clone(),
             },
             HydroNode::ReduceKeyedWatermark {
@@ -3921,6 +3948,15 @@ impl HydroNode {
                                     && graph_builders.singleton_intermediates()
                                     && !node.metadata().collection_kind.is_bounded()
                                 {
+                                    let HydroNode::Fold { input, commutativity_proven, .. } = &*node else { unreachable!() };
+                                    let hooked_input_ident = graph_builders.emit_fold_hook(
+                                        &input.metadata().location_id,
+                                        &input_ident,
+                                        &input.metadata().collection_kind,
+                                        *commutativity_proven,
+                                        &node.metadata().op,
+                                    ).unwrap_or(input_ident);
+
                                     let builder = graph_builders.get_dfir_mut(&out_location);
 
                                     let acc: syn::Expr = parse_quote!({
@@ -3934,7 +3970,7 @@ impl HydroNode {
                                     builder.add_dfir(
                                         parse_quote! {
                                             source_iter([(#init)()]) -> [0]#fold_ident;
-                                            #input_ident -> scan::<#lifetime>(#init, #acc) -> [1]#fold_ident;
+                                            #hooked_input_ident -> scan::<#lifetime>(#init, #acc) -> [1]#fold_ident;
                                             #fold_ident = chain();
                                         },
                                         None,
@@ -3946,6 +3982,14 @@ impl HydroNode {
                                     && graph_builders.singleton_intermediates()
                                     && !node.metadata().collection_kind.is_bounded()
                                 {
+                                    let HydroNode::FoldKeyed { input, commutativity_proven, .. } = &*node else { unreachable!() };
+                                    let hooked_input_ident = graph_builders.emit_fold_hook(
+                                        &input.metadata().location_id,
+                                        &input_ident,
+                                        &input.metadata().collection_kind,
+                                        *commutativity_proven,
+                                        &node.metadata().op,
+                                    ).unwrap_or(input_ident);
                                     let builder = graph_builders.get_dfir_mut(&out_location);
 
                                     let acc: syn::Expr = parse_quote!({
@@ -3963,7 +4007,7 @@ impl HydroNode {
 
                                     builder.add_dfir(
                                         parse_quote! {
-                                            #fold_ident = #input_ident -> scan::<#lifetime>(|| ::std::collections::HashMap::new(), #acc);
+                                            #fold_ident = #hooked_input_ident -> scan::<#lifetime>(|| ::std::collections::HashMap::new(), #acc);
                                         },
                                         None,
                                         Some(&next_stmt_id.to_string()),

--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -392,6 +392,7 @@ pub trait DfirBuilder {
     /// Gets the DFIR builder for the given location, creating it if necessary.
     fn get_dfir_mut(&mut self, location: &LocationId) -> &mut FlatGraphBuilder;
 
+    #[expect(clippy::too_many_arguments, reason = "TODO")]
     fn batch(
         &mut self,
         in_ident: syn::Ident,
@@ -400,6 +401,7 @@ pub trait DfirBuilder {
         out_ident: &syn::Ident,
         out_location: &LocationId,
         op_meta: &HydroIrOpMetadata,
+        fold_hooked_idents: &HashSet<String>,
     );
     fn yield_from_tick(
         &mut self,
@@ -486,29 +488,13 @@ pub trait DfirBuilder {
 
     /// Optionally emit a fold hook that buffers and permutes inputs before the fold.
     /// Returns the new input ident to use for the fold if a hook was emitted.
-    /// The default implementation does nothing (no hook needed outside simulation).
-    #[expect(unused_variables, reason = "default impl ignores all params")]
     fn emit_fold_hook(
         &mut self,
         location: &LocationId,
         in_ident: &syn::Ident,
         in_kind: &CollectionKind,
-        commutativity_proven: bool,
         op_meta: &HydroIrOpMetadata,
-    ) -> Option<syn::Ident> {
-        None
-    }
-
-    /// Register a fold output ident as being controlled by a fold hook.
-    /// When this ident is later batched as a Singleton, the batch can skip the SingletonHook.
-    #[expect(unused_variables, reason = "default impl ignores all params")]
-    fn register_fold_hooked_output(&mut self, fold_output_ident: &syn::Ident) {}
-
-    /// Check if an ident is a fold-hooked output (controlled by a TopLevelFoldHook).
-    #[expect(unused_variables, reason = "default impl ignores all params")]
-    fn is_fold_hooked_output(&self, ident: &syn::Ident) -> bool {
-        false
-    }
+    ) -> Option<syn::Ident>;
 }
 
 #[cfg(feature = "build")]
@@ -531,6 +517,7 @@ impl DfirBuilder for SecondaryMap<LocationKey, FlatGraphBuilder> {
         out_ident: &syn::Ident,
         _out_location: &LocationId,
         _op_meta: &HydroIrOpMetadata,
+        _fold_hooked_idents: &HashSet<String>,
     ) {
         let builder = self.get_dfir_mut(in_location.root());
         if in_kind.is_bounded()
@@ -764,6 +751,16 @@ impl DfirBuilder for SecondaryMap<LocationKey, FlatGraphBuilder> {
                 Some(&format!("send{}", tag_id)),
             );
         }
+    }
+
+    fn emit_fold_hook(
+        &mut self,
+        _location: &LocationId,
+        _in_ident: &syn::Ident,
+        _in_kind: &CollectionKind,
+        _op_meta: &HydroIrOpMetadata,
+    ) -> Option<syn::Ident> {
+        None
     }
 }
 
@@ -1301,6 +1298,7 @@ impl HydroRoot {
         seen_tees: &mut SeenSharedNodes,
         built_tees: &mut HashMap<*const RefCell<HydroNode>, Vec<syn::Ident>>,
         next_stmt_id: &mut usize,
+        fold_hooked_idents: &mut HashSet<String>,
     ) {
         self.emit_core(
             &mut BuildersOrCallback::<
@@ -1310,6 +1308,7 @@ impl HydroRoot {
             seen_tees,
             built_tees,
             next_stmt_id,
+            fold_hooked_idents,
         );
     }
 
@@ -1323,11 +1322,17 @@ impl HydroRoot {
         seen_tees: &mut SeenSharedNodes,
         built_tees: &mut HashMap<*const RefCell<HydroNode>, Vec<syn::Ident>>,
         next_stmt_id: &mut usize,
+        fold_hooked_idents: &mut HashSet<String>,
     ) {
         match self {
             HydroRoot::ForEach { f, input, .. } => {
-                let input_ident =
-                    input.emit_core(builders_or_callback, seen_tees, built_tees, next_stmt_id);
+                let input_ident = input.emit_core(
+                    builders_or_callback,
+                    seen_tees,
+                    built_tees,
+                    next_stmt_id,
+                    fold_hooked_idents,
+                );
 
                 match builders_or_callback {
                     BuildersOrCallback::Builders(graph_builders) => {
@@ -1355,8 +1360,13 @@ impl HydroRoot {
                 input,
                 ..
             } => {
-                let input_ident =
-                    input.emit_core(builders_or_callback, seen_tees, built_tees, next_stmt_id);
+                let input_ident = input.emit_core(
+                    builders_or_callback,
+                    seen_tees,
+                    built_tees,
+                    next_stmt_id,
+                    fold_hooked_idents,
+                );
 
                 match builders_or_callback {
                     BuildersOrCallback::Builders(graph_builders) => {
@@ -1388,8 +1398,13 @@ impl HydroRoot {
             }
 
             HydroRoot::DestSink { sink, input, .. } => {
-                let input_ident =
-                    input.emit_core(builders_or_callback, seen_tees, built_tees, next_stmt_id);
+                let input_ident = input.emit_core(
+                    builders_or_callback,
+                    seen_tees,
+                    built_tees,
+                    next_stmt_id,
+                    fold_hooked_idents,
+                );
 
                 match builders_or_callback {
                     BuildersOrCallback::Builders(graph_builders) => {
@@ -1414,8 +1429,13 @@ impl HydroRoot {
             HydroRoot::CycleSink {
                 cycle_id, input, ..
             } => {
-                let input_ident =
-                    input.emit_core(builders_or_callback, seen_tees, built_tees, next_stmt_id);
+                let input_ident = input.emit_core(
+                    builders_or_callback,
+                    seen_tees,
+                    built_tees,
+                    next_stmt_id,
+                    fold_hooked_idents,
+                );
 
                 match builders_or_callback {
                     BuildersOrCallback::Builders(graph_builders) => {
@@ -1456,8 +1476,13 @@ impl HydroRoot {
             }
 
             HydroRoot::EmbeddedOutput { ident, input, .. } => {
-                let input_ident =
-                    input.emit_core(builders_or_callback, seen_tees, built_tees, next_stmt_id);
+                let input_ident = input.emit_core(
+                    builders_or_callback,
+                    seen_tees,
+                    built_tees,
+                    next_stmt_id,
+                    fold_hooked_idents,
+                );
 
                 match builders_or_callback {
                     BuildersOrCallback::Builders(graph_builders) => {
@@ -1480,8 +1505,13 @@ impl HydroRoot {
             }
 
             HydroRoot::Null { input, .. } => {
-                let input_ident =
-                    input.emit_core(builders_or_callback, seen_tees, built_tees, next_stmt_id);
+                let input_ident = input.emit_core(
+                    builders_or_callback,
+                    seen_tees,
+                    built_tees,
+                    next_stmt_id,
+                    fold_hooked_idents,
+                );
 
                 match builders_or_callback {
                     BuildersOrCallback::Builders(graph_builders) => {
@@ -1653,12 +1683,14 @@ pub fn emit(ir: &mut Vec<HydroRoot>) -> SecondaryMap<LocationKey, FlatGraphBuild
     let mut seen_tees = HashMap::new();
     let mut built_tees = HashMap::new();
     let mut next_stmt_id = 0;
+    let mut fold_hooked_idents = HashSet::new();
     for leaf in ir {
         leaf.emit(
             &mut builders,
             &mut seen_tees,
             &mut built_tees,
             &mut next_stmt_id,
+            &mut fold_hooked_idents,
         );
     }
     builders
@@ -1673,6 +1705,7 @@ pub fn traverse_dfir(
     let mut seen_tees = HashMap::new();
     let mut built_tees = HashMap::new();
     let mut next_stmt_id = 0;
+    let mut fold_hooked_idents = HashSet::new();
     let mut callback = BuildersOrCallback::Callback(transform_root, transform_node);
     ir.iter_mut().for_each(|leaf| {
         leaf.emit_core(
@@ -1680,6 +1713,7 @@ pub fn traverse_dfir(
             &mut seen_tees,
             &mut built_tees,
             &mut next_stmt_id,
+            &mut fold_hooked_idents,
         );
     });
 }
@@ -2213,11 +2247,6 @@ pub enum HydroNode {
         init: DebugExpr,
         acc: DebugExpr,
         input: Box<HydroNode>,
-        /// If true, the fold function has a user-provided commutativity proof,
-        /// so the simulator can skip exploring different input orderings.
-        /// This is set when the input stream is `NoOrder` (which requires the
-        /// user to prove commutativity via the type system).
-        commutativity_proven: bool,
         metadata: HydroIrMetadata,
     },
 
@@ -2237,9 +2266,6 @@ pub enum HydroNode {
         init: DebugExpr,
         acc: DebugExpr,
         input: Box<HydroNode>,
-        /// If true, the fold function has a user-provided commutativity proof,
-        /// so the simulator can skip exploring different input orderings.
-        commutativity_proven: bool,
         metadata: HydroIrMetadata,
     },
 
@@ -2675,13 +2701,11 @@ impl HydroNode {
                 init,
                 acc,
                 input,
-                commutativity_proven,
                 metadata,
             } => HydroNode::Fold {
                 init: init.clone(),
                 acc: acc.clone(),
                 input: Box::new(input.deep_clone(seen_tees)),
-                commutativity_proven: *commutativity_proven,
                 metadata: metadata.clone(),
             },
             HydroNode::Scan {
@@ -2710,13 +2734,11 @@ impl HydroNode {
                 init,
                 acc,
                 input,
-                commutativity_proven,
                 metadata,
             } => HydroNode::FoldKeyed {
                 init: init.clone(),
                 acc: acc.clone(),
                 input: Box::new(input.deep_clone(seen_tees)),
-                commutativity_proven: *commutativity_proven,
                 metadata: metadata.clone(),
             },
             HydroNode::ReduceKeyedWatermark {
@@ -2802,6 +2824,7 @@ impl HydroNode {
         seen_tees: &mut SeenSharedNodes,
         built_tees: &mut HashMap<*const RefCell<HydroNode>, Vec<syn::Ident>>,
         next_stmt_id: &mut usize,
+        fold_hooked_idents: &mut HashSet<String>,
     ) -> syn::Ident {
         let mut ident_stack: Vec<syn::Ident> = Vec::new();
 
@@ -2877,6 +2900,7 @@ impl HydroNode {
                                     &batch_ident,
                                     &out_location,
                                     &metadata.op,
+                                    fold_hooked_idents,
                                 );
                             }
                             BuildersOrCallback::Callback(_, node_callback) => {
@@ -3154,8 +3178,19 @@ impl HydroNode {
 
                             match builders_or_callback {
                                 BuildersOrCallback::Builders(graph_builders) => {
-                                    if graph_builders.is_fold_hooked_output(&inner_ident) {
-                                        graph_builders.register_fold_hooked_output(&tee_ident);
+                                    // NOTE: With `forward_ref`, the fold codegen may not have
+                                    // run yet when we reach this tee, so `fold_hooked_idents`
+                                    // might not contain the inner ident. In that case we won't
+                                    // propagate the "hooked" status to the tee and the
+                                    // downstream singleton batch will use the normal
+                                    // `SingletonHook` instead of `PassthroughSingletonHook`.
+                                    // This is not a soundness issue: the fallback hook still
+                                    // produces correct behavior, just with a redundant decision
+                                    // point. TODO(https://github.com/hydro-project/hydro/issues/2856):
+                                    // fix ordering so forward_ref folds are always processed
+                                    // before their downstream tees.
+                                    if fold_hooked_idents.contains(&inner_ident.to_string()) {
+                                        fold_hooked_idents.insert(tee_ident.to_string());
                                     }
                                     let builder = graph_builders.get_dfir_mut(&out_location);
                                     builder.add_dfir(
@@ -3962,19 +3997,15 @@ impl HydroNode {
                                     && graph_builders.singleton_intermediates()
                                     && !node.metadata().collection_kind.is_bounded()
                                 {
-                                    let HydroNode::Fold { input, commutativity_proven, .. } = &*node else { unreachable!() };
+                                    let HydroNode::Fold { input, .. } = &*node else { unreachable!() };
                                     let hooked_input_ident = graph_builders.emit_fold_hook(
                                         &input.metadata().location_id,
                                         &input_ident,
                                         &input.metadata().collection_kind,
-                                        *commutativity_proven,
                                         &node.metadata().op,
                                     );
 
-                                    let builder = graph_builders.get_dfir_mut(&out_location);
-
-                                    if let Some(hooked_input_ident) = hooked_input_ident {
-                                        // Fold hook emitted: input is Vec<T> batches
+                                    let (effective_input, acc) = if let Some(ref hooked) = hooked_input_ident {
                                         let acc: syn::Expr = parse_quote!({
                                             let mut __inner = #acc;
                                             move |__state, __batch: Vec<_>| {
@@ -3987,20 +4018,8 @@ impl HydroNode {
                                                 Some(__state.clone())
                                             }
                                         });
-
-                                        builder.add_dfir(
-                                            parse_quote! {
-                                                source_iter([(#init)()]) -> [0]#fold_ident;
-                                                #hooked_input_ident -> scan::<#lifetime>(#init, #acc) -> [1]#fold_ident;
-                                                #fold_ident = chain();
-                                            },
-                                            None,
-                                            Some(&next_stmt_id.to_string()),
-                                        );
-
-                                        graph_builders.register_fold_hooked_output(&fold_ident);
+                                        (hooked, acc)
                                     } else {
-                                        // No fold hook: input is individual elements
                                         let acc: syn::Expr = parse_quote!({
                                             let mut __inner = #acc;
                                             move |__state, __value| {
@@ -4008,16 +4027,22 @@ impl HydroNode {
                                                 Some(__state.clone())
                                             }
                                         });
+                                        (&input_ident, acc)
+                                    };
 
-                                        builder.add_dfir(
-                                            parse_quote! {
-                                                source_iter([(#init)()]) -> [0]#fold_ident;
-                                                #input_ident -> scan::<#lifetime>(#init, #acc) -> [1]#fold_ident;
-                                                #fold_ident = chain();
-                                            },
-                                            None,
-                                            Some(&next_stmt_id.to_string()),
-                                        );
+                                    let builder = graph_builders.get_dfir_mut(&out_location);
+                                    builder.add_dfir(
+                                        parse_quote! {
+                                            source_iter([(#init)()]) -> [0]#fold_ident;
+                                            #effective_input -> scan::<#lifetime>(#init, #acc) -> [1]#fold_ident;
+                                            #fold_ident = chain();
+                                        },
+                                        None,
+                                        Some(&next_stmt_id.to_string()),
+                                    );
+
+                                    if hooked_input_ident.is_some() {
+                                        fold_hooked_idents.insert(fold_ident.to_string());
                                     }
                                 } else if matches!(node, HydroNode::FoldKeyed { .. })
                                     && node.metadata().location_id.is_top_level()
@@ -4025,32 +4050,29 @@ impl HydroNode {
                                     && graph_builders.singleton_intermediates()
                                     && !node.metadata().collection_kind.is_bounded()
                                 {
-                                    let HydroNode::FoldKeyed { input, commutativity_proven, .. } = &*node else { unreachable!() };
+                                    let HydroNode::FoldKeyed { input, .. } = &*node else { unreachable!() };
                                     let hooked_input_ident = graph_builders.emit_fold_hook(
                                         &input.metadata().location_id,
                                         &input_ident,
                                         &input.metadata().collection_kind,
-                                        *commutativity_proven,
                                         &node.metadata().op,
                                     );
                                     let builder = graph_builders.get_dfir_mut(&out_location);
 
-                                    if let Some(hooked_input_ident) = hooked_input_ident {
-                                        // Fold hook emitted: input is Vec<(K, V)> batches.
-                                        // Flatten and process per-element to emit per-key updates.
-                                        let acc: syn::Expr = parse_quote!({
-                                            let mut __init = #init;
-                                            let mut __inner = #acc;
-                                            move |__state, __kv: (_, _)| {
-                                                // TODO(shadaj): we can avoid the clone when the entry exists
-                                                let __state = __state
-                                                    .entry(::std::clone::Clone::clone(&__kv.0))
-                                                    .or_insert_with(|| (__init)());
-                                                __inner(__state, __kv.1);
-                                                Some((__kv.0, ::std::clone::Clone::clone(&*__state)))
-                                            }
-                                        });
+                                    let acc: syn::Expr = parse_quote!({
+                                        let mut __init = #init;
+                                        let mut __inner = #acc;
+                                        move |__state, __kv: (_, _)| {
+                                            // TODO(shadaj): we can avoid the clone when the entry exists
+                                            let __state = __state
+                                                .entry(::std::clone::Clone::clone(&__kv.0))
+                                                .or_insert_with(|| (__init)());
+                                            __inner(__state, __kv.1);
+                                            Some((__kv.0, ::std::clone::Clone::clone(&*__state)))
+                                        }
+                                    });
 
+                                    if let Some(hooked_input_ident) = hooked_input_ident {
                                         builder.add_dfir(
                                             parse_quote! {
                                                 #fold_ident = #hooked_input_ident -> flatten() -> scan::<#lifetime>(|| ::std::collections::HashMap::new(), #acc);
@@ -4059,22 +4081,8 @@ impl HydroNode {
                                             Some(&next_stmt_id.to_string()),
                                         );
 
-                                        graph_builders.register_fold_hooked_output(&fold_ident);
+                                        fold_hooked_idents.insert(fold_ident.to_string());
                                     } else {
-                                        // No fold hook: input is individual (K, V) elements
-                                        let acc: syn::Expr = parse_quote!({
-                                            let mut __init = #init;
-                                            let mut __inner = #acc;
-                                            move |__state, __kv: (_, _)| {
-                                                // TODO(shadaj): we can avoid the clone when the entry exists
-                                                let __state = __state
-                                                    .entry(::std::clone::Clone::clone(&__kv.0))
-                                                    .or_insert_with(|| (__init)());
-                                                __inner(__state, __kv.1);
-                                                Some((__kv.0, ::std::clone::Clone::clone(&*__state)))
-                                            }
-                                        });
-
                                         builder.add_dfir(
                                             parse_quote! {
                                                 #fold_ident = #input_ident -> scan::<#lifetime>(|| ::std::collections::HashMap::new(), #acc);
@@ -4083,21 +4091,20 @@ impl HydroNode {
                                             Some(&next_stmt_id.to_string()),
                                         );
                                     }
-                                } else if (matches!(node, HydroNode::Fold { commutativity_proven: true, .. })
-                                    || matches!(node, HydroNode::FoldKeyed { commutativity_proven: true, .. }))
+                                } else if (matches!(node, HydroNode::Fold { .. })
+                                    || matches!(node, HydroNode::FoldKeyed { .. }))
                                     && !node.metadata().location_id.is_top_level()
                                     && graph_builders.singleton_intermediates()
                                 {
-                                    let (input_ref, commutativity_proven) = match &*node {
-                                        HydroNode::Fold { input, commutativity_proven, .. } => (input, *commutativity_proven),
-                                        HydroNode::FoldKeyed { input, commutativity_proven, .. } => (input, *commutativity_proven),
+                                    let input_ref = match &*node {
+                                        HydroNode::Fold { input, .. } => input,
+                                        HydroNode::FoldKeyed { input, .. } => input,
                                         _ => unreachable!(),
                                     };
                                     let hooked_input_ident = graph_builders.emit_fold_hook(
                                         &input_ref.metadata().location_id,
                                         &input_ident,
                                         &input_ref.metadata().collection_kind,
-                                        commutativity_proven,
                                         &node.metadata().op,
                                     );
 

--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -498,6 +498,17 @@ pub trait DfirBuilder {
     ) -> Option<syn::Ident> {
         None
     }
+
+    /// Register a fold output ident as being controlled by a fold hook.
+    /// When this ident is later batched as a Singleton, the batch can skip the SingletonHook.
+    #[expect(unused_variables, reason = "default impl ignores all params")]
+    fn register_fold_hooked_output(&mut self, fold_output_ident: &syn::Ident) {}
+
+    /// Check if an ident is a fold-hooked output (controlled by a TopLevelFoldHook).
+    #[expect(unused_variables, reason = "default impl ignores all params")]
+    fn is_fold_hooked_output(&self, ident: &syn::Ident) -> bool {
+        false
+    }
 }
 
 #[cfg(feature = "build")]
@@ -3143,6 +3154,9 @@ impl HydroNode {
 
                             match builders_or_callback {
                                 BuildersOrCallback::Builders(graph_builders) => {
+                                    if graph_builders.is_fold_hooked_output(&inner_ident) {
+                                        graph_builders.register_fold_hooked_output(&tee_ident);
+                                    }
                                     let builder = graph_builders.get_dfir_mut(&out_location);
                                     builder.add_dfir(
                                         parse_quote! {
@@ -3955,27 +3969,56 @@ impl HydroNode {
                                         &input.metadata().collection_kind,
                                         *commutativity_proven,
                                         &node.metadata().op,
-                                    ).unwrap_or(input_ident);
+                                    );
 
                                     let builder = graph_builders.get_dfir_mut(&out_location);
 
-                                    let acc: syn::Expr = parse_quote!({
-                                        let mut __inner = #acc;
-                                        move |__state, __value| {
-                                            __inner(__state, __value);
-                                            Some(__state.clone())
-                                        }
-                                    });
+                                    if let Some(hooked_input_ident) = hooked_input_ident {
+                                        // Fold hook emitted: input is Vec<T> batches
+                                        let acc: syn::Expr = parse_quote!({
+                                            let mut __inner = #acc;
+                                            move |__state, __batch: Vec<_>| {
+                                                if __batch.is_empty() {
+                                                    return None;
+                                                }
+                                                for __value in __batch {
+                                                    __inner(__state, __value);
+                                                }
+                                                Some(__state.clone())
+                                            }
+                                        });
 
-                                    builder.add_dfir(
-                                        parse_quote! {
-                                            source_iter([(#init)()]) -> [0]#fold_ident;
-                                            #hooked_input_ident -> scan::<#lifetime>(#init, #acc) -> [1]#fold_ident;
-                                            #fold_ident = chain();
-                                        },
-                                        None,
-                                        Some(&next_stmt_id.to_string()),
-                                    );
+                                        builder.add_dfir(
+                                            parse_quote! {
+                                                source_iter([(#init)()]) -> [0]#fold_ident;
+                                                #hooked_input_ident -> scan::<#lifetime>(#init, #acc) -> [1]#fold_ident;
+                                                #fold_ident = chain();
+                                            },
+                                            None,
+                                            Some(&next_stmt_id.to_string()),
+                                        );
+
+                                        graph_builders.register_fold_hooked_output(&fold_ident);
+                                    } else {
+                                        // No fold hook: input is individual elements
+                                        let acc: syn::Expr = parse_quote!({
+                                            let mut __inner = #acc;
+                                            move |__state, __value| {
+                                                __inner(__state, __value);
+                                                Some(__state.clone())
+                                            }
+                                        });
+
+                                        builder.add_dfir(
+                                            parse_quote! {
+                                                source_iter([(#init)()]) -> [0]#fold_ident;
+                                                #input_ident -> scan::<#lifetime>(#init, #acc) -> [1]#fold_ident;
+                                                #fold_ident = chain();
+                                            },
+                                            None,
+                                            Some(&next_stmt_id.to_string()),
+                                        );
+                                    }
                                 } else if matches!(node, HydroNode::FoldKeyed { .. })
                                     && node.metadata().location_id.is_top_level()
                                     && !(matches!(node.metadata().location_id, LocationId::Atomic(_)))
@@ -3989,29 +4032,57 @@ impl HydroNode {
                                         &input.metadata().collection_kind,
                                         *commutativity_proven,
                                         &node.metadata().op,
-                                    ).unwrap_or(input_ident);
+                                    );
                                     let builder = graph_builders.get_dfir_mut(&out_location);
 
-                                    let acc: syn::Expr = parse_quote!({
-                                        let mut __init = #init;
-                                        let mut __inner = #acc;
-                                        move |__state, __kv: (_, _)| {
-                                            // TODO(shadaj): we can avoid the clone when the entry exists
-                                            let __state = __state
-                                                .entry(::std::clone::Clone::clone(&__kv.0))
-                                                .or_insert_with(|| (__init)());
-                                            __inner(__state, __kv.1);
-                                            Some((__kv.0, ::std::clone::Clone::clone(&*__state)))
-                                        }
-                                    });
+                                    if let Some(hooked_input_ident) = hooked_input_ident {
+                                        // Fold hook emitted: input is Vec<(K, V)> batches.
+                                        // Flatten and process per-element to emit per-key updates.
+                                        let acc: syn::Expr = parse_quote!({
+                                            let mut __init = #init;
+                                            let mut __inner = #acc;
+                                            move |__state, __kv: (_, _)| {
+                                                // TODO(shadaj): we can avoid the clone when the entry exists
+                                                let __state = __state
+                                                    .entry(::std::clone::Clone::clone(&__kv.0))
+                                                    .or_insert_with(|| (__init)());
+                                                __inner(__state, __kv.1);
+                                                Some((__kv.0, ::std::clone::Clone::clone(&*__state)))
+                                            }
+                                        });
 
-                                    builder.add_dfir(
-                                        parse_quote! {
-                                            #fold_ident = #hooked_input_ident -> scan::<#lifetime>(|| ::std::collections::HashMap::new(), #acc);
-                                        },
-                                        None,
-                                        Some(&next_stmt_id.to_string()),
-                                    );
+                                        builder.add_dfir(
+                                            parse_quote! {
+                                                #fold_ident = #hooked_input_ident -> flatten() -> scan::<#lifetime>(|| ::std::collections::HashMap::new(), #acc);
+                                            },
+                                            None,
+                                            Some(&next_stmt_id.to_string()),
+                                        );
+
+                                        graph_builders.register_fold_hooked_output(&fold_ident);
+                                    } else {
+                                        // No fold hook: input is individual (K, V) elements
+                                        let acc: syn::Expr = parse_quote!({
+                                            let mut __init = #init;
+                                            let mut __inner = #acc;
+                                            move |__state, __kv: (_, _)| {
+                                                // TODO(shadaj): we can avoid the clone when the entry exists
+                                                let __state = __state
+                                                    .entry(::std::clone::Clone::clone(&__kv.0))
+                                                    .or_insert_with(|| (__init)());
+                                                __inner(__state, __kv.1);
+                                                Some((__kv.0, ::std::clone::Clone::clone(&*__state)))
+                                            }
+                                        });
+
+                                        builder.add_dfir(
+                                            parse_quote! {
+                                                #fold_ident = #input_ident -> scan::<#lifetime>(|| ::std::collections::HashMap::new(), #acc);
+                                            },
+                                            None,
+                                            Some(&next_stmt_id.to_string()),
+                                        );
+                                    }
                                 } else {
                                     let builder = graph_builders.get_dfir_mut(&out_location);
                                     builder.add_dfir(

--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -4083,6 +4083,33 @@ impl HydroNode {
                                             Some(&next_stmt_id.to_string()),
                                         );
                                     }
+                                } else if (matches!(node, HydroNode::Fold { commutativity_proven: true, .. })
+                                    || matches!(node, HydroNode::FoldKeyed { commutativity_proven: true, .. }))
+                                    && !node.metadata().location_id.is_top_level()
+                                    && graph_builders.singleton_intermediates()
+                                {
+                                    let (input_ref, commutativity_proven) = match &*node {
+                                        HydroNode::Fold { input, commutativity_proven, .. } => (input, *commutativity_proven),
+                                        HydroNode::FoldKeyed { input, commutativity_proven, .. } => (input, *commutativity_proven),
+                                        _ => unreachable!(),
+                                    };
+                                    let hooked_input_ident = graph_builders.emit_fold_hook(
+                                        &input_ref.metadata().location_id,
+                                        &input_ident,
+                                        &input_ref.metadata().collection_kind,
+                                        commutativity_proven,
+                                        &node.metadata().op,
+                                    );
+
+                                    let actual_input = hooked_input_ident.as_ref().unwrap_or(&input_ident);
+                                    let builder = graph_builders.get_dfir_mut(&out_location);
+                                    builder.add_dfir(
+                                        parse_quote! {
+                                            #fold_ident = #actual_input -> #operator::<#lifetime>(#init, #acc);
+                                        },
+                                        None,
+                                        Some(&next_stmt_id.to_string()),
+                                    );
                                 } else {
                                     let builder = graph_builders.get_dfir_mut(&out_location);
                                     builder.add_dfir(

--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -1861,17 +1861,19 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
         let (comb, proof) = comb.splice_fn2_borrow_mut_ctx_props(&self.location);
         proof.register_proof(&comb);
 
-        let ordered = self
-            .assume_retries::<ExactlyOnce>(nondet!(/** the combinator function is idempotent */))
-            .assume_ordering::<TotalOrder>(nondet!(/** the combinator function is commutative */));
+        let retried = self
+            .assume_retries::<ExactlyOnce>(nondet!(/** the combinator function is idempotent */));
+
+        let commutativity_proven = O::ORDERING_KIND == StreamOrder::NoOrder;
 
         KeyedSingleton::new(
-            ordered.location.clone(),
+            retried.location.clone(),
             HydroNode::FoldKeyed {
                 init,
                 acc: comb.into(),
-                input: Box::new(ordered.ir_node.replace(HydroNode::Placeholder)),
-                metadata: ordered
+                input: Box::new(retried.ir_node.replace(HydroNode::Placeholder)),
+                commutativity_proven,
+                metadata: retried
                     .location
                     .new_node_metadata(KeyedSingleton::<K, A, L, B2>::collection_kind()),
             },

--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -1864,15 +1864,12 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
         let retried = self
             .assume_retries::<ExactlyOnce>(nondet!(/** the combinator function is idempotent */));
 
-        let commutativity_proven = O::ORDERING_KIND == StreamOrder::NoOrder;
-
         KeyedSingleton::new(
             retried.location.clone(),
             HydroNode::FoldKeyed {
                 init,
                 acc: comb.into(),
                 input: Box::new(retried.ir_node.replace(HydroNode::Placeholder)),
-                commutativity_proven,
                 metadata: retried
                     .location
                     .new_node_metadata(KeyedSingleton::<K, A, L, B2>::collection_kind()),

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -1234,19 +1234,24 @@ where
         let (comb, proof) = comb.splice_fn2_borrow_mut_ctx_props(&self.location);
         proof.register_proof(&comb);
 
+        // Only assume_retries (for idempotence), not assume_ordering.
+        // The fold hook in the simulator handles ordering non-determinism directly.
         let nondet = nondet!(/** the combinator function is commutative and idempotent */);
-        let ordered_etc: Stream<T, L, B> = self.assume_retries(nondet).assume_ordering(nondet);
+        let retried: Stream<T, L, B, O, ExactlyOnce> = self.assume_retries(nondet);
+
+        let commutativity_proven = O::ORDERING_KIND == StreamOrder::NoOrder;
 
         let core = HydroNode::Fold {
             init,
             acc: comb.into(),
-            input: Box::new(ordered_etc.ir_node.replace(HydroNode::Placeholder)),
-            metadata: ordered_etc
+            input: Box::new(retried.ir_node.replace(HydroNode::Placeholder)),
+            commutativity_proven,
+            metadata: retried
                 .location
                 .new_node_metadata(Singleton::<A, L, B2>::collection_kind()),
         };
 
-        Singleton::new(ordered_etc.location.clone(), core)
+        Singleton::new(retried.location.clone(), core)
     }
 
     /// Combines elements of the stream into an [`Optional`], by starting with the first element in the stream,

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -1239,13 +1239,10 @@ where
         let nondet = nondet!(/** the combinator function is commutative and idempotent */);
         let retried: Stream<T, L, B, O, ExactlyOnce> = self.assume_retries(nondet);
 
-        let commutativity_proven = O::ORDERING_KIND == StreamOrder::NoOrder;
-
         let core = HydroNode::Fold {
             init,
             acc: comb.into(),
             input: Box::new(retried.ir_node.replace(HydroNode::Placeholder)),
-            commutativity_proven,
             metadata: retried
                 .location
                 .new_node_metadata(Singleton::<A, L, B2>::collection_kind()),

--- a/hydro_lang/src/sim/builder.rs
+++ b/hydro_lang/src/sim/builder.rs
@@ -35,10 +35,6 @@ pub struct SimBuilder {
     pub cluster_tick_dfirs: BTreeMap<LocationId, FlatGraphBuilder>,
     pub next_hoff_id: usize,
     pub test_safety_only: bool,
-    /// Idents whose output is controlled by a TopLevelFoldHook (emits exactly one value per hook
-    /// release). When such an ident is batched as a Singleton, we can skip the SingletonHook
-    /// because the fold hook already makes the only meaningful decision.
-    pub fold_hooked_idents: HashSet<String>,
 }
 
 impl SimBuilder {
@@ -131,6 +127,7 @@ impl DfirBuilder for SimBuilder {
         out_ident: &syn::Ident,
         out_location: &LocationId,
         op_meta: &HydroIrOpMetadata,
+        fold_hooked_idents: &HashSet<String>,
     ) {
         if let LocationId::Atomic(_) = in_location {
             let builder = self.get_dfir_mut(in_location);
@@ -284,100 +281,63 @@ impl DfirBuilder for SimBuilder {
                 CollectionKind::Singleton { element_type, .. } => {
                     debug_assert!(in_location.is_top_level());
 
-                    if self.fold_hooked_idents.contains(&in_ident.to_string()) {
+                    let hoff_id = self.next_hoff_id;
+                    self.next_hoff_id += 1;
+
+                    let buffered_ident =
+                        syn::Ident::new(&format!("__buffered_{hoff_id}"), Span::call_site());
+                    let hoff_send_ident =
+                        syn::Ident::new(&format!("__hoff_send_{hoff_id}"), Span::call_site());
+                    let hoff_recv_ident =
+                        syn::Ident::new(&format!("__hoff_recv_{hoff_id}"), Span::call_site());
+
+                    let hook_expr: syn::Expr = if fold_hooked_idents.contains(&in_ident.to_string())
+                    {
                         // The fold hook already controls when new values are produced.
                         // Use a PassthroughSingletonHook that always releases the latest
                         // value without non-deterministic decisions.
-                        let hoff_id = self.next_hoff_id;
-                        self.next_hoff_id += 1;
-
-                        let buffered_ident =
-                            syn::Ident::new(&format!("__buffered_{hoff_id}"), Span::call_site());
-                        let hoff_send_ident =
-                            syn::Ident::new(&format!("__hoff_send_{hoff_id}"), Span::call_site());
-                        let hoff_recv_ident =
-                            syn::Ident::new(&format!("__hoff_recv_{hoff_id}"), Span::call_site());
-
-                        self.add_extra_stmt_internal(in_location, syn::parse_quote! {
-                            let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unbounded_channel();
-                        });
-                        self.add_extra_stmt_internal(in_location, syn::parse_quote! {
-                            let #buffered_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(::std::collections::VecDeque::new()));
-                        });
-                        self.add_hook(
-                            in_location,
-                            out_location,
-                            syn::parse_quote! (
-                                Box::new(#root::sim::runtime::PassthroughSingletonHook::<_>::new(
-                                    #buffered_ident.clone(),
-                                    #hoff_send_ident,
-                                    (#batch_location, #line, #caret),
-                                    #root::__maybe_debug__!(#element_type),
-                                ))
-                            ),
-                        );
-
-                        self.get_dfir_mut(in_location).add_dfir(
-                            parse_quote! {
-                                #in_ident -> for_each(|v| #buffered_ident.borrow_mut().push_back(v));
-                            },
-                            None,
-                            None,
-                        );
-
-                        self.get_dfir_mut(out_location).add_dfir(
-                            parse_quote! {
-                                #out_ident = source_stream(#hoff_recv_ident);
-                            },
-                            None,
-                            None,
-                        );
+                        syn::parse_quote!(
+                            Box::new(#root::sim::runtime::PassthroughSingletonHook::<_>::new(
+                                #buffered_ident.clone(),
+                                #hoff_send_ident,
+                                (#batch_location, #line, #caret),
+                                #root::__maybe_debug__!(#element_type),
+                            ))
+                        )
                     } else {
-                        let hoff_id = self.next_hoff_id;
-                        self.next_hoff_id += 1;
+                        syn::parse_quote!(
+                            Box::new(#root::sim::runtime::SingletonHook::<_>::new(
+                                #buffered_ident.clone(),
+                                #hoff_send_ident,
+                                (#batch_location, #line, #caret),
+                                #root::__maybe_debug__!(#element_type),
+                            ))
+                        )
+                    };
 
-                        let buffered_ident =
-                            syn::Ident::new(&format!("__buffered_{hoff_id}"), Span::call_site());
-                        let hoff_send_ident =
-                            syn::Ident::new(&format!("__hoff_send_{hoff_id}"), Span::call_site());
-                        let hoff_recv_ident =
-                            syn::Ident::new(&format!("__hoff_recv_{hoff_id}"), Span::call_site());
+                    self.add_extra_stmt_internal(in_location, syn::parse_quote! {
+                        let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unbounded_channel();
+                    });
+                    self.add_extra_stmt_internal(in_location, syn::parse_quote! {
+                        let #buffered_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(::std::collections::VecDeque::new()));
+                    });
+                    self.add_hook(in_location, out_location, hook_expr);
 
-                        self.add_extra_stmt_internal(in_location, syn::parse_quote! {
-                            let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unbounded_channel();
-                        });
-                        self.add_extra_stmt_internal(in_location, syn::parse_quote! {
-                            let #buffered_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(::std::collections::VecDeque::new()));
-                        });
-                        self.add_hook(
-                            in_location,
-                            out_location,
-                            syn::parse_quote! (
-                                Box::new(#root::sim::runtime::SingletonHook::<_>::new(
-                                    #buffered_ident.clone(),
-                                    #hoff_send_ident,
-                                    (#batch_location, #line, #caret),
-                                    #root::__maybe_debug__!(#element_type),
-                                ))
-                            ),
-                        );
+                    self.get_dfir_mut(in_location).add_dfir(
+                        parse_quote! {
+                            #in_ident -> for_each(|v| #buffered_ident.borrow_mut().push_back(v));
+                        },
+                        None,
+                        None,
+                    );
 
-                        self.get_dfir_mut(in_location).add_dfir(
-                            parse_quote! {
-                                #in_ident -> for_each(|v| #buffered_ident.borrow_mut().push_back(v));
-                            },
-                            None,
-                            None,
-                        );
-
-                        self.get_dfir_mut(out_location).add_dfir(
-                            parse_quote! {
-                                #out_ident = source_stream(#hoff_recv_ident);
-                            },
-                            None,
-                            None,
-                        );
-                    }
+                    self.get_dfir_mut(out_location).add_dfir(
+                        parse_quote! {
+                            #out_ident = source_stream(#hoff_recv_ident);
+                        },
+                        None,
+                        None,
+                    );
                 }
                 CollectionKind::KeyedSingleton {
                     key_type,
@@ -526,6 +486,7 @@ impl DfirBuilder for SimBuilder {
         out_location: &LocationId,
         op_meta: &HydroIrOpMetadata,
     ) {
+        // Atomic boundaries never involve fold-hooked idents.
         self.batch(
             in_ident,
             in_location,
@@ -533,6 +494,7 @@ impl DfirBuilder for SimBuilder {
             out_ident,
             out_location,
             op_meta,
+            &HashSet::new(),
         );
     }
 
@@ -1541,16 +1503,11 @@ impl DfirBuilder for SimBuilder {
         location: &LocationId,
         in_ident: &syn::Ident,
         in_kind: &CollectionKind,
-        commutativity_proven: bool,
         op_meta: &HydroIrOpMetadata,
     ) -> Option<syn::Ident> {
         if !location.is_top_level() {
-            // For in-tick folds with commutativity_proven on NoOrder input,
+            // For in-tick folds on NoOrder input,
             // emit an inline shuffle hook to permute elements before the fold.
-            if !commutativity_proven {
-                return None;
-            }
-
             let element_type = match in_kind {
                 CollectionKind::Stream {
                     order: StreamOrder::NoOrder,
@@ -1585,9 +1542,12 @@ impl DfirBuilder for SimBuilder {
                 let #hoff_recv_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(#hoff_recv_ident.into_inner()));
             });
 
-            self.add_extra_stmt_internal(tick_location.root(), syn::parse_quote! {
-                let #buffered_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(None));
-            });
+            self.add_extra_stmt_internal(
+                tick_location.root(),
+                syn::parse_quote! {
+                    let #buffered_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(None));
+                },
+            );
 
             self.add_inline_hook(
                 tick_location,
@@ -1633,131 +1593,68 @@ impl DfirBuilder for SimBuilder {
         let (assume_location, line, caret) = location_for_op(op_meta);
         let root = get_this_crate();
 
-        match in_kind {
+        let debug_type: syn::Type = match in_kind {
             CollectionKind::Stream {
                 order: StreamOrder::NoOrder,
                 retry: StreamRetry::ExactlyOnce,
                 element_type,
                 ..
-            } => {
-                let hoff_id = self.next_hoff_id;
-                self.next_hoff_id += 1;
-
-                let buffered_ident =
-                    syn::Ident::new(&format!("__buffered_{hoff_id}"), Span::call_site());
-                let hoff_send_ident =
-                    syn::Ident::new(&format!("__hoff_send_{hoff_id}"), Span::call_site());
-                let hoff_recv_ident =
-                    syn::Ident::new(&format!("__hoff_recv_{hoff_id}"), Span::call_site());
-                let out_ident =
-                    syn::Ident::new(&format!("__fold_hook_out_{hoff_id}"), Span::call_site());
-
-                self.add_extra_stmt_internal(location, syn::parse_quote! {
-                    let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unbounded_channel();
-                });
-                self.add_extra_stmt_internal(location, syn::parse_quote! {
-                    let #buffered_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(::std::collections::VecDeque::new()));
-                });
-                self.add_hook(
-                    location,
-                    location,
-                    syn::parse_quote!(
-                        Box::new(#root::sim::runtime::TopLevelFoldHook::<_> {
-                            input: #buffered_ident.clone(),
-                            to_release: None,
-                            output: #hoff_send_ident,
-                            location: (#assume_location, #line, #caret),
-                            format_item_debug: #root::__maybe_debug__!(#element_type),
-                        })
-                    ),
-                );
-
-                self.get_dfir_mut(location).add_dfir(
-                    parse_quote! {
-                        #in_ident -> for_each(|v| #buffered_ident.borrow_mut().push_back(v));
-                    },
-                    None,
-                    None,
-                );
-
-                self.get_dfir_mut(location).add_dfir(
-                    parse_quote! {
-                        #out_ident = source_stream(#hoff_recv_ident);
-                    },
-                    None,
-                    None,
-                );
-
-                Some(out_ident)
-            }
+            } => (*element_type.0).clone(),
             CollectionKind::KeyedStream {
                 value_order: StreamOrder::NoOrder,
                 value_retry: StreamRetry::ExactlyOnce,
                 key_type,
                 value_type,
                 ..
-            } => {
-                let hoff_id = self.next_hoff_id;
-                self.next_hoff_id += 1;
+            } => syn::parse_quote!((#key_type, #value_type)),
+            _ => return None,
+        };
 
-                let buffered_ident =
-                    syn::Ident::new(&format!("__buffered_{hoff_id}"), Span::call_site());
-                let hoff_send_ident =
-                    syn::Ident::new(&format!("__hoff_send_{hoff_id}"), Span::call_site());
-                let hoff_recv_ident =
-                    syn::Ident::new(&format!("__hoff_recv_{hoff_id}"), Span::call_site());
-                let out_ident =
-                    syn::Ident::new(&format!("__fold_hook_out_{hoff_id}"), Span::call_site());
+        let hoff_id = self.next_hoff_id;
+        self.next_hoff_id += 1;
 
-                self.add_extra_stmt_internal(location, syn::parse_quote! {
-                    let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unbounded_channel();
-                });
-                self.add_extra_stmt_internal(location, syn::parse_quote! {
-                    let #buffered_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(::std::collections::VecDeque::new()));
-                });
-                self.add_hook(
-                    location,
-                    location,
-                    syn::parse_quote!(
-                        Box::new(#root::sim::runtime::TopLevelFoldHook::<_> {
-                            input: #buffered_ident.clone(),
-                            to_release: None,
-                            output: #hoff_send_ident,
-                            location: (#assume_location, #line, #caret),
-                            format_item_debug: #root::__maybe_debug__!((#key_type, #value_type)),
-                        })
-                    ),
-                );
+        let buffered_ident = syn::Ident::new(&format!("__buffered_{hoff_id}"), Span::call_site());
+        let hoff_send_ident = syn::Ident::new(&format!("__hoff_send_{hoff_id}"), Span::call_site());
+        let hoff_recv_ident = syn::Ident::new(&format!("__hoff_recv_{hoff_id}"), Span::call_site());
+        let out_ident = syn::Ident::new(&format!("__fold_hook_out_{hoff_id}"), Span::call_site());
 
-                self.get_dfir_mut(location).add_dfir(
-                    parse_quote! {
-                        #in_ident -> for_each(|v| #buffered_ident.borrow_mut().push_back(v));
-                    },
-                    None,
-                    None,
-                );
+        self.add_extra_stmt_internal(location, syn::parse_quote! {
+            let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unbounded_channel();
+        });
+        self.add_extra_stmt_internal(location, syn::parse_quote! {
+            let #buffered_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(::std::collections::VecDeque::new()));
+        });
+        self.add_hook(
+            location,
+            location,
+            syn::parse_quote!(
+                Box::new(#root::sim::runtime::TopLevelFoldHook::<_> {
+                    input: #buffered_ident.clone(),
+                    to_release: None,
+                    output: #hoff_send_ident,
+                    location: (#assume_location, #line, #caret),
+                    format_item_debug: #root::__maybe_debug__!(#debug_type),
+                })
+            ),
+        );
 
-                self.get_dfir_mut(location).add_dfir(
-                    parse_quote! {
-                        #out_ident = source_stream(#hoff_recv_ident);
-                    },
-                    None,
-                    None,
-                );
+        self.get_dfir_mut(location).add_dfir(
+            parse_quote! {
+                #in_ident -> for_each(|v| #buffered_ident.borrow_mut().push_back(v));
+            },
+            None,
+            None,
+        );
 
-                Some(out_ident)
-            }
-            _ => None,
-        }
-    }
+        self.get_dfir_mut(location).add_dfir(
+            parse_quote! {
+                #out_ident = source_stream(#hoff_recv_ident);
+            },
+            None,
+            None,
+        );
 
-    fn register_fold_hooked_output(&mut self, fold_output_ident: &syn::Ident) {
-        self.fold_hooked_idents
-            .insert(fold_output_ident.to_string());
-    }
-
-    fn is_fold_hooked_output(&self, ident: &syn::Ident) -> bool {
-        self.fold_hooked_idents.contains(&ident.to_string())
+        Some(out_ident)
     }
 }
 

--- a/hydro_lang/src/sim/builder.rs
+++ b/hydro_lang/src/sim/builder.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 
 use dfir_lang::graph::FlatGraphBuilder;
 use proc_macro2::Span;
@@ -35,6 +35,10 @@ pub struct SimBuilder {
     pub cluster_tick_dfirs: BTreeMap<LocationId, FlatGraphBuilder>,
     pub next_hoff_id: usize,
     pub test_safety_only: bool,
+    /// Idents whose output is controlled by a TopLevelFoldHook (emits exactly one value per hook
+    /// release). When such an ident is batched as a Singleton, we can skip the SingletonHook
+    /// because the fold hook already makes the only meaningful decision.
+    pub fold_hooked_idents: HashSet<String>,
 }
 
 impl SimBuilder {
@@ -280,50 +284,100 @@ impl DfirBuilder for SimBuilder {
                 CollectionKind::Singleton { element_type, .. } => {
                     debug_assert!(in_location.is_top_level());
 
-                    let hoff_id = self.next_hoff_id;
-                    self.next_hoff_id += 1;
+                    if self.fold_hooked_idents.contains(&in_ident.to_string()) {
+                        // The fold hook already controls when new values are produced.
+                        // Use a PassthroughSingletonHook that always releases the latest
+                        // value without non-deterministic decisions.
+                        let hoff_id = self.next_hoff_id;
+                        self.next_hoff_id += 1;
 
-                    let buffered_ident =
-                        syn::Ident::new(&format!("__buffered_{hoff_id}"), Span::call_site());
-                    let hoff_send_ident =
-                        syn::Ident::new(&format!("__hoff_send_{hoff_id}"), Span::call_site());
-                    let hoff_recv_ident =
-                        syn::Ident::new(&format!("__hoff_recv_{hoff_id}"), Span::call_site());
+                        let buffered_ident =
+                            syn::Ident::new(&format!("__buffered_{hoff_id}"), Span::call_site());
+                        let hoff_send_ident =
+                            syn::Ident::new(&format!("__hoff_send_{hoff_id}"), Span::call_site());
+                        let hoff_recv_ident =
+                            syn::Ident::new(&format!("__hoff_recv_{hoff_id}"), Span::call_site());
 
-                    self.add_extra_stmt_internal(in_location, syn::parse_quote! {
-                        let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unbounded_channel();
-                    });
-                    self.add_extra_stmt_internal(in_location, syn::parse_quote! {
-                        let #buffered_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(::std::collections::VecDeque::new()));
-                    });
-                    self.add_hook(
-                        in_location,
-                        out_location,
-                        syn::parse_quote! (
-                            Box::new(#root::sim::runtime::SingletonHook::<_>::new(
-                                #buffered_ident.clone(),
-                                #hoff_send_ident,
-                                (#batch_location, #line, #caret),
-                                #root::__maybe_debug__!(#element_type),
-                            ))
-                        ),
-                    );
+                        self.add_extra_stmt_internal(in_location, syn::parse_quote! {
+                            let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unbounded_channel();
+                        });
+                        self.add_extra_stmt_internal(in_location, syn::parse_quote! {
+                            let #buffered_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(::std::collections::VecDeque::new()));
+                        });
+                        self.add_hook(
+                            in_location,
+                            out_location,
+                            syn::parse_quote! (
+                                Box::new(#root::sim::runtime::PassthroughSingletonHook::<_>::new(
+                                    #buffered_ident.clone(),
+                                    #hoff_send_ident,
+                                    (#batch_location, #line, #caret),
+                                    #root::__maybe_debug__!(#element_type),
+                                ))
+                            ),
+                        );
 
-                    self.get_dfir_mut(in_location).add_dfir(
-                        parse_quote! {
-                            #in_ident -> for_each(|v| #buffered_ident.borrow_mut().push_back(v));
-                        },
-                        None,
-                        None,
-                    );
+                        self.get_dfir_mut(in_location).add_dfir(
+                            parse_quote! {
+                                #in_ident -> for_each(|v| #buffered_ident.borrow_mut().push_back(v));
+                            },
+                            None,
+                            None,
+                        );
 
-                    self.get_dfir_mut(out_location).add_dfir(
-                        parse_quote! {
-                            #out_ident = source_stream(#hoff_recv_ident);
-                        },
-                        None,
-                        None,
-                    );
+                        self.get_dfir_mut(out_location).add_dfir(
+                            parse_quote! {
+                                #out_ident = source_stream(#hoff_recv_ident);
+                            },
+                            None,
+                            None,
+                        );
+                    } else {
+                        let hoff_id = self.next_hoff_id;
+                        self.next_hoff_id += 1;
+
+                        let buffered_ident =
+                            syn::Ident::new(&format!("__buffered_{hoff_id}"), Span::call_site());
+                        let hoff_send_ident =
+                            syn::Ident::new(&format!("__hoff_send_{hoff_id}"), Span::call_site());
+                        let hoff_recv_ident =
+                            syn::Ident::new(&format!("__hoff_recv_{hoff_id}"), Span::call_site());
+
+                        self.add_extra_stmt_internal(in_location, syn::parse_quote! {
+                            let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unbounded_channel();
+                        });
+                        self.add_extra_stmt_internal(in_location, syn::parse_quote! {
+                            let #buffered_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(::std::collections::VecDeque::new()));
+                        });
+                        self.add_hook(
+                            in_location,
+                            out_location,
+                            syn::parse_quote! (
+                                Box::new(#root::sim::runtime::SingletonHook::<_>::new(
+                                    #buffered_ident.clone(),
+                                    #hoff_send_ident,
+                                    (#batch_location, #line, #caret),
+                                    #root::__maybe_debug__!(#element_type),
+                                ))
+                            ),
+                        );
+
+                        self.get_dfir_mut(in_location).add_dfir(
+                            parse_quote! {
+                                #in_ident -> for_each(|v| #buffered_ident.borrow_mut().push_back(v));
+                            },
+                            None,
+                            None,
+                        );
+
+                        self.get_dfir_mut(out_location).add_dfir(
+                            parse_quote! {
+                                #out_ident = source_stream(#hoff_recv_ident);
+                            },
+                            None,
+                            None,
+                        );
+                    }
                 }
                 CollectionKind::KeyedSingleton {
                     key_type,
@@ -1487,13 +1541,12 @@ impl DfirBuilder for SimBuilder {
         location: &LocationId,
         in_ident: &syn::Ident,
         in_kind: &CollectionKind,
-        commutativity_proven: bool,
+        _commutativity_proven: bool,
         op_meta: &HydroIrOpMetadata,
     ) -> Option<syn::Ident> {
         // Only emit a hook for top-level unbounded streams.
-        // In-tick folds don't need a hook because:
-        // - NoOrder in-tick inputs require proven commutativity (type system enforces this),
-        //   so order doesn't affect the final fold value within a tick.
+        // In-tick folds don't need a separate fold hook because the StreamHook<NoOrder>
+        // already explores permutations of the batch before it enters the tick.
         // - TotalOrder in-tick inputs have a determined order, no non-determinism to explore.
         if !location.is_top_level() {
             return None;
@@ -1535,7 +1588,6 @@ impl DfirBuilder for SimBuilder {
                             input: #buffered_ident.clone(),
                             to_release: None,
                             output: #hoff_send_ident,
-                            commutativity_proven: #commutativity_proven,
                             location: (#assume_location, #line, #caret),
                             format_item_debug: #root::__maybe_debug__!(#element_type),
                         })
@@ -1593,7 +1645,6 @@ impl DfirBuilder for SimBuilder {
                             input: #buffered_ident.clone(),
                             to_release: None,
                             output: #hoff_send_ident,
-                            commutativity_proven: #commutativity_proven,
                             location: (#assume_location, #line, #caret),
                             format_item_debug: #root::__maybe_debug__!((#key_type, #value_type)),
                         })
@@ -1620,6 +1671,15 @@ impl DfirBuilder for SimBuilder {
             }
             _ => None,
         }
+    }
+
+    fn register_fold_hooked_output(&mut self, fold_output_ident: &syn::Ident) {
+        self.fold_hooked_idents
+            .insert(fold_output_ident.to_string());
+    }
+
+    fn is_fold_hooked_output(&self, ident: &syn::Ident) -> bool {
+        self.fold_hooked_idents.contains(&ident.to_string())
     }
 }
 

--- a/hydro_lang/src/sim/builder.rs
+++ b/hydro_lang/src/sim/builder.rs
@@ -1541,15 +1541,93 @@ impl DfirBuilder for SimBuilder {
         location: &LocationId,
         in_ident: &syn::Ident,
         in_kind: &CollectionKind,
-        _commutativity_proven: bool,
+        commutativity_proven: bool,
         op_meta: &HydroIrOpMetadata,
     ) -> Option<syn::Ident> {
-        // Only emit a hook for top-level unbounded streams.
-        // In-tick folds don't need a separate fold hook because the StreamHook<NoOrder>
-        // already explores permutations of the batch before it enters the tick.
-        // - TotalOrder in-tick inputs have a determined order, no non-determinism to explore.
         if !location.is_top_level() {
-            return None;
+            // For in-tick folds with commutativity_proven on NoOrder input,
+            // emit an inline shuffle hook to permute elements before the fold.
+            if !commutativity_proven {
+                return None;
+            }
+
+            let element_type = match in_kind {
+                CollectionKind::Stream {
+                    order: StreamOrder::NoOrder,
+                    retry: StreamRetry::ExactlyOnce,
+                    element_type,
+                    ..
+                } => element_type.clone(),
+                _ => return None,
+            };
+
+            let (assume_location, line, caret) = location_for_op(op_meta);
+            let root = get_this_crate();
+
+            let tick_location = location;
+            let hoff_id = self.next_hoff_id;
+            self.next_hoff_id += 1;
+
+            let buffered_ident =
+                syn::Ident::new(&format!("__buffered_{hoff_id}"), Span::call_site());
+            let hoff_send_ident =
+                syn::Ident::new(&format!("__hoff_send_{hoff_id}"), Span::call_site());
+            let hoff_recv_ident =
+                syn::Ident::new(&format!("__hoff_recv_{hoff_id}"), Span::call_site());
+            let out_ident =
+                syn::Ident::new(&format!("__fold_hook_out_{hoff_id}"), Span::call_site());
+
+            self.add_extra_stmt_internal(tick_location.root(), syn::parse_quote! {
+                let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unbounded_channel();
+            });
+
+            self.add_extra_stmt_internal(tick_location.root(), syn::parse_quote! {
+                let #hoff_recv_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(#hoff_recv_ident.into_inner()));
+            });
+
+            self.add_extra_stmt_internal(tick_location.root(), syn::parse_quote! {
+                let #buffered_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(None));
+            });
+
+            self.add_inline_hook(
+                tick_location,
+                syn::parse_quote!(
+                    Box::new(#root::sim::runtime::StreamOrderHook::<_>::new(
+                        #buffered_ident.clone(),
+                        #hoff_send_ident,
+                        (#assume_location, #line, #caret),
+                        #root::__maybe_debug__!(#element_type),
+                    ))
+                ),
+            );
+
+            let builder = self.get_dfir_mut(tick_location);
+            builder.add_dfir(
+                parse_quote! {
+                    #out_ident = #in_ident -> fold::<'tick>(
+                        || ::std::vec::Vec::new(),
+                        |acc, v| {
+                            acc.push(v);
+                        }
+                    ) -> map(|v| {
+                        let #buffered_ident = #buffered_ident.clone();
+                        let #hoff_recv_ident = #hoff_recv_ident.clone();
+                        async move {
+                            fn force_matching_type<T>(a: &mut Option<::std::vec::Vec<T>>, b: ::std::vec::Vec<T>) -> ::std::vec::Vec<T> {
+                                b
+                            }
+
+                            let mut out_holder = Some(v);
+                            *#buffered_ident.borrow_mut() = out_holder.take();
+                            force_matching_type(&mut out_holder, #hoff_recv_ident.borrow_mut().recv().await.unwrap())
+                        }
+                    }) -> resolve_futures_blocking() -> flatten();
+                },
+                None,
+                None,
+            );
+
+            return Some(out_ident);
         }
 
         let (assume_location, line, caret) = location_for_op(op_meta);

--- a/hydro_lang/src/sim/builder.rs
+++ b/hydro_lang/src/sim/builder.rs
@@ -1481,6 +1481,146 @@ impl DfirBuilder for SimBuilder {
             );
         }
     }
+
+    fn emit_fold_hook(
+        &mut self,
+        location: &LocationId,
+        in_ident: &syn::Ident,
+        in_kind: &CollectionKind,
+        commutativity_proven: bool,
+        op_meta: &HydroIrOpMetadata,
+    ) -> Option<syn::Ident> {
+        // Only emit a hook for top-level unbounded streams.
+        // In-tick folds don't need a hook because:
+        // - NoOrder in-tick inputs require proven commutativity (type system enforces this),
+        //   so order doesn't affect the final fold value within a tick.
+        // - TotalOrder in-tick inputs have a determined order, no non-determinism to explore.
+        if !location.is_top_level() {
+            return None;
+        }
+
+        let (assume_location, line, caret) = location_for_op(op_meta);
+        let root = get_this_crate();
+
+        match in_kind {
+            CollectionKind::Stream {
+                order: StreamOrder::NoOrder,
+                retry: StreamRetry::ExactlyOnce,
+                element_type,
+                ..
+            } => {
+                let hoff_id = self.next_hoff_id;
+                self.next_hoff_id += 1;
+
+                let buffered_ident =
+                    syn::Ident::new(&format!("__buffered_{hoff_id}"), Span::call_site());
+                let hoff_send_ident =
+                    syn::Ident::new(&format!("__hoff_send_{hoff_id}"), Span::call_site());
+                let hoff_recv_ident =
+                    syn::Ident::new(&format!("__hoff_recv_{hoff_id}"), Span::call_site());
+                let out_ident =
+                    syn::Ident::new(&format!("__fold_hook_out_{hoff_id}"), Span::call_site());
+
+                self.add_extra_stmt_internal(location, syn::parse_quote! {
+                    let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unbounded_channel();
+                });
+                self.add_extra_stmt_internal(location, syn::parse_quote! {
+                    let #buffered_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(::std::collections::VecDeque::new()));
+                });
+                self.add_hook(
+                    location,
+                    location,
+                    syn::parse_quote!(
+                        Box::new(#root::sim::runtime::TopLevelFoldHook::<_> {
+                            input: #buffered_ident.clone(),
+                            to_release: None,
+                            output: #hoff_send_ident,
+                            commutativity_proven: #commutativity_proven,
+                            location: (#assume_location, #line, #caret),
+                            format_item_debug: #root::__maybe_debug__!(#element_type),
+                        })
+                    ),
+                );
+
+                self.get_dfir_mut(location).add_dfir(
+                    parse_quote! {
+                        #in_ident -> for_each(|v| #buffered_ident.borrow_mut().push_back(v));
+                    },
+                    None,
+                    None,
+                );
+
+                self.get_dfir_mut(location).add_dfir(
+                    parse_quote! {
+                        #out_ident = source_stream(#hoff_recv_ident);
+                    },
+                    None,
+                    None,
+                );
+
+                Some(out_ident)
+            }
+            CollectionKind::KeyedStream {
+                value_order: StreamOrder::NoOrder,
+                value_retry: StreamRetry::ExactlyOnce,
+                key_type,
+                value_type,
+                ..
+            } => {
+                let hoff_id = self.next_hoff_id;
+                self.next_hoff_id += 1;
+
+                let buffered_ident =
+                    syn::Ident::new(&format!("__buffered_{hoff_id}"), Span::call_site());
+                let hoff_send_ident =
+                    syn::Ident::new(&format!("__hoff_send_{hoff_id}"), Span::call_site());
+                let hoff_recv_ident =
+                    syn::Ident::new(&format!("__hoff_recv_{hoff_id}"), Span::call_site());
+                let out_ident =
+                    syn::Ident::new(&format!("__fold_hook_out_{hoff_id}"), Span::call_site());
+
+                self.add_extra_stmt_internal(location, syn::parse_quote! {
+                    let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unbounded_channel();
+                });
+                self.add_extra_stmt_internal(location, syn::parse_quote! {
+                    let #buffered_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(::std::collections::VecDeque::new()));
+                });
+                self.add_hook(
+                    location,
+                    location,
+                    syn::parse_quote!(
+                        Box::new(#root::sim::runtime::TopLevelFoldHook::<_> {
+                            input: #buffered_ident.clone(),
+                            to_release: None,
+                            output: #hoff_send_ident,
+                            commutativity_proven: #commutativity_proven,
+                            location: (#assume_location, #line, #caret),
+                            format_item_debug: #root::__maybe_debug__!((#key_type, #value_type)),
+                        })
+                    ),
+                );
+
+                self.get_dfir_mut(location).add_dfir(
+                    parse_quote! {
+                        #in_ident -> for_each(|v| #buffered_ident.borrow_mut().push_back(v));
+                    },
+                    None,
+                    None,
+                );
+
+                self.get_dfir_mut(location).add_dfir(
+                    parse_quote! {
+                        #out_ident = source_stream(#hoff_recv_ident);
+                    },
+                    None,
+                    None,
+                );
+
+                Some(out_ident)
+            }
+            _ => None,
+        }
+    }
 }
 
 /// Extract a location string, line, and caret indent from an op's metadata backtrace.

--- a/hydro_lang/src/sim/flow.rs
+++ b/hydro_lang/src/sim/flow.rs
@@ -119,6 +119,7 @@ impl<'a> SimFlow<'a> {
             extra_stmts_cluster: BTreeMap::new(),
             next_hoff_id: 0,
             test_safety_only: self.test_safety_only,
+            fold_hooked_idents: HashSet::new(),
         };
 
         // Ensure the default (0) external is always present.

--- a/hydro_lang/src/sim/flow.rs
+++ b/hydro_lang/src/sim/flow.rs
@@ -119,7 +119,6 @@ impl<'a> SimFlow<'a> {
             extra_stmts_cluster: BTreeMap::new(),
             next_hoff_id: 0,
             test_safety_only: self.test_safety_only,
-            fold_hooked_idents: HashSet::new(),
         };
 
         // Ensure the default (0) external is always present.
@@ -147,12 +146,14 @@ impl<'a> SimFlow<'a> {
         let mut seen_tees = HashMap::new();
         let mut built_tees = HashMap::new();
         let mut next_stmt_id = 0;
+        let mut fold_hooked_idents = HashSet::new();
         for leaf in &mut self.ir {
             leaf.emit(
                 &mut sim_emit,
                 &mut seen_tees,
                 &mut built_tees,
                 &mut next_stmt_id,
+                &mut fold_hooked_idents,
             );
         }
 

--- a/hydro_lang/src/sim/runtime.rs
+++ b/hydro_lang/src/sim/runtime.rs
@@ -1351,6 +1351,121 @@ impl<T> SimHook for TopLevelStreamOrderHook<T> {
     }
 }
 
+/// Hook for top-level folds. Selects a non-empty subset of buffered inputs to release,
+/// optionally permuting them if commutativity is not proven. Unselected elements remain
+/// in the buffer for future releases (modeling delayed/lossy inputs).
+pub struct TopLevelFoldHook<T> {
+    pub input: Rc<RefCell<VecDeque<T>>>,
+    pub to_release: Option<Vec<T>>,
+    pub output: UnboundedSender<T>,
+    /// If true, the user has proven commutativity, so we skip permutation.
+    /// If false, we explore different orderings via Fisher-Yates shuffle.
+    pub commutativity_proven: bool,
+    pub location: HookLocationMeta,
+    pub format_item_debug: fn(&T) -> Option<String>,
+}
+
+impl<T> SimHook for TopLevelFoldHook<T> {
+    fn current_decision(&self) -> Option<bool> {
+        self.to_release.as_ref().map(|v| !v.is_empty())
+    }
+
+    fn can_make_nontrivial_decision(&self) -> bool {
+        !self.input.borrow().is_empty()
+    }
+
+    fn autonomous_decision<'a>(
+        &mut self,
+        driver: &mut Borrowed<'a>,
+        force_nontrivial: bool,
+    ) -> bool {
+        let mut current_input = self.input.borrow_mut();
+
+        if current_input.is_empty() {
+            if force_nontrivial {
+                panic!("Cannot make nontrivial decision when there is no input");
+            }
+            self.to_release = Some(vec![]);
+            return false;
+        }
+
+        // Select a non-empty subset: for each element, decide include/exclude.
+        // Only force inclusion on the last element if nothing was selected yet.
+        let mut selected = Vec::new();
+        let mut remaining = VecDeque::new();
+
+        let len = current_input.len();
+        for (i, item) in current_input.drain(..).enumerate() {
+            let is_last = i == len - 1;
+            let must_include = is_last && selected.is_empty();
+            if must_include || produce().generate(driver).unwrap() {
+                selected.push(item);
+            } else {
+                remaining.push_back(item);
+            }
+        }
+
+        // Put unselected elements back
+        *current_input = remaining;
+
+        // Permute selected elements if commutativity is not proven (Fisher-Yates)
+        if !self.commutativity_proven {
+            let slen = selected.len();
+            for i in (1..slen).rev() {
+                let j = (0..=i).generate(driver).unwrap();
+                selected.swap(i, j);
+            }
+        }
+
+        self.to_release = Some(selected);
+        true
+    }
+
+    fn release_decision(&mut self, log_writer: &mut dyn std::fmt::Write) {
+        if let Some(to_release) = self.to_release.take() {
+            if !to_release.is_empty() {
+                let (batch_location, line, caret_indent) = self.location;
+                let note_str = format!(
+                    "^ fold input batch ({}): {:?}",
+                    if self.commutativity_proven {
+                        "commutative"
+                    } else {
+                        "permuted"
+                    },
+                    TruncatedVecDebug(
+                        RefCell::new(Some(to_release.iter())),
+                        8,
+                        self.format_item_debug
+                    )
+                );
+
+                let _ = writeln!(
+                    log_writer,
+                    "\n{} {}",
+                    "-->".color(colored::Color::Blue),
+                    batch_location
+                );
+
+                let _ = writeln!(log_writer, " {}{}", "|".color(colored::Color::Blue), line);
+
+                let _ = writeln!(
+                    log_writer,
+                    " {}{}{}",
+                    "|".color(colored::Color::Blue),
+                    caret_indent,
+                    note_str.color(colored::Color::Green)
+                );
+            }
+
+            for item in to_release {
+                self.output.send(item).unwrap();
+            }
+        } else {
+            panic!("No decision to release");
+        }
+    }
+}
+
 /// Keyed variant of [`TopLevelStreamOrderHook`]. Same one-at-a-time release
 /// strategy to simulate causal interleavings -- see the comment on
 /// [`TopLevelStreamOrderHook`] for the full explanation.

--- a/hydro_lang/src/sim/runtime.rs
+++ b/hydro_lang/src/sim/runtime.rs
@@ -646,6 +646,92 @@ impl<T: Clone> SimHook for SingletonHook<T> {
     }
 }
 
+/// A passthrough singleton hook for fold outputs that are already controlled by a
+/// `TopLevelFoldHook`. Always releases the latest value without any non-deterministic
+/// decisions, since the fold hook already made the only meaningful choice (which subset
+/// of inputs to process).
+pub struct PassthroughSingletonHook<T> {
+    input: Rc<RefCell<VecDeque<T>>>,
+    to_release: Option<T>,
+    output: UnboundedSender<T>,
+    batch_location: HookLocationMeta,
+    format_item_debug: fn(&T) -> Option<String>,
+}
+
+impl<T> PassthroughSingletonHook<T> {
+    pub fn new(
+        input: Rc<RefCell<VecDeque<T>>>,
+        output: UnboundedSender<T>,
+        batch_location: HookLocationMeta,
+        format_item_debug: fn(&T) -> Option<String>,
+    ) -> Self {
+        Self {
+            input,
+            to_release: None,
+            output,
+            batch_location,
+            format_item_debug,
+        }
+    }
+}
+
+impl<T> SimHook for PassthroughSingletonHook<T> {
+    fn current_decision(&self) -> Option<bool> {
+        self.to_release.as_ref().map(|_| true)
+    }
+
+    fn can_make_nontrivial_decision(&self) -> bool {
+        !self.input.borrow().is_empty()
+    }
+
+    fn autonomous_decision<'a>(
+        &mut self,
+        _driver: &mut Borrowed<'a>,
+        _force_nontrivial: bool,
+    ) -> bool {
+        let mut current_input = self.input.borrow_mut();
+        // Always take the last (most recent) value, discard intermediates.
+        if let Some(item) = current_input.pop_back() {
+            current_input.clear();
+            self.to_release = Some(item);
+            true
+        } else {
+            false
+        }
+    }
+
+    fn release_decision(&mut self, log_writer: &mut dyn std::fmt::Write) {
+        if let Some(to_release) = self.to_release.take() {
+            let (batch_location, line, caret_indent) = self.batch_location;
+            let note_str = format!(
+                "^ releasing snapshot: {:?}",
+                ManualDebug(&to_release, self.format_item_debug)
+            );
+
+            let _ = writeln!(
+                log_writer,
+                "{} {}",
+                "-->".color(colored::Color::Blue),
+                batch_location
+            );
+
+            let _ = writeln!(log_writer, " {}{}", "|".color(colored::Color::Blue), line);
+
+            let _ = writeln!(
+                log_writer,
+                " {}{}{}",
+                "|".color(colored::Color::Blue),
+                caret_indent,
+                note_str.color(colored::Color::Green)
+            );
+
+            self.output.send(to_release).unwrap();
+        } else {
+            panic!("No decision to release");
+        }
+    }
+}
+
 pub struct KeyedSingletonHook<K: Hash + Eq + Clone, V: Clone> {
     input: Rc<RefCell<FxHashMap<K, VecDeque<V>>>>, // FxHasher is deterministic
     to_release: Option<Vec<(K, V, bool)>>,         // (key, data, is new)
@@ -1352,15 +1438,12 @@ impl<T> SimHook for TopLevelStreamOrderHook<T> {
 }
 
 /// Hook for top-level folds. Selects a non-empty subset of buffered inputs to release,
-/// optionally permuting them if commutativity is not proven. Unselected elements remain
+/// always permuting them to explore all orderings. Unselected elements remain
 /// in the buffer for future releases (modeling delayed/lossy inputs).
 pub struct TopLevelFoldHook<T> {
     pub input: Rc<RefCell<VecDeque<T>>>,
     pub to_release: Option<Vec<T>>,
-    pub output: UnboundedSender<T>,
-    /// If true, the user has proven commutativity, so we skip permutation.
-    /// If false, we explore different orderings via Fisher-Yates shuffle.
-    pub commutativity_proven: bool,
+    pub output: UnboundedSender<Vec<T>>,
     pub location: HookLocationMeta,
     pub format_item_debug: fn(&T) -> Option<String>,
 }
@@ -1408,8 +1491,10 @@ impl<T> SimHook for TopLevelFoldHook<T> {
         // Put unselected elements back
         *current_input = remaining;
 
-        // Permute selected elements if commutativity is not proven (Fisher-Yates)
-        if !self.commutativity_proven {
+        // Always permute selected elements (Fisher-Yates) to explore all orderings.
+        // Even if commutativity is claimed via manual_proof!, the simulator is
+        // conservative and does not trust it — it still explores permutations.
+        {
             let slen = selected.len();
             for i in (1..slen).rev() {
                 let j = (0..=i).generate(driver).unwrap();
@@ -1426,12 +1511,7 @@ impl<T> SimHook for TopLevelFoldHook<T> {
             if !to_release.is_empty() {
                 let (batch_location, line, caret_indent) = self.location;
                 let note_str = format!(
-                    "^ fold input batch ({}): {:?}",
-                    if self.commutativity_proven {
-                        "commutative"
-                    } else {
-                        "permuted"
-                    },
+                    "^ fold input batch (permuted): {:?}",
                     TruncatedVecDebug(
                         RefCell::new(Some(to_release.iter())),
                         8,
@@ -1457,9 +1537,7 @@ impl<T> SimHook for TopLevelFoldHook<T> {
                 );
             }
 
-            for item in to_release {
-                self.output.send(item).unwrap();
-            }
+            self.output.send(to_release).unwrap();
         } else {
             panic!("No decision to release");
         }

--- a/hydro_lang/src/sim/tests/mod.rs
+++ b/hydro_lang/src/sim/tests/mod.rs
@@ -389,7 +389,7 @@ fn sim_fold_sample_eager_state_count() {
         assert_eq!(*all.last().unwrap(), 6);
     });
 
-    assert_eq!(count, 432, "Exhaustive states explored");
+    assert_eq!(count, 108, "Exhaustive states explored");
 }
 
 #[test]
@@ -473,7 +473,7 @@ fn sim_fold_total_order_no_permutation() {
 }
 
 #[test]
-fn sim_fold_commutative_skips_permutations() {
+fn sim_fold_commutative_state_count() {
     use crate::live_collections::stream::NoOrder;
     use crate::properties::manual_proof;
 
@@ -499,9 +499,9 @@ fn sim_fold_commutative_skips_permutations() {
         assert_eq!(*all.last().unwrap(), 6);
     });
 
-    // 432 states with subset selection (no permutation).
-    // Previously 270 with ObserveNonDet (one-at-a-time + ordering).
-    assert_eq!(count, 432);
+    // 108 states with batch-fold optimization + passthrough singleton hook + always permute.
+    // Previously 339 with batch-fold + full SingletonHook + commutativity skip.
+    assert_eq!(count, 108);
 }
 
 #[test]
@@ -582,5 +582,98 @@ fn sim_fold_tee_downstream_sees_different_subsets() {
         "Expected at least one execution where downstream consumers see different intermediate states, \
          but all observed pairs were identical: {:?}",
         observed_pairs
+    );
+}
+
+/// Demonstrates that the simulator catches a bug in a fold that falsely claims commutativity.
+/// String concatenation is NOT commutative, but we lie with `manual_proof!`.
+/// The exhaustive run should observe different final values (e.g. "ab" vs "ba"),
+/// which would violate the invariant that a commutative fold's result is order-independent.
+#[test]
+fn sim_fold_catches_false_commutativity() {
+    use std::collections::HashSet;
+
+    use crate::live_collections::stream::NoOrder;
+    use crate::properties::manual_proof;
+
+    let mut flow = FlowBuilder::new();
+    let node = flow.process::<()>();
+
+    let (in_send, input) = node.sim_input::<String, NoOrder, ExactlyOnce>();
+    // LIE: string concatenation is NOT commutative, but we claim it is.
+    let folded = input.fold(
+        q!(|| String::new()),
+        q!(|acc, v| acc.push_str(&v), commutative = manual_proof!(/** WRONG */)),
+    );
+    let out_recv = sliced! {
+        let snapshot = use(folded, nondet!(/** test */));
+        snapshot.into_stream()
+    }
+    .sim_output();
+
+    let mut final_values = HashSet::new();
+
+    flow.sim().exhaustive(async || {
+        in_send.send_many_unordered(["a".to_owned(), "b".to_owned()]);
+        let all: Vec<String> = out_recv.collect().await;
+        final_values.insert(all.last().unwrap().clone());
+    });
+
+    // If commutativity held, we'd only ever see "ab" (or only "ba").
+    // Because it doesn't, the simulator explores both orderings via
+    // different subset/batch sequences and observes both final values.
+    assert!(
+        final_values.contains("ab") && final_values.contains("ba"),
+        "Expected both 'ab' and 'ba' to be observed, got: {:?}",
+        final_values
+    );
+}
+
+/// Documents that the simulator does NOT yet catch false commutativity for in-tick
+/// folds on NoOrder streams. The StreamHook<NoOrder> currently skips within-batch
+/// permutation. A follow-up PR will add full permutation to StreamHook<NoOrder>,
+/// which will enable catching this class of bugs.
+///
+/// Top-level folds ARE tested via cross-batch subset selection + permutation
+/// (see `sim_fold_catches_false_commutativity`).
+#[test]
+fn sim_fold_in_tick_does_not_yet_catch_false_commutativity() {
+    use std::collections::HashSet;
+
+    use crate::live_collections::stream::NoOrder;
+    use crate::properties::manual_proof;
+
+    let mut flow = FlowBuilder::new();
+    let node = flow.process::<()>();
+
+    let (in_send, input) = node.sim_input::<String, NoOrder, ExactlyOnce>();
+
+    let tick = node.tick();
+    let out_recv = input
+        .batch(&tick, nondet!(/** test */))
+        .fold(
+            q!(|| String::new()),
+            q!(|acc, v| acc.push_str(&v), commutative = manual_proof!(/** WRONG */)),
+        )
+        .into_stream()
+        .all_ticks()
+        .sim_output();
+
+    let mut final_values = HashSet::new();
+
+    flow.sim().exhaustive(async || {
+        in_send.send_many_unordered(["a".to_owned(), "b".to_owned()]);
+        let all: Vec<String> = out_recv.collect().await;
+        for v in all {
+            final_values.insert(v);
+        }
+    });
+
+    // Currently "ba" is NOT observed because StreamHook<NoOrder> doesn't permute.
+    // A follow-up PR will add permutation to StreamHook<NoOrder> to fix this.
+    assert!(
+        !final_values.contains("ba"),
+        "StreamHook<NoOrder> should not yet permute within a batch, got: {:?}",
+        final_values
     );
 }

--- a/hydro_lang/src/sim/tests/mod.rs
+++ b/hydro_lang/src/sim/tests/mod.rs
@@ -366,6 +366,8 @@ fn sim_fold_sample_eager_state_count() {
     use crate::live_collections::stream::NoOrder;
     use crate::properties::manual_proof;
 
+    // Assert the exact exhaustive state count to detect regressions.
+    // 108 states with batch-fold optimization + passthrough singleton hook + always permute.
     let mut flow = FlowBuilder::new();
     let node = flow.process::<()>();
 
@@ -373,7 +375,10 @@ fn sim_fold_sample_eager_state_count() {
 
     let folded = input.fold(
         q!(|| 0),
-        q!(|acc, v| *acc += v, commutative = manual_proof!(/** integer addition is commutative */)),
+        q!(
+            |acc, v| *acc += v,
+            commutative = manual_proof!(/** integer addition is commutative */)
+        ),
     );
     let out_recv = sliced! {
         let snapshot = use(folded, nondet!(/** test */));
@@ -408,7 +413,10 @@ fn sim_fold_commutative_explores_all_subset_sums() {
     let (in_send, input) = node.sim_input::<i32, NoOrder, ExactlyOnce>();
     let folded = input.fold(
         q!(|| 0),
-        q!(|acc, v| *acc += v, commutative = manual_proof!(/** addition is commutative */)),
+        q!(
+            |acc, v| *acc += v,
+            commutative = manual_proof!(/** addition is commutative */)
+        ),
     );
     let out_recv = sliced! {
         let snapshot = use(folded, nondet!(/** test */));
@@ -473,38 +481,6 @@ fn sim_fold_total_order_no_permutation() {
 }
 
 #[test]
-fn sim_fold_commutative_state_count() {
-    use crate::live_collections::stream::NoOrder;
-    use crate::properties::manual_proof;
-
-    // With commutativity proven, the hook skips Fisher-Yates permutation.
-    // This means fewer states are explored compared to the old ObserveNonDet approach (270).
-    // Assert the exact count to detect regressions in either direction.
-    let mut flow = FlowBuilder::new();
-    let node = flow.process::<()>();
-    let (in_send, input) = node.sim_input::<i32, NoOrder, ExactlyOnce>();
-    let folded = input.fold(
-        q!(|| 0),
-        q!(|acc, v| *acc += v, commutative = manual_proof!(/** commutative */)),
-    );
-    let out_recv = sliced! {
-        let snapshot = use(folded, nondet!(/** test */));
-        snapshot.into_stream()
-    }
-    .sim_output();
-
-    let count = flow.sim().exhaustive(async || {
-        in_send.send_many_unordered([1, 2, 3]);
-        let all: Vec<i32> = out_recv.collect().await;
-        assert_eq!(*all.last().unwrap(), 6);
-    });
-
-    // 108 states with batch-fold optimization + passthrough singleton hook + always permute.
-    // Previously 339 with batch-fold + full SingletonHook + commutativity skip.
-    assert_eq!(count, 108);
-}
-
-#[test]
 fn sim_fold_keyed_no_order() {
     use crate::live_collections::stream::NoOrder;
     use crate::properties::manual_proof;
@@ -515,7 +491,10 @@ fn sim_fold_keyed_no_order() {
 
     let folded = input.into_keyed().fold(
         q!(|| 0),
-        q!(|acc, v| *acc += v, commutative = manual_proof!(/** addition is commutative */)),
+        q!(
+            |acc, v| *acc += v,
+            commutative = manual_proof!(/** addition is commutative */)
+        ),
     );
     let out_recv = sliced! {
         let snapshot = use(folded, nondet!(/** test */));
@@ -576,6 +555,7 @@ fn sim_fold_tee_downstream_sees_different_subsets() {
 
     // There must exist at least one execution where the two downstreams
     // observed different sequences of intermediate states.
+    #[expect(clippy::disallowed_methods, reason = "order is not used in test")]
     let has_divergent = observed_pairs.iter().any(|(a, b)| a != b);
     assert!(
         has_divergent,
@@ -586,7 +566,6 @@ fn sim_fold_tee_downstream_sees_different_subsets() {
 }
 
 /// Demonstrates that the simulator catches a bug in a fold that falsely claims commutativity.
-/// String concatenation is NOT commutative, but we lie with `manual_proof!`.
 /// The exhaustive run should observe different final values (e.g. "ab" vs "ba"),
 /// which would violate the invariant that a commutative fold's result is order-independent.
 #[test]
@@ -600,10 +579,14 @@ fn sim_fold_catches_false_commutativity() {
     let node = flow.process::<()>();
 
     let (in_send, input) = node.sim_input::<String, NoOrder, ExactlyOnce>();
-    // LIE: string concatenation is NOT commutative, but we claim it is.
+    // string concatenation is not commutative, but lets claim it is, what
+    // could go wrong
     let folded = input.fold(
         q!(|| String::new()),
-        q!(|acc, v| acc.push_str(&v), commutative = manual_proof!(/** WRONG */)),
+        q!(
+            |acc, v| acc.push_str(&v),
+            commutative = manual_proof!(/** WRONG */)
+        ),
     );
     let out_recv = sliced! {
         let snapshot = use(folded, nondet!(/** test */));
@@ -616,12 +599,13 @@ fn sim_fold_catches_false_commutativity() {
     flow.sim().exhaustive(async || {
         in_send.send_many_unordered(["a".to_owned(), "b".to_owned()]);
         let all: Vec<String> = out_recv.collect().await;
-        final_values.insert(all.last().unwrap().clone());
+        // Collect the first values we see to verify we're fully exploring
+        // the state space. If we're _not_ then we wouldn't see a "ba"
+        // permutation as the first result
+        final_values.insert(all.first().unwrap().clone());
     });
 
-    // If commutativity held, we'd only ever see "ab" (or only "ba").
-    // Because it doesn't, the simulator explores both orderings via
-    // different subset/batch sequences and observes both final values.
+    // If commutativity held, we wouldn't see "ba"
     assert!(
         final_values.contains("ab") && final_values.contains("ba"),
         "Expected both 'ab' and 'ba' to be observed, got: {:?}",
@@ -635,7 +619,7 @@ fn sim_fold_catches_false_commutativity() {
 /// Top-level folds ARE tested via cross-batch subset selection + permutation
 /// (see `sim_fold_catches_false_commutativity`).
 #[test]
-fn sim_fold_in_tick_does_not_yet_catch_false_commutativity() {
+fn sim_fold_in_tick_catches_false_commutativity() {
     use std::collections::HashSet;
 
     use crate::live_collections::stream::NoOrder;
@@ -651,7 +635,10 @@ fn sim_fold_in_tick_does_not_yet_catch_false_commutativity() {
         .batch(&tick, nondet!(/** test */))
         .fold(
             q!(|| String::new()),
-            q!(|acc, v| acc.push_str(&v), commutative = manual_proof!(/** WRONG */)),
+            q!(
+                |acc, v| acc.push_str(&v),
+                commutative = manual_proof!(/** WRONG */)
+            ),
         )
         .into_stream()
         .all_ticks()

--- a/hydro_lang/src/sim/tests/mod.rs
+++ b/hydro_lang/src/sim/tests/mod.rs
@@ -629,10 +629,8 @@ fn sim_fold_catches_false_commutativity() {
     );
 }
 
-/// Documents that the simulator does NOT yet catch false commutativity for in-tick
-/// folds on NoOrder streams. The StreamHook<NoOrder> currently skips within-batch
-/// permutation. A follow-up PR will add full permutation to StreamHook<NoOrder>,
-/// which will enable catching this class of bugs.
+/// Verifies that the simulator catches false commutativity for in-tick folds on
+/// NoOrder streams by permuting the batch before it reaches the fold.
 ///
 /// Top-level folds ARE tested via cross-batch subset selection + permutation
 /// (see `sim_fold_catches_false_commutativity`).
@@ -669,11 +667,9 @@ fn sim_fold_in_tick_does_not_yet_catch_false_commutativity() {
         }
     });
 
-    // Currently "ba" is NOT observed because StreamHook<NoOrder> doesn't permute.
-    // A follow-up PR will add permutation to StreamHook<NoOrder> to fix this.
     assert!(
-        !final_values.contains("ba"),
-        "StreamHook<NoOrder> should not yet permute within a batch, got: {:?}",
+        final_values.contains("ab") && final_values.contains("ba"),
+        "Expected both \"ab\" and \"ba\" to be observed, got: {:?}",
         final_values
     );
 }

--- a/hydro_lang/src/sim/tests/mod.rs
+++ b/hydro_lang/src/sim/tests/mod.rs
@@ -360,3 +360,80 @@ fn sim_collect_waits_for_all_ticks() {
         assert_eq!(all, vec![1, 2, 3]);
     });
 }
+
+#[test]
+fn sim_fold_sample_eager_state_count() {
+    use crate::live_collections::stream::NoOrder;
+    use crate::properties::manual_proof;
+
+    let mut flow = FlowBuilder::new();
+    let node = flow.process::<()>();
+
+    let (in_send, input) = node.sim_input::<i32, NoOrder, ExactlyOnce>();
+
+    let folded = input.fold(
+        q!(|| 0),
+        q!(|acc, v| *acc += v, commutative = manual_proof!(/** integer addition is commutative */)),
+    );
+    let out_recv = sliced! {
+        let snapshot = use(folded, nondet!(/** test */));
+        snapshot.into_stream()
+    }
+    .sim_output();
+
+    let count = flow.sim().exhaustive(async || {
+        in_send.send_many_unordered([1, 2, 3]);
+
+        let all: Vec<i32> = out_recv.collect().await;
+        // The final value must always be 6 (1+2+3)
+        assert_eq!(*all.last().unwrap(), 6);
+    });
+
+    assert_eq!(count, 270, "Exhaustive states explored");
+}
+
+#[test]
+fn sim_fold_commutative_explores_all_subset_sums() {
+    use std::collections::HashSet;
+
+    use crate::live_collections::stream::NoOrder;
+    use crate::properties::manual_proof;
+
+    // With inputs [1, 2, 4], the possible subset sums are:
+    // {1}, {2}, {4}, {1,2}, {1,4}, {2,4}, {1,2,4} → sums: 1, 2, 4, 3, 5, 6, 7
+    // The fold can be snapshotted after processing any prefix of subsets.
+    let mut flow = FlowBuilder::new();
+    let node = flow.process::<()>();
+
+    let (in_send, input) = node.sim_input::<i32, NoOrder, ExactlyOnce>();
+    let folded = input.fold(
+        q!(|| 0),
+        q!(|acc, v| *acc += v, commutative = manual_proof!(/** addition is commutative */)),
+    );
+    let out_recv = sliced! {
+        let snapshot = use(folded, nondet!(/** test */));
+        snapshot.into_stream()
+    }
+    .sim_output();
+
+    let mut observed_values = HashSet::new();
+
+    flow.sim().exhaustive(async || {
+        in_send.send_many_unordered([1, 2, 4]);
+        let all: Vec<i32> = out_recv.collect().await;
+        assert_eq!(*all.last().unwrap(), 7);
+        for &v in &all {
+            observed_values.insert(v);
+        }
+    });
+
+    // The exhaustive exploration should observe every possible subset sum.
+    // With inputs [1, 2, 4], the fold can be snapshotted after processing any
+    // non-empty subset, so all values 1..=7 must appear, plus 0 (initial state).
+    let expected: HashSet<i32> = (0..=7).collect();
+    assert_eq!(
+        observed_values, expected,
+        "Should observe all subset sums across all executions"
+    );
+}
+

--- a/hydro_lang/src/sim/tests/mod.rs
+++ b/hydro_lang/src/sim/tests/mod.rs
@@ -389,7 +389,7 @@ fn sim_fold_sample_eager_state_count() {
         assert_eq!(*all.last().unwrap(), 6);
     });
 
-    assert_eq!(count, 270, "Exhaustive states explored");
+    assert_eq!(count, 432, "Exhaustive states explored");
 }
 
 #[test]
@@ -427,7 +427,7 @@ fn sim_fold_commutative_explores_all_subset_sums() {
         }
     });
 
-    // The exhaustive exploration should observe every possible subset sum.
+    // The exhaustive exploration must observe every possible subset sum.
     // With inputs [1, 2, 4], the fold can be snapshotted after processing any
     // non-empty subset, so all values 1..=7 must appear, plus 0 (initial state).
     let expected: HashSet<i32> = (0..=7).collect();
@@ -437,3 +437,150 @@ fn sim_fold_commutative_explores_all_subset_sums() {
     );
 }
 
+#[test]
+fn sim_fold_total_order_no_permutation() {
+    // Non-commutative fold on TotalOrder: no hook emitted, order is fixed.
+    // Every intermediate must be a prefix-concatenation of "a","b","c".
+    let mut flow = FlowBuilder::new();
+    let node = flow.process::<()>();
+
+    let source = node.source_stream(q!(tokio_stream::iter(vec!["a", "b", "c"])));
+    let folded = source.fold(q!(|| String::new()), q!(|acc, v| acc.push_str(v)));
+    let out_recv = sliced! {
+        let snapshot = use(folded, nondet!(/** test */));
+        snapshot.into_stream()
+    }
+    .sim_output();
+
+    let mut all_observed = std::collections::HashSet::new();
+
+    flow.sim().exhaustive(async || {
+        let all: Vec<String> = out_recv.collect().await;
+        assert_eq!(all.last().unwrap(), "abc");
+        for v in all {
+            all_observed.insert(v);
+        }
+    });
+
+    // Only valid prefixes should be observed (no permutations like "ba", "cab", etc.)
+    for v in &all_observed {
+        assert!(
+            ["", "a", "ab", "abc"].contains(&v.as_str()),
+            "Unexpected intermediate: {:?}",
+            v
+        );
+    }
+}
+
+#[test]
+fn sim_fold_commutative_skips_permutations() {
+    use crate::live_collections::stream::NoOrder;
+    use crate::properties::manual_proof;
+
+    // With commutativity proven, the hook skips Fisher-Yates permutation.
+    // This means fewer states are explored compared to the old ObserveNonDet approach (270).
+    // Assert the exact count to detect regressions in either direction.
+    let mut flow = FlowBuilder::new();
+    let node = flow.process::<()>();
+    let (in_send, input) = node.sim_input::<i32, NoOrder, ExactlyOnce>();
+    let folded = input.fold(
+        q!(|| 0),
+        q!(|acc, v| *acc += v, commutative = manual_proof!(/** commutative */)),
+    );
+    let out_recv = sliced! {
+        let snapshot = use(folded, nondet!(/** test */));
+        snapshot.into_stream()
+    }
+    .sim_output();
+
+    let count = flow.sim().exhaustive(async || {
+        in_send.send_many_unordered([1, 2, 3]);
+        let all: Vec<i32> = out_recv.collect().await;
+        assert_eq!(*all.last().unwrap(), 6);
+    });
+
+    // 432 states with subset selection (no permutation).
+    // Previously 270 with ObserveNonDet (one-at-a-time + ordering).
+    assert_eq!(count, 432);
+}
+
+#[test]
+fn sim_fold_keyed_no_order() {
+    use crate::live_collections::stream::NoOrder;
+    use crate::properties::manual_proof;
+
+    let mut flow = FlowBuilder::new();
+    let node = flow.process::<()>();
+    let (in_send, input) = node.sim_input::<(u32, i32), NoOrder, ExactlyOnce>();
+
+    let folded = input.into_keyed().fold(
+        q!(|| 0),
+        q!(|acc, v| *acc += v, commutative = manual_proof!(/** addition is commutative */)),
+    );
+    let out_recv = sliced! {
+        let snapshot = use(folded, nondet!(/** test */));
+        snapshot.entries()
+    }
+    .sim_output();
+
+    flow.sim().exhaustive(async || {
+        in_send.send_many_unordered([(1, 10), (2, 20), (1, 30)]);
+        let all: Vec<(u32, i32)> = out_recv.collect_sorted().await;
+        let mut last_by_key = std::collections::HashMap::new();
+        for (k, v) in all {
+            last_by_key.insert(k, v);
+        }
+        assert_eq!(last_by_key.get(&1), Some(&40));
+        assert_eq!(last_by_key.get(&2), Some(&20));
+    });
+}
+
+#[test]
+fn sim_fold_tee_downstream_sees_different_subsets() {
+    use std::collections::HashSet;
+
+    // Two downstream consumers of the same fold([1, 2, 3]) accumulator can
+    // independently snapshot at different times. One might see {3, 6} while
+    // the other sees {1, 3, 6} — they are not forced to observe the same
+    // intermediate states.
+    let mut flow = FlowBuilder::new();
+    let node = flow.process::<()>();
+
+    let source = node.source_stream(q!(tokio_stream::iter(vec![1, 2, 3])));
+    let folded = source.fold(q!(|| 0), q!(|acc, v| *acc += v));
+
+    let out_a = sliced! {
+        let snapshot = use(folded.clone(), nondet!(/** test */));
+        snapshot.into_stream()
+    }
+    .sim_output();
+
+    let out_b = sliced! {
+        let snapshot = use(folded, nondet!(/** test */));
+        snapshot.into_stream()
+    }
+    .sim_output();
+
+    let mut observed_pairs: HashSet<(Vec<i32>, Vec<i32>)> = HashSet::new();
+
+    flow.sim().exhaustive(async || {
+        let a_values: Vec<i32> = out_a.collect().await;
+        let b_values: Vec<i32> = out_b.collect().await;
+
+        // Both must end at 6 (1+2+3)
+        assert_eq!(*a_values.last().unwrap(), 6);
+        assert_eq!(*b_values.last().unwrap(), 6);
+
+        observed_pairs.insert((a_values, b_values));
+    });
+
+    // There must exist at least one execution where the two downstreams
+    // observed different sequences of intermediate states.
+    let has_divergent = observed_pairs.iter().any(|(a, b)| a != b);
+    assert!(
+        has_divergent,
+        "Expected at least one execution where downstream consumers see different intermediate states, \
+         but all observed pairs were identical: {:?}",
+        observed_pairs
+    );
+}

--- a/hydro_lang/src/viz/render.rs
+++ b/hydro_lang/src/viz/render.rs
@@ -1389,12 +1389,14 @@ impl HydroNode {
                 acc,
                 input,
                 metadata,
+                ..
             }
             | HydroNode::FoldKeyed {
                 init,
                 acc,
                 input,
                 metadata,
+                ..
             }
             | HydroNode::Scan {
                 init,

--- a/hydro_test/src/cluster/snapshots/paxos_ir.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir.snap
@@ -1372,26 +1372,14 @@ expression: built.ir()
                                                                                                                                                                                         init: stageleft :: runtime_support :: fn0_type_hint :: < core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | | None }),
                                                                                                                                                                                         acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant > , hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | latest , _ | { * latest = Some (Instant :: now ()) ; } }),
                                                                                                                                                                                         input: ObserveNonDet {
-                                                                                                                                                                                            inner: ObserveNonDet {
-                                                                                                                                                                                                inner: Tee {
-                                                                                                                                                                                                    inner: <shared 3>,
-                                                                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                                                                        location_id: Cluster(loc1v1),
-                                                                                                                                                                                                        collection_kind: Stream {
-                                                                                                                                                                                                            bound: Unbounded,
-                                                                                                                                                                                                            order: NoOrder,
-                                                                                                                                                                                                            retry: AtLeastOnce,
-                                                                                                                                                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                                                                                                                        },
-                                                                                                                                                                                                    },
-                                                                                                                                                                                                },
-                                                                                                                                                                                                trusted: false,
+                                                                                                                                                                                            inner: Tee {
+                                                                                                                                                                                                inner: <shared 3>,
                                                                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                                                                     location_id: Cluster(loc1v1),
                                                                                                                                                                                                     collection_kind: Stream {
                                                                                                                                                                                                         bound: Unbounded,
                                                                                                                                                                                                         order: NoOrder,
-                                                                                                                                                                                                        retry: ExactlyOnce,
+                                                                                                                                                                                                        retry: AtLeastOnce,
                                                                                                                                                                                                         element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                                                                                                                                                     },
                                                                                                                                                                                                 },
@@ -1401,7 +1389,7 @@ expression: built.ir()
                                                                                                                                                                                                 location_id: Cluster(loc1v1),
                                                                                                                                                                                                 collection_kind: Stream {
                                                                                                                                                                                                     bound: Unbounded,
-                                                                                                                                                                                                    order: TotalOrder,
+                                                                                                                                                                                                    order: NoOrder,
                                                                                                                                                                                                     retry: ExactlyOnce,
                                                                                                                                                                                                     element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                                                                                                                                                 },
@@ -2138,37 +2126,24 @@ expression: built.ir()
                                     inner: <shared 12>: FoldKeyed {
                                         init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | | (0 , 0) }),
                                         acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } } }),
-                                        input: ObserveNonDet {
-                                            inner: Cast {
-                                                inner: Tee {
-                                                    inner: <shared 7>,
-                                                    metadata: HydroIrMetadata {
-                                                        location_id: Tick(10, Cluster(loc1v1)),
-                                                        collection_kind: Stream {
-                                                            bound: Bounded,
-                                                            order: NoOrder,
-                                                            retry: ExactlyOnce,
-                                                            element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
-                                                        },
-                                                    },
-                                                },
+                                        input: Cast {
+                                            inner: Tee {
+                                                inner: <shared 7>,
                                                 metadata: HydroIrMetadata {
                                                     location_id: Tick(10, Cluster(loc1v1)),
-                                                    collection_kind: KeyedStream {
+                                                    collection_kind: Stream {
                                                         bound: Bounded,
-                                                        value_order: NoOrder,
-                                                        value_retry: ExactlyOnce,
-                                                        key_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                        value_type: core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >,
+                                                        order: NoOrder,
+                                                        retry: ExactlyOnce,
+                                                        element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
                                                     },
                                                 },
                                             },
-                                            trusted: false,
                                             metadata: HydroIrMetadata {
                                                 location_id: Tick(10, Cluster(loc1v1)),
                                                 collection_kind: KeyedStream {
                                                     bound: Bounded,
-                                                    value_order: TotalOrder,
+                                                    value_order: NoOrder,
                                                     value_retry: ExactlyOnce,
                                                     key_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                     value_type: core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >,
@@ -3909,32 +3884,21 @@ expression: built.ir()
                                                                                                 input: FoldKeyed {
                                                                                                     init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | | (0 , None) }),
                                                                                                     acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | curr_entry , new_entry | { if let Some (curr_entry_payload) = & mut curr_entry . 1 { let same_values = new_entry . value == curr_entry_payload . value ; let higher_ballot = new_entry . ballot > curr_entry_payload . ballot ; if same_values { curr_entry . 0 += 1 ; } if higher_ballot { curr_entry_payload . ballot = new_entry . ballot ; if ! same_values { curr_entry . 0 = 1 ; curr_entry_payload . value = new_entry . value ; } } } else { * curr_entry = (1 , Some (new_entry)) ; } } }),
-                                                                                                    input: ObserveNonDet {
-                                                                                                        inner: Cast {
-                                                                                                            inner: FlatMap {
-                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | d | d }),
-                                                                                                                input: Map {
-                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (_checkpoint , log) | log }),
-                                                                                                                    input: Tee {
-                                                                                                                        inner: <shared 23>: FlatMap {
-                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | v }),
-                                                                                                                            input: Cast {
-                                                                                                                                inner: Tee {
-                                                                                                                                    inner: <shared 14>,
-                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                        location_id: Tick(16, Cluster(loc1v1)),
-                                                                                                                                        collection_kind: Optional {
-                                                                                                                                            bound: Bounded,
-                                                                                                                                            element_type: std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >,
-                                                                                                                                        },
-                                                                                                                                    },
-                                                                                                                                },
+                                                                                                    input: Cast {
+                                                                                                        inner: FlatMap {
+                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | d | d }),
+                                                                                                            input: Map {
+                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (_checkpoint , log) | log }),
+                                                                                                                input: Tee {
+                                                                                                                    inner: <shared 23>: FlatMap {
+                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | v }),
+                                                                                                                        input: Cast {
+                                                                                                                            inner: Tee {
+                                                                                                                                inner: <shared 14>,
                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                     location_id: Tick(16, Cluster(loc1v1)),
-                                                                                                                                    collection_kind: Stream {
+                                                                                                                                    collection_kind: Optional {
                                                                                                                                         bound: Bounded,
-                                                                                                                                        order: TotalOrder,
-                                                                                                                                        retry: ExactlyOnce,
                                                                                                                                         element_type: std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >,
                                                                                                                                     },
                                                                                                                                 },
@@ -3943,9 +3907,9 @@ expression: built.ir()
                                                                                                                                 location_id: Tick(16, Cluster(loc1v1)),
                                                                                                                                 collection_kind: Stream {
                                                                                                                                     bound: Bounded,
-                                                                                                                                    order: NoOrder,
+                                                                                                                                    order: TotalOrder,
                                                                                                                                     retry: ExactlyOnce,
-                                                                                                                                    element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
+                                                                                                                                    element_type: std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >,
                                                                                                                                 },
                                                                                                                             },
                                                                                                                         },
@@ -3965,7 +3929,7 @@ expression: built.ir()
                                                                                                                             bound: Bounded,
                                                                                                                             order: NoOrder,
                                                                                                                             retry: ExactlyOnce,
-                                                                                                                            element_type: std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >,
+                                                                                                                            element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
                                                                                                                         },
                                                                                                                     },
                                                                                                                 },
@@ -3975,27 +3939,25 @@ expression: built.ir()
                                                                                                                         bound: Bounded,
                                                                                                                         order: NoOrder,
                                                                                                                         retry: ExactlyOnce,
-                                                                                                                        element_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                                                        element_type: std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >,
                                                                                                                     },
                                                                                                                 },
                                                                                                             },
                                                                                                             metadata: HydroIrMetadata {
                                                                                                                 location_id: Tick(16, Cluster(loc1v1)),
-                                                                                                                collection_kind: KeyedStream {
+                                                                                                                collection_kind: Stream {
                                                                                                                     bound: Bounded,
-                                                                                                                    value_order: NoOrder,
-                                                                                                                    value_retry: ExactlyOnce,
-                                                                                                                    key_type: usize,
-                                                                                                                    value_type: hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >,
+                                                                                                                    order: NoOrder,
+                                                                                                                    retry: ExactlyOnce,
+                                                                                                                    element_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
                                                                                                                 },
                                                                                                             },
                                                                                                         },
-                                                                                                        trusted: false,
                                                                                                         metadata: HydroIrMetadata {
                                                                                                             location_id: Tick(16, Cluster(loc1v1)),
                                                                                                             collection_kind: KeyedStream {
                                                                                                                 bound: Bounded,
-                                                                                                                value_order: TotalOrder,
+                                                                                                                value_order: NoOrder,
                                                                                                                 value_retry: ExactlyOnce,
                                                                                                                 key_type: usize,
                                                                                                                 value_type: hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >,
@@ -5259,37 +5221,24 @@ expression: built.ir()
                                     inner: <shared 30>: FoldKeyed {
                                         init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | | (0 , 0) }),
                                         acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } } }),
-                                        input: ObserveNonDet {
-                                            inner: Cast {
-                                                inner: Tee {
-                                                    inner: <shared 24>,
-                                                    metadata: HydroIrMetadata {
-                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                        collection_kind: Stream {
-                                                            bound: Bounded,
-                                                            order: NoOrder,
-                                                            retry: ExactlyOnce,
-                                                            element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
-                                                        },
-                                                    },
-                                                },
+                                        input: Cast {
+                                            inner: Tee {
+                                                inner: <shared 24>,
                                                 metadata: HydroIrMetadata {
                                                     location_id: Tick(15, Cluster(loc1v1)),
-                                                    collection_kind: KeyedStream {
+                                                    collection_kind: Stream {
                                                         bound: Bounded,
-                                                        value_order: NoOrder,
-                                                        value_retry: ExactlyOnce,
-                                                        key_type: (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot),
-                                                        value_type: core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >,
+                                                        order: NoOrder,
+                                                        retry: ExactlyOnce,
+                                                        element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
                                                     },
                                                 },
                                             },
-                                            trusted: false,
                                             metadata: HydroIrMetadata {
                                                 location_id: Tick(15, Cluster(loc1v1)),
                                                 collection_kind: KeyedStream {
                                                     bound: Bounded,
-                                                    value_order: TotalOrder,
+                                                    value_order: NoOrder,
                                                     value_retry: ExactlyOnce,
                                                     key_type: (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot),
                                                     value_type: core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >,
@@ -5765,44 +5714,35 @@ expression: built.ir()
                         right: Fold {
                             init: stageleft :: runtime_support :: fn0_type_hint :: < std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | | HashMap :: new () }),
                             acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | map , (slot , entry) | { map . insert (slot , entry) ; } }),
-                            input: ObserveNonDet {
+                            input: Cast {
                                 inner: Cast {
-                                    inner: Cast {
-                                        inner: Batch {
-                                            inner: ReduceKeyedWatermark {
-                                                f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | prev_entry , entry | { if entry . ballot > prev_entry . ballot { * prev_entry = LogValue { ballot : entry . ballot , value : entry . value , } ; } } }),
-                                                input: ObserveNonDet {
-                                                    inner: Cast {
-                                                        inner: YieldConcat {
-                                                            inner: FilterMap {
-                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (p2a , max_ballot) | if p2a . ballot >= max_ballot { Some ((p2a . slot , LogValue { ballot : p2a . ballot , value : p2a . value , })) } else { None } }),
-                                                                input: CrossSingleton {
-                                                                    left: Tee {
-                                                                        inner: <shared 26>,
-                                                                        metadata: HydroIrMetadata {
-                                                                            location_id: Tick(2, Cluster(loc2v1)),
-                                                                            collection_kind: Stream {
-                                                                                bound: Bounded,
-                                                                                order: NoOrder,
-                                                                                retry: ExactlyOnce,
-                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
-                                                                            },
+                                    inner: Batch {
+                                        inner: ReduceKeyedWatermark {
+                                            f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | prev_entry , entry | { if entry . ballot > prev_entry . ballot { * prev_entry = LogValue { ballot : entry . ballot , value : entry . value , } ; } } }),
+                                            input: ObserveNonDet {
+                                                inner: Cast {
+                                                    inner: YieldConcat {
+                                                        inner: FilterMap {
+                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (p2a , max_ballot) | if p2a . ballot >= max_ballot { Some ((p2a . slot , LogValue { ballot : p2a . ballot , value : p2a . value , })) } else { None } }),
+                                                            input: CrossSingleton {
+                                                                left: Tee {
+                                                                    inner: <shared 26>,
+                                                                    metadata: HydroIrMetadata {
+                                                                        location_id: Tick(2, Cluster(loc2v1)),
+                                                                        collection_kind: Stream {
+                                                                            bound: Bounded,
+                                                                            order: NoOrder,
+                                                                            retry: ExactlyOnce,
+                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                                                         },
                                                                     },
-                                                                    right: Cast {
-                                                                        inner: Tee {
-                                                                            inner: <shared 10>,
-                                                                            metadata: HydroIrMetadata {
-                                                                                location_id: Tick(2, Cluster(loc2v1)),
-                                                                                collection_kind: Singleton {
-                                                                                    bound: Bounded,
-                                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                },
-                                                                            },
-                                                                        },
+                                                                },
+                                                                right: Cast {
+                                                                    inner: Tee {
+                                                                        inner: <shared 10>,
                                                                         metadata: HydroIrMetadata {
                                                                             location_id: Tick(2, Cluster(loc2v1)),
-                                                                            collection_kind: Optional {
+                                                                            collection_kind: Singleton {
                                                                                 bound: Bounded,
                                                                                 element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                             },
@@ -5810,11 +5750,9 @@ expression: built.ir()
                                                                     },
                                                                     metadata: HydroIrMetadata {
                                                                         location_id: Tick(2, Cluster(loc2v1)),
-                                                                        collection_kind: Stream {
+                                                                        collection_kind: Optional {
                                                                             bound: Bounded,
-                                                                            order: NoOrder,
-                                                                            retry: ExactlyOnce,
-                                                                            element_type: (hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                         },
                                                                     },
                                                                 },
@@ -5824,14 +5762,14 @@ expression: built.ir()
                                                                         bound: Bounded,
                                                                         order: NoOrder,
                                                                         retry: ExactlyOnce,
-                                                                        element_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                        element_type: (hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
                                                                     },
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Atomic(Tick(2, Cluster(loc2v1))),
+                                                                location_id: Tick(2, Cluster(loc2v1)),
                                                                 collection_kind: Stream {
-                                                                    bound: Unbounded,
+                                                                    bound: Bounded,
                                                                     order: NoOrder,
                                                                     retry: ExactlyOnce,
                                                                     element_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
@@ -5840,50 +5778,51 @@ expression: built.ir()
                                                         },
                                                         metadata: HydroIrMetadata {
                                                             location_id: Atomic(Tick(2, Cluster(loc2v1))),
-                                                            collection_kind: KeyedStream {
+                                                            collection_kind: Stream {
                                                                 bound: Unbounded,
-                                                                value_order: NoOrder,
-                                                                value_retry: ExactlyOnce,
-                                                                key_type: usize,
-                                                                value_type: hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >,
+                                                                order: NoOrder,
+                                                                retry: ExactlyOnce,
+                                                                element_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
                                                             },
                                                         },
                                                     },
-                                                    trusted: false,
                                                     metadata: HydroIrMetadata {
                                                         location_id: Atomic(Tick(2, Cluster(loc2v1))),
                                                         collection_kind: KeyedStream {
                                                             bound: Unbounded,
-                                                            value_order: TotalOrder,
+                                                            value_order: NoOrder,
                                                             value_retry: ExactlyOnce,
                                                             key_type: usize,
                                                             value_type: hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >,
                                                         },
                                                     },
                                                 },
-                                                watermark: Tee {
-                                                    inner: <shared 34>,
-                                                    metadata: HydroIrMetadata {
-                                                        location_id: Tick(2, Cluster(loc2v1)),
-                                                        collection_kind: Optional {
-                                                            bound: Bounded,
-                                                            element_type: usize,
-                                                        },
-                                                    },
-                                                },
+                                                trusted: false,
                                                 metadata: HydroIrMetadata {
                                                     location_id: Atomic(Tick(2, Cluster(loc2v1))),
-                                                    collection_kind: KeyedSingleton {
+                                                    collection_kind: KeyedStream {
                                                         bound: Unbounded,
+                                                        value_order: TotalOrder,
+                                                        value_retry: ExactlyOnce,
                                                         key_type: usize,
                                                         value_type: hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >,
                                                     },
                                                 },
                                             },
+                                            watermark: Tee {
+                                                inner: <shared 34>,
+                                                metadata: HydroIrMetadata {
+                                                    location_id: Tick(2, Cluster(loc2v1)),
+                                                    collection_kind: Optional {
+                                                        bound: Bounded,
+                                                        element_type: usize,
+                                                    },
+                                                },
+                                            },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(2, Cluster(loc2v1)),
+                                                location_id: Atomic(Tick(2, Cluster(loc2v1))),
                                                 collection_kind: KeyedSingleton {
-                                                    bound: Bounded,
+                                                    bound: Unbounded,
                                                     key_type: usize,
                                                     value_type: hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >,
                                                 },
@@ -5891,10 +5830,8 @@ expression: built.ir()
                                         },
                                         metadata: HydroIrMetadata {
                                             location_id: Tick(2, Cluster(loc2v1)),
-                                            collection_kind: KeyedStream {
+                                            collection_kind: KeyedSingleton {
                                                 bound: Bounded,
-                                                value_order: TotalOrder,
-                                                value_retry: ExactlyOnce,
                                                 key_type: usize,
                                                 value_type: hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >,
                                             },
@@ -5902,20 +5839,20 @@ expression: built.ir()
                                     },
                                     metadata: HydroIrMetadata {
                                         location_id: Tick(2, Cluster(loc2v1)),
-                                        collection_kind: Stream {
+                                        collection_kind: KeyedStream {
                                             bound: Bounded,
-                                            order: NoOrder,
-                                            retry: ExactlyOnce,
-                                            element_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                            value_order: TotalOrder,
+                                            value_retry: ExactlyOnce,
+                                            key_type: usize,
+                                            value_type: hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >,
                                         },
                                     },
                                 },
-                                trusted: false,
                                 metadata: HydroIrMetadata {
                                     location_id: Tick(2, Cluster(loc2v1)),
                                     collection_kind: Stream {
                                         bound: Bounded,
-                                        order: TotalOrder,
+                                        order: NoOrder,
                                         retry: ExactlyOnce,
                                         element_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
                                     },
@@ -7577,37 +7514,24 @@ expression: built.ir()
                                 inner: <shared 44>: FoldKeyed {
                                     init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | | (0 , 0) }),
                                     acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < () , () > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } } }),
-                                    input: ObserveNonDet {
-                                        inner: Cast {
-                                            inner: Tee {
-                                                inner: <shared 41>,
-                                                metadata: HydroIrMetadata {
-                                                    location_id: Tick(21, Cluster(loc3v1)),
-                                                    collection_kind: Stream {
-                                                        bound: Bounded,
-                                                        order: NoOrder,
-                                                        retry: ExactlyOnce,
-                                                        element_type: ((u32 , i32) , core :: result :: Result < () , () >),
-                                                    },
-                                                },
-                                            },
+                                    input: Cast {
+                                        inner: Tee {
+                                            inner: <shared 41>,
                                             metadata: HydroIrMetadata {
                                                 location_id: Tick(21, Cluster(loc3v1)),
-                                                collection_kind: KeyedStream {
+                                                collection_kind: Stream {
                                                     bound: Bounded,
-                                                    value_order: NoOrder,
-                                                    value_retry: ExactlyOnce,
-                                                    key_type: (u32 , i32),
-                                                    value_type: core :: result :: Result < () , () >,
+                                                    order: NoOrder,
+                                                    retry: ExactlyOnce,
+                                                    element_type: ((u32 , i32) , core :: result :: Result < () , () >),
                                                 },
                                             },
                                         },
-                                        trusted: false,
                                         metadata: HydroIrMetadata {
                                             location_id: Tick(21, Cluster(loc3v1)),
                                             collection_kind: KeyedStream {
                                                 bound: Bounded,
-                                                value_order: TotalOrder,
+                                                value_order: NoOrder,
                                                 value_retry: ExactlyOnce,
                                                 key_type: (u32 , i32),
                                                 value_type: core :: result :: Result < () , () >,
@@ -7809,66 +7733,43 @@ expression: built.ir()
                             inner: <shared 46>: Fold {
                                 init: stageleft :: runtime_support :: fn0_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; move | | Histogram :: < u64 > :: new (3) . unwrap () }),
                                 acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , core :: time :: Duration , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; move | latencies , latency | { latencies . record (latency . as_nanos () as u64) . unwrap () ; } }),
-                                input: ObserveNonDet {
-                                    inner: Tee {
-                                        inner: <shared 47>: Batch {
-                                            inner: Map {
-                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , (i32 , core :: time :: Duration)) , core :: time :: Duration > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; | (_virtual_client_id , (_output , latency)) | latency }),
-                                                input: Cast {
-                                                    inner: YieldConcat {
+                                input: Tee {
+                                    inner: <shared 47>: Batch {
+                                        inner: Map {
+                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , (i32 , core :: time :: Duration)) , core :: time :: Duration > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; | (_virtual_client_id , (_output , latency)) | latency }),
+                                            input: Cast {
+                                                inner: YieldConcat {
+                                                    inner: Cast {
                                                         inner: Cast {
-                                                            inner: Cast {
-                                                                inner: Map {
-                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , (std :: time :: Instant , (std :: time :: Instant , i32))) , (u32 , (i32 , core :: time :: Duration)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < (std :: time :: Instant , (std :: time :: Instant , i32)) , (i32 , core :: time :: Duration) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (start_time , (end_time , output)) | (output , end_time . duration_since (start_time)) }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
-                                                                    input: Cast {
-                                                                        inner: Cast {
-                                                                            inner: JoinHalf {
-                                                                                left: Cast {
-                                                                                    inner: Cast {
-                                                                                        inner: DeferTick {
-                                                                                            input: Batch {
-                                                                                                inner: FoldKeyed {
-                                                                                                    init: stageleft :: runtime_support :: fn0_type_hint :: < std :: time :: Instant > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | | Instant :: now () }),
-                                                                                                    acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: time :: Instant , i32 , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | curr , _new | { * curr = Instant :: now () ; } }),
-                                                                                                    input: ObserveNonDet {
-                                                                                                        inner: Tee {
-                                                                                                            inner: <shared 16>,
-                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                location_id: Cluster(loc3v1),
-                                                                                                                collection_kind: KeyedStream {
-                                                                                                                    bound: Unbounded,
-                                                                                                                    value_order: NoOrder,
-                                                                                                                    value_retry: ExactlyOnce,
-                                                                                                                    key_type: u32,
-                                                                                                                    value_type: i32,
-                                                                                                                },
-                                                                                                            },
-                                                                                                        },
-                                                                                                        trusted: false,
-                                                                                                        metadata: HydroIrMetadata {
-                                                                                                            location_id: Cluster(loc3v1),
-                                                                                                            collection_kind: KeyedStream {
-                                                                                                                bound: Unbounded,
-                                                                                                                value_order: TotalOrder,
-                                                                                                                value_retry: ExactlyOnce,
-                                                                                                                key_type: u32,
-                                                                                                                value_type: i32,
-                                                                                                            },
-                                                                                                        },
-                                                                                                    },
+                                                            inner: Map {
+                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , (std :: time :: Instant , (std :: time :: Instant , i32))) , (u32 , (i32 , core :: time :: Duration)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < (std :: time :: Instant , (std :: time :: Instant , i32)) , (i32 , core :: time :: Duration) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (start_time , (end_time , output)) | (output , end_time . duration_since (start_time)) }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
+                                                                input: Cast {
+                                                                    inner: Cast {
+                                                                        inner: JoinHalf {
+                                                                            left: Cast {
+                                                                                inner: Cast {
+                                                                                    inner: DeferTick {
+                                                                                        input: Batch {
+                                                                                            inner: FoldKeyed {
+                                                                                                init: stageleft :: runtime_support :: fn0_type_hint :: < std :: time :: Instant > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | | Instant :: now () }),
+                                                                                                acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: time :: Instant , i32 , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | curr , _new | { * curr = Instant :: now () ; } }),
+                                                                                                input: Tee {
+                                                                                                    inner: <shared 16>,
                                                                                                     metadata: HydroIrMetadata {
                                                                                                         location_id: Cluster(loc3v1),
-                                                                                                        collection_kind: KeyedSingleton {
+                                                                                                        collection_kind: KeyedStream {
                                                                                                             bound: Unbounded,
+                                                                                                            value_order: NoOrder,
+                                                                                                            value_retry: ExactlyOnce,
                                                                                                             key_type: u32,
-                                                                                                            value_type: std :: time :: Instant,
+                                                                                                            value_type: i32,
                                                                                                         },
                                                                                                     },
                                                                                                 },
                                                                                                 metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(22, Cluster(loc3v1)),
+                                                                                                    location_id: Cluster(loc3v1),
                                                                                                     collection_kind: KeyedSingleton {
-                                                                                                        bound: Bounded,
+                                                                                                        bound: Unbounded,
                                                                                                         key_type: u32,
                                                                                                         value_type: std :: time :: Instant,
                                                                                                     },
@@ -7885,10 +7786,8 @@ expression: built.ir()
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
                                                                                             location_id: Tick(22, Cluster(loc3v1)),
-                                                                                            collection_kind: KeyedStream {
+                                                                                            collection_kind: KeyedSingleton {
                                                                                                 bound: Bounded,
-                                                                                                value_order: TotalOrder,
-                                                                                                value_retry: ExactlyOnce,
                                                                                                 key_type: u32,
                                                                                                 value_type: std :: time :: Instant,
                                                                                             },
@@ -7896,39 +7795,39 @@ expression: built.ir()
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_id: Tick(22, Cluster(loc3v1)),
-                                                                                        collection_kind: Stream {
+                                                                                        collection_kind: KeyedStream {
                                                                                             bound: Bounded,
-                                                                                            order: NoOrder,
-                                                                                            retry: ExactlyOnce,
-                                                                                            element_type: (u32 , std :: time :: Instant),
+                                                                                            value_order: TotalOrder,
+                                                                                            value_retry: ExactlyOnce,
+                                                                                            key_type: u32,
+                                                                                            value_type: std :: time :: Instant,
                                                                                         },
                                                                                     },
                                                                                 },
-                                                                                right: Cast {
-                                                                                    inner: Cast {
-                                                                                        inner: Map {
-                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , i32) , (u32 , (std :: time :: Instant , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < i32 , (std :: time :: Instant , i32) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | output | (Instant :: now () , output) }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
-                                                                                            input: ReduceKeyed {
-                                                                                                f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < i32 , i32 , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | curr , new | { * curr = new ; } }),
-                                                                                                input: ObserveNonDet {
-                                                                                                    inner: Batch {
-                                                                                                        inner: Tee {
-                                                                                                            inner: <shared 45>,
-                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                location_id: Cluster(loc3v1),
-                                                                                                                collection_kind: KeyedStream {
-                                                                                                                    bound: Unbounded,
-                                                                                                                    value_order: NoOrder,
-                                                                                                                    value_retry: ExactlyOnce,
-                                                                                                                    key_type: u32,
-                                                                                                                    value_type: i32,
-                                                                                                                },
-                                                                                                            },
-                                                                                                        },
+                                                                                metadata: HydroIrMetadata {
+                                                                                    location_id: Tick(22, Cluster(loc3v1)),
+                                                                                    collection_kind: Stream {
+                                                                                        bound: Bounded,
+                                                                                        order: NoOrder,
+                                                                                        retry: ExactlyOnce,
+                                                                                        element_type: (u32 , std :: time :: Instant),
+                                                                                    },
+                                                                                },
+                                                                            },
+                                                                            right: Cast {
+                                                                                inner: Cast {
+                                                                                    inner: Map {
+                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , i32) , (u32 , (std :: time :: Instant , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < i32 , (std :: time :: Instant , i32) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | output | (Instant :: now () , output) }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
+                                                                                        input: ReduceKeyed {
+                                                                                            f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < i32 , i32 , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | curr , new | { * curr = new ; } }),
+                                                                                            input: ObserveNonDet {
+                                                                                                inner: Batch {
+                                                                                                    inner: Tee {
+                                                                                                        inner: <shared 45>,
                                                                                                         metadata: HydroIrMetadata {
-                                                                                                            location_id: Tick(22, Cluster(loc3v1)),
+                                                                                                            location_id: Cluster(loc3v1),
                                                                                                             collection_kind: KeyedStream {
-                                                                                                                bound: Bounded,
+                                                                                                                bound: Unbounded,
                                                                                                                 value_order: NoOrder,
                                                                                                                 value_retry: ExactlyOnce,
                                                                                                                 key_type: u32,
@@ -7936,22 +7835,24 @@ expression: built.ir()
                                                                                                             },
                                                                                                         },
                                                                                                     },
-                                                                                                    trusted: false,
                                                                                                     metadata: HydroIrMetadata {
                                                                                                         location_id: Tick(22, Cluster(loc3v1)),
                                                                                                         collection_kind: KeyedStream {
                                                                                                             bound: Bounded,
-                                                                                                            value_order: TotalOrder,
+                                                                                                            value_order: NoOrder,
                                                                                                             value_retry: ExactlyOnce,
                                                                                                             key_type: u32,
                                                                                                             value_type: i32,
                                                                                                         },
                                                                                                     },
                                                                                                 },
+                                                                                                trusted: false,
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_id: Tick(22, Cluster(loc3v1)),
-                                                                                                    collection_kind: KeyedSingleton {
+                                                                                                    collection_kind: KeyedStream {
                                                                                                         bound: Bounded,
+                                                                                                        value_order: TotalOrder,
+                                                                                                        value_retry: ExactlyOnce,
                                                                                                         key_type: u32,
                                                                                                         value_type: i32,
                                                                                                     },
@@ -7962,16 +7863,14 @@ expression: built.ir()
                                                                                                 collection_kind: KeyedSingleton {
                                                                                                     bound: Bounded,
                                                                                                     key_type: u32,
-                                                                                                    value_type: (std :: time :: Instant , i32),
+                                                                                                    value_type: i32,
                                                                                                 },
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
                                                                                             location_id: Tick(22, Cluster(loc3v1)),
-                                                                                            collection_kind: KeyedStream {
+                                                                                            collection_kind: KeyedSingleton {
                                                                                                 bound: Bounded,
-                                                                                                value_order: TotalOrder,
-                                                                                                value_retry: ExactlyOnce,
                                                                                                 key_type: u32,
                                                                                                 value_type: (std :: time :: Instant , i32),
                                                                                             },
@@ -7979,11 +7878,12 @@ expression: built.ir()
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_id: Tick(22, Cluster(loc3v1)),
-                                                                                        collection_kind: Stream {
+                                                                                        collection_kind: KeyedStream {
                                                                                             bound: Bounded,
-                                                                                            order: NoOrder,
-                                                                                            retry: ExactlyOnce,
-                                                                                            element_type: (u32 , (std :: time :: Instant , i32)),
+                                                                                            value_order: TotalOrder,
+                                                                                            value_retry: ExactlyOnce,
+                                                                                            key_type: u32,
+                                                                                            value_type: (std :: time :: Instant , i32),
                                                                                         },
                                                                                     },
                                                                                 },
@@ -7993,25 +7893,26 @@ expression: built.ir()
                                                                                         bound: Bounded,
                                                                                         order: NoOrder,
                                                                                         retry: ExactlyOnce,
-                                                                                        element_type: (u32 , (std :: time :: Instant , (std :: time :: Instant , i32))),
+                                                                                        element_type: (u32 , (std :: time :: Instant , i32)),
                                                                                     },
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
                                                                                 location_id: Tick(22, Cluster(loc3v1)),
-                                                                                collection_kind: KeyedStream {
+                                                                                collection_kind: Stream {
                                                                                     bound: Bounded,
-                                                                                    value_order: NoOrder,
-                                                                                    value_retry: ExactlyOnce,
-                                                                                    key_type: u32,
-                                                                                    value_type: (std :: time :: Instant , (std :: time :: Instant , i32)),
+                                                                                    order: NoOrder,
+                                                                                    retry: ExactlyOnce,
+                                                                                    element_type: (u32 , (std :: time :: Instant , (std :: time :: Instant , i32))),
                                                                                 },
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
                                                                             location_id: Tick(22, Cluster(loc3v1)),
-                                                                            collection_kind: KeyedSingleton {
+                                                                            collection_kind: KeyedStream {
                                                                                 bound: Bounded,
+                                                                                value_order: NoOrder,
+                                                                                value_retry: ExactlyOnce,
                                                                                 key_type: u32,
                                                                                 value_type: (std :: time :: Instant , (std :: time :: Instant , i32)),
                                                                             },
@@ -8022,16 +7923,14 @@ expression: built.ir()
                                                                         collection_kind: KeyedSingleton {
                                                                             bound: Bounded,
                                                                             key_type: u32,
-                                                                            value_type: (i32 , core :: time :: Duration),
+                                                                            value_type: (std :: time :: Instant , (std :: time :: Instant , i32)),
                                                                         },
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
                                                                     location_id: Tick(22, Cluster(loc3v1)),
-                                                                    collection_kind: KeyedStream {
+                                                                    collection_kind: KeyedSingleton {
                                                                         bound: Bounded,
-                                                                        value_order: TotalOrder,
-                                                                        value_retry: ExactlyOnce,
                                                                         key_type: u32,
                                                                         value_type: (i32 , core :: time :: Duration),
                                                                     },
@@ -8041,7 +7940,7 @@ expression: built.ir()
                                                                 location_id: Tick(22, Cluster(loc3v1)),
                                                                 collection_kind: KeyedStream {
                                                                     bound: Bounded,
-                                                                    value_order: NoOrder,
+                                                                    value_order: TotalOrder,
                                                                     value_retry: ExactlyOnce,
                                                                     key_type: u32,
                                                                     value_type: (i32 , core :: time :: Duration),
@@ -8049,9 +7948,9 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Cluster(loc3v1),
+                                                            location_id: Tick(22, Cluster(loc3v1)),
                                                             collection_kind: KeyedStream {
-                                                                bound: Unbounded,
+                                                                bound: Bounded,
                                                                 value_order: NoOrder,
                                                                 value_retry: ExactlyOnce,
                                                                 key_type: u32,
@@ -8061,11 +7960,12 @@ expression: built.ir()
                                                     },
                                                     metadata: HydroIrMetadata {
                                                         location_id: Cluster(loc3v1),
-                                                        collection_kind: Stream {
+                                                        collection_kind: KeyedStream {
                                                             bound: Unbounded,
-                                                            order: NoOrder,
-                                                            retry: ExactlyOnce,
-                                                            element_type: (u32 , (i32 , core :: time :: Duration)),
+                                                            value_order: NoOrder,
+                                                            value_retry: ExactlyOnce,
+                                                            key_type: u32,
+                                                            value_type: (i32 , core :: time :: Duration),
                                                         },
                                                     },
                                                 },
@@ -8075,14 +7975,14 @@ expression: built.ir()
                                                         bound: Unbounded,
                                                         order: NoOrder,
                                                         retry: ExactlyOnce,
-                                                        element_type: core :: time :: Duration,
+                                                        element_type: (u32 , (i32 , core :: time :: Duration)),
                                                     },
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(23, Cluster(loc3v1)),
+                                                location_id: Cluster(loc3v1),
                                                 collection_kind: Stream {
-                                                    bound: Bounded,
+                                                    bound: Unbounded,
                                                     order: NoOrder,
                                                     retry: ExactlyOnce,
                                                     element_type: core :: time :: Duration,
@@ -8099,12 +7999,11 @@ expression: built.ir()
                                             },
                                         },
                                     },
-                                    trusted: false,
                                     metadata: HydroIrMetadata {
                                         location_id: Tick(23, Cluster(loc3v1)),
                                         collection_kind: Stream {
                                             bound: Bounded,
-                                            order: TotalOrder,
+                                            order: NoOrder,
                                             retry: ExactlyOnce,
                                             element_type: core :: time :: Duration,
                                         },
@@ -9276,65 +9175,56 @@ expression: built.ir()
         input: Fold {
             init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | | 0usize }),
             acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | curr , new | { * curr += new ; } }),
-            input: ObserveNonDet {
-                inner: Chain {
-                    first: Batch {
-                        inner: Map {
-                            f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , usize) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                            input: Cast {
-                                inner: Cast {
-                                    inner: Network {
-                                        name: None,
-                                        networking_info: Tcp {
-                                            fault: FailStop,
-                                        },
-                                        serialize_fn: Some(
-                                            hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < usize , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
-                                        ),
-                                        instantiate_fn: <network instantiate>,
-                                        deserialize_fn: Some(
-                                            | res | { let (id , b) = res . unwrap () ; (hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos_bench :: Client > :: from_tagless (id as hydro_lang :: __staged :: location :: TaglessMemberId) , hydro_lang :: runtime_support :: bincode :: deserialize :: < usize > (& b) . unwrap ()) },
-                                        ),
-                                        input: YieldConcat {
-                                            inner: Cast {
-                                                inner: Map {
-                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                                                    input: CrossSingleton {
-                                                        left: Tee {
-                                                            inner: <shared 53>,
-                                                            metadata: HydroIrMetadata {
-                                                                location_id: Tick(23, Cluster(loc3v1)),
-                                                                collection_kind: Singleton {
-                                                                    bound: Bounded,
-                                                                    element_type: usize,
-                                                                },
+            input: Chain {
+                first: Batch {
+                    inner: Map {
+                        f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , usize) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
+                        input: Cast {
+                            inner: Cast {
+                                inner: Network {
+                                    name: None,
+                                    networking_info: Tcp {
+                                        fault: FailStop,
+                                    },
+                                    serialize_fn: Some(
+                                        hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < usize , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
+                                    ),
+                                    instantiate_fn: <network instantiate>,
+                                    deserialize_fn: Some(
+                                        | res | { let (id , b) = res . unwrap () ; (hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos_bench :: Client > :: from_tagless (id as hydro_lang :: __staged :: location :: TaglessMemberId) , hydro_lang :: runtime_support :: bincode :: deserialize :: < usize > (& b) . unwrap ()) },
+                                    ),
+                                    input: YieldConcat {
+                                        inner: Cast {
+                                            inner: Map {
+                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
+                                                input: CrossSingleton {
+                                                    left: Tee {
+                                                        inner: <shared 53>,
+                                                        metadata: HydroIrMetadata {
+                                                            location_id: Tick(23, Cluster(loc3v1)),
+                                                            collection_kind: Singleton {
+                                                                bound: Bounded,
+                                                                element_type: usize,
                                                             },
                                                         },
-                                                        right: Filter {
-                                                            f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
-                                                            input: Map {
-                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_some () }),
-                                                                input: Cast {
-                                                                    inner: ChainFirst {
-                                                                        first: Map {
-                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                                            input: Map {
-                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                                                input: Tee {
-                                                                                    inner: <shared 50>,
-                                                                                    metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(23, Cluster(loc3v1)),
-                                                                                        collection_kind: Optional {
-                                                                                            bound: Bounded,
-                                                                                            element_type: hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
-                                                                                        },
-                                                                                    },
-                                                                                },
+                                                    },
+                                                    right: Filter {
+                                                        f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
+                                                        input: Map {
+                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_some () }),
+                                                            input: Cast {
+                                                                inner: ChainFirst {
+                                                                    first: Map {
+                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
+                                                                        input: Map {
+                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                                            input: Tee {
+                                                                                inner: <shared 50>,
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_id: Tick(23, Cluster(loc3v1)),
                                                                                     collection_kind: Optional {
                                                                                         bound: Bounded,
-                                                                                        element_type: (),
+                                                                                        element_type: hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
                                                                                     },
                                                                                 },
                                                                             },
@@ -9342,25 +9232,25 @@ expression: built.ir()
                                                                                 location_id: Tick(23, Cluster(loc3v1)),
                                                                                 collection_kind: Optional {
                                                                                     bound: Bounded,
-                                                                                    element_type: core :: option :: Option < () >,
+                                                                                    element_type: (),
                                                                                 },
                                                                             },
                                                                         },
-                                                                        second: Cast {
-                                                                            inner: SingletonSource {
-                                                                                value: :: std :: option :: Option :: None,
-                                                                                first_tick_only: false,
-                                                                                metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(23, Cluster(loc3v1)),
-                                                                                    collection_kind: Singleton {
-                                                                                        bound: Bounded,
-                                                                                        element_type: core :: option :: Option < () >,
-                                                                                    },
-                                                                                },
+                                                                        metadata: HydroIrMetadata {
+                                                                            location_id: Tick(23, Cluster(loc3v1)),
+                                                                            collection_kind: Optional {
+                                                                                bound: Bounded,
+                                                                                element_type: core :: option :: Option < () >,
                                                                             },
+                                                                        },
+                                                                    },
+                                                                    second: Cast {
+                                                                        inner: SingletonSource {
+                                                                            value: :: std :: option :: Option :: None,
+                                                                            first_tick_only: false,
                                                                             metadata: HydroIrMetadata {
                                                                                 location_id: Tick(23, Cluster(loc3v1)),
-                                                                                collection_kind: Optional {
+                                                                                collection_kind: Singleton {
                                                                                     bound: Bounded,
                                                                                     element_type: core :: option :: Option < () >,
                                                                                 },
@@ -9376,7 +9266,7 @@ expression: built.ir()
                                                                     },
                                                                     metadata: HydroIrMetadata {
                                                                         location_id: Tick(23, Cluster(loc3v1)),
-                                                                        collection_kind: Singleton {
+                                                                        collection_kind: Optional {
                                                                             bound: Bounded,
                                                                             element_type: core :: option :: Option < () >,
                                                                         },
@@ -9386,13 +9276,13 @@ expression: built.ir()
                                                                     location_id: Tick(23, Cluster(loc3v1)),
                                                                     collection_kind: Singleton {
                                                                         bound: Bounded,
-                                                                        element_type: bool,
+                                                                        element_type: core :: option :: Option < () >,
                                                                     },
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
                                                                 location_id: Tick(23, Cluster(loc3v1)),
-                                                                collection_kind: Optional {
+                                                                collection_kind: Singleton {
                                                                     bound: Bounded,
                                                                     element_type: bool,
                                                                 },
@@ -9402,7 +9292,7 @@ expression: built.ir()
                                                             location_id: Tick(23, Cluster(loc3v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
-                                                                element_type: (usize , bool),
+                                                                element_type: bool,
                                                             },
                                                         },
                                                     },
@@ -9410,24 +9300,22 @@ expression: built.ir()
                                                         location_id: Tick(23, Cluster(loc3v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
-                                                            element_type: usize,
+                                                            element_type: (usize , bool),
                                                         },
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
                                                     location_id: Tick(23, Cluster(loc3v1)),
-                                                    collection_kind: Stream {
+                                                    collection_kind: Optional {
                                                         bound: Bounded,
-                                                        order: TotalOrder,
-                                                        retry: ExactlyOnce,
                                                         element_type: usize,
                                                     },
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Cluster(loc3v1),
+                                                location_id: Tick(23, Cluster(loc3v1)),
                                                 collection_kind: Stream {
-                                                    bound: Unbounded,
+                                                    bound: Bounded,
                                                     order: TotalOrder,
                                                     retry: ExactlyOnce,
                                                     element_type: usize,
@@ -9435,33 +9323,33 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Process(loc4v1),
+                                            location_id: Cluster(loc3v1),
                                             collection_kind: Stream {
                                                 bound: Unbounded,
                                                 order: TotalOrder,
                                                 retry: ExactlyOnce,
-                                                element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , usize),
+                                                element_type: usize,
                                             },
                                         },
                                     },
                                     metadata: HydroIrMetadata {
                                         location_id: Process(loc4v1),
-                                        collection_kind: KeyedStream {
+                                        collection_kind: Stream {
                                             bound: Unbounded,
-                                            value_order: TotalOrder,
-                                            value_retry: ExactlyOnce,
-                                            key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >,
-                                            value_type: usize,
+                                            order: TotalOrder,
+                                            retry: ExactlyOnce,
+                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , usize),
                                         },
                                     },
                                 },
                                 metadata: HydroIrMetadata {
                                     location_id: Process(loc4v1),
-                                    collection_kind: Stream {
+                                    collection_kind: KeyedStream {
                                         bound: Unbounded,
-                                        order: NoOrder,
-                                        retry: ExactlyOnce,
-                                        element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , usize),
+                                        value_order: TotalOrder,
+                                        value_retry: ExactlyOnce,
+                                        key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >,
+                                        value_type: usize,
                                     },
                                 },
                             },
@@ -9471,201 +9359,15 @@ expression: built.ir()
                                     bound: Unbounded,
                                     order: NoOrder,
                                     retry: ExactlyOnce,
-                                    element_type: usize,
+                                    element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , usize),
                                 },
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(24, Process(loc4v1)),
+                            location_id: Process(loc4v1),
                             collection_kind: Stream {
-                                bound: Bounded,
+                                bound: Unbounded,
                                 order: NoOrder,
-                                retry: ExactlyOnce,
-                                element_type: usize,
-                            },
-                        },
-                    },
-                    second: Cast {
-                        inner: Map {
-                            f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                            input: CrossSingleton {
-                                left: Tee {
-                                    inner: <shared 56>: Cast {
-                                        inner: ChainFirst {
-                                            first: DeferTick {
-                                                input: CycleSource {
-                                                    cycle_id: CycleId(
-                                                        24,
-                                                    ),
-                                                    metadata: HydroIrMetadata {
-                                                        location_id: Tick(24, Process(loc4v1)),
-                                                        collection_kind: Singleton {
-                                                            bound: Bounded,
-                                                            element_type: usize,
-                                                        },
-                                                    },
-                                                },
-                                                metadata: HydroIrMetadata {
-                                                    location_id: Tick(24, Process(loc4v1)),
-                                                    collection_kind: Optional {
-                                                        bound: Bounded,
-                                                        element_type: usize,
-                                                    },
-                                                },
-                                            },
-                                            second: Cast {
-                                                inner: SingletonSource {
-                                                    value: { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; 0usize },
-                                                    first_tick_only: false,
-                                                    metadata: HydroIrMetadata {
-                                                        location_id: Tick(24, Process(loc4v1)),
-                                                        collection_kind: Singleton {
-                                                            bound: Bounded,
-                                                            element_type: usize,
-                                                        },
-                                                    },
-                                                },
-                                                metadata: HydroIrMetadata {
-                                                    location_id: Tick(24, Process(loc4v1)),
-                                                    collection_kind: Optional {
-                                                        bound: Bounded,
-                                                        element_type: usize,
-                                                    },
-                                                },
-                                            },
-                                            metadata: HydroIrMetadata {
-                                                location_id: Tick(24, Process(loc4v1)),
-                                                collection_kind: Optional {
-                                                    bound: Bounded,
-                                                    element_type: usize,
-                                                },
-                                            },
-                                        },
-                                        metadata: HydroIrMetadata {
-                                            location_id: Tick(24, Process(loc4v1)),
-                                            collection_kind: Singleton {
-                                                bound: Bounded,
-                                                element_type: usize,
-                                            },
-                                        },
-                                    },
-                                    metadata: HydroIrMetadata {
-                                        location_id: Tick(24, Process(loc4v1)),
-                                        collection_kind: Singleton {
-                                            bound: Bounded,
-                                            element_type: usize,
-                                        },
-                                    },
-                                },
-                                right: Filter {
-                                    f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
-                                    input: Map {
-                                        f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_none () }),
-                                        input: Cast {
-                                            inner: ChainFirst {
-                                                first: Map {
-                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                    input: Map {
-                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                        input: Tee {
-                                                            inner: <shared 55>,
-                                                            metadata: HydroIrMetadata {
-                                                                location_id: Tick(24, Process(loc4v1)),
-                                                                collection_kind: Optional {
-                                                                    bound: Bounded,
-                                                                    element_type: hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
-                                                                },
-                                                            },
-                                                        },
-                                                        metadata: HydroIrMetadata {
-                                                            location_id: Tick(24, Process(loc4v1)),
-                                                            collection_kind: Optional {
-                                                                bound: Bounded,
-                                                                element_type: (),
-                                                            },
-                                                        },
-                                                    },
-                                                    metadata: HydroIrMetadata {
-                                                        location_id: Tick(24, Process(loc4v1)),
-                                                        collection_kind: Optional {
-                                                            bound: Bounded,
-                                                            element_type: core :: option :: Option < () >,
-                                                        },
-                                                    },
-                                                },
-                                                second: Cast {
-                                                    inner: SingletonSource {
-                                                        value: :: std :: option :: Option :: None,
-                                                        first_tick_only: false,
-                                                        metadata: HydroIrMetadata {
-                                                            location_id: Tick(24, Process(loc4v1)),
-                                                            collection_kind: Singleton {
-                                                                bound: Bounded,
-                                                                element_type: core :: option :: Option < () >,
-                                                            },
-                                                        },
-                                                    },
-                                                    metadata: HydroIrMetadata {
-                                                        location_id: Tick(24, Process(loc4v1)),
-                                                        collection_kind: Optional {
-                                                            bound: Bounded,
-                                                            element_type: core :: option :: Option < () >,
-                                                        },
-                                                    },
-                                                },
-                                                metadata: HydroIrMetadata {
-                                                    location_id: Tick(24, Process(loc4v1)),
-                                                    collection_kind: Optional {
-                                                        bound: Bounded,
-                                                        element_type: core :: option :: Option < () >,
-                                                    },
-                                                },
-                                            },
-                                            metadata: HydroIrMetadata {
-                                                location_id: Tick(24, Process(loc4v1)),
-                                                collection_kind: Singleton {
-                                                    bound: Bounded,
-                                                    element_type: core :: option :: Option < () >,
-                                                },
-                                            },
-                                        },
-                                        metadata: HydroIrMetadata {
-                                            location_id: Tick(24, Process(loc4v1)),
-                                            collection_kind: Singleton {
-                                                bound: Bounded,
-                                                element_type: bool,
-                                            },
-                                        },
-                                    },
-                                    metadata: HydroIrMetadata {
-                                        location_id: Tick(24, Process(loc4v1)),
-                                        collection_kind: Optional {
-                                            bound: Bounded,
-                                            element_type: bool,
-                                        },
-                                    },
-                                },
-                                metadata: HydroIrMetadata {
-                                    location_id: Tick(24, Process(loc4v1)),
-                                    collection_kind: Optional {
-                                        bound: Bounded,
-                                        element_type: (usize , bool),
-                                    },
-                                },
-                            },
-                            metadata: HydroIrMetadata {
-                                location_id: Tick(24, Process(loc4v1)),
-                                collection_kind: Optional {
-                                    bound: Bounded,
-                                    element_type: usize,
-                                },
-                            },
-                        },
-                        metadata: HydroIrMetadata {
-                            location_id: Tick(24, Process(loc4v1)),
-                            collection_kind: Stream {
-                                bound: Bounded,
-                                order: TotalOrder,
                                 retry: ExactlyOnce,
                                 element_type: usize,
                             },
@@ -9681,12 +9383,197 @@ expression: built.ir()
                         },
                     },
                 },
-                trusted: false,
+                second: Cast {
+                    inner: Map {
+                        f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
+                        input: CrossSingleton {
+                            left: Tee {
+                                inner: <shared 56>: Cast {
+                                    inner: ChainFirst {
+                                        first: DeferTick {
+                                            input: CycleSource {
+                                                cycle_id: CycleId(
+                                                    24,
+                                                ),
+                                                metadata: HydroIrMetadata {
+                                                    location_id: Tick(24, Process(loc4v1)),
+                                                    collection_kind: Singleton {
+                                                        bound: Bounded,
+                                                        element_type: usize,
+                                                    },
+                                                },
+                                            },
+                                            metadata: HydroIrMetadata {
+                                                location_id: Tick(24, Process(loc4v1)),
+                                                collection_kind: Optional {
+                                                    bound: Bounded,
+                                                    element_type: usize,
+                                                },
+                                            },
+                                        },
+                                        second: Cast {
+                                            inner: SingletonSource {
+                                                value: { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; 0usize },
+                                                first_tick_only: false,
+                                                metadata: HydroIrMetadata {
+                                                    location_id: Tick(24, Process(loc4v1)),
+                                                    collection_kind: Singleton {
+                                                        bound: Bounded,
+                                                        element_type: usize,
+                                                    },
+                                                },
+                                            },
+                                            metadata: HydroIrMetadata {
+                                                location_id: Tick(24, Process(loc4v1)),
+                                                collection_kind: Optional {
+                                                    bound: Bounded,
+                                                    element_type: usize,
+                                                },
+                                            },
+                                        },
+                                        metadata: HydroIrMetadata {
+                                            location_id: Tick(24, Process(loc4v1)),
+                                            collection_kind: Optional {
+                                                bound: Bounded,
+                                                element_type: usize,
+                                            },
+                                        },
+                                    },
+                                    metadata: HydroIrMetadata {
+                                        location_id: Tick(24, Process(loc4v1)),
+                                        collection_kind: Singleton {
+                                            bound: Bounded,
+                                            element_type: usize,
+                                        },
+                                    },
+                                },
+                                metadata: HydroIrMetadata {
+                                    location_id: Tick(24, Process(loc4v1)),
+                                    collection_kind: Singleton {
+                                        bound: Bounded,
+                                        element_type: usize,
+                                    },
+                                },
+                            },
+                            right: Filter {
+                                f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
+                                input: Map {
+                                    f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_none () }),
+                                    input: Cast {
+                                        inner: ChainFirst {
+                                            first: Map {
+                                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
+                                                input: Map {
+                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                    input: Tee {
+                                                        inner: <shared 55>,
+                                                        metadata: HydroIrMetadata {
+                                                            location_id: Tick(24, Process(loc4v1)),
+                                                            collection_kind: Optional {
+                                                                bound: Bounded,
+                                                                element_type: hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
+                                                            },
+                                                        },
+                                                    },
+                                                    metadata: HydroIrMetadata {
+                                                        location_id: Tick(24, Process(loc4v1)),
+                                                        collection_kind: Optional {
+                                                            bound: Bounded,
+                                                            element_type: (),
+                                                        },
+                                                    },
+                                                },
+                                                metadata: HydroIrMetadata {
+                                                    location_id: Tick(24, Process(loc4v1)),
+                                                    collection_kind: Optional {
+                                                        bound: Bounded,
+                                                        element_type: core :: option :: Option < () >,
+                                                    },
+                                                },
+                                            },
+                                            second: Cast {
+                                                inner: SingletonSource {
+                                                    value: :: std :: option :: Option :: None,
+                                                    first_tick_only: false,
+                                                    metadata: HydroIrMetadata {
+                                                        location_id: Tick(24, Process(loc4v1)),
+                                                        collection_kind: Singleton {
+                                                            bound: Bounded,
+                                                            element_type: core :: option :: Option < () >,
+                                                        },
+                                                    },
+                                                },
+                                                metadata: HydroIrMetadata {
+                                                    location_id: Tick(24, Process(loc4v1)),
+                                                    collection_kind: Optional {
+                                                        bound: Bounded,
+                                                        element_type: core :: option :: Option < () >,
+                                                    },
+                                                },
+                                            },
+                                            metadata: HydroIrMetadata {
+                                                location_id: Tick(24, Process(loc4v1)),
+                                                collection_kind: Optional {
+                                                    bound: Bounded,
+                                                    element_type: core :: option :: Option < () >,
+                                                },
+                                            },
+                                        },
+                                        metadata: HydroIrMetadata {
+                                            location_id: Tick(24, Process(loc4v1)),
+                                            collection_kind: Singleton {
+                                                bound: Bounded,
+                                                element_type: core :: option :: Option < () >,
+                                            },
+                                        },
+                                    },
+                                    metadata: HydroIrMetadata {
+                                        location_id: Tick(24, Process(loc4v1)),
+                                        collection_kind: Singleton {
+                                            bound: Bounded,
+                                            element_type: bool,
+                                        },
+                                    },
+                                },
+                                metadata: HydroIrMetadata {
+                                    location_id: Tick(24, Process(loc4v1)),
+                                    collection_kind: Optional {
+                                        bound: Bounded,
+                                        element_type: bool,
+                                    },
+                                },
+                            },
+                            metadata: HydroIrMetadata {
+                                location_id: Tick(24, Process(loc4v1)),
+                                collection_kind: Optional {
+                                    bound: Bounded,
+                                    element_type: (usize , bool),
+                                },
+                            },
+                        },
+                        metadata: HydroIrMetadata {
+                            location_id: Tick(24, Process(loc4v1)),
+                            collection_kind: Optional {
+                                bound: Bounded,
+                                element_type: usize,
+                            },
+                        },
+                    },
+                    metadata: HydroIrMetadata {
+                        location_id: Tick(24, Process(loc4v1)),
+                        collection_kind: Stream {
+                            bound: Bounded,
+                            order: TotalOrder,
+                            retry: ExactlyOnce,
+                            element_type: usize,
+                        },
+                    },
+                },
                 metadata: HydroIrMetadata {
                     location_id: Tick(24, Process(loc4v1)),
                     collection_kind: Stream {
                         bound: Bounded,
-                        order: TotalOrder,
+                        order: NoOrder,
                         retry: ExactlyOnce,
                         element_type: usize,
                     },

--- a/hydro_test/src/cluster/snapshots/paxos_ir@acceptor_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir@acceptor_mermaid.snap
@@ -130,157 +130,157 @@ subgraph var_cycle_4 ["var <tt>cycle_4</tt>"]
     style var_cycle_4 fill:transparent
     40v1
 end
-subgraph var_reduce_keyed_watermark_chain_530 ["var <tt>reduce_keyed_watermark_chain_530</tt>"]
-    style var_reduce_keyed_watermark_chain_530 fill:transparent
+subgraph var_reduce_keyed_watermark_chain_526 ["var <tt>reduce_keyed_watermark_chain_526</tt>"]
+    style var_reduce_keyed_watermark_chain_526 fill:transparent
     33v1
 end
-subgraph var_stream_165 ["var <tt>stream_165</tt>"]
-    style var_stream_165 fill:transparent
+subgraph var_stream_164 ["var <tt>stream_164</tt>"]
+    style var_stream_164 fill:transparent
     3v1
     4v1
 end
-subgraph var_stream_167 ["var <tt>stream_167</tt>"]
-    style var_stream_167 fill:transparent
+subgraph var_stream_166 ["var <tt>stream_166</tt>"]
+    style var_stream_166 fill:transparent
     5v1
 end
-subgraph var_stream_169 ["var <tt>stream_169</tt>"]
-    style var_stream_169 fill:transparent
+subgraph var_stream_168 ["var <tt>stream_168</tt>"]
+    style var_stream_168 fill:transparent
     6v1
 end
-subgraph var_stream_171 ["var <tt>stream_171</tt>"]
-    style var_stream_171 fill:transparent
+subgraph var_stream_170 ["var <tt>stream_170</tt>"]
+    style var_stream_170 fill:transparent
     7v1
 end
-subgraph var_stream_174 ["var <tt>stream_174</tt>"]
-    style var_stream_174 fill:transparent
+subgraph var_stream_173 ["var <tt>stream_173</tt>"]
+    style var_stream_173 fill:transparent
     8v1
 end
-subgraph var_stream_176 ["var <tt>stream_176</tt>"]
-    style var_stream_176 fill:transparent
+subgraph var_stream_175 ["var <tt>stream_175</tt>"]
+    style var_stream_175 fill:transparent
     9v1
     10v1
 end
-subgraph var_stream_178 ["var <tt>stream_178</tt>"]
-    style var_stream_178 fill:transparent
+subgraph var_stream_177 ["var <tt>stream_177</tt>"]
+    style var_stream_177 fill:transparent
     11v1
 end
-subgraph var_stream_180 ["var <tt>stream_180</tt>"]
-    style var_stream_180 fill:transparent
+subgraph var_stream_179 ["var <tt>stream_179</tt>"]
+    style var_stream_179 fill:transparent
     12v1
 end
-subgraph var_stream_182 ["var <tt>stream_182</tt>"]
-    style var_stream_182 fill:transparent
+subgraph var_stream_181 ["var <tt>stream_181</tt>"]
+    style var_stream_181 fill:transparent
     13v1
+end
+subgraph var_stream_184 ["var <tt>stream_184</tt>"]
+    style var_stream_184 fill:transparent
+    14v1
 end
 subgraph var_stream_185 ["var <tt>stream_185</tt>"]
     style var_stream_185 fill:transparent
-    14v1
-end
-subgraph var_stream_186 ["var <tt>stream_186</tt>"]
-    style var_stream_186 fill:transparent
     15v1
 end
 subgraph var_stream_24 ["var <tt>stream_24</tt>"]
     style var_stream_24 fill:transparent
     1v1
 end
-subgraph var_stream_459 ["var <tt>stream_459</tt>"]
-    style var_stream_459 fill:transparent
+subgraph var_stream_456 ["var <tt>stream_456</tt>"]
+    style var_stream_456 fill:transparent
     18v1
     19v1
 end
-subgraph var_stream_461 ["var <tt>stream_461</tt>"]
-    style var_stream_461 fill:transparent
+subgraph var_stream_458 ["var <tt>stream_458</tt>"]
+    style var_stream_458 fill:transparent
     20v1
+end
+subgraph var_stream_460 ["var <tt>stream_460</tt>"]
+    style var_stream_460 fill:transparent
+    21v1
 end
 subgraph var_stream_463 ["var <tt>stream_463</tt>"]
     style var_stream_463 fill:transparent
-    21v1
-end
-subgraph var_stream_466 ["var <tt>stream_466</tt>"]
-    style var_stream_466 fill:transparent
     22v1
 end
-subgraph var_stream_467 ["var <tt>stream_467</tt>"]
-    style var_stream_467 fill:transparent
+subgraph var_stream_464 ["var <tt>stream_464</tt>"]
+    style var_stream_464 fill:transparent
     23v1
 end
-subgraph var_stream_515 ["var <tt>stream_515</tt>"]
-    style var_stream_515 fill:transparent
+subgraph var_stream_511 ["var <tt>stream_511</tt>"]
+    style var_stream_511 fill:transparent
     26v1
 end
-subgraph var_stream_516 ["var <tt>stream_516</tt>"]
-    style var_stream_516 fill:transparent
+subgraph var_stream_512 ["var <tt>stream_512</tt>"]
+    style var_stream_512 fill:transparent
     27v1
 end
-subgraph var_stream_517 ["var <tt>stream_517</tt>"]
-    style var_stream_517 fill:transparent
+subgraph var_stream_513 ["var <tt>stream_513</tt>"]
+    style var_stream_513 fill:transparent
     28v1
     29v1
 end
-subgraph var_stream_519 ["var <tt>stream_519</tt>"]
-    style var_stream_519 fill:transparent
+subgraph var_stream_515 ["var <tt>stream_515</tt>"]
+    style var_stream_515 fill:transparent
     30v1
 end
-subgraph var_stream_524 ["var <tt>stream_524</tt>"]
-    style var_stream_524 fill:transparent
+subgraph var_stream_520 ["var <tt>stream_520</tt>"]
+    style var_stream_520 fill:transparent
     31v1
 end
-subgraph var_stream_525 ["var <tt>stream_525</tt>"]
-    style var_stream_525 fill:transparent
+subgraph var_stream_521 ["var <tt>stream_521</tt>"]
+    style var_stream_521 fill:transparent
     32v1
 end
-subgraph var_stream_530 ["var <tt>stream_530</tt>"]
-    style var_stream_530 fill:transparent
+subgraph var_stream_526 ["var <tt>stream_526</tt>"]
+    style var_stream_526 fill:transparent
     36v1
     37v1
 end
-subgraph var_stream_535 ["var <tt>stream_535</tt>"]
-    style var_stream_535 fill:transparent
+subgraph var_stream_530 ["var <tt>stream_530</tt>"]
+    style var_stream_530 fill:transparent
     38v1
 end
-subgraph var_stream_536 ["var <tt>stream_536</tt>"]
-    style var_stream_536 fill:transparent
+subgraph var_stream_531 ["var <tt>stream_531</tt>"]
+    style var_stream_531 fill:transparent
     39v1
 end
-subgraph var_stream_648 ["var <tt>stream_648</tt>"]
-    style var_stream_648 fill:transparent
+subgraph var_stream_643 ["var <tt>stream_643</tt>"]
+    style var_stream_643 fill:transparent
     41v1
     42v1
 end
-subgraph var_stream_649 ["var <tt>stream_649</tt>"]
-    style var_stream_649 fill:transparent
+subgraph var_stream_644 ["var <tt>stream_644</tt>"]
+    style var_stream_644 fill:transparent
     43v1
 end
-subgraph var_stream_651 ["var <tt>stream_651</tt>"]
-    style var_stream_651 fill:transparent
+subgraph var_stream_646 ["var <tt>stream_646</tt>"]
+    style var_stream_646 fill:transparent
     44v1
+end
+subgraph var_stream_653 ["var <tt>stream_653</tt>"]
+    style var_stream_653 fill:transparent
+    45v1
+end
+subgraph var_stream_654 ["var <tt>stream_654</tt>"]
+    style var_stream_654 fill:transparent
+    46v1
+end
+subgraph var_stream_655 ["var <tt>stream_655</tt>"]
+    style var_stream_655 fill:transparent
+    47v1
+end
+subgraph var_stream_656 ["var <tt>stream_656</tt>"]
+    style var_stream_656 fill:transparent
+    48v1
+end
+subgraph var_stream_657 ["var <tt>stream_657</tt>"]
+    style var_stream_657 fill:transparent
+    49v1
 end
 subgraph var_stream_658 ["var <tt>stream_658</tt>"]
     style var_stream_658 fill:transparent
-    45v1
-end
-subgraph var_stream_659 ["var <tt>stream_659</tt>"]
-    style var_stream_659 fill:transparent
-    46v1
+    50v1
 end
 subgraph var_stream_660 ["var <tt>stream_660</tt>"]
     style var_stream_660 fill:transparent
-    47v1
-end
-subgraph var_stream_661 ["var <tt>stream_661</tt>"]
-    style var_stream_661 fill:transparent
-    48v1
-end
-subgraph var_stream_662 ["var <tt>stream_662</tt>"]
-    style var_stream_662 fill:transparent
-    49v1
-end
-subgraph var_stream_663 ["var <tt>stream_663</tt>"]
-    style var_stream_663 fill:transparent
-    50v1
-end
-subgraph var_stream_665 ["var <tt>stream_665</tt>"]
-    style var_stream_665 fill:transparent
     51v1
 end

--- a/hydro_test/src/cluster/snapshots/paxos_ir@proposer_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir@proposer_mermaid.snap
@@ -667,326 +667,330 @@ subgraph var_stream_117 ["var <tt>stream_117</tt>"]
     style var_stream_117 fill:transparent
     56v1
 end
-subgraph var_stream_123 ["var <tt>stream_123</tt>"]
-    style var_stream_123 fill:transparent
+subgraph var_stream_122 ["var <tt>stream_122</tt>"]
+    style var_stream_122 fill:transparent
     57v1
 end
-subgraph var_stream_125 ["var <tt>stream_125</tt>"]
-    style var_stream_125 fill:transparent
+subgraph var_stream_124 ["var <tt>stream_124</tt>"]
+    style var_stream_124 fill:transparent
     58v1
+end
+subgraph var_stream_128 ["var <tt>stream_128</tt>"]
+    style var_stream_128 fill:transparent
+    59v1
 end
 subgraph var_stream_129 ["var <tt>stream_129</tt>"]
     style var_stream_129 fill:transparent
-    59v1
+    60v1
 end
 subgraph var_stream_130 ["var <tt>stream_130</tt>"]
     style var_stream_130 fill:transparent
-    60v1
+    61v1
 end
 subgraph var_stream_131 ["var <tt>stream_131</tt>"]
     style var_stream_131 fill:transparent
-    61v1
+    62v1
 end
 subgraph var_stream_132 ["var <tt>stream_132</tt>"]
     style var_stream_132 fill:transparent
-    62v1
+    63v1
 end
 subgraph var_stream_133 ["var <tt>stream_133</tt>"]
     style var_stream_133 fill:transparent
-    63v1
+    64v1
 end
 subgraph var_stream_134 ["var <tt>stream_134</tt>"]
     style var_stream_134 fill:transparent
-    64v1
-end
-subgraph var_stream_135 ["var <tt>stream_135</tt>"]
-    style var_stream_135 fill:transparent
     65v1
     66v1
 end
-subgraph var_stream_137 ["var <tt>stream_137</tt>"]
-    style var_stream_137 fill:transparent
+subgraph var_stream_136 ["var <tt>stream_136</tt>"]
+    style var_stream_136 fill:transparent
     67v1
+end
+subgraph var_stream_138 ["var <tt>stream_138</tt>"]
+    style var_stream_138 fill:transparent
+    68v1
 end
 subgraph var_stream_139 ["var <tt>stream_139</tt>"]
     style var_stream_139 fill:transparent
-    68v1
-end
-subgraph var_stream_140 ["var <tt>stream_140</tt>"]
-    style var_stream_140 fill:transparent
     69v1
+end
+subgraph var_stream_141 ["var <tt>stream_141</tt>"]
+    style var_stream_141 fill:transparent
+    70v1
 end
 subgraph var_stream_142 ["var <tt>stream_142</tt>"]
     style var_stream_142 fill:transparent
-    70v1
+    71v1
 end
 subgraph var_stream_143 ["var <tt>stream_143</tt>"]
     style var_stream_143 fill:transparent
-    71v1
+    72v1
 end
 subgraph var_stream_144 ["var <tt>stream_144</tt>"]
     style var_stream_144 fill:transparent
-    72v1
+    73v1
 end
 subgraph var_stream_145 ["var <tt>stream_145</tt>"]
     style var_stream_145 fill:transparent
-    73v1
+    74v1
 end
 subgraph var_stream_146 ["var <tt>stream_146</tt>"]
     style var_stream_146 fill:transparent
-    74v1
-end
-subgraph var_stream_147 ["var <tt>stream_147</tt>"]
-    style var_stream_147 fill:transparent
     75v1
     76v1
 end
-subgraph var_stream_149 ["var <tt>stream_149</tt>"]
-    style var_stream_149 fill:transparent
+subgraph var_stream_148 ["var <tt>stream_148</tt>"]
+    style var_stream_148 fill:transparent
     77v1
+end
+subgraph var_stream_150 ["var <tt>stream_150</tt>"]
+    style var_stream_150 fill:transparent
+    78v1
 end
 subgraph var_stream_151 ["var <tt>stream_151</tt>"]
     style var_stream_151 fill:transparent
-    78v1
-end
-subgraph var_stream_152 ["var <tt>stream_152</tt>"]
-    style var_stream_152 fill:transparent
     79v1
+end
+subgraph var_stream_153 ["var <tt>stream_153</tt>"]
+    style var_stream_153 fill:transparent
+    80v1
 end
 subgraph var_stream_154 ["var <tt>stream_154</tt>"]
     style var_stream_154 fill:transparent
-    80v1
+    81v1
 end
 subgraph var_stream_155 ["var <tt>stream_155</tt>"]
     style var_stream_155 fill:transparent
-    81v1
+    82v1
 end
 subgraph var_stream_156 ["var <tt>stream_156</tt>"]
     style var_stream_156 fill:transparent
-    82v1
-end
-subgraph var_stream_157 ["var <tt>stream_157</tt>"]
-    style var_stream_157 fill:transparent
     83v1
 end
-subgraph var_stream_160 ["var <tt>stream_160</tt>"]
-    style var_stream_160 fill:transparent
+subgraph var_stream_159 ["var <tt>stream_159</tt>"]
+    style var_stream_159 fill:transparent
     84v1
 end
-subgraph var_stream_162 ["var <tt>stream_162</tt>"]
-    style var_stream_162 fill:transparent
+subgraph var_stream_161 ["var <tt>stream_161</tt>"]
+    style var_stream_161 fill:transparent
     85v1
 end
-subgraph var_stream_189 ["var <tt>stream_189</tt>"]
-    style var_stream_189 fill:transparent
+subgraph var_stream_188 ["var <tt>stream_188</tt>"]
+    style var_stream_188 fill:transparent
     88v1
     89v1
 end
+subgraph var_stream_190 ["var <tt>stream_190</tt>"]
+    style var_stream_190 fill:transparent
+    90v1
+end
 subgraph var_stream_191 ["var <tt>stream_191</tt>"]
     style var_stream_191 fill:transparent
-    90v1
+    91v1
 end
 subgraph var_stream_192 ["var <tt>stream_192</tt>"]
     style var_stream_192 fill:transparent
-    91v1
-end
-subgraph var_stream_193 ["var <tt>stream_193</tt>"]
-    style var_stream_193 fill:transparent
     92v1
+end
+subgraph var_stream_194 ["var <tt>stream_194</tt>"]
+    style var_stream_194 fill:transparent
+    93v1
 end
 subgraph var_stream_195 ["var <tt>stream_195</tt>"]
     style var_stream_195 fill:transparent
-    93v1
-end
-subgraph var_stream_196 ["var <tt>stream_196</tt>"]
-    style var_stream_196 fill:transparent
     94v1
+end
+subgraph var_stream_198 ["var <tt>stream_198</tt>"]
+    style var_stream_198 fill:transparent
+    95v1
+end
+subgraph var_stream_199 ["var <tt>stream_199</tt>"]
+    style var_stream_199 fill:transparent
+    96v1
 end
 subgraph var_stream_200 ["var <tt>stream_200</tt>"]
     style var_stream_200 fill:transparent
-    95v1
-end
-subgraph var_stream_201 ["var <tt>stream_201</tt>"]
-    style var_stream_201 fill:transparent
-    96v1
-end
-subgraph var_stream_202 ["var <tt>stream_202</tt>"]
-    style var_stream_202 fill:transparent
     97v1
+end
+subgraph var_stream_203 ["var <tt>stream_203</tt>"]
+    style var_stream_203 fill:transparent
+    98v1
+end
+subgraph var_stream_204 ["var <tt>stream_204</tt>"]
+    style var_stream_204 fill:transparent
+    99v1
 end
 subgraph var_stream_205 ["var <tt>stream_205</tt>"]
     style var_stream_205 fill:transparent
-    98v1
-end
-subgraph var_stream_206 ["var <tt>stream_206</tt>"]
-    style var_stream_206 fill:transparent
-    99v1
+    100v1
 end
 subgraph var_stream_207 ["var <tt>stream_207</tt>"]
     style var_stream_207 fill:transparent
-    100v1
-end
-subgraph var_stream_209 ["var <tt>stream_209</tt>"]
-    style var_stream_209 fill:transparent
     102v1
+end
+subgraph var_stream_210 ["var <tt>stream_210</tt>"]
+    style var_stream_210 fill:transparent
+    103v1
 end
 subgraph var_stream_212 ["var <tt>stream_212</tt>"]
     style var_stream_212 fill:transparent
-    103v1
-end
-subgraph var_stream_214 ["var <tt>stream_214</tt>"]
-    style var_stream_214 fill:transparent
     104v1
 end
-subgraph var_stream_217 ["var <tt>stream_217</tt>"]
-    style var_stream_217 fill:transparent
+subgraph var_stream_215 ["var <tt>stream_215</tt>"]
+    style var_stream_215 fill:transparent
     106v1
+end
+subgraph var_stream_218 ["var <tt>stream_218</tt>"]
+    style var_stream_218 fill:transparent
+    107v1
+end
+subgraph var_stream_219 ["var <tt>stream_219</tt>"]
+    style var_stream_219 fill:transparent
+    108v1
 end
 subgraph var_stream_22 ["var <tt>stream_22</tt>"]
     style var_stream_22 fill:transparent
     1v1
 end
-subgraph var_stream_220 ["var <tt>stream_220</tt>"]
-    style var_stream_220 fill:transparent
-    107v1
-end
 subgraph var_stream_221 ["var <tt>stream_221</tt>"]
     style var_stream_221 fill:transparent
-    108v1
+    109v1
+end
+subgraph var_stream_222 ["var <tt>stream_222</tt>"]
+    style var_stream_222 fill:transparent
+    110v1
 end
 subgraph var_stream_223 ["var <tt>stream_223</tt>"]
     style var_stream_223 fill:transparent
-    109v1
-end
-subgraph var_stream_224 ["var <tt>stream_224</tt>"]
-    style var_stream_224 fill:transparent
-    110v1
-end
-subgraph var_stream_225 ["var <tt>stream_225</tt>"]
-    style var_stream_225 fill:transparent
     111v1
 end
-subgraph var_stream_229 ["var <tt>stream_229</tt>"]
-    style var_stream_229 fill:transparent
+subgraph var_stream_227 ["var <tt>stream_227</tt>"]
+    style var_stream_227 fill:transparent
     112v1
 end
-subgraph var_stream_230 ["var <tt>stream_230</tt>"]
-    style var_stream_230 fill:transparent
+subgraph var_stream_228 ["var <tt>stream_228</tt>"]
+    style var_stream_228 fill:transparent
     113v1
 end
-subgraph var_stream_235 ["var <tt>stream_235</tt>"]
-    style var_stream_235 fill:transparent
+subgraph var_stream_233 ["var <tt>stream_233</tt>"]
+    style var_stream_233 fill:transparent
     114v1
+end
+subgraph var_stream_237 ["var <tt>stream_237</tt>"]
+    style var_stream_237 fill:transparent
+    115v1
+end
+subgraph var_stream_238 ["var <tt>stream_238</tt>"]
+    style var_stream_238 fill:transparent
+    116v1
 end
 subgraph var_stream_239 ["var <tt>stream_239</tt>"]
     style var_stream_239 fill:transparent
-    115v1
+    117v1
 end
 subgraph var_stream_240 ["var <tt>stream_240</tt>"]
     style var_stream_240 fill:transparent
-    116v1
+    118v1
 end
 subgraph var_stream_241 ["var <tt>stream_241</tt>"]
     style var_stream_241 fill:transparent
-    117v1
+    119v1
 end
 subgraph var_stream_242 ["var <tt>stream_242</tt>"]
     style var_stream_242 fill:transparent
-    118v1
-end
-subgraph var_stream_243 ["var <tt>stream_243</tt>"]
-    style var_stream_243 fill:transparent
-    119v1
-end
-subgraph var_stream_244 ["var <tt>stream_244</tt>"]
-    style var_stream_244 fill:transparent
     120v1
     121v1
 end
-subgraph var_stream_246 ["var <tt>stream_246</tt>"]
-    style var_stream_246 fill:transparent
+subgraph var_stream_244 ["var <tt>stream_244</tt>"]
+    style var_stream_244 fill:transparent
     122v1
 end
-subgraph var_stream_248 ["var <tt>stream_248</tt>"]
-    style var_stream_248 fill:transparent
+subgraph var_stream_246 ["var <tt>stream_246</tt>"]
+    style var_stream_246 fill:transparent
     123v1
+end
+subgraph var_stream_249 ["var <tt>stream_249</tt>"]
+    style var_stream_249 fill:transparent
+    124v1
 end
 subgraph var_stream_251 ["var <tt>stream_251</tt>"]
     style var_stream_251 fill:transparent
-    124v1
-end
-subgraph var_stream_253 ["var <tt>stream_253</tt>"]
-    style var_stream_253 fill:transparent
     125v1
+end
+subgraph var_stream_254 ["var <tt>stream_254</tt>"]
+    style var_stream_254 fill:transparent
+    126v1
 end
 subgraph var_stream_256 ["var <tt>stream_256</tt>"]
     style var_stream_256 fill:transparent
-    126v1
-end
-subgraph var_stream_258 ["var <tt>stream_258</tt>"]
-    style var_stream_258 fill:transparent
     127v1
+end
+subgraph var_stream_257 ["var <tt>stream_257</tt>"]
+    style var_stream_257 fill:transparent
+    128v1
 end
 subgraph var_stream_259 ["var <tt>stream_259</tt>"]
     style var_stream_259 fill:transparent
-    128v1
-end
-subgraph var_stream_261 ["var <tt>stream_261</tt>"]
-    style var_stream_261 fill:transparent
     130v1
 end
-subgraph var_stream_262 ["var <tt>stream_262</tt>"]
-    style var_stream_262 fill:transparent
+subgraph var_stream_260 ["var <tt>stream_260</tt>"]
+    style var_stream_260 fill:transparent
     131v1
+end
+subgraph var_stream_278 ["var <tt>stream_278</tt>"]
+    style var_stream_278 fill:transparent
+    133v1
+end
+subgraph var_stream_279 ["var <tt>stream_279</tt>"]
+    style var_stream_279 fill:transparent
+    134v1
 end
 subgraph var_stream_28 ["var <tt>stream_28</tt>"]
     style var_stream_28 fill:transparent
     3v1
 end
-subgraph var_stream_280 ["var <tt>stream_280</tt>"]
-    style var_stream_280 fill:transparent
-    133v1
-end
 subgraph var_stream_281 ["var <tt>stream_281</tt>"]
     style var_stream_281 fill:transparent
-    134v1
+    135v1
 end
 subgraph var_stream_283 ["var <tt>stream_283</tt>"]
     style var_stream_283 fill:transparent
-    135v1
-end
-subgraph var_stream_285 ["var <tt>stream_285</tt>"]
-    style var_stream_285 fill:transparent
     136v1
 end
-subgraph var_stream_288 ["var <tt>stream_288</tt>"]
-    style var_stream_288 fill:transparent
+subgraph var_stream_286 ["var <tt>stream_286</tt>"]
+    style var_stream_286 fill:transparent
     137v1
+end
+subgraph var_stream_291 ["var <tt>stream_291</tt>"]
+    style var_stream_291 fill:transparent
+    138v1
+end
+subgraph var_stream_292 ["var <tt>stream_292</tt>"]
+    style var_stream_292 fill:transparent
+    139v1
 end
 subgraph var_stream_293 ["var <tt>stream_293</tt>"]
     style var_stream_293 fill:transparent
-    138v1
+    140v1
 end
 subgraph var_stream_294 ["var <tt>stream_294</tt>"]
     style var_stream_294 fill:transparent
-    139v1
+    141v1
 end
 subgraph var_stream_295 ["var <tt>stream_295</tt>"]
     style var_stream_295 fill:transparent
-    140v1
+    142v1
 end
 subgraph var_stream_296 ["var <tt>stream_296</tt>"]
     style var_stream_296 fill:transparent
-    141v1
-end
-subgraph var_stream_297 ["var <tt>stream_297</tt>"]
-    style var_stream_297 fill:transparent
-    142v1
+    143v1
+    144v1
 end
 subgraph var_stream_298 ["var <tt>stream_298</tt>"]
     style var_stream_298 fill:transparent
-    143v1
-    144v1
+    145v1
 end
 subgraph var_stream_30 ["var <tt>stream_30</tt>"]
     style var_stream_30 fill:transparent
@@ -994,428 +998,436 @@ subgraph var_stream_30 ["var <tt>stream_30</tt>"]
 end
 subgraph var_stream_300 ["var <tt>stream_300</tt>"]
     style var_stream_300 fill:transparent
-    145v1
-end
-subgraph var_stream_302 ["var <tt>stream_302</tt>"]
-    style var_stream_302 fill:transparent
     146v1
+end
+subgraph var_stream_301 ["var <tt>stream_301</tt>"]
+    style var_stream_301 fill:transparent
+    147v1
 end
 subgraph var_stream_303 ["var <tt>stream_303</tt>"]
     style var_stream_303 fill:transparent
-    147v1
+    148v1
+end
+subgraph var_stream_304 ["var <tt>stream_304</tt>"]
+    style var_stream_304 fill:transparent
+    149v1
 end
 subgraph var_stream_305 ["var <tt>stream_305</tt>"]
     style var_stream_305 fill:transparent
-    148v1
+    150v1
 end
 subgraph var_stream_306 ["var <tt>stream_306</tt>"]
     style var_stream_306 fill:transparent
-    149v1
+    151v1
 end
 subgraph var_stream_307 ["var <tt>stream_307</tt>"]
     style var_stream_307 fill:transparent
-    150v1
-end
-subgraph var_stream_308 ["var <tt>stream_308</tt>"]
-    style var_stream_308 fill:transparent
-    151v1
-end
-subgraph var_stream_309 ["var <tt>stream_309</tt>"]
-    style var_stream_309 fill:transparent
     152v1
 end
-subgraph var_stream_313 ["var <tt>stream_313</tt>"]
-    style var_stream_313 fill:transparent
+subgraph var_stream_311 ["var <tt>stream_311</tt>"]
+    style var_stream_311 fill:transparent
     153v1
 end
 subgraph var_stream_33 ["var <tt>stream_33</tt>"]
     style var_stream_33 fill:transparent
     5v1
 end
-subgraph var_stream_341 ["var <tt>stream_341</tt>"]
-    style var_stream_341 fill:transparent
+subgraph var_stream_339 ["var <tt>stream_339</tt>"]
+    style var_stream_339 fill:transparent
     156v1
     157v1
 end
-subgraph var_stream_343 ["var <tt>stream_343</tt>"]
-    style var_stream_343 fill:transparent
+subgraph var_stream_341 ["var <tt>stream_341</tt>"]
+    style var_stream_341 fill:transparent
     158v1
+end
+subgraph var_stream_345 ["var <tt>stream_345</tt>"]
+    style var_stream_345 fill:transparent
+    159v1
+end
+subgraph var_stream_346 ["var <tt>stream_346</tt>"]
+    style var_stream_346 fill:transparent
+    160v1
 end
 subgraph var_stream_347 ["var <tt>stream_347</tt>"]
     style var_stream_347 fill:transparent
-    159v1
-end
-subgraph var_stream_348 ["var <tt>stream_348</tt>"]
-    style var_stream_348 fill:transparent
-    160v1
-end
-subgraph var_stream_349 ["var <tt>stream_349</tt>"]
-    style var_stream_349 fill:transparent
     161v1
 end
 subgraph var_stream_35 ["var <tt>stream_35</tt>"]
     style var_stream_35 fill:transparent
     6v1
 end
-subgraph var_stream_352 ["var <tt>stream_352</tt>"]
-    style var_stream_352 fill:transparent
+subgraph var_stream_350 ["var <tt>stream_350</tt>"]
+    style var_stream_350 fill:transparent
     162v1
+end
+subgraph var_stream_353 ["var <tt>stream_353</tt>"]
+    style var_stream_353 fill:transparent
+    163v1
+end
+subgraph var_stream_354 ["var <tt>stream_354</tt>"]
+    style var_stream_354 fill:transparent
+    164v1
 end
 subgraph var_stream_355 ["var <tt>stream_355</tt>"]
     style var_stream_355 fill:transparent
-    163v1
+    165v1
 end
 subgraph var_stream_356 ["var <tt>stream_356</tt>"]
     style var_stream_356 fill:transparent
-    164v1
-end
-subgraph var_stream_357 ["var <tt>stream_357</tt>"]
-    style var_stream_357 fill:transparent
-    165v1
+    166v1
 end
 subgraph var_stream_358 ["var <tt>stream_358</tt>"]
     style var_stream_358 fill:transparent
-    166v1
+    167v1
+end
+subgraph var_stream_359 ["var <tt>stream_359</tt>"]
+    style var_stream_359 fill:transparent
+    168v1
 end
 subgraph var_stream_36 ["var <tt>stream_36</tt>"]
     style var_stream_36 fill:transparent
     7v1
 end
-subgraph var_stream_361 ["var <tt>stream_361</tt>"]
-    style var_stream_361 fill:transparent
-    167v1
-end
-subgraph var_stream_362 ["var <tt>stream_362</tt>"]
-    style var_stream_362 fill:transparent
-    168v1
+subgraph var_stream_360 ["var <tt>stream_360</tt>"]
+    style var_stream_360 fill:transparent
+    169v1
 end
 subgraph var_stream_363 ["var <tt>stream_363</tt>"]
     style var_stream_363 fill:transparent
-    169v1
+    170v1
+end
+subgraph var_stream_365 ["var <tt>stream_365</tt>"]
+    style var_stream_365 fill:transparent
+    171v1
 end
 subgraph var_stream_366 ["var <tt>stream_366</tt>"]
     style var_stream_366 fill:transparent
-    170v1
-end
-subgraph var_stream_368 ["var <tt>stream_368</tt>"]
-    style var_stream_368 fill:transparent
-    171v1
+    172v1
 end
 subgraph var_stream_369 ["var <tt>stream_369</tt>"]
     style var_stream_369 fill:transparent
-    172v1
+    173v1
+end
+subgraph var_stream_371 ["var <tt>stream_371</tt>"]
+    style var_stream_371 fill:transparent
+    174v1
 end
 subgraph var_stream_372 ["var <tt>stream_372</tt>"]
     style var_stream_372 fill:transparent
-    173v1
-end
-subgraph var_stream_374 ["var <tt>stream_374</tt>"]
-    style var_stream_374 fill:transparent
-    174v1
-end
-subgraph var_stream_375 ["var <tt>stream_375</tt>"]
-    style var_stream_375 fill:transparent
     175v1
     176v1
 end
-subgraph var_stream_377 ["var <tt>stream_377</tt>"]
-    style var_stream_377 fill:transparent
+subgraph var_stream_374 ["var <tt>stream_374</tt>"]
+    style var_stream_374 fill:transparent
     177v1
 end
-subgraph var_stream_380 ["var <tt>stream_380</tt>"]
-    style var_stream_380 fill:transparent
+subgraph var_stream_377 ["var <tt>stream_377</tt>"]
+    style var_stream_377 fill:transparent
     178v1
+end
+subgraph var_stream_379 ["var <tt>stream_379</tt>"]
+    style var_stream_379 fill:transparent
+    179v1
+end
+subgraph var_stream_381 ["var <tt>stream_381</tt>"]
+    style var_stream_381 fill:transparent
+    180v1
 end
 subgraph var_stream_382 ["var <tt>stream_382</tt>"]
     style var_stream_382 fill:transparent
-    179v1
+    181v1
+end
+subgraph var_stream_383 ["var <tt>stream_383</tt>"]
+    style var_stream_383 fill:transparent
+    182v1
 end
 subgraph var_stream_384 ["var <tt>stream_384</tt>"]
     style var_stream_384 fill:transparent
-    180v1
-end
-subgraph var_stream_385 ["var <tt>stream_385</tt>"]
-    style var_stream_385 fill:transparent
-    181v1
+    183v1
 end
 subgraph var_stream_386 ["var <tt>stream_386</tt>"]
     style var_stream_386 fill:transparent
-    182v1
-end
-subgraph var_stream_387 ["var <tt>stream_387</tt>"]
-    style var_stream_387 fill:transparent
-    183v1
-end
-subgraph var_stream_389 ["var <tt>stream_389</tt>"]
-    style var_stream_389 fill:transparent
     184v1
+end
+subgraph var_stream_388 ["var <tt>stream_388</tt>"]
+    style var_stream_388 fill:transparent
+    185v1
+end
+subgraph var_stream_390 ["var <tt>stream_390</tt>"]
+    style var_stream_390 fill:transparent
+    187v1
 end
 subgraph var_stream_391 ["var <tt>stream_391</tt>"]
     style var_stream_391 fill:transparent
-    185v1
+    188v1
 end
-subgraph var_stream_393 ["var <tt>stream_393</tt>"]
-    style var_stream_393 fill:transparent
-    187v1
+subgraph var_stream_392 ["var <tt>stream_392</tt>"]
+    style var_stream_392 fill:transparent
+    189v1
 end
 subgraph var_stream_394 ["var <tt>stream_394</tt>"]
     style var_stream_394 fill:transparent
-    188v1
-end
-subgraph var_stream_395 ["var <tt>stream_395</tt>"]
-    style var_stream_395 fill:transparent
-    189v1
-end
-subgraph var_stream_397 ["var <tt>stream_397</tt>"]
-    style var_stream_397 fill:transparent
     190v1
+end
+subgraph var_stream_396 ["var <tt>stream_396</tt>"]
+    style var_stream_396 fill:transparent
+    191v1
 end
 subgraph var_stream_399 ["var <tt>stream_399</tt>"]
     style var_stream_399 fill:transparent
-    191v1
+    192v1
 end
 subgraph var_stream_40 ["var <tt>stream_40</tt>"]
     style var_stream_40 fill:transparent
     8v1
 end
-subgraph var_stream_402 ["var <tt>stream_402</tt>"]
-    style var_stream_402 fill:transparent
-    192v1
-end
-subgraph var_stream_409 ["var <tt>stream_409</tt>"]
-    style var_stream_409 fill:transparent
+subgraph var_stream_406 ["var <tt>stream_406</tt>"]
+    style var_stream_406 fill:transparent
     193v1
 end
-subgraph var_stream_410 ["var <tt>stream_410</tt>"]
-    style var_stream_410 fill:transparent
+subgraph var_stream_407 ["var <tt>stream_407</tt>"]
+    style var_stream_407 fill:transparent
     194v1
 end
-subgraph var_stream_416 ["var <tt>stream_416</tt>"]
-    style var_stream_416 fill:transparent
+subgraph var_stream_413 ["var <tt>stream_413</tt>"]
+    style var_stream_413 fill:transparent
     195v1
+end
+subgraph var_stream_415 ["var <tt>stream_415</tt>"]
+    style var_stream_415 fill:transparent
+    196v1
+end
+subgraph var_stream_417 ["var <tt>stream_417</tt>"]
+    style var_stream_417 fill:transparent
+    197v1
 end
 subgraph var_stream_418 ["var <tt>stream_418</tt>"]
     style var_stream_418 fill:transparent
-    196v1
-end
-subgraph var_stream_420 ["var <tt>stream_420</tt>"]
-    style var_stream_420 fill:transparent
-    197v1
-end
-subgraph var_stream_421 ["var <tt>stream_421</tt>"]
-    style var_stream_421 fill:transparent
     198v1
 end
-subgraph var_stream_422 ["var <tt>stream_422</tt>"]
-    style var_stream_422 fill:transparent
+subgraph var_stream_419 ["var <tt>stream_419</tt>"]
+    style var_stream_419 fill:transparent
     199v1
     200v1
 end
-subgraph var_stream_424 ["var <tt>stream_424</tt>"]
-    style var_stream_424 fill:transparent
+subgraph var_stream_421 ["var <tt>stream_421</tt>"]
+    style var_stream_421 fill:transparent
     201v1
+end
+subgraph var_stream_423 ["var <tt>stream_423</tt>"]
+    style var_stream_423 fill:transparent
+    202v1
+end
+subgraph var_stream_425 ["var <tt>stream_425</tt>"]
+    style var_stream_425 fill:transparent
+    203v1
 end
 subgraph var_stream_426 ["var <tt>stream_426</tt>"]
     style var_stream_426 fill:transparent
-    202v1
-end
-subgraph var_stream_428 ["var <tt>stream_428</tt>"]
-    style var_stream_428 fill:transparent
-    203v1
-end
-subgraph var_stream_429 ["var <tt>stream_429</tt>"]
-    style var_stream_429 fill:transparent
     204v1
 end
-subgraph var_stream_433 ["var <tt>stream_433</tt>"]
-    style var_stream_433 fill:transparent
+subgraph var_stream_430 ["var <tt>stream_430</tt>"]
+    style var_stream_430 fill:transparent
     205v1
 end
-subgraph var_stream_435 ["var <tt>stream_435</tt>"]
-    style var_stream_435 fill:transparent
+subgraph var_stream_432 ["var <tt>stream_432</tt>"]
+    style var_stream_432 fill:transparent
     206v1
 end
-subgraph var_stream_439 ["var <tt>stream_439</tt>"]
-    style var_stream_439 fill:transparent
+subgraph var_stream_436 ["var <tt>stream_436</tt>"]
+    style var_stream_436 fill:transparent
     207v1
+end
+subgraph var_stream_437 ["var <tt>stream_437</tt>"]
+    style var_stream_437 fill:transparent
+    208v1
 end
 subgraph var_stream_440 ["var <tt>stream_440</tt>"]
     style var_stream_440 fill:transparent
-    208v1
+    209v1
+end
+subgraph var_stream_441 ["var <tt>stream_441</tt>"]
+    style var_stream_441 fill:transparent
+    210v1
+end
+subgraph var_stream_442 ["var <tt>stream_442</tt>"]
+    style var_stream_442 fill:transparent
+    211v1
 end
 subgraph var_stream_443 ["var <tt>stream_443</tt>"]
     style var_stream_443 fill:transparent
-    209v1
-end
-subgraph var_stream_444 ["var <tt>stream_444</tt>"]
-    style var_stream_444 fill:transparent
-    210v1
+    212v1
 end
 subgraph var_stream_445 ["var <tt>stream_445</tt>"]
     style var_stream_445 fill:transparent
-    211v1
+    213v1
 end
 subgraph var_stream_446 ["var <tt>stream_446</tt>"]
     style var_stream_446 fill:transparent
-    212v1
+    214v1
 end
-subgraph var_stream_448 ["var <tt>stream_448</tt>"]
-    style var_stream_448 fill:transparent
-    213v1
+subgraph var_stream_447 ["var <tt>stream_447</tt>"]
+    style var_stream_447 fill:transparent
+    215v1
 end
 subgraph var_stream_449 ["var <tt>stream_449</tt>"]
     style var_stream_449 fill:transparent
-    214v1
-end
-subgraph var_stream_450 ["var <tt>stream_450</tt>"]
-    style var_stream_450 fill:transparent
-    215v1
-end
-subgraph var_stream_452 ["var <tt>stream_452</tt>"]
-    style var_stream_452 fill:transparent
     216v1
 end
-subgraph var_stream_454 ["var <tt>stream_454</tt>"]
-    style var_stream_454 fill:transparent
+subgraph var_stream_451 ["var <tt>stream_451</tt>"]
+    style var_stream_451 fill:transparent
     217v1
 end
-subgraph var_stream_456 ["var <tt>stream_456</tt>"]
-    style var_stream_456 fill:transparent
+subgraph var_stream_453 ["var <tt>stream_453</tt>"]
+    style var_stream_453 fill:transparent
     218v1
 end
 subgraph var_stream_46 ["var <tt>stream_46</tt>"]
     style var_stream_46 fill:transparent
     9v1
 end
-subgraph var_stream_470 ["var <tt>stream_470</tt>"]
-    style var_stream_470 fill:transparent
+subgraph var_stream_467 ["var <tt>stream_467</tt>"]
+    style var_stream_467 fill:transparent
     221v1
     222v1
 end
+subgraph var_stream_469 ["var <tt>stream_469</tt>"]
+    style var_stream_469 fill:transparent
+    223v1
+end
+subgraph var_stream_470 ["var <tt>stream_470</tt>"]
+    style var_stream_470 fill:transparent
+    224v1
+end
 subgraph var_stream_472 ["var <tt>stream_472</tt>"]
     style var_stream_472 fill:transparent
-    223v1
+    225v1
 end
 subgraph var_stream_473 ["var <tt>stream_473</tt>"]
     style var_stream_473 fill:transparent
-    224v1
-end
-subgraph var_stream_475 ["var <tt>stream_475</tt>"]
-    style var_stream_475 fill:transparent
-    225v1
+    226v1
 end
 subgraph var_stream_476 ["var <tt>stream_476</tt>"]
     style var_stream_476 fill:transparent
-    226v1
+    227v1
+end
+subgraph var_stream_477 ["var <tt>stream_477</tt>"]
+    style var_stream_477 fill:transparent
+    228v1
+end
+subgraph var_stream_478 ["var <tt>stream_478</tt>"]
+    style var_stream_478 fill:transparent
+    229v1
 end
 subgraph var_stream_48 ["var <tt>stream_48</tt>"]
     style var_stream_48 fill:transparent
     10v1
 end
-subgraph var_stream_480 ["var <tt>stream_480</tt>"]
-    style var_stream_480 fill:transparent
-    227v1
-end
 subgraph var_stream_481 ["var <tt>stream_481</tt>"]
     style var_stream_481 fill:transparent
-    228v1
+    230v1
 end
 subgraph var_stream_482 ["var <tt>stream_482</tt>"]
     style var_stream_482 fill:transparent
-    229v1
-end
-subgraph var_stream_485 ["var <tt>stream_485</tt>"]
-    style var_stream_485 fill:transparent
-    230v1
-end
-subgraph var_stream_486 ["var <tt>stream_486</tt>"]
-    style var_stream_486 fill:transparent
     231v1
+end
+subgraph var_stream_483 ["var <tt>stream_483</tt>"]
+    style var_stream_483 fill:transparent
+    232v1
 end
 subgraph var_stream_487 ["var <tt>stream_487</tt>"]
     style var_stream_487 fill:transparent
-    232v1
+    234v1
+end
+subgraph var_stream_488 ["var <tt>stream_488</tt>"]
+    style var_stream_488 fill:transparent
+    235v1
 end
 subgraph var_stream_49 ["var <tt>stream_49</tt>"]
     style var_stream_49 fill:transparent
     11v1
     12v1
 end
-subgraph var_stream_491 ["var <tt>stream_491</tt>"]
-    style var_stream_491 fill:transparent
-    234v1
+subgraph var_stream_490 ["var <tt>stream_490</tt>"]
+    style var_stream_490 fill:transparent
+    236v1
 end
 subgraph var_stream_492 ["var <tt>stream_492</tt>"]
     style var_stream_492 fill:transparent
-    235v1
-end
-subgraph var_stream_494 ["var <tt>stream_494</tt>"]
-    style var_stream_494 fill:transparent
-    236v1
-end
-subgraph var_stream_496 ["var <tt>stream_496</tt>"]
-    style var_stream_496 fill:transparent
     238v1
+end
+subgraph var_stream_497 ["var <tt>stream_497</tt>"]
+    style var_stream_497 fill:transparent
+    239v1
+end
+subgraph var_stream_498 ["var <tt>stream_498</tt>"]
+    style var_stream_498 fill:transparent
+    240v1
 end
 subgraph var_stream_501 ["var <tt>stream_501</tt>"]
     style var_stream_501 fill:transparent
-    239v1
+    241v1
 end
 subgraph var_stream_502 ["var <tt>stream_502</tt>"]
     style var_stream_502 fill:transparent
-    240v1
+    242v1
 end
-subgraph var_stream_505 ["var <tt>stream_505</tt>"]
-    style var_stream_505 fill:transparent
-    241v1
+subgraph var_stream_504 ["var <tt>stream_504</tt>"]
+    style var_stream_504 fill:transparent
+    243v1
 end
 subgraph var_stream_506 ["var <tt>stream_506</tt>"]
     style var_stream_506 fill:transparent
-    242v1
+    244v1
+end
+subgraph var_stream_507 ["var <tt>stream_507</tt>"]
+    style var_stream_507 fill:transparent
+    245v1
 end
 subgraph var_stream_508 ["var <tt>stream_508</tt>"]
     style var_stream_508 fill:transparent
-    243v1
+    246v1
 end
 subgraph var_stream_51 ["var <tt>stream_51</tt>"]
     style var_stream_51 fill:transparent
     13v1
 end
-subgraph var_stream_510 ["var <tt>stream_510</tt>"]
-    style var_stream_510 fill:transparent
-    244v1
-end
-subgraph var_stream_511 ["var <tt>stream_511</tt>"]
-    style var_stream_511 fill:transparent
-    245v1
-end
-subgraph var_stream_512 ["var <tt>stream_512</tt>"]
-    style var_stream_512 fill:transparent
-    246v1
-end
 subgraph var_stream_53 ["var <tt>stream_53</tt>"]
     style var_stream_53 fill:transparent
     14v1
 end
+subgraph var_stream_536 ["var <tt>stream_536</tt>"]
+    style var_stream_536 fill:transparent
+    248v1
+end
+subgraph var_stream_537 ["var <tt>stream_537</tt>"]
+    style var_stream_537 fill:transparent
+    249v1
+end
+subgraph var_stream_540 ["var <tt>stream_540</tt>"]
+    style var_stream_540 fill:transparent
+    251v1
+end
 subgraph var_stream_541 ["var <tt>stream_541</tt>"]
     style var_stream_541 fill:transparent
-    248v1
+    252v1
 end
 subgraph var_stream_542 ["var <tt>stream_542</tt>"]
     style var_stream_542 fill:transparent
-    249v1
-end
-subgraph var_stream_545 ["var <tt>stream_545</tt>"]
-    style var_stream_545 fill:transparent
-    251v1
+    253v1
 end
 subgraph var_stream_546 ["var <tt>stream_546</tt>"]
     style var_stream_546 fill:transparent
-    252v1
+    255v1
 end
 subgraph var_stream_547 ["var <tt>stream_547</tt>"]
     style var_stream_547 fill:transparent
-    253v1
+    256v1
+end
+subgraph var_stream_549 ["var <tt>stream_549</tt>"]
+    style var_stream_549 fill:transparent
+    257v1
 end
 subgraph var_stream_55 ["var <tt>stream_55</tt>"]
     style var_stream_55 fill:transparent
@@ -1423,42 +1435,30 @@ subgraph var_stream_55 ["var <tt>stream_55</tt>"]
 end
 subgraph var_stream_551 ["var <tt>stream_551</tt>"]
     style var_stream_551 fill:transparent
-    255v1
-end
-subgraph var_stream_552 ["var <tt>stream_552</tt>"]
-    style var_stream_552 fill:transparent
-    256v1
+    258v1
 end
 subgraph var_stream_554 ["var <tt>stream_554</tt>"]
     style var_stream_554 fill:transparent
-    257v1
+    259v1
 end
-subgraph var_stream_556 ["var <tt>stream_556</tt>"]
-    style var_stream_556 fill:transparent
-    258v1
+subgraph var_stream_558 ["var <tt>stream_558</tt>"]
+    style var_stream_558 fill:transparent
+    260v1
 end
 subgraph var_stream_559 ["var <tt>stream_559</tt>"]
     style var_stream_559 fill:transparent
-    259v1
+    261v1
 end
 subgraph var_stream_56 ["var <tt>stream_56</tt>"]
     style var_stream_56 fill:transparent
     16v1
 end
-subgraph var_stream_563 ["var <tt>stream_563</tt>"]
-    style var_stream_563 fill:transparent
-    260v1
-end
-subgraph var_stream_564 ["var <tt>stream_564</tt>"]
-    style var_stream_564 fill:transparent
-    261v1
-end
-subgraph var_stream_566 ["var <tt>stream_566</tt>"]
-    style var_stream_566 fill:transparent
+subgraph var_stream_561 ["var <tt>stream_561</tt>"]
+    style var_stream_561 fill:transparent
     262v1
 end
-subgraph var_stream_568 ["var <tt>stream_568</tt>"]
-    style var_stream_568 fill:transparent
+subgraph var_stream_563 ["var <tt>stream_563</tt>"]
+    style var_stream_563 fill:transparent
     263v1
 end
 subgraph var_stream_57 ["var <tt>stream_57</tt>"]

--- a/hydro_test/src/cluster/snapshots/two_pc_ir.snap
+++ b/hydro_test/src/cluster/snapshots/two_pc_ir.snap
@@ -729,37 +729,24 @@ expression: built.ir()
                                 inner: <shared 5>: FoldKeyed {
                                     init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | | (0 , 0) }),
                                     acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < () , () > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } } }),
-                                    input: ObserveNonDet {
-                                        inner: Cast {
-                                            inner: Tee {
-                                                inner: <shared 1>,
-                                                metadata: HydroIrMetadata {
-                                                    location_id: Tick(2, Process(loc1v1)),
-                                                    collection_kind: Stream {
-                                                        bound: Bounded,
-                                                        order: NoOrder,
-                                                        retry: ExactlyOnce,
-                                                        element_type: ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) , core :: result :: Result < () , () >),
-                                                    },
-                                                },
-                                            },
+                                    input: Cast {
+                                        inner: Tee {
+                                            inner: <shared 1>,
                                             metadata: HydroIrMetadata {
                                                 location_id: Tick(2, Process(loc1v1)),
-                                                collection_kind: KeyedStream {
+                                                collection_kind: Stream {
                                                     bound: Bounded,
-                                                    value_order: NoOrder,
-                                                    value_retry: ExactlyOnce,
-                                                    key_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)),
-                                                    value_type: core :: result :: Result < () , () >,
+                                                    order: NoOrder,
+                                                    retry: ExactlyOnce,
+                                                    element_type: ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) , core :: result :: Result < () , () >),
                                                 },
                                             },
                                         },
-                                        trusted: false,
                                         metadata: HydroIrMetadata {
                                             location_id: Tick(2, Process(loc1v1)),
                                             collection_kind: KeyedStream {
                                                 bound: Bounded,
-                                                value_order: TotalOrder,
+                                                value_order: NoOrder,
                                                 value_retry: ExactlyOnce,
                                                 key_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)),
                                                 value_type: core :: result :: Result < () , () >,
@@ -1257,37 +1244,24 @@ expression: built.ir()
                                 inner: <shared 9>: FoldKeyed {
                                     init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | | (0 , 0) }),
                                     acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < () , () > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } } }),
-                                    input: ObserveNonDet {
-                                        inner: Cast {
-                                            inner: Tee {
-                                                inner: <shared 6>,
-                                                metadata: HydroIrMetadata {
-                                                    location_id: Tick(4, Process(loc1v1)),
-                                                    collection_kind: Stream {
-                                                        bound: Bounded,
-                                                        order: NoOrder,
-                                                        retry: ExactlyOnce,
-                                                        element_type: ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) , core :: result :: Result < () , () >),
-                                                    },
-                                                },
-                                            },
+                                    input: Cast {
+                                        inner: Tee {
+                                            inner: <shared 6>,
                                             metadata: HydroIrMetadata {
                                                 location_id: Tick(4, Process(loc1v1)),
-                                                collection_kind: KeyedStream {
+                                                collection_kind: Stream {
                                                     bound: Bounded,
-                                                    value_order: NoOrder,
-                                                    value_retry: ExactlyOnce,
-                                                    key_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)),
-                                                    value_type: core :: result :: Result < () , () >,
+                                                    order: NoOrder,
+                                                    retry: ExactlyOnce,
+                                                    element_type: ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) , core :: result :: Result < () , () >),
                                                 },
                                             },
                                         },
-                                        trusted: false,
                                         metadata: HydroIrMetadata {
                                             location_id: Tick(4, Process(loc1v1)),
                                             collection_kind: KeyedStream {
                                                 bound: Bounded,
-                                                value_order: TotalOrder,
+                                                value_order: NoOrder,
                                                 value_retry: ExactlyOnce,
                                                 key_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)),
                                                 value_type: core :: result :: Result < () , () >,
@@ -1523,66 +1497,43 @@ expression: built.ir()
                             inner: <shared 11>: Fold {
                                 init: stageleft :: runtime_support :: fn0_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; move | | Histogram :: < u64 > :: new (3) . unwrap () }),
                                 acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , core :: time :: Duration , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; move | latencies , latency | { latencies . record (latency . as_nanos () as u64) . unwrap () ; } }),
-                                input: ObserveNonDet {
-                                    inner: Tee {
-                                        inner: <shared 12>: Batch {
-                                            inner: Map {
-                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , (i32 , core :: time :: Duration)) , core :: time :: Duration > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: two_pc_bench :: * ; | (_virtual_client_id , (_output , latency)) | latency }),
-                                                input: Cast {
-                                                    inner: YieldConcat {
+                                input: Tee {
+                                    inner: <shared 12>: Batch {
+                                        inner: Map {
+                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , (i32 , core :: time :: Duration)) , core :: time :: Duration > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: two_pc_bench :: * ; | (_virtual_client_id , (_output , latency)) | latency }),
+                                            input: Cast {
+                                                inner: YieldConcat {
+                                                    inner: Cast {
                                                         inner: Cast {
-                                                            inner: Cast {
-                                                                inner: Map {
-                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , (std :: time :: Instant , (std :: time :: Instant , i32))) , (u32 , (i32 , core :: time :: Duration)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < (std :: time :: Instant , (std :: time :: Instant , i32)) , (i32 , core :: time :: Duration) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (start_time , (end_time , output)) | (output , end_time . duration_since (start_time)) }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
-                                                                    input: Cast {
-                                                                        inner: Cast {
-                                                                            inner: JoinHalf {
-                                                                                left: Cast {
-                                                                                    inner: Cast {
-                                                                                        inner: DeferTick {
-                                                                                            input: Batch {
-                                                                                                inner: FoldKeyed {
-                                                                                                    init: stageleft :: runtime_support :: fn0_type_hint :: < std :: time :: Instant > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | | Instant :: now () }),
-                                                                                                    acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: time :: Instant , i32 , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | curr , _new | { * curr = Instant :: now () ; } }),
-                                                                                                    input: ObserveNonDet {
-                                                                                                        inner: Tee {
-                                                                                                            inner: <shared 3>,
-                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                location_id: Cluster(loc3v1),
-                                                                                                                collection_kind: KeyedStream {
-                                                                                                                    bound: Unbounded,
-                                                                                                                    value_order: NoOrder,
-                                                                                                                    value_retry: ExactlyOnce,
-                                                                                                                    key_type: u32,
-                                                                                                                    value_type: i32,
-                                                                                                                },
-                                                                                                            },
-                                                                                                        },
-                                                                                                        trusted: false,
-                                                                                                        metadata: HydroIrMetadata {
-                                                                                                            location_id: Cluster(loc3v1),
-                                                                                                            collection_kind: KeyedStream {
-                                                                                                                bound: Unbounded,
-                                                                                                                value_order: TotalOrder,
-                                                                                                                value_retry: ExactlyOnce,
-                                                                                                                key_type: u32,
-                                                                                                                value_type: i32,
-                                                                                                            },
-                                                                                                        },
-                                                                                                    },
+                                                            inner: Map {
+                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , (std :: time :: Instant , (std :: time :: Instant , i32))) , (u32 , (i32 , core :: time :: Duration)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < (std :: time :: Instant , (std :: time :: Instant , i32)) , (i32 , core :: time :: Duration) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (start_time , (end_time , output)) | (output , end_time . duration_since (start_time)) }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
+                                                                input: Cast {
+                                                                    inner: Cast {
+                                                                        inner: JoinHalf {
+                                                                            left: Cast {
+                                                                                inner: Cast {
+                                                                                    inner: DeferTick {
+                                                                                        input: Batch {
+                                                                                            inner: FoldKeyed {
+                                                                                                init: stageleft :: runtime_support :: fn0_type_hint :: < std :: time :: Instant > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | | Instant :: now () }),
+                                                                                                acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: time :: Instant , i32 , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | curr , _new | { * curr = Instant :: now () ; } }),
+                                                                                                input: Tee {
+                                                                                                    inner: <shared 3>,
                                                                                                     metadata: HydroIrMetadata {
                                                                                                         location_id: Cluster(loc3v1),
-                                                                                                        collection_kind: KeyedSingleton {
+                                                                                                        collection_kind: KeyedStream {
                                                                                                             bound: Unbounded,
+                                                                                                            value_order: NoOrder,
+                                                                                                            value_retry: ExactlyOnce,
                                                                                                             key_type: u32,
-                                                                                                            value_type: std :: time :: Instant,
+                                                                                                            value_type: i32,
                                                                                                         },
                                                                                                     },
                                                                                                 },
                                                                                                 metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(5, Cluster(loc3v1)),
+                                                                                                    location_id: Cluster(loc3v1),
                                                                                                     collection_kind: KeyedSingleton {
-                                                                                                        bound: Bounded,
+                                                                                                        bound: Unbounded,
                                                                                                         key_type: u32,
                                                                                                         value_type: std :: time :: Instant,
                                                                                                     },
@@ -1599,10 +1550,8 @@ expression: built.ir()
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
                                                                                             location_id: Tick(5, Cluster(loc3v1)),
-                                                                                            collection_kind: KeyedStream {
+                                                                                            collection_kind: KeyedSingleton {
                                                                                                 bound: Bounded,
-                                                                                                value_order: TotalOrder,
-                                                                                                value_retry: ExactlyOnce,
                                                                                                 key_type: u32,
                                                                                                 value_type: std :: time :: Instant,
                                                                                             },
@@ -1610,39 +1559,39 @@ expression: built.ir()
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_id: Tick(5, Cluster(loc3v1)),
-                                                                                        collection_kind: Stream {
+                                                                                        collection_kind: KeyedStream {
                                                                                             bound: Bounded,
-                                                                                            order: NoOrder,
-                                                                                            retry: ExactlyOnce,
-                                                                                            element_type: (u32 , std :: time :: Instant),
+                                                                                            value_order: TotalOrder,
+                                                                                            value_retry: ExactlyOnce,
+                                                                                            key_type: u32,
+                                                                                            value_type: std :: time :: Instant,
                                                                                         },
                                                                                     },
                                                                                 },
-                                                                                right: Cast {
-                                                                                    inner: Cast {
-                                                                                        inner: Map {
-                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , i32) , (u32 , (std :: time :: Instant , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < i32 , (std :: time :: Instant , i32) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | output | (Instant :: now () , output) }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
-                                                                                            input: ReduceKeyed {
-                                                                                                f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < i32 , i32 , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | curr , new | { * curr = new ; } }),
-                                                                                                input: ObserveNonDet {
-                                                                                                    inner: Batch {
-                                                                                                        inner: Tee {
-                                                                                                            inner: <shared 10>,
-                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                location_id: Cluster(loc3v1),
-                                                                                                                collection_kind: KeyedStream {
-                                                                                                                    bound: Unbounded,
-                                                                                                                    value_order: NoOrder,
-                                                                                                                    value_retry: ExactlyOnce,
-                                                                                                                    key_type: u32,
-                                                                                                                    value_type: i32,
-                                                                                                                },
-                                                                                                            },
-                                                                                                        },
+                                                                                metadata: HydroIrMetadata {
+                                                                                    location_id: Tick(5, Cluster(loc3v1)),
+                                                                                    collection_kind: Stream {
+                                                                                        bound: Bounded,
+                                                                                        order: NoOrder,
+                                                                                        retry: ExactlyOnce,
+                                                                                        element_type: (u32 , std :: time :: Instant),
+                                                                                    },
+                                                                                },
+                                                                            },
+                                                                            right: Cast {
+                                                                                inner: Cast {
+                                                                                    inner: Map {
+                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , i32) , (u32 , (std :: time :: Instant , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < i32 , (std :: time :: Instant , i32) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | output | (Instant :: now () , output) }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
+                                                                                        input: ReduceKeyed {
+                                                                                            f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < i32 , i32 , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | curr , new | { * curr = new ; } }),
+                                                                                            input: ObserveNonDet {
+                                                                                                inner: Batch {
+                                                                                                    inner: Tee {
+                                                                                                        inner: <shared 10>,
                                                                                                         metadata: HydroIrMetadata {
-                                                                                                            location_id: Tick(5, Cluster(loc3v1)),
+                                                                                                            location_id: Cluster(loc3v1),
                                                                                                             collection_kind: KeyedStream {
-                                                                                                                bound: Bounded,
+                                                                                                                bound: Unbounded,
                                                                                                                 value_order: NoOrder,
                                                                                                                 value_retry: ExactlyOnce,
                                                                                                                 key_type: u32,
@@ -1650,22 +1599,24 @@ expression: built.ir()
                                                                                                             },
                                                                                                         },
                                                                                                     },
-                                                                                                    trusted: false,
                                                                                                     metadata: HydroIrMetadata {
                                                                                                         location_id: Tick(5, Cluster(loc3v1)),
                                                                                                         collection_kind: KeyedStream {
                                                                                                             bound: Bounded,
-                                                                                                            value_order: TotalOrder,
+                                                                                                            value_order: NoOrder,
                                                                                                             value_retry: ExactlyOnce,
                                                                                                             key_type: u32,
                                                                                                             value_type: i32,
                                                                                                         },
                                                                                                     },
                                                                                                 },
+                                                                                                trusted: false,
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_id: Tick(5, Cluster(loc3v1)),
-                                                                                                    collection_kind: KeyedSingleton {
+                                                                                                    collection_kind: KeyedStream {
                                                                                                         bound: Bounded,
+                                                                                                        value_order: TotalOrder,
+                                                                                                        value_retry: ExactlyOnce,
                                                                                                         key_type: u32,
                                                                                                         value_type: i32,
                                                                                                     },
@@ -1676,16 +1627,14 @@ expression: built.ir()
                                                                                                 collection_kind: KeyedSingleton {
                                                                                                     bound: Bounded,
                                                                                                     key_type: u32,
-                                                                                                    value_type: (std :: time :: Instant , i32),
+                                                                                                    value_type: i32,
                                                                                                 },
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
                                                                                             location_id: Tick(5, Cluster(loc3v1)),
-                                                                                            collection_kind: KeyedStream {
+                                                                                            collection_kind: KeyedSingleton {
                                                                                                 bound: Bounded,
-                                                                                                value_order: TotalOrder,
-                                                                                                value_retry: ExactlyOnce,
                                                                                                 key_type: u32,
                                                                                                 value_type: (std :: time :: Instant , i32),
                                                                                             },
@@ -1693,11 +1642,12 @@ expression: built.ir()
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_id: Tick(5, Cluster(loc3v1)),
-                                                                                        collection_kind: Stream {
+                                                                                        collection_kind: KeyedStream {
                                                                                             bound: Bounded,
-                                                                                            order: NoOrder,
-                                                                                            retry: ExactlyOnce,
-                                                                                            element_type: (u32 , (std :: time :: Instant , i32)),
+                                                                                            value_order: TotalOrder,
+                                                                                            value_retry: ExactlyOnce,
+                                                                                            key_type: u32,
+                                                                                            value_type: (std :: time :: Instant , i32),
                                                                                         },
                                                                                     },
                                                                                 },
@@ -1707,25 +1657,26 @@ expression: built.ir()
                                                                                         bound: Bounded,
                                                                                         order: NoOrder,
                                                                                         retry: ExactlyOnce,
-                                                                                        element_type: (u32 , (std :: time :: Instant , (std :: time :: Instant , i32))),
+                                                                                        element_type: (u32 , (std :: time :: Instant , i32)),
                                                                                     },
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
                                                                                 location_id: Tick(5, Cluster(loc3v1)),
-                                                                                collection_kind: KeyedStream {
+                                                                                collection_kind: Stream {
                                                                                     bound: Bounded,
-                                                                                    value_order: NoOrder,
-                                                                                    value_retry: ExactlyOnce,
-                                                                                    key_type: u32,
-                                                                                    value_type: (std :: time :: Instant , (std :: time :: Instant , i32)),
+                                                                                    order: NoOrder,
+                                                                                    retry: ExactlyOnce,
+                                                                                    element_type: (u32 , (std :: time :: Instant , (std :: time :: Instant , i32))),
                                                                                 },
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
                                                                             location_id: Tick(5, Cluster(loc3v1)),
-                                                                            collection_kind: KeyedSingleton {
+                                                                            collection_kind: KeyedStream {
                                                                                 bound: Bounded,
+                                                                                value_order: NoOrder,
+                                                                                value_retry: ExactlyOnce,
                                                                                 key_type: u32,
                                                                                 value_type: (std :: time :: Instant , (std :: time :: Instant , i32)),
                                                                             },
@@ -1736,16 +1687,14 @@ expression: built.ir()
                                                                         collection_kind: KeyedSingleton {
                                                                             bound: Bounded,
                                                                             key_type: u32,
-                                                                            value_type: (i32 , core :: time :: Duration),
+                                                                            value_type: (std :: time :: Instant , (std :: time :: Instant , i32)),
                                                                         },
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
                                                                     location_id: Tick(5, Cluster(loc3v1)),
-                                                                    collection_kind: KeyedStream {
+                                                                    collection_kind: KeyedSingleton {
                                                                         bound: Bounded,
-                                                                        value_order: TotalOrder,
-                                                                        value_retry: ExactlyOnce,
                                                                         key_type: u32,
                                                                         value_type: (i32 , core :: time :: Duration),
                                                                     },
@@ -1755,7 +1704,7 @@ expression: built.ir()
                                                                 location_id: Tick(5, Cluster(loc3v1)),
                                                                 collection_kind: KeyedStream {
                                                                     bound: Bounded,
-                                                                    value_order: NoOrder,
+                                                                    value_order: TotalOrder,
                                                                     value_retry: ExactlyOnce,
                                                                     key_type: u32,
                                                                     value_type: (i32 , core :: time :: Duration),
@@ -1763,9 +1712,9 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Cluster(loc3v1),
+                                                            location_id: Tick(5, Cluster(loc3v1)),
                                                             collection_kind: KeyedStream {
-                                                                bound: Unbounded,
+                                                                bound: Bounded,
                                                                 value_order: NoOrder,
                                                                 value_retry: ExactlyOnce,
                                                                 key_type: u32,
@@ -1775,11 +1724,12 @@ expression: built.ir()
                                                     },
                                                     metadata: HydroIrMetadata {
                                                         location_id: Cluster(loc3v1),
-                                                        collection_kind: Stream {
+                                                        collection_kind: KeyedStream {
                                                             bound: Unbounded,
-                                                            order: NoOrder,
-                                                            retry: ExactlyOnce,
-                                                            element_type: (u32 , (i32 , core :: time :: Duration)),
+                                                            value_order: NoOrder,
+                                                            value_retry: ExactlyOnce,
+                                                            key_type: u32,
+                                                            value_type: (i32 , core :: time :: Duration),
                                                         },
                                                     },
                                                 },
@@ -1789,14 +1739,14 @@ expression: built.ir()
                                                         bound: Unbounded,
                                                         order: NoOrder,
                                                         retry: ExactlyOnce,
-                                                        element_type: core :: time :: Duration,
+                                                        element_type: (u32 , (i32 , core :: time :: Duration)),
                                                     },
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(6, Cluster(loc3v1)),
+                                                location_id: Cluster(loc3v1),
                                                 collection_kind: Stream {
-                                                    bound: Bounded,
+                                                    bound: Unbounded,
                                                     order: NoOrder,
                                                     retry: ExactlyOnce,
                                                     element_type: core :: time :: Duration,
@@ -1813,12 +1763,11 @@ expression: built.ir()
                                             },
                                         },
                                     },
-                                    trusted: false,
                                     metadata: HydroIrMetadata {
                                         location_id: Tick(6, Cluster(loc3v1)),
                                         collection_kind: Stream {
                                             bound: Bounded,
-                                            order: TotalOrder,
+                                            order: NoOrder,
                                             retry: ExactlyOnce,
                                             element_type: core :: time :: Duration,
                                         },
@@ -2990,65 +2939,56 @@ expression: built.ir()
         input: Fold {
             init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | | 0usize }),
             acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | curr , new | { * curr += new ; } }),
-            input: ObserveNonDet {
-                inner: Chain {
-                    first: Batch {
-                        inner: Map {
-                            f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , usize) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                            input: Cast {
-                                inner: Cast {
-                                    inner: Network {
-                                        name: None,
-                                        networking_info: Tcp {
-                                            fault: FailStop,
-                                        },
-                                        serialize_fn: Some(
-                                            hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < usize , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
-                                        ),
-                                        instantiate_fn: <network instantiate>,
-                                        deserialize_fn: Some(
-                                            | res | { let (id , b) = res . unwrap () ; (hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > :: from_tagless (id as hydro_lang :: __staged :: location :: TaglessMemberId) , hydro_lang :: runtime_support :: bincode :: deserialize :: < usize > (& b) . unwrap ()) },
-                                        ),
-                                        input: YieldConcat {
-                                            inner: Cast {
-                                                inner: Map {
-                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                                                    input: CrossSingleton {
-                                                        left: Tee {
-                                                            inner: <shared 18>,
-                                                            metadata: HydroIrMetadata {
-                                                                location_id: Tick(6, Cluster(loc3v1)),
-                                                                collection_kind: Singleton {
-                                                                    bound: Bounded,
-                                                                    element_type: usize,
-                                                                },
+            input: Chain {
+                first: Batch {
+                    inner: Map {
+                        f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , usize) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
+                        input: Cast {
+                            inner: Cast {
+                                inner: Network {
+                                    name: None,
+                                    networking_info: Tcp {
+                                        fault: FailStop,
+                                    },
+                                    serialize_fn: Some(
+                                        hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < usize , _ > (| data | { hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into () }),
+                                    ),
+                                    instantiate_fn: <network instantiate>,
+                                    deserialize_fn: Some(
+                                        | res | { let (id , b) = res . unwrap () ; (hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > :: from_tagless (id as hydro_lang :: __staged :: location :: TaglessMemberId) , hydro_lang :: runtime_support :: bincode :: deserialize :: < usize > (& b) . unwrap ()) },
+                                    ),
+                                    input: YieldConcat {
+                                        inner: Cast {
+                                            inner: Map {
+                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
+                                                input: CrossSingleton {
+                                                    left: Tee {
+                                                        inner: <shared 18>,
+                                                        metadata: HydroIrMetadata {
+                                                            location_id: Tick(6, Cluster(loc3v1)),
+                                                            collection_kind: Singleton {
+                                                                bound: Bounded,
+                                                                element_type: usize,
                                                             },
                                                         },
-                                                        right: Filter {
-                                                            f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
-                                                            input: Map {
-                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_some () }),
-                                                                input: Cast {
-                                                                    inner: ChainFirst {
-                                                                        first: Map {
-                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                                            input: Map {
-                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                                                input: Tee {
-                                                                                    inner: <shared 15>,
-                                                                                    metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(6, Cluster(loc3v1)),
-                                                                                        collection_kind: Optional {
-                                                                                            bound: Bounded,
-                                                                                            element_type: hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
-                                                                                        },
-                                                                                    },
-                                                                                },
+                                                    },
+                                                    right: Filter {
+                                                        f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
+                                                        input: Map {
+                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_some () }),
+                                                            input: Cast {
+                                                                inner: ChainFirst {
+                                                                    first: Map {
+                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
+                                                                        input: Map {
+                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                                            input: Tee {
+                                                                                inner: <shared 15>,
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_id: Tick(6, Cluster(loc3v1)),
                                                                                     collection_kind: Optional {
                                                                                         bound: Bounded,
-                                                                                        element_type: (),
+                                                                                        element_type: hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
                                                                                     },
                                                                                 },
                                                                             },
@@ -3056,25 +2996,25 @@ expression: built.ir()
                                                                                 location_id: Tick(6, Cluster(loc3v1)),
                                                                                 collection_kind: Optional {
                                                                                     bound: Bounded,
-                                                                                    element_type: core :: option :: Option < () >,
+                                                                                    element_type: (),
                                                                                 },
                                                                             },
                                                                         },
-                                                                        second: Cast {
-                                                                            inner: SingletonSource {
-                                                                                value: :: std :: option :: Option :: None,
-                                                                                first_tick_only: false,
-                                                                                metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(6, Cluster(loc3v1)),
-                                                                                    collection_kind: Singleton {
-                                                                                        bound: Bounded,
-                                                                                        element_type: core :: option :: Option < () >,
-                                                                                    },
-                                                                                },
+                                                                        metadata: HydroIrMetadata {
+                                                                            location_id: Tick(6, Cluster(loc3v1)),
+                                                                            collection_kind: Optional {
+                                                                                bound: Bounded,
+                                                                                element_type: core :: option :: Option < () >,
                                                                             },
+                                                                        },
+                                                                    },
+                                                                    second: Cast {
+                                                                        inner: SingletonSource {
+                                                                            value: :: std :: option :: Option :: None,
+                                                                            first_tick_only: false,
                                                                             metadata: HydroIrMetadata {
                                                                                 location_id: Tick(6, Cluster(loc3v1)),
-                                                                                collection_kind: Optional {
+                                                                                collection_kind: Singleton {
                                                                                     bound: Bounded,
                                                                                     element_type: core :: option :: Option < () >,
                                                                                 },
@@ -3090,7 +3030,7 @@ expression: built.ir()
                                                                     },
                                                                     metadata: HydroIrMetadata {
                                                                         location_id: Tick(6, Cluster(loc3v1)),
-                                                                        collection_kind: Singleton {
+                                                                        collection_kind: Optional {
                                                                             bound: Bounded,
                                                                             element_type: core :: option :: Option < () >,
                                                                         },
@@ -3100,13 +3040,13 @@ expression: built.ir()
                                                                     location_id: Tick(6, Cluster(loc3v1)),
                                                                     collection_kind: Singleton {
                                                                         bound: Bounded,
-                                                                        element_type: bool,
+                                                                        element_type: core :: option :: Option < () >,
                                                                     },
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
                                                                 location_id: Tick(6, Cluster(loc3v1)),
-                                                                collection_kind: Optional {
+                                                                collection_kind: Singleton {
                                                                     bound: Bounded,
                                                                     element_type: bool,
                                                                 },
@@ -3116,7 +3056,7 @@ expression: built.ir()
                                                             location_id: Tick(6, Cluster(loc3v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
-                                                                element_type: (usize , bool),
+                                                                element_type: bool,
                                                             },
                                                         },
                                                     },
@@ -3124,24 +3064,22 @@ expression: built.ir()
                                                         location_id: Tick(6, Cluster(loc3v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
-                                                            element_type: usize,
+                                                            element_type: (usize , bool),
                                                         },
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
                                                     location_id: Tick(6, Cluster(loc3v1)),
-                                                    collection_kind: Stream {
+                                                    collection_kind: Optional {
                                                         bound: Bounded,
-                                                        order: TotalOrder,
-                                                        retry: ExactlyOnce,
                                                         element_type: usize,
                                                     },
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Cluster(loc3v1),
+                                                location_id: Tick(6, Cluster(loc3v1)),
                                                 collection_kind: Stream {
-                                                    bound: Unbounded,
+                                                    bound: Bounded,
                                                     order: TotalOrder,
                                                     retry: ExactlyOnce,
                                                     element_type: usize,
@@ -3149,33 +3087,33 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Process(loc4v1),
+                                            location_id: Cluster(loc3v1),
                                             collection_kind: Stream {
                                                 bound: Unbounded,
                                                 order: TotalOrder,
                                                 retry: ExactlyOnce,
-                                                element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , usize),
+                                                element_type: usize,
                                             },
                                         },
                                     },
                                     metadata: HydroIrMetadata {
                                         location_id: Process(loc4v1),
-                                        collection_kind: KeyedStream {
+                                        collection_kind: Stream {
                                             bound: Unbounded,
-                                            value_order: TotalOrder,
-                                            value_retry: ExactlyOnce,
-                                            key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client >,
-                                            value_type: usize,
+                                            order: TotalOrder,
+                                            retry: ExactlyOnce,
+                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , usize),
                                         },
                                     },
                                 },
                                 metadata: HydroIrMetadata {
                                     location_id: Process(loc4v1),
-                                    collection_kind: Stream {
+                                    collection_kind: KeyedStream {
                                         bound: Unbounded,
-                                        order: NoOrder,
-                                        retry: ExactlyOnce,
-                                        element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , usize),
+                                        value_order: TotalOrder,
+                                        value_retry: ExactlyOnce,
+                                        key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client >,
+                                        value_type: usize,
                                     },
                                 },
                             },
@@ -3185,201 +3123,15 @@ expression: built.ir()
                                     bound: Unbounded,
                                     order: NoOrder,
                                     retry: ExactlyOnce,
-                                    element_type: usize,
+                                    element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , usize),
                                 },
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(7, Process(loc4v1)),
+                            location_id: Process(loc4v1),
                             collection_kind: Stream {
-                                bound: Bounded,
+                                bound: Unbounded,
                                 order: NoOrder,
-                                retry: ExactlyOnce,
-                                element_type: usize,
-                            },
-                        },
-                    },
-                    second: Cast {
-                        inner: Map {
-                            f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                            input: CrossSingleton {
-                                left: Tee {
-                                    inner: <shared 21>: Cast {
-                                        inner: ChainFirst {
-                                            first: DeferTick {
-                                                input: CycleSource {
-                                                    cycle_id: CycleId(
-                                                        9,
-                                                    ),
-                                                    metadata: HydroIrMetadata {
-                                                        location_id: Tick(7, Process(loc4v1)),
-                                                        collection_kind: Singleton {
-                                                            bound: Bounded,
-                                                            element_type: usize,
-                                                        },
-                                                    },
-                                                },
-                                                metadata: HydroIrMetadata {
-                                                    location_id: Tick(7, Process(loc4v1)),
-                                                    collection_kind: Optional {
-                                                        bound: Bounded,
-                                                        element_type: usize,
-                                                    },
-                                                },
-                                            },
-                                            second: Cast {
-                                                inner: SingletonSource {
-                                                    value: { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; 0usize },
-                                                    first_tick_only: false,
-                                                    metadata: HydroIrMetadata {
-                                                        location_id: Tick(7, Process(loc4v1)),
-                                                        collection_kind: Singleton {
-                                                            bound: Bounded,
-                                                            element_type: usize,
-                                                        },
-                                                    },
-                                                },
-                                                metadata: HydroIrMetadata {
-                                                    location_id: Tick(7, Process(loc4v1)),
-                                                    collection_kind: Optional {
-                                                        bound: Bounded,
-                                                        element_type: usize,
-                                                    },
-                                                },
-                                            },
-                                            metadata: HydroIrMetadata {
-                                                location_id: Tick(7, Process(loc4v1)),
-                                                collection_kind: Optional {
-                                                    bound: Bounded,
-                                                    element_type: usize,
-                                                },
-                                            },
-                                        },
-                                        metadata: HydroIrMetadata {
-                                            location_id: Tick(7, Process(loc4v1)),
-                                            collection_kind: Singleton {
-                                                bound: Bounded,
-                                                element_type: usize,
-                                            },
-                                        },
-                                    },
-                                    metadata: HydroIrMetadata {
-                                        location_id: Tick(7, Process(loc4v1)),
-                                        collection_kind: Singleton {
-                                            bound: Bounded,
-                                            element_type: usize,
-                                        },
-                                    },
-                                },
-                                right: Filter {
-                                    f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
-                                    input: Map {
-                                        f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_none () }),
-                                        input: Cast {
-                                            inner: ChainFirst {
-                                                first: Map {
-                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                    input: Map {
-                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                        input: Tee {
-                                                            inner: <shared 20>,
-                                                            metadata: HydroIrMetadata {
-                                                                location_id: Tick(7, Process(loc4v1)),
-                                                                collection_kind: Optional {
-                                                                    bound: Bounded,
-                                                                    element_type: hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
-                                                                },
-                                                            },
-                                                        },
-                                                        metadata: HydroIrMetadata {
-                                                            location_id: Tick(7, Process(loc4v1)),
-                                                            collection_kind: Optional {
-                                                                bound: Bounded,
-                                                                element_type: (),
-                                                            },
-                                                        },
-                                                    },
-                                                    metadata: HydroIrMetadata {
-                                                        location_id: Tick(7, Process(loc4v1)),
-                                                        collection_kind: Optional {
-                                                            bound: Bounded,
-                                                            element_type: core :: option :: Option < () >,
-                                                        },
-                                                    },
-                                                },
-                                                second: Cast {
-                                                    inner: SingletonSource {
-                                                        value: :: std :: option :: Option :: None,
-                                                        first_tick_only: false,
-                                                        metadata: HydroIrMetadata {
-                                                            location_id: Tick(7, Process(loc4v1)),
-                                                            collection_kind: Singleton {
-                                                                bound: Bounded,
-                                                                element_type: core :: option :: Option < () >,
-                                                            },
-                                                        },
-                                                    },
-                                                    metadata: HydroIrMetadata {
-                                                        location_id: Tick(7, Process(loc4v1)),
-                                                        collection_kind: Optional {
-                                                            bound: Bounded,
-                                                            element_type: core :: option :: Option < () >,
-                                                        },
-                                                    },
-                                                },
-                                                metadata: HydroIrMetadata {
-                                                    location_id: Tick(7, Process(loc4v1)),
-                                                    collection_kind: Optional {
-                                                        bound: Bounded,
-                                                        element_type: core :: option :: Option < () >,
-                                                    },
-                                                },
-                                            },
-                                            metadata: HydroIrMetadata {
-                                                location_id: Tick(7, Process(loc4v1)),
-                                                collection_kind: Singleton {
-                                                    bound: Bounded,
-                                                    element_type: core :: option :: Option < () >,
-                                                },
-                                            },
-                                        },
-                                        metadata: HydroIrMetadata {
-                                            location_id: Tick(7, Process(loc4v1)),
-                                            collection_kind: Singleton {
-                                                bound: Bounded,
-                                                element_type: bool,
-                                            },
-                                        },
-                                    },
-                                    metadata: HydroIrMetadata {
-                                        location_id: Tick(7, Process(loc4v1)),
-                                        collection_kind: Optional {
-                                            bound: Bounded,
-                                            element_type: bool,
-                                        },
-                                    },
-                                },
-                                metadata: HydroIrMetadata {
-                                    location_id: Tick(7, Process(loc4v1)),
-                                    collection_kind: Optional {
-                                        bound: Bounded,
-                                        element_type: (usize , bool),
-                                    },
-                                },
-                            },
-                            metadata: HydroIrMetadata {
-                                location_id: Tick(7, Process(loc4v1)),
-                                collection_kind: Optional {
-                                    bound: Bounded,
-                                    element_type: usize,
-                                },
-                            },
-                        },
-                        metadata: HydroIrMetadata {
-                            location_id: Tick(7, Process(loc4v1)),
-                            collection_kind: Stream {
-                                bound: Bounded,
-                                order: TotalOrder,
                                 retry: ExactlyOnce,
                                 element_type: usize,
                             },
@@ -3395,12 +3147,197 @@ expression: built.ir()
                         },
                     },
                 },
-                trusted: false,
+                second: Cast {
+                    inner: Map {
+                        f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
+                        input: CrossSingleton {
+                            left: Tee {
+                                inner: <shared 21>: Cast {
+                                    inner: ChainFirst {
+                                        first: DeferTick {
+                                            input: CycleSource {
+                                                cycle_id: CycleId(
+                                                    9,
+                                                ),
+                                                metadata: HydroIrMetadata {
+                                                    location_id: Tick(7, Process(loc4v1)),
+                                                    collection_kind: Singleton {
+                                                        bound: Bounded,
+                                                        element_type: usize,
+                                                    },
+                                                },
+                                            },
+                                            metadata: HydroIrMetadata {
+                                                location_id: Tick(7, Process(loc4v1)),
+                                                collection_kind: Optional {
+                                                    bound: Bounded,
+                                                    element_type: usize,
+                                                },
+                                            },
+                                        },
+                                        second: Cast {
+                                            inner: SingletonSource {
+                                                value: { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; 0usize },
+                                                first_tick_only: false,
+                                                metadata: HydroIrMetadata {
+                                                    location_id: Tick(7, Process(loc4v1)),
+                                                    collection_kind: Singleton {
+                                                        bound: Bounded,
+                                                        element_type: usize,
+                                                    },
+                                                },
+                                            },
+                                            metadata: HydroIrMetadata {
+                                                location_id: Tick(7, Process(loc4v1)),
+                                                collection_kind: Optional {
+                                                    bound: Bounded,
+                                                    element_type: usize,
+                                                },
+                                            },
+                                        },
+                                        metadata: HydroIrMetadata {
+                                            location_id: Tick(7, Process(loc4v1)),
+                                            collection_kind: Optional {
+                                                bound: Bounded,
+                                                element_type: usize,
+                                            },
+                                        },
+                                    },
+                                    metadata: HydroIrMetadata {
+                                        location_id: Tick(7, Process(loc4v1)),
+                                        collection_kind: Singleton {
+                                            bound: Bounded,
+                                            element_type: usize,
+                                        },
+                                    },
+                                },
+                                metadata: HydroIrMetadata {
+                                    location_id: Tick(7, Process(loc4v1)),
+                                    collection_kind: Singleton {
+                                        bound: Bounded,
+                                        element_type: usize,
+                                    },
+                                },
+                            },
+                            right: Filter {
+                                f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
+                                input: Map {
+                                    f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_none () }),
+                                    input: Cast {
+                                        inner: ChainFirst {
+                                            first: Map {
+                                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
+                                                input: Map {
+                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                    input: Tee {
+                                                        inner: <shared 20>,
+                                                        metadata: HydroIrMetadata {
+                                                            location_id: Tick(7, Process(loc4v1)),
+                                                            collection_kind: Optional {
+                                                                bound: Bounded,
+                                                                element_type: hydro_test :: __staged :: __deps :: tokio :: time :: Instant,
+                                                            },
+                                                        },
+                                                    },
+                                                    metadata: HydroIrMetadata {
+                                                        location_id: Tick(7, Process(loc4v1)),
+                                                        collection_kind: Optional {
+                                                            bound: Bounded,
+                                                            element_type: (),
+                                                        },
+                                                    },
+                                                },
+                                                metadata: HydroIrMetadata {
+                                                    location_id: Tick(7, Process(loc4v1)),
+                                                    collection_kind: Optional {
+                                                        bound: Bounded,
+                                                        element_type: core :: option :: Option < () >,
+                                                    },
+                                                },
+                                            },
+                                            second: Cast {
+                                                inner: SingletonSource {
+                                                    value: :: std :: option :: Option :: None,
+                                                    first_tick_only: false,
+                                                    metadata: HydroIrMetadata {
+                                                        location_id: Tick(7, Process(loc4v1)),
+                                                        collection_kind: Singleton {
+                                                            bound: Bounded,
+                                                            element_type: core :: option :: Option < () >,
+                                                        },
+                                                    },
+                                                },
+                                                metadata: HydroIrMetadata {
+                                                    location_id: Tick(7, Process(loc4v1)),
+                                                    collection_kind: Optional {
+                                                        bound: Bounded,
+                                                        element_type: core :: option :: Option < () >,
+                                                    },
+                                                },
+                                            },
+                                            metadata: HydroIrMetadata {
+                                                location_id: Tick(7, Process(loc4v1)),
+                                                collection_kind: Optional {
+                                                    bound: Bounded,
+                                                    element_type: core :: option :: Option < () >,
+                                                },
+                                            },
+                                        },
+                                        metadata: HydroIrMetadata {
+                                            location_id: Tick(7, Process(loc4v1)),
+                                            collection_kind: Singleton {
+                                                bound: Bounded,
+                                                element_type: core :: option :: Option < () >,
+                                            },
+                                        },
+                                    },
+                                    metadata: HydroIrMetadata {
+                                        location_id: Tick(7, Process(loc4v1)),
+                                        collection_kind: Singleton {
+                                            bound: Bounded,
+                                            element_type: bool,
+                                        },
+                                    },
+                                },
+                                metadata: HydroIrMetadata {
+                                    location_id: Tick(7, Process(loc4v1)),
+                                    collection_kind: Optional {
+                                        bound: Bounded,
+                                        element_type: bool,
+                                    },
+                                },
+                            },
+                            metadata: HydroIrMetadata {
+                                location_id: Tick(7, Process(loc4v1)),
+                                collection_kind: Optional {
+                                    bound: Bounded,
+                                    element_type: (usize , bool),
+                                },
+                            },
+                        },
+                        metadata: HydroIrMetadata {
+                            location_id: Tick(7, Process(loc4v1)),
+                            collection_kind: Optional {
+                                bound: Bounded,
+                                element_type: usize,
+                            },
+                        },
+                    },
+                    metadata: HydroIrMetadata {
+                        location_id: Tick(7, Process(loc4v1)),
+                        collection_kind: Stream {
+                            bound: Bounded,
+                            order: TotalOrder,
+                            retry: ExactlyOnce,
+                            element_type: usize,
+                        },
+                    },
+                },
                 metadata: HydroIrMetadata {
                     location_id: Tick(7, Process(loc4v1)),
                     collection_kind: Stream {
                         bound: Bounded,
-                        order: TotalOrder,
+                        order: NoOrder,
                         retry: ExactlyOnce,
                         element_type: usize,
                     },

--- a/hydro_test/src/cluster/snapshots/two_pc_ir@coordinator_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/two_pc_ir@coordinator_mermaid.snap
@@ -141,40 +141,36 @@ subgraph var_cycle_5 ["var <tt>cycle_5</tt>"]
     style var_cycle_5 fill:transparent
     52v1
 end
-subgraph var_stream_100 ["var <tt>stream_100</tt>"]
-    style var_stream_100 fill:transparent
-    42v1
+subgraph var_stream_101 ["var <tt>stream_101</tt>"]
+    style var_stream_101 fill:transparent
+    43v1
 end
 subgraph var_stream_102 ["var <tt>stream_102</tt>"]
     style var_stream_102 fill:transparent
-    43v1
-end
-subgraph var_stream_103 ["var <tt>stream_103</tt>"]
-    style var_stream_103 fill:transparent
     44v1
 end
-subgraph var_stream_107 ["var <tt>stream_107</tt>"]
-    style var_stream_107 fill:transparent
+subgraph var_stream_105 ["var <tt>stream_105</tt>"]
+    style var_stream_105 fill:transparent
     45v1
+end
+subgraph var_stream_109 ["var <tt>stream_109</tt>"]
+    style var_stream_109 fill:transparent
+    47v1
+end
+subgraph var_stream_110 ["var <tt>stream_110</tt>"]
+    style var_stream_110 fill:transparent
+    48v1
 end
 subgraph var_stream_111 ["var <tt>stream_111</tt>"]
     style var_stream_111 fill:transparent
-    47v1
-end
-subgraph var_stream_112 ["var <tt>stream_112</tt>"]
-    style var_stream_112 fill:transparent
-    48v1
+    49v1
 end
 subgraph var_stream_113 ["var <tt>stream_113</tt>"]
     style var_stream_113 fill:transparent
-    49v1
+    51v1
 end
 subgraph var_stream_115 ["var <tt>stream_115</tt>"]
     style var_stream_115 fill:transparent
-    51v1
-end
-subgraph var_stream_117 ["var <tt>stream_117</tt>"]
-    style var_stream_117 fill:transparent
     53v1
 end
 subgraph var_stream_23 ["var <tt>stream_23</tt>"]
@@ -235,68 +231,72 @@ subgraph var_stream_60 ["var <tt>stream_60</tt>"]
     style var_stream_60 fill:transparent
     18v1
 end
-subgraph var_stream_64 ["var <tt>stream_64</tt>"]
-    style var_stream_64 fill:transparent
+subgraph var_stream_63 ["var <tt>stream_63</tt>"]
+    style var_stream_63 fill:transparent
     19v1
+end
+subgraph var_stream_67 ["var <tt>stream_67</tt>"]
+    style var_stream_67 fill:transparent
+    21v1
 end
 subgraph var_stream_68 ["var <tt>stream_68</tt>"]
     style var_stream_68 fill:transparent
-    21v1
+    22v1
 end
 subgraph var_stream_69 ["var <tt>stream_69</tt>"]
     style var_stream_69 fill:transparent
-    22v1
-end
-subgraph var_stream_70 ["var <tt>stream_70</tt>"]
-    style var_stream_70 fill:transparent
     23v1
 end
-subgraph var_stream_72 ["var <tt>stream_72</tt>"]
-    style var_stream_72 fill:transparent
+subgraph var_stream_71 ["var <tt>stream_71</tt>"]
+    style var_stream_71 fill:transparent
     25v1
 end
-subgraph var_stream_74 ["var <tt>stream_74</tt>"]
-    style var_stream_74 fill:transparent
+subgraph var_stream_73 ["var <tt>stream_73</tt>"]
+    style var_stream_73 fill:transparent
     27v1
+end
+subgraph var_stream_76 ["var <tt>stream_76</tt>"]
+    style var_stream_76 fill:transparent
+    29v1
 end
 subgraph var_stream_77 ["var <tt>stream_77</tt>"]
     style var_stream_77 fill:transparent
-    29v1
+    30v1
 end
 subgraph var_stream_78 ["var <tt>stream_78</tt>"]
     style var_stream_78 fill:transparent
-    30v1
-end
-subgraph var_stream_79 ["var <tt>stream_79</tt>"]
-    style var_stream_79 fill:transparent
     31v1
 end
-subgraph var_stream_81 ["var <tt>stream_81</tt>"]
-    style var_stream_81 fill:transparent
+subgraph var_stream_80 ["var <tt>stream_80</tt>"]
+    style var_stream_80 fill:transparent
     32v1
 end
-subgraph var_stream_83 ["var <tt>stream_83</tt>"]
-    style var_stream_83 fill:transparent
+subgraph var_stream_82 ["var <tt>stream_82</tt>"]
+    style var_stream_82 fill:transparent
     33v1
 end
-subgraph var_stream_86 ["var <tt>stream_86</tt>"]
-    style var_stream_86 fill:transparent
+subgraph var_stream_85 ["var <tt>stream_85</tt>"]
+    style var_stream_85 fill:transparent
     34v1
 end
-subgraph var_stream_91 ["var <tt>stream_91</tt>"]
-    style var_stream_91 fill:transparent
+subgraph var_stream_90 ["var <tt>stream_90</tt>"]
+    style var_stream_90 fill:transparent
     35v1
 end
-subgraph var_stream_95 ["var <tt>stream_95</tt>"]
-    style var_stream_95 fill:transparent
+subgraph var_stream_94 ["var <tt>stream_94</tt>"]
+    style var_stream_94 fill:transparent
     38v1
     39v1
 end
+subgraph var_stream_97 ["var <tt>stream_97</tt>"]
+    style var_stream_97 fill:transparent
+    40v1
+end
 subgraph var_stream_98 ["var <tt>stream_98</tt>"]
     style var_stream_98 fill:transparent
-    40v1
+    41v1
 end
 subgraph var_stream_99 ["var <tt>stream_99</tt>"]
     style var_stream_99 fill:transparent
-    41v1
+    42v1
 end

--- a/hydro_test/src/cluster/snapshots/two_pc_ir@participants_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/two_pc_ir@participants_mermaid.snap
@@ -1,7 +1,6 @@
 ---
 source: hydro_test/src/cluster/two_pc_bench.rs
 expression: "preview.dfir_for(&participants).to_mermaid(&WriteConfig\n{\n    no_subgraphs: true, no_pull_push: true, no_handoffs: true,\n    op_text_no_imports: true, ..WriteConfig::default()\n})"
-snapshot_kind: text
 ---
 %%{init:{'theme':'base','themeVariables':{'clusterBkg':'#ddd','clusterBorder':'#888'}}}%%
 flowchart TD
@@ -32,8 +31,8 @@ subgraph var_stream_51 ["var <tt>stream_51</tt>"]
     1v1
     2v1
 end
-subgraph var_stream_94 ["var <tt>stream_94</tt>"]
-    style var_stream_94 fill:transparent
+subgraph var_stream_93 ["var <tt>stream_93</tt>"]
+    style var_stream_93 fill:transparent
     5v1
     6v1
 end


### PR DESCRIPTION
Addresses #2656 

## Dedicated fold hooks for the simulator

Replaces the previous `ObserveNonDet`-before-folds approach with fold hooks that model non-deterministic input ordering and batching for folds in the simulator.

### What changed

**New `TopLevelFoldHook`** — For top-level (cross-tick) folds, a dedicated hook selects a non-empty subset of buffered inputs and permutes them before releasing to the fold. Unselected elements remain buffered for future ticks, modeling delayed/lossy delivery. This replaces the old pattern of observing non-determinism on the input stream separately.

**In-tick fold permutation via `StreamOrderHook`** — For in-tick folds on `NoOrder` inputs, an inline shuffle hook permutes elements before the fold to catch commutativity bugs. In future we can add a feature to allow sim callers to skip permutations when commutativity proofs are provided.

**`PassthroughSingletonHook`** — When a fold output is already controlled by a `TopLevelFoldHook`, the downstream singleton batch skips the normal `SingletonHook` (which would add redundant decisions) and uses a passthrough that always releases the latest value.
