### PR TITLE
ci: do not use `pull_request_target` for conventional commit check

### DIFF
--- a/.github/workflows/conventional_commits.yml
+++ b/.github/workflows/conventional_commits.yml
@@ -1,7 +1,7 @@
 name: Conventional Commits
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited


### PR DESCRIPTION
https://github.com/amannn/action-semantic-pull-request/issues/219