### PR TITLE
feat(dfir_lang): support `#var` references to `singleton()` handoffs

### DIFF
--- a/dfir_lang/src/graph/flat_graph_builder.rs
+++ b/dfir_lang/src/graph/flat_graph_builder.rs
@@ -854,13 +854,18 @@ impl FlatGraphBuilder {
                         &mut self.diagnostics,
                     );
                     let out_degree = self.flat_graph.node_degree_out(node_id);
+                    let out_degree_range = match kind {
+                        HandoffKind::Vec => 1..=1,
+                        // `singleton()` may be no-output, only by ref. In the future this will also apply to vec.
+                        HandoffKind::Option => 0..=1,
+                    };
                     emit_arity_error(
                         *src_span,
                         op_name,
                         false,
                         true,
                         out_degree,
-                        &(1..=1),
+                        &out_degree_range,
                         &mut self.diagnostics,
                     );
                 }

--- a/dfir_lang/src/graph/flat_graph_builder.rs
+++ b/dfir_lang/src/graph/flat_graph_builder.rs
@@ -12,7 +12,9 @@ use syn::{Error, Ident, ItemUse};
 
 use super::ops::next_iteration::NEXT_ITERATION;
 use super::ops::{FloType, Persistence};
-use super::{DfirGraph, GraphEdgeId, GraphLoopId, GraphNode, GraphNodeId, PortIndexValue};
+use super::{
+    DfirGraph, GraphEdgeId, GraphLoopId, GraphNode, GraphNodeId, HandoffKind, PortIndexValue,
+};
 use crate::diagnostic::{Diagnostic, Diagnostics, Level};
 use crate::graph::ops::{PortListSpec, RangeTrait};
 use crate::graph::{HandoffKind, graph_algorithms};
@@ -794,7 +796,7 @@ impl FlatGraphBuilder {
                         &mut self.diagnostics,
                     );
 
-                    // Check that singleton references actually reference *stateful* operators.
+                    // Check that singleton references actually reference valid targets.
                     {
                         let singletons_resolved =
                             self.flat_graph.node_singleton_references(node_id);
@@ -806,6 +808,16 @@ impl FlatGraphBuilder {
                                 // Error already emitted by `connect_operator_links`, "Cannot find referenced name...".
                                 continue;
                             };
+                            // HandoffKind::Option nodes are valid singleton reference targets.
+                            if matches!(
+                                self.flat_graph.node(singleton_node_id),
+                                GraphNode::Handoff {
+                                    kind: HandoffKind::Option,
+                                    ..
+                                }
+                            ) {
+                                continue;
+                            }
                             let Some(ref_op_inst) = self.flat_graph.node_op_inst(singleton_node_id)
                             else {
                                 // Error already emitted by `insert_node_op_insts_all`.

--- a/dfir_lang/src/graph/flat_graph_builder.rs
+++ b/dfir_lang/src/graph/flat_graph_builder.rs
@@ -10,14 +10,13 @@ use quote::ToTokens;
 use syn::spanned::Spanned;
 use syn::{Error, Ident, ItemUse};
 
-use super::ops::next_iteration::NEXT_ITERATION;
-use super::ops::{FloType, Persistence};
-use super::{
-    DfirGraph, GraphEdgeId, GraphLoopId, GraphNode, GraphNodeId, HandoffKind, PortIndexValue,
-};
 use crate::diagnostic::{Diagnostic, Diagnostics, Level};
-use crate::graph::ops::{PortListSpec, RangeTrait};
-use crate::graph::{HandoffKind, graph_algorithms};
+use crate::graph::ops::next_iteration::NEXT_ITERATION;
+use crate::graph::ops::{FloType, Persistence, PortListSpec, RangeTrait};
+use crate::graph::{
+    DfirGraph, GraphEdgeId, GraphLoopId, GraphNode, GraphNodeId, HandoffKind, PortIndexValue,
+    graph_algorithms,
+};
 use crate::parse::{DfirCode, DfirStatement, Operator, Pipeline};
 use crate::pretty_span::PrettySpan;
 

--- a/dfir_lang/src/graph/flat_to_partitioned.rs
+++ b/dfir_lang/src/graph/flat_to_partitioned.rs
@@ -355,7 +355,7 @@ fn order_subgraphs(
     }
     // Include singleton reference edges.
     for &(pred, succ) in barrier_crossers.singleton_barrier_crossers.iter() {
-        assert_ne!(pred, succ, "TODO(mingwei)");
+        assert_ne!(pred, succ);
         // For handoff nodes (which have no subgraph), use the predecessor's subgraph.
         let pred_sg = if let Some(sg) = partitioned_graph.node_subgraph(pred) {
             sg
@@ -373,14 +373,13 @@ fn order_subgraphs(
         }
         sg_preds.entry(succ_sg).or_default().push(pred_sg);
 
-        // For HandoffKind::Option: borrower must run before pipe consumer.
-        if matches!(
-            partitioned_graph.node(pred),
-            GraphNode::Handoff {
-                kind: HandoffKind::Option,
-                ..
-            }
-        ) {
+        // For handoff nodes: borrower must run before pipe consumer.
+        // All handoffs should have at most one successor.
+        if matches!(partitioned_graph.node(pred), GraphNode::Handoff { .. }) {
+            assert!(
+                partitioned_graph.node_degree_out(pred) <= 1,
+                "handoff should have at most one successor"
+            );
             for (_edge, consumer) in partitioned_graph.node_successors(pred) {
                 let consumer_sg = partitioned_graph.node_subgraph(consumer).unwrap();
                 if consumer_sg != succ_sg {

--- a/dfir_lang/src/graph/flat_to_partitioned.rs
+++ b/dfir_lang/src/graph/flat_to_partitioned.rs
@@ -380,7 +380,7 @@ fn order_subgraphs(
                 partitioned_graph.node_degree_out(pred) <= 1,
                 "handoff should have at most one successor"
             );
-            for (_edge, consumer) in partitioned_graph.node_successors(pred) {
+            if let Some((_edge, consumer)) = partitioned_graph.node_successors(pred).next() {
                 let consumer_sg = partitioned_graph.node_subgraph(consumer).unwrap();
                 if consumer_sg != succ_sg {
                     sg_preds.entry(consumer_sg).or_default().push(succ_sg);

--- a/dfir_lang/src/graph/flat_to_partitioned.rs
+++ b/dfir_lang/src/graph/flat_to_partitioned.rs
@@ -322,7 +322,13 @@ fn order_subgraphs(
         if !matches!(hoff, GraphNode::Handoff { .. }) {
             continue;
         }
+
+        // Handoffs may have 0 successors if only used by reference. Skip ordering those.
+        if partitioned_graph.node_degree_out(hoff_id) == 0 {
+            continue;
+        }
         assert_eq!(1, partitioned_graph.node_degree_out(hoff_id));
+
         let (succ_edge, succ) = partitioned_graph.node_successors(hoff_id).next().unwrap();
 
         let succ_edge_delaytype = barrier_crossers

--- a/dfir_lang/src/graph/flat_to_partitioned.rs
+++ b/dfir_lang/src/graph/flat_to_partitioned.rs
@@ -350,10 +350,38 @@ fn order_subgraphs(
     // Include singleton reference edges.
     for &(pred, succ) in barrier_crossers.singleton_barrier_crossers.iter() {
         assert_ne!(pred, succ, "TODO(mingwei)");
-        let pred_sg = partitioned_graph.node_subgraph(pred).unwrap();
+        // For handoff nodes (which have no subgraph), use the predecessor's subgraph.
+        let pred_sg = if let Some(sg) = partitioned_graph.node_subgraph(pred) {
+            sg
+        } else {
+            // pred is a handoff node — find its predecessor operator's subgraph.
+            let (_edge, pred_pred) = partitioned_graph
+                .node_predecessors(pred)
+                .next()
+                .expect("handoff must have a predecessor");
+            partitioned_graph.node_subgraph(pred_pred).unwrap()
+        };
         let succ_sg = partitioned_graph.node_subgraph(succ).unwrap();
-        assert_ne!(pred_sg, succ_sg);
+        if pred_sg == succ_sg {
+            continue;
+        }
         sg_preds.entry(succ_sg).or_default().push(pred_sg);
+
+        // For HandoffKind::Option: borrower must run before pipe consumer.
+        if matches!(
+            partitioned_graph.node(pred),
+            GraphNode::Handoff {
+                kind: HandoffKind::Option,
+                ..
+            }
+        ) {
+            for (_edge, consumer) in partitioned_graph.node_successors(pred) {
+                let consumer_sg = partitioned_graph.node_subgraph(consumer).unwrap();
+                if consumer_sg != succ_sg {
+                    sg_preds.entry(consumer_sg).or_default().push(succ_sg);
+                }
+            }
+        }
     }
 
     // Topological sort — rejects intra-tick cycles.

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1059,16 +1059,15 @@ impl DfirGraph {
                             self.node_degree_out(src_ref_id) <= 1,
                             "handoff should have at most one successor"
                         );
-                        for (_edge, succ_id) in self.node_successors(src_ref_id) {
-                            if let Some(consumer_sg) = self.node_subgraph(succ_id)
-                                && consumer_sg != dst_sg
-                            {
-                                sg_preds
-                                    .entry(consumer_sg)
-                                    .unwrap()
-                                    .or_default()
-                                    .push(dst_sg);
-                            }
+                        if let Some((_edge, succ_id)) = self.node_successors(src_ref_id).next()
+                            && let Some(consumer_sg) = self.node_subgraph(succ_id)
+                            && consumer_sg != dst_sg
+                        {
+                            sg_preds
+                                .entry(consumer_sg)
+                                .unwrap()
+                                .or_default()
+                                .push(dst_sg);
                         }
                     }
                 }

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1101,6 +1101,21 @@ impl DfirGraph {
             })
             .collect();
 
+        // Generate drain code for handoffs with no pipe consumer (0 successors).
+        // These are only accessed via #var references and must be cleared each tick.
+        let no_consumer_drain_code: Vec<TokenStream> = handoff_nodes
+            .iter()
+            .filter(|&&(node_id, _, _)| self.node_successors(node_id).len() == 0)
+            .map(|&(node_id, kind, (src_span, dst_span))| {
+                let span = src_span.join(dst_span).unwrap_or(src_span);
+                let buf_ident = self.hoff_buf_ident(node_id, span);
+                match kind {
+                    HandoffKind::Option => quote_spanned! {span=> #buf_ident.take(); },
+                    HandoffKind::Vec => quote_spanned! {span=> #buf_ident.clear(); },
+                }
+            })
+            .collect();
+
         let mut op_prologue_code = Vec::new();
         let mut op_tick_end_code = Vec::new();
         let mut subgraph_blocks = Vec::new();
@@ -1730,6 +1745,11 @@ impl DfirGraph {
 
                     // End-of-tick state reset (e.g. 'tick persistence).
                     #( #op_tick_end_code )*
+
+                    // Drain handoff buffers that have no pipe consumer (e.g. singleton
+                    // used only via #var reference). Without this, the value would
+                    // persist across ticks and cause panics on the next write.
+                    #( #no_consumer_drain_code )*
 
                     #df.__end_tick();
                     ::std::mem::take(&mut __dfir_work_done)

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -840,29 +840,6 @@ impl DfirGraph {
             .collect::<Vec<_>>()
     }
 
-    /// Resolve singleton references as raw idents for mutable handle access.
-    /// Used by operators like `lattice_bimorphism` that need direct state access.
-    fn helper_resolve_singletons_handles(&self, node_id: GraphNodeId, span: Span) -> Vec<Ident> {
-        self.node_singleton_references(node_id)
-            .iter()
-            .map(|singleton_node_id| {
-                let ref_node_id = singleton_node_id
-                    .expect("Expected singleton to be resolved but was not, this is a bug.");
-                if matches!(
-                    self.node(ref_node_id),
-                    GraphNode::Handoff {
-                        kind: HandoffKind::Option,
-                        ..
-                    }
-                ) {
-                    self.hoff_buf_ident(ref_node_id, span)
-                } else {
-                    self.node_as_singleton_ident(ref_node_id, span)
-                }
-            })
-            .collect::<Vec<_>>()
-    }
-
     /// Returns each subgraph's receive and send handoffs.
     /// `Map<GraphSubgraphId, (recv handoffs, send handoffs)>`
     fn helper_collect_subgraph_handoffs(
@@ -1325,13 +1302,6 @@ impl DfirGraph {
                                 op_inst.arguments_raw.clone(),
                                 singletons_resolved,
                             );
-                            let singletons_resolved_handles =
-                                self.helper_resolve_singletons_handles(node_id, op_span);
-                            let arguments_handles =
-                                &process_singletons::postprocess_singletons_handles(
-                                    op_inst.arguments_raw.clone(),
-                                    singletons_resolved_handles,
-                                );
 
                             let source_tag = 'a: {
                                 if let Some(tag) = self.operator_tag.get(node_id).cloned() {
@@ -1393,7 +1363,6 @@ impl DfirGraph {
                                 op_name,
                                 op_inst,
                                 arguments,
-                                arguments_handles,
                             };
 
                             let write_result =

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1051,15 +1051,14 @@ impl DfirGraph {
                         sg_preds.entry(dst_sg).unwrap().or_default().push(src_sg);
                     }
 
-                    // For HandoffKind::Option references: ensure the borrower runs
-                    // before the pipe consumer (which takes the value via .take()).
-                    if matches!(
-                        self.node(src_ref_id),
-                        GraphNode::Handoff {
-                            kind: HandoffKind::Option,
-                            ..
-                        }
-                    ) {
+                    // Ensure the borrower runs before the pipe consumer
+                    // (which takes/drains the value).
+                    // All handoffs should have at most one successor.
+                    if self.node_subgraph(src_ref_id).is_none() {
+                        assert!(
+                            self.node_degree_out(src_ref_id) <= 1,
+                            "handoff should have at most one successor"
+                        );
                         for (_edge, succ_id) in self.node_successors(src_ref_id) {
                             if let Some(consumer_sg) = self.node_subgraph(succ_id)
                                 && consumer_sg != dst_sg
@@ -1105,7 +1104,7 @@ impl DfirGraph {
         // These are only accessed via #var references and must be cleared each tick.
         let no_consumer_drain_code: Vec<TokenStream> = handoff_nodes
             .iter()
-            .filter(|&&(node_id, _, _)| self.node_successors(node_id).len() == 0)
+            .filter(|&&(node_id, _, _)| self.node_degree_out(node_id) == 0)
             .map(|&(node_id, kind, (src_span, dst_span))| {
                 let span = src_span.join(dst_span).unwrap_or(src_span);
                 let buf_ident = self.hoff_buf_ident(node_id, span);

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -815,7 +815,8 @@ impl DfirGraph {
     /// Resolve the singletons via [`Self::node_singleton_references`] for the given `node_id`.
     /// Returns token streams for each reference:
     /// - For stateful operators: `&singleton_op_XXX` (borrow the operator's state)
-    /// - For HandoffKind::Option: `hoff_XXX_buf.as_ref().unwrap()` (borrow from the slot)
+    /// - For HandoffKind::Option: `&(hoff_XXX_buf.as_ref().unwrap())` (intentionally produce `&&T`
+    ///   so the later `(*expr)` deref yields `&T`) - TODO(mingwei)
     fn helper_resolve_singletons(&self, node_id: GraphNodeId, span: Span) -> Vec<TokenStream> {
         self.node_singleton_references(node_id)
             .iter()

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -840,6 +840,29 @@ impl DfirGraph {
             .collect::<Vec<_>>()
     }
 
+    /// Resolve singleton references as raw idents for mutable handle access.
+    /// Used by operators like `lattice_bimorphism` that need direct state access.
+    fn helper_resolve_singletons_handles(&self, node_id: GraphNodeId, span: Span) -> Vec<Ident> {
+        self.node_singleton_references(node_id)
+            .iter()
+            .map(|singleton_node_id| {
+                let ref_node_id = singleton_node_id
+                    .expect("Expected singleton to be resolved but was not, this is a bug.");
+                if matches!(
+                    self.node(ref_node_id),
+                    GraphNode::Handoff {
+                        kind: HandoffKind::Option,
+                        ..
+                    }
+                ) {
+                    self.hoff_buf_ident(ref_node_id, span)
+                } else {
+                    self.node_as_singleton_ident(ref_node_id, span)
+                }
+            })
+            .collect::<Vec<_>>()
+    }
+
     /// Returns each subgraph's receive and send handoffs.
     /// `Map<GraphSubgraphId, (recv handoffs, send handoffs)>`
     fn helper_collect_subgraph_handoffs(
@@ -1300,12 +1323,14 @@ impl DfirGraph {
 
                             let arguments = &process_singletons::postprocess_singletons(
                                 op_inst.arguments_raw.clone(),
-                                singletons_resolved.clone(),
+                                singletons_resolved,
                             );
+                            let singletons_resolved_handles =
+                                self.helper_resolve_singletons_handles(node_id, op_span);
                             let arguments_handles =
                                 &process_singletons::postprocess_singletons_handles(
                                     op_inst.arguments_raw.clone(),
-                                    singletons_resolved.clone(),
+                                    singletons_resolved_handles,
                                 );
 
                             let source_tag = 'a: {

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1044,14 +1044,14 @@ impl DfirGraph {
                         }
                     ) {
                         for (_edge, succ_id) in self.node_successors(src_ref_id) {
-                            if let Some(consumer_sg) = self.node_subgraph(succ_id) {
-                                if consumer_sg != dst_sg {
-                                    sg_preds
-                                        .entry(consumer_sg)
-                                        .unwrap()
-                                        .or_default()
-                                        .push(dst_sg);
-                                }
+                            if let Some(consumer_sg) = self.node_subgraph(succ_id)
+                                && consumer_sg != dst_sg
+                            {
+                                sg_preds
+                                    .entry(consumer_sg)
+                                    .unwrap()
+                                    .or_default()
+                                    .push(dst_sg);
                             }
                         }
                     }

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -831,7 +831,10 @@ impl DfirGraph {
                     }
                 ) {
                     let buf_ident = self.hoff_buf_ident(ref_node_id, span);
-                    quote_spanned! {span=> #buf_ident.as_ref().unwrap() }
+                    // Wrapping in &(...) produces &&T so that postprocess_singletons'
+                    // (*expr) deref gives &T — matching `type O = &'a T`.
+                    // TODO(mingwei): Make postprocess_singletons not deref, remove old singletons (the `else` case below).
+                    quote_spanned! {span=> &(#buf_ident.as_ref().unwrap()) }
                 } else {
                     let singleton_ident = self.node_as_singleton_ident(ref_node_id, span);
                     quote_spanned! {span=> &#singleton_ident }

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1017,14 +1017,43 @@ impl DfirGraph {
                     .copied()
                     .flatten()
                 {
-                    let src_sg = self
-                        .node_subgraph(src_ref_id)
-                        .expect("bug: singleton ref node must belong to a subgraph");
+                    // For handoff nodes (no subgraph), use the predecessor's subgraph.
+                    let src_sg = if let Some(sg) = self.node_subgraph(src_ref_id) {
+                        sg
+                    } else {
+                        let (_edge, pred) = self
+                            .node_predecessors(src_ref_id)
+                            .next()
+                            .expect("handoff must have a predecessor");
+                        self.node_subgraph(pred).unwrap()
+                    };
                     let dst_sg = self
                         .node_subgraph(dst_id)
                         .expect("bug: singleton ref consumer must belong to a subgraph");
                     if src_sg != dst_sg {
                         sg_preds.entry(dst_sg).unwrap().or_default().push(src_sg);
+                    }
+
+                    // For HandoffKind::Option references: ensure the borrower runs
+                    // before the pipe consumer (which takes the value via .take()).
+                    if matches!(
+                        self.node(src_ref_id),
+                        GraphNode::Handoff {
+                            kind: HandoffKind::Option,
+                            ..
+                        }
+                    ) {
+                        for (_edge, succ_id) in self.node_successors(src_ref_id) {
+                            if let Some(consumer_sg) = self.node_subgraph(succ_id) {
+                                if consumer_sg != dst_sg {
+                                    sg_preds
+                                        .entry(consumer_sg)
+                                        .unwrap()
+                                        .or_default()
+                                        .push(dst_sg);
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -1255,6 +1284,33 @@ impl DfirGraph {
 
                             let singletons_resolved =
                                 self.helper_resolve_singletons(node_id, op_span);
+
+                            // For HandoffKind::Option references, generate local bindings
+                            // that unwrap the Option so the `(*&ident)` pattern works.
+                            let handoff_singleton_bindings: Vec<TokenStream> = self
+                                .node_singleton_references(node_id)
+                                .iter()
+                                .zip(singletons_resolved.iter())
+                                .filter_map(|(ref_node_id, resolved_ident)| {
+                                    let ref_node_id = (*ref_node_id)?;
+                                    if !matches!(
+                                        self.node(ref_node_id),
+                                        GraphNode::Handoff {
+                                            kind: HandoffKind::Option,
+                                            ..
+                                        }
+                                    ) {
+                                        return None;
+                                    }
+                                    let buf_ident =
+                                        self.hoff_buf_ident(ref_node_id, resolved_ident.span());
+                                    let singleton_ident = resolved_ident;
+                                    Some(quote_spanned! {op_span=>
+                                        let #singleton_ident = #buf_ident.as_ref().unwrap();
+                                    })
+                                })
+                                .collect();
+
                             let arguments = &process_singletons::postprocess_singletons(
                                 op_inst.arguments_raw.clone(),
                                 singletons_resolved.clone(),
@@ -1364,6 +1420,10 @@ impl DfirGraph {
                             });
                             op_prologue_code.push(write_prologue);
                             op_tick_end_code.push(write_tick_end);
+                            // Emit bindings for HandoffKind::Option singleton references.
+                            for binding in &handoff_singleton_bindings {
+                                subgraph_op_iter_code.push(binding.clone());
+                            }
                             subgraph_op_iter_code.push(write_iterator);
 
                             if include_type_guards {

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -813,16 +813,29 @@ impl DfirGraph {
     }
 
     /// Resolve the singletons via [`Self::node_singleton_references`] for the given `node_id`.
-    fn helper_resolve_singletons(&self, node_id: GraphNodeId, span: Span) -> Vec<Ident> {
+    /// Returns token streams for each reference:
+    /// - For stateful operators: `&singleton_op_XXX` (borrow the operator's state)
+    /// - For HandoffKind::Option: `hoff_XXX_buf.as_ref().unwrap()` (borrow from the slot)
+    fn helper_resolve_singletons(&self, node_id: GraphNodeId, span: Span) -> Vec<TokenStream> {
         self.node_singleton_references(node_id)
             .iter()
             .map(|singleton_node_id| {
                 // TODO(mingwei): this `expect` should be caught in error checking
-                self.node_as_singleton_ident(
-                    singleton_node_id
-                        .expect("Expected singleton to be resolved but was not, this is a bug."),
-                    span,
-                )
+                let ref_node_id = singleton_node_id
+                    .expect("Expected singleton to be resolved but was not, this is a bug.");
+                if matches!(
+                    self.node(ref_node_id),
+                    GraphNode::Handoff {
+                        kind: HandoffKind::Option,
+                        ..
+                    }
+                ) {
+                    let buf_ident = self.hoff_buf_ident(ref_node_id, span);
+                    quote_spanned! {span=> #buf_ident.as_ref().unwrap() }
+                } else {
+                    let singleton_ident = self.node_as_singleton_ident(ref_node_id, span);
+                    quote_spanned! {span=> &#singleton_ident }
+                }
             })
             .collect::<Vec<_>>()
     }
@@ -1285,32 +1298,6 @@ impl DfirGraph {
                             let singletons_resolved =
                                 self.helper_resolve_singletons(node_id, op_span);
 
-                            // For HandoffKind::Option references, generate local bindings
-                            // that unwrap the Option so the `(*&ident)` pattern works.
-                            let handoff_singleton_bindings: Vec<TokenStream> = self
-                                .node_singleton_references(node_id)
-                                .iter()
-                                .zip(singletons_resolved.iter())
-                                .filter_map(|(ref_node_id, resolved_ident)| {
-                                    let ref_node_id = (*ref_node_id)?;
-                                    if !matches!(
-                                        self.node(ref_node_id),
-                                        GraphNode::Handoff {
-                                            kind: HandoffKind::Option,
-                                            ..
-                                        }
-                                    ) {
-                                        return None;
-                                    }
-                                    let buf_ident =
-                                        self.hoff_buf_ident(ref_node_id, resolved_ident.span());
-                                    let singleton_ident = resolved_ident;
-                                    Some(quote_spanned! {op_span=>
-                                        let #singleton_ident = #buf_ident.as_ref().unwrap();
-                                    })
-                                })
-                                .collect();
-
                             let arguments = &process_singletons::postprocess_singletons(
                                 op_inst.arguments_raw.clone(),
                                 singletons_resolved.clone(),
@@ -1420,10 +1407,6 @@ impl DfirGraph {
                             });
                             op_prologue_code.push(write_prologue);
                             op_tick_end_code.push(write_tick_end);
-                            // Emit bindings for HandoffKind::Option singleton references.
-                            for binding in &handoff_singleton_bindings {
-                                subgraph_op_iter_code.push(binding.clone());
-                            }
                             subgraph_op_iter_code.push(write_iterator);
 
                             if include_type_guards {

--- a/dfir_lang/src/graph/ops/lattice_bimorphism.rs
+++ b/dfir_lang/src/graph/ops/lattice_bimorphism.rs
@@ -62,15 +62,14 @@ pub const LATTICE_BIMORPHISM: OperatorConstraints = OperatorConstraints {
                    ident,
                    inputs,
                    arguments,
-                   arguments_handles,
                    ..
                },
                _| {
         assert!(is_pull);
 
         let func = &arguments[0];
-        let lhs_state_handle = &arguments_handles[1];
-        let rhs_state_handle = &arguments_handles[2];
+        let lhs_state = &arguments[1];
+        let rhs_state = &arguments[2];
 
         let lhs_items = &inputs[0];
         let rhs_items = &inputs[1];
@@ -78,8 +77,8 @@ pub const LATTICE_BIMORPHISM: OperatorConstraints = OperatorConstraints {
         let write_iterator = quote_spanned! {op_span=>
             let #ident = {
                 let (lhs_state, rhs_state) = (
-                    &#lhs_state_handle,
-                    &#rhs_state_handle,
+                    &#lhs_state,
+                    &#rhs_state,
                 );
                 #[inline(always)]
                 fn check_inputs<'a, Func, LhsPull, RhsPull, LhsState, RhsState, Output>(

--- a/dfir_lang/src/graph/ops/mod.rs
+++ b/dfir_lang/src/graph/ops/mod.rs
@@ -428,8 +428,6 @@ pub struct WriteContextArgs<'a> {
     /// These arguments include singleton postprocessing codegen, with
     /// [`std::cell::RefCell::borrow_mut`] code pre-generated.
     pub arguments: &'a Punctuated<Expr, Token![,]>,
-    /// Same as [`Self::arguments`] but with only raw idents, no borrowing code.
-    pub arguments_handles: &'a Punctuated<Expr, Token![,]>,
 }
 impl WriteContextArgs<'_> {
     /// Generate a (almost certainly) unique identifier with the given suffix.

--- a/dfir_lang/src/process_singletons.rs
+++ b/dfir_lang/src/process_singletons.rs
@@ -23,48 +23,46 @@ pub fn preprocess_singletons(tokens: TokenStream, found_idents: &mut Vec<Ident>)
 /// Replaces singleton references `#my_var` with the code needed to actually get the value inside.
 ///
 /// * `tokens` - The tokens to update singleton references within.
-/// * `resolved_idents` - The local variable idents that correspond 1:1 and in the same
+/// * `resolved_exprs` - Token streams that correspond 1:1 and in the same
 ///   order as the singleton references within `tokens` (found in-order via [`preprocess_singletons`]).
 ///
-/// Generates `(*&ident)` — an immutable place expression that prevents consumer mutation.
+/// Generates `(*expr)` — an immutable place expression that prevents consumer mutation.
 /// Use [`postprocess_singletons_handles`] for just the raw idents.
 pub fn postprocess_singletons(
     tokens: TokenStream,
-    resolved_idents: impl IntoIterator<Item = Ident>,
+    resolved_exprs: impl IntoIterator<Item = TokenStream>,
 ) -> Punctuated<Expr, Token![,]> {
-    let mut resolved_idents_iter = resolved_idents.into_iter();
+    let mut resolved_exprs_iter = resolved_exprs.into_iter();
     let processed = process_singletons(tokens, &mut |singleton_ident| {
         let span = singleton_ident.span();
-        let mut resolved_ident = resolved_idents_iter.next().unwrap();
-        resolved_ident.set_span(span);
-        // Emit `(*&ident)` so consumers get an immutable place expression.
-        // The `&` prevents mutation (can't assign through a shared reference),
-        // and the `*` dereferences back to the original type for ergonomic use.
-        let deref_ref_tokens: TokenStream = [
-            TokenTree::Punct(proc_macro2::Punct::new('*', proc_macro2::Spacing::Alone)),
-            TokenTree::Punct(proc_macro2::Punct::new('&', proc_macro2::Spacing::Alone)),
-            TokenTree::Ident(resolved_ident),
-        ]
-        .into_iter()
+        let expr_tokens = resolved_exprs_iter.next().unwrap();
+        // Emit `(*expr)` so consumers get an immutable place expression.
+        let deref_tokens: TokenStream = std::iter::once(TokenTree::Punct(proc_macro2::Punct::new(
+            '*',
+            proc_macro2::Spacing::Alone,
+        )))
+        .chain(expr_tokens)
         .collect();
-        let mut group = Group::new(proc_macro2::Delimiter::Parenthesis, deref_ref_tokens);
+        let mut group = Group::new(proc_macro2::Delimiter::Parenthesis, deref_tokens);
         group.set_span(span);
         TokenTree::Group(group)
     });
     parse_terminated(processed).unwrap()
 }
 
-/// Same as [`postprocess_singletons`] but generates just the raw ident rather than
-/// `RefCell` borrowing code.
+/// Same as [`postprocess_singletons`] but generates just the raw expression rather than
+/// wrapping in `(*...)`.
 pub fn postprocess_singletons_handles(
     tokens: TokenStream,
-    resolved_idents: impl IntoIterator<Item = Ident>,
+    resolved_exprs: impl IntoIterator<Item = TokenStream>,
 ) -> Punctuated<Expr, Token![,]> {
-    let mut resolved_idents_iter = resolved_idents.into_iter();
+    let mut resolved_exprs_iter = resolved_exprs.into_iter();
     let processed = process_singletons(tokens, &mut |singleton_ident| {
-        let mut resolved_ident = resolved_idents_iter.next().unwrap();
-        resolved_ident.set_span(singleton_ident.span().resolved_at(resolved_ident.span()));
-        TokenTree::Ident(resolved_ident)
+        let span = singleton_ident.span();
+        let expr_tokens = resolved_exprs_iter.next().unwrap();
+        let mut group = Group::new(proc_macro2::Delimiter::Parenthesis, expr_tokens);
+        group.set_span(span);
+        TokenTree::Group(group)
     });
     parse_terminated(processed).unwrap()
 }

--- a/dfir_lang/src/process_singletons.rs
+++ b/dfir_lang/src/process_singletons.rs
@@ -50,19 +50,17 @@ pub fn postprocess_singletons(
     parse_terminated(processed).unwrap()
 }
 
-/// Same as [`postprocess_singletons`] but generates just the raw expression rather than
-/// wrapping in `(*...)`.
+/// Same as [`postprocess_singletons`] but generates just the raw ident rather than
+/// wrapping in `(*...)`. Used for mutable state handles.
 pub fn postprocess_singletons_handles(
     tokens: TokenStream,
-    resolved_exprs: impl IntoIterator<Item = TokenStream>,
+    resolved_idents: impl IntoIterator<Item = Ident>,
 ) -> Punctuated<Expr, Token![,]> {
-    let mut resolved_exprs_iter = resolved_exprs.into_iter();
+    let mut resolved_idents_iter = resolved_idents.into_iter();
     let processed = process_singletons(tokens, &mut |singleton_ident| {
-        let span = singleton_ident.span();
-        let expr_tokens = resolved_exprs_iter.next().unwrap();
-        let mut group = Group::new(proc_macro2::Delimiter::Parenthesis, expr_tokens);
-        group.set_span(span);
-        TokenTree::Group(group)
+        let mut resolved_ident = resolved_idents_iter.next().unwrap();
+        resolved_ident.set_span(singleton_ident.span().resolved_at(resolved_ident.span()));
+        TokenTree::Ident(resolved_ident)
     });
     parse_terminated(processed).unwrap()
 }

--- a/dfir_lang/src/process_singletons.rs
+++ b/dfir_lang/src/process_singletons.rs
@@ -50,21 +50,6 @@ pub fn postprocess_singletons(
     parse_terminated(processed).unwrap()
 }
 
-/// Same as [`postprocess_singletons`] but generates just the raw ident rather than
-/// wrapping in `(*...)`. Used for mutable state handles.
-pub fn postprocess_singletons_handles(
-    tokens: TokenStream,
-    resolved_idents: impl IntoIterator<Item = Ident>,
-) -> Punctuated<Expr, Token![,]> {
-    let mut resolved_idents_iter = resolved_idents.into_iter();
-    let processed = process_singletons(tokens, &mut |singleton_ident| {
-        let mut resolved_ident = resolved_idents_iter.next().unwrap();
-        resolved_ident.set_span(singleton_ident.span().resolved_at(resolved_ident.span()));
-        TokenTree::Ident(resolved_ident)
-    });
-    parse_terminated(processed).unwrap()
-}
-
 /// Traverse the token stream, applying the `map_singleton_fn` whenever a singleton is found,
 /// returning the transformed token stream.
 fn process_singletons(

--- a/dfir_lang/src/process_singletons.rs
+++ b/dfir_lang/src/process_singletons.rs
@@ -27,7 +27,6 @@ pub fn preprocess_singletons(tokens: TokenStream, found_idents: &mut Vec<Ident>)
 ///   order as the singleton references within `tokens` (found in-order via [`preprocess_singletons`]).
 ///
 /// Generates `(*expr)` — an immutable place expression that prevents consumer mutation.
-/// Use [`postprocess_singletons_handles`] for just the raw idents.
 pub fn postprocess_singletons(
     tokens: TokenStream,
     resolved_exprs: impl IntoIterator<Item = TokenStream>,

--- a/dfir_rs/tests/compile-fail/stable/surface_singleton_mutation.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_singleton_mutation.stderr
@@ -1,5 +1,7 @@
 error[E0594]: cannot assign to data in a `&` reference
  --> tests/compile-fail/stable/surface_singleton_mutation.rs:9:18
   |
+8 |             -> map(|x| {
+  |                --- this cannot be written to
 9 |                 #max_of_stream2 = 999;
   |                  ^^^^^^^^^^^^^^^^^^^^ cannot assign

--- a/dfir_rs/tests/surface_handoff.rs
+++ b/dfir_rs/tests/surface_handoff.rs
@@ -100,3 +100,18 @@ pub async fn test_singleton_multi_tick() {
     flow.run_tick().await;
     assert_eq!(vec![10, 15, 15], *output.borrow());
 }
+
+/// Test: singleton() can be referenced via #var.
+#[dfir_rs::test]
+pub async fn test_singleton_reference() {
+    let mut output = Vec::<i32>::new();
+    let out = &mut output;
+    let mut flow = dfir_rs::dfir_syntax! {
+        my_val = source_iter([42_i32]) -> singleton();
+        my_val -> for_each(|_| {});
+        source_iter(1..=3_i32) -> map(|x| x + #my_val) -> for_each(|v: i32| out.push(v));
+    };
+    flow.run_tick().await;
+    drop(flow);
+    assert_eq!(vec![43, 44, 45], output);
+}

--- a/dfir_rs/tests/surface_handoff.rs
+++ b/dfir_rs/tests/surface_handoff.rs
@@ -105,8 +105,6 @@ pub async fn test_singleton_multi_tick_consumed() {
 #[dfir_rs::test]
 pub async fn test_singleton_multi_tick() {
     let (send, recv) = dfir_rs::util::unbounded_channel::<i32>();
-    let output = std::rc::Rc::new(std::cell::RefCell::new(Vec::<i32>::new()));
-    let out = output.clone();
     let mut flow = dfir_rs::dfir_syntax! {
         source_stream(recv)
             -> fold::<'static>(|| 0_i32, |acc: &mut i32, x| *acc += x)
@@ -114,15 +112,9 @@ pub async fn test_singleton_multi_tick() {
     };
     send.send(10).unwrap();
     flow.run_tick().await;
-    assert_eq!(vec![10], *output.borrow());
-
     send.send(5).unwrap();
     flow.run_tick().await;
-    assert_eq!(vec![10, 15], *output.borrow());
-
-    // No new input: fold still emits its accumulated value.
     flow.run_tick().await;
-    assert_eq!(vec![10, 15, 15], *output.borrow());
 }
 
 /// Test: singleton() can be referenced via #var.
@@ -152,4 +144,28 @@ pub async fn test_singleton_reference_only() {
     flow.run_tick().await;
     drop(flow);
     assert_eq!(vec![43, 44, 45], output);
+}
+
+/// Test: singleton() referenced via #var with no direct consumer (0 successors), multiple ticks.
+#[dfir_rs::test]
+pub async fn test_singleton_reference_only_multi_tick() {
+    let (send, recv) = dfir_rs::util::unbounded_channel::<i32>();
+    let output = std::rc::Rc::new(std::cell::RefCell::new(Vec::<i32>::new()));
+    let out = output.clone();
+    let mut flow = dfir_rs::dfir_syntax! {
+        my_val = source_iter([42_i32])
+            -> persist::<'static>()
+            -> singleton();
+        source_stream(recv)
+            -> map(|x| x + #my_val)
+            -> for_each(|v: i32| out.borrow_mut().push(v));
+    };
+    send.send(1).unwrap();
+    send.send(3).unwrap();
+    flow.run_tick().await;
+    assert_eq!(vec![43, 45], *output.borrow());
+
+    send.send(100).unwrap();
+    flow.run_tick().await;
+    assert_eq!(vec![142], *output.borrow());
 }

--- a/dfir_rs/tests/surface_handoff.rs
+++ b/dfir_rs/tests/surface_handoff.rs
@@ -34,7 +34,7 @@ pub async fn test_handoff_mid_pipeline() {
     assert_eq!(vec![6, 8], output);
 }
 
-/// Test: singleton() stores exactly one item and passes it through.
+/// Test: `singleton()` stores exactly one item and passes it through.
 #[dfir_rs::test]
 pub async fn test_singleton_basic() {
     let mut output = Vec::<i32>::new();
@@ -48,7 +48,7 @@ pub async fn test_singleton_basic() {
     assert_eq!(vec![42], output);
 }
 
-/// Test: singleton() in a pipeline with transforms.
+/// Test: `singleton()` in a pipeline with transforms.
 #[dfir_rs::test]
 pub async fn test_singleton_with_fold() {
     let mut output = Vec::<i32>::new();
@@ -66,7 +66,7 @@ pub async fn test_singleton_with_fold() {
     assert_eq!(vec![150], output);
 }
 
-/// Test: singleton() panics if it receives more than one item.
+/// Test: `singleton()` panics if it receives more than one item.
 #[dfir_rs::test]
 #[should_panic(expected = "singleton() received more than one item")]
 pub async fn test_singleton_panics_on_multiple_items() {
@@ -76,9 +76,9 @@ pub async fn test_singleton_panics_on_multiple_items() {
     flow.run_tick().await;
 }
 
-/// Test: singleton() across multiple ticks verifies the slot is drained each tick.
+/// Test: `singleton()` w/ consumer across multiple ticks verifies the slot is drained each tick.
 #[dfir_rs::test]
-pub async fn test_singleton_multi_tick() {
+pub async fn test_singleton_multi_tick_consumed() {
     let (send, recv) = dfir_rs::util::unbounded_channel::<i32>();
     let output = std::rc::Rc::new(std::cell::RefCell::new(Vec::<i32>::new()));
     let out = output.clone();
@@ -87,6 +87,30 @@ pub async fn test_singleton_multi_tick() {
             -> fold::<'static>(|| 0_i32, |acc: &mut i32, x| *acc += x)
             -> singleton()
             -> for_each(|v: i32| out.borrow_mut().push(v));
+    };
+    send.send(10).unwrap();
+    flow.run_tick().await;
+    assert_eq!(vec![10], *output.borrow());
+
+    send.send(5).unwrap();
+    flow.run_tick().await;
+    assert_eq!(vec![10, 15], *output.borrow());
+
+    // No new input: fold still emits its accumulated value.
+    flow.run_tick().await;
+    assert_eq!(vec![10, 15, 15], *output.borrow());
+}
+
+/// Test: `singleton()` w/o consumer across multiple ticks verifies the slot is drained each tick.
+#[dfir_rs::test]
+pub async fn test_singleton_multi_tick() {
+    let (send, recv) = dfir_rs::util::unbounded_channel::<i32>();
+    let output = std::rc::Rc::new(std::cell::RefCell::new(Vec::<i32>::new()));
+    let out = output.clone();
+    let mut flow = dfir_rs::dfir_syntax! {
+        source_stream(recv)
+            -> fold::<'static>(|| 0_i32, |acc: &mut i32, x| *acc += x)
+            -> singleton();
     };
     send.send(10).unwrap();
     flow.run_tick().await;

--- a/dfir_rs/tests/surface_handoff.rs
+++ b/dfir_rs/tests/surface_handoff.rs
@@ -117,7 +117,7 @@ pub async fn test_singleton_multi_tick() {
     flow.run_tick().await;
 }
 
-/// Test: singleton() can be referenced via #var.
+/// Test: `singleton()` can be referenced via `#var`.
 #[dfir_rs::test]
 pub async fn test_singleton_reference() {
     let mut output = Vec::<i32>::new();
@@ -132,7 +132,7 @@ pub async fn test_singleton_reference() {
     assert_eq!(vec![43, 44, 45], output);
 }
 
-/// Test: singleton() referenced via #var with no direct consumer (0 successors).
+/// Test: `singleton()` referenced via `#var` with no direct consumer (0 successors).
 #[dfir_rs::test]
 pub async fn test_singleton_reference_only() {
     let mut output = Vec::<i32>::new();
@@ -146,7 +146,7 @@ pub async fn test_singleton_reference_only() {
     assert_eq!(vec![43, 44, 45], output);
 }
 
-/// Test: singleton() referenced via #var with no direct consumer (0 successors), multiple ticks.
+/// Test: `singleton()` referenced via #var with no direct consumer (0 successors), multiple ticks.
 #[dfir_rs::test]
 pub async fn test_singleton_reference_only_multi_tick() {
     let (send, recv) = dfir_rs::util::unbounded_channel::<i32>();
@@ -167,5 +167,5 @@ pub async fn test_singleton_reference_only_multi_tick() {
 
     send.send(100).unwrap();
     flow.run_tick().await;
-    assert_eq!(vec![142], *output.borrow());
+    assert_eq!(vec![43, 45, 142], *output.borrow());
 }

--- a/dfir_rs/tests/surface_handoff.rs
+++ b/dfir_rs/tests/surface_handoff.rs
@@ -139,3 +139,17 @@ pub async fn test_singleton_reference() {
     drop(flow);
     assert_eq!(vec![43, 44, 45], output);
 }
+
+/// Test: singleton() referenced via #var with no direct consumer (0 successors).
+#[dfir_rs::test]
+pub async fn test_singleton_reference_only() {
+    let mut output = Vec::<i32>::new();
+    let out = &mut output;
+    let mut flow = dfir_rs::dfir_syntax! {
+        my_val = source_iter([42_i32]) -> singleton();
+        source_iter(1..=3_i32) -> map(|x| x + #my_val) -> for_each(|v: i32| out.push(v));
+    };
+    flow.run_tick().await;
+    drop(flow);
+    assert_eq!(vec![43, 44, 45], output);
+}


### PR DESCRIPTION
Removes the `arguments_handles` / `postprocess_singletons_handles` codepath, unifying singleton reference resolution into a single mechanism.

Also allows `singleton()` handoff to have no output consumer - would only have referencers

## Motivation

Previously there were two parallel paths for resolving `#var` singleton references in operator codegen:
- `arguments` via `postprocess_singletons` — generates `(*expr)` (immutable place expression)
- `arguments_handles` via `postprocess_singletons_handles` — generates raw idents for operators that manage their own borrowing

Only `lattice_bimorphism` used the `_handles` path. It did `&#state_handle` to get `&T`. With the unified path, it now does `&#state` where `#state` = `(*&singleton_op_XXX)`, so `&(*&singleton_op_XXX)` = `&T`. Same result, one codepath.

## Changes

- `dfir_lang/src/graph/ops/mod.rs` — Remove `arguments_handles` field from `WriteContextArgs`
- `dfir_lang/src/graph/ops/lattice_bimorphism.rs` — Use `arguments` instead of `arguments_handles`
- `dfir_lang/src/process_singletons.rs` — Remove `postprocess_singletons_handles` function
- `dfir_lang/src/graph/meta_graph.rs` — Remove `helper_resolve_singletons_handles` method and `arguments_handles` generation