### PR TITLE
chore: update to rust 1.95.0

### DIFF
--- a/dfir_rs/tests/compile-fail/stable/surface_anti_join_badtypes.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_anti_join_badtypes.stderr
@@ -9,11 +9,11 @@ help: the trait `Borrow<str>` is implemented for `std::string::String`
   |
   | impl Borrow<str> for String {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: required by a bound in `HashSet::<T, S>::contains`
+note: required by a bound in `HashSet::<T, S, A>::contains`
  --> $RUST/std/src/collections/hash/set.rs
   |
   |     pub fn contains<Q: ?Sized>(&self, value: &Q) -> bool
   |            -------- required by a bound in this associated function
   |     where
   |         T: Borrow<Q>,
-  |            ^^^^^^^^^ required by this bound in `HashSet::<T, S>::contains`
+  |            ^^^^^^^^^ required by this bound in `HashSet::<T, S, A>::contains`

--- a/dfir_rs/tests/compile-fail/stable/surface_demuxenum_wrongfields_1.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_demuxenum_wrongfields_1.stderr
@@ -16,18 +16,18 @@ error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<u32, (), Can
              `dfir_rs::dfir_pipes::push::FilterMap<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<In, Meta>`
            and $N others
 note: required for `Shape` to implement `DemuxEnumPush<(Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64,)) {std::mem::drop::<(f64,)>}> as dfir_rs::dfir_pipes::push::Push<(f64,), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64, f64), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64, f64)) {std::mem::drop::<(f64, f64)>}> as dfir_rs::dfir_pipes::push::Push<(f64, f64), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<u32, (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<{closure@$DIR/tests/compile-fail/stable/surface_demuxenum_wrongfields_1.rs:20:38: 20:49}> as dfir_rs::dfir_pipes::push::Push<u32, ()>>::CanPend>>), ()>`
-  --> tests/compile-fail/stable/surface_demuxenum_wrongfields_1.rs:5:14
+  --> tests/compile-fail/stable/surface_demuxenum_wrongfields_1.rs:6:10
    |
  5 |     #[derive(DemuxEnum)]
-   |              ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+   |              --------- type parameter would need to implement `DemuxEnumPush<(Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64,)) {std::mem::drop::<(f64,)>}> as dfir_rs::dfir_pipes::push::Push<(f64,), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64, f64), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64, f64)) {std::mem::drop::<(f64, f64)>}> as dfir_rs::dfir_pipes::push::Push<(f64, f64), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<u32, (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<{closure@$DIR/tests/compile-fail/stable/surface_demuxenum_wrongfields_1.rs:20:38: 20:49}> as dfir_rs::dfir_pipes::push::Push<u32, ()>>::CanPend>>), ()>`
  6 |     enum Shape {
    |          ^^^^^
+   = help: consider manually implementing `DemuxEnumPush<(Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64,)) {std::mem::drop::<(f64,)>}> as dfir_rs::dfir_pipes::push::Push<(f64,), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64, f64), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64, f64)) {std::mem::drop::<(f64, f64)>}> as dfir_rs::dfir_pipes::push::Push<(f64, f64), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<u32, (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<{closure@$DIR/tests/compile-fail/stable/surface_demuxenum_wrongfields_1.rs:20:38: 20:49}> as dfir_rs::dfir_pipes::push::Push<u32, ()>>::CanPend>>), ()>` to avoid undesired bounds
 note: required by a bound in `demux_enum_guard`
   --> tests/compile-fail/stable/surface_demuxenum_wrongfields_1.rs:17:15
    |
 17 |         ]) -> demux_enum::<Shape>();
    |               ^^^^^^^^^^ required by this bound in `demux_enum_guard`
-   = note: this error originates in the derive macro `DemuxEnum` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<u32, (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<{closure@$DIR/tests/compile-fail/stable/surface_demuxenum_wrongfields_1.rs:20:38: 20:49}> as dfir_rs::dfir_pipes::push::Push<u32, ()>>::CanPend>: dfir_rs::dfir_pipes::push::Push<(f64,), ()>` is not satisfied
   --> tests/compile-fail/stable/surface_demuxenum_wrongfields_1.rs:17:15
@@ -47,15 +47,15 @@ error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<u32, (), Can
              `dfir_rs::dfir_pipes::push::FilterMap<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<In, Meta>`
            and $N others
 note: required for `Shape` to implement `DemuxEnumPush<(Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64,)) {std::mem::drop::<(f64,)>}> as dfir_rs::dfir_pipes::push::Push<(f64,), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64, f64), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64, f64)) {std::mem::drop::<(f64, f64)>}> as dfir_rs::dfir_pipes::push::Push<(f64, f64), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<u32, (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<{closure@$DIR/tests/compile-fail/stable/surface_demuxenum_wrongfields_1.rs:20:38: 20:49}> as dfir_rs::dfir_pipes::push::Push<u32, ()>>::CanPend>>), ()>`
-  --> tests/compile-fail/stable/surface_demuxenum_wrongfields_1.rs:5:14
+  --> tests/compile-fail/stable/surface_demuxenum_wrongfields_1.rs:6:10
    |
  5 |     #[derive(DemuxEnum)]
-   |              ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+   |              --------- type parameter would need to implement `DemuxEnumPush<(Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64,)) {std::mem::drop::<(f64,)>}> as dfir_rs::dfir_pipes::push::Push<(f64,), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64, f64), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64, f64)) {std::mem::drop::<(f64, f64)>}> as dfir_rs::dfir_pipes::push::Push<(f64, f64), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<u32, (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<{closure@$DIR/tests/compile-fail/stable/surface_demuxenum_wrongfields_1.rs:20:38: 20:49}> as dfir_rs::dfir_pipes::push::Push<u32, ()>>::CanPend>>), ()>`
  6 |     enum Shape {
    |          ^^^^^
+   = help: consider manually implementing `DemuxEnumPush<(Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64,)) {std::mem::drop::<(f64,)>}> as dfir_rs::dfir_pipes::push::Push<(f64,), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64, f64), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64, f64)) {std::mem::drop::<(f64, f64)>}> as dfir_rs::dfir_pipes::push::Push<(f64, f64), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<u32, (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<{closure@$DIR/tests/compile-fail/stable/surface_demuxenum_wrongfields_1.rs:20:38: 20:49}> as dfir_rs::dfir_pipes::push::Push<u32, ()>>::CanPend>>), ()>` to avoid undesired bounds
 note: required by a bound in `demux_enum_guard`
   --> tests/compile-fail/stable/surface_demuxenum_wrongfields_1.rs:17:15
    |
 17 |         ]) -> demux_enum::<Shape>();
    |               ^^^^^^^^^^ required by this bound in `demux_enum_guard`
-   = note: this error originates in the derive macro `DemuxEnum` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/dfir_rs/tests/compile-fail/stable/surface_demuxenum_wrongfields_2.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_demuxenum_wrongfields_2.stderr
@@ -16,18 +16,18 @@ error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<(u32,), (), 
              `dfir_rs::dfir_pipes::push::FilterMap<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<In, Meta>`
            and $N others
 note: required for `Shape` to implement `DemuxEnumPush<(Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64,)) {std::mem::drop::<(f64,)>}> as dfir_rs::dfir_pipes::push::Push<(f64,), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64, f64), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64, f64)) {std::mem::drop::<(f64, f64)>}> as dfir_rs::dfir_pipes::push::Push<(f64, f64), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(u32,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<{closure@$DIR/tests/compile-fail/stable/surface_demuxenum_wrongfields_2.rs:20:38: 20:52}> as dfir_rs::dfir_pipes::push::Push<(u32,), ()>>::CanPend>>), ()>`
-  --> tests/compile-fail/stable/surface_demuxenum_wrongfields_2.rs:5:14
+  --> tests/compile-fail/stable/surface_demuxenum_wrongfields_2.rs:6:10
    |
  5 |     #[derive(DemuxEnum)]
-   |              ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+   |              --------- type parameter would need to implement `DemuxEnumPush<(Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64,)) {std::mem::drop::<(f64,)>}> as dfir_rs::dfir_pipes::push::Push<(f64,), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64, f64), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64, f64)) {std::mem::drop::<(f64, f64)>}> as dfir_rs::dfir_pipes::push::Push<(f64, f64), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(u32,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<{closure@$DIR/tests/compile-fail/stable/surface_demuxenum_wrongfields_2.rs:20:38: 20:52}> as dfir_rs::dfir_pipes::push::Push<(u32,), ()>>::CanPend>>), ()>`
  6 |     enum Shape {
    |          ^^^^^
+   = help: consider manually implementing `DemuxEnumPush<(Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64,)) {std::mem::drop::<(f64,)>}> as dfir_rs::dfir_pipes::push::Push<(f64,), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64, f64), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64, f64)) {std::mem::drop::<(f64, f64)>}> as dfir_rs::dfir_pipes::push::Push<(f64, f64), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(u32,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<{closure@$DIR/tests/compile-fail/stable/surface_demuxenum_wrongfields_2.rs:20:38: 20:52}> as dfir_rs::dfir_pipes::push::Push<(u32,), ()>>::CanPend>>), ()>` to avoid undesired bounds
 note: required by a bound in `demux_enum_guard`
   --> tests/compile-fail/stable/surface_demuxenum_wrongfields_2.rs:17:15
    |
 17 |         ]) -> demux_enum::<Shape>();
    |               ^^^^^^^^^^ required by this bound in `demux_enum_guard`
-   = note: this error originates in the derive macro `DemuxEnum` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<(u32,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<{closure@$DIR/tests/compile-fail/stable/surface_demuxenum_wrongfields_2.rs:20:38: 20:52}> as dfir_rs::dfir_pipes::push::Push<(u32,), ()>>::CanPend>: dfir_rs::dfir_pipes::push::Push<(f64,), ()>` is not satisfied
   --> tests/compile-fail/stable/surface_demuxenum_wrongfields_2.rs:17:15
@@ -47,15 +47,15 @@ error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<(u32,), (), 
              `dfir_rs::dfir_pipes::push::FilterMap<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<In, Meta>`
            and $N others
 note: required for `Shape` to implement `DemuxEnumPush<(Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64,)) {std::mem::drop::<(f64,)>}> as dfir_rs::dfir_pipes::push::Push<(f64,), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64, f64), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64, f64)) {std::mem::drop::<(f64, f64)>}> as dfir_rs::dfir_pipes::push::Push<(f64, f64), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(u32,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<{closure@$DIR/tests/compile-fail/stable/surface_demuxenum_wrongfields_2.rs:20:38: 20:52}> as dfir_rs::dfir_pipes::push::Push<(u32,), ()>>::CanPend>>), ()>`
-  --> tests/compile-fail/stable/surface_demuxenum_wrongfields_2.rs:5:14
+  --> tests/compile-fail/stable/surface_demuxenum_wrongfields_2.rs:6:10
    |
  5 |     #[derive(DemuxEnum)]
-   |              ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+   |              --------- type parameter would need to implement `DemuxEnumPush<(Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64,)) {std::mem::drop::<(f64,)>}> as dfir_rs::dfir_pipes::push::Push<(f64,), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64, f64), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64, f64)) {std::mem::drop::<(f64, f64)>}> as dfir_rs::dfir_pipes::push::Push<(f64, f64), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(u32,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<{closure@$DIR/tests/compile-fail/stable/surface_demuxenum_wrongfields_2.rs:20:38: 20:52}> as dfir_rs::dfir_pipes::push::Push<(u32,), ()>>::CanPend>>), ()>`
  6 |     enum Shape {
    |          ^^^^^
+   = help: consider manually implementing `DemuxEnumPush<(Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64,)) {std::mem::drop::<(f64,)>}> as dfir_rs::dfir_pipes::push::Push<(f64,), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64, f64), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64, f64)) {std::mem::drop::<(f64, f64)>}> as dfir_rs::dfir_pipes::push::Push<(f64, f64), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(u32,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<{closure@$DIR/tests/compile-fail/stable/surface_demuxenum_wrongfields_2.rs:20:38: 20:52}> as dfir_rs::dfir_pipes::push::Push<(u32,), ()>>::CanPend>>), ()>` to avoid undesired bounds
 note: required by a bound in `demux_enum_guard`
   --> tests/compile-fail/stable/surface_demuxenum_wrongfields_2.rs:17:15
    |
 17 |         ]) -> demux_enum::<Shape>();
    |               ^^^^^^^^^^ required by this bound in `demux_enum_guard`
-   = note: this error originates in the derive macro `DemuxEnum` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/dfir_rs/tests/compile-fail/stable/surface_fold_keyed_generics_bad.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_fold_keyed_generics_bad.stderr
@@ -36,8 +36,8 @@ error[E0271]: expected `new` to return `usize`, but it returns `String`
   |                |
   |                required by a bound introduced by this call
   |
-note: required by a bound in `std::collections::hash_map::Entry::<'a, K, V>::or_insert_with`
+note: required by a bound in `std::collections::hash_map::Entry::<'a, K, V, A>::or_insert_with`
  --> $RUST/std/src/collections/hash/map.rs
   |
   |     pub fn or_insert_with<F: FnOnce() -> V>(self, default: F) -> &'a mut V {
-  |                                          ^ required by this bound in `Entry::<'a, K, V>::or_insert_with`
+  |                                          ^ required by this bound in `Entry::<'a, K, V, A>::or_insert_with`

--- a/dfir_rs/tests/surface_sort.rs
+++ b/dfir_rs/tests/surface_sort.rs
@@ -72,7 +72,7 @@ fn test_sort_by_owned() {
     };
     df.run_available_sync();
     let results = collect_ready::<Vec<_>, _>(&mut out_recv);
-    dummies_saved.sort_unstable_by(|d1, d2| d1.y.cmp(&d2.y));
+    dummies_saved.sort_unstable_by_key(|d| d.y);
     assert_ne!(&dummies_saved, &*results);
     dummies_saved.sort_unstable_by(|d1, d2| d1.x.cmp(&d2.x));
     assert_eq!(&dummies_saved, &*results);

--- a/hydro_build_utils/src/lib.rs
+++ b/hydro_build_utils/src/lib.rs
@@ -55,13 +55,19 @@ macro_rules! trybuild_compile_fail {
         let source_dir = std::path::Path::new("tests/compile-fail");
         let stderr_dir = source_dir.join(if cfg!(nightly) { "nightly" } else { "stable" });
 
+        // Remove any existing .rs files/symlinks in the channel dir first.
+        // Stale broken symlinks (e.g. from rebasing) break trybuild.
+        for entry in std::fs::read_dir(&stderr_dir).unwrap().flatten() {
+            if entry.path().extension().and_then(|e| e.to_str()) == Some("rs") {
+                let _ = std::fs::remove_file(entry.path());
+            }
+        }
         // Symlink all .rs files from the source directory into the channel-specific
         // stderr directory so trybuild can find them next to the .stderr files.
         for entry in std::fs::read_dir(source_dir).unwrap().flatten() {
             let path = entry.path();
             if path.extension().and_then(|e| e.to_str()) == Some("rs") {
                 let dest = stderr_dir.join(entry.file_name());
-                let _ = std::fs::remove_file(&dest);
                 let original = std::path::Path::new("..").join(entry.file_name());
                 #[cfg(unix)]
                 std::os::unix::fs::symlink(&original, &dest).unwrap();

--- a/hydro_lang/src/compile/embedded.rs
+++ b/hydro_lang/src/compile/embedded.rs
@@ -536,11 +536,11 @@ impl super::deploy::DeployFlow<'_, EmbeddedDeploy> {
 
             // Get inputs for this location, sorted by name.
             let mut loc_inputs = env.inputs.get(location_key).cloned().unwrap_or_default();
-            loc_inputs.sort_by(|a, b| a.0.to_string().cmp(&b.0.to_string()));
+            loc_inputs.sort_by(|a, b| a.0.cmp(&b.0));
 
             // Get outputs for this location, sorted by name.
             let mut loc_outputs = env.outputs.get(location_key).cloned().unwrap_or_default();
-            loc_outputs.sort_by(|a, b| a.0.to_string().cmp(&b.0.to_string()));
+            loc_outputs.sort_by(|a, b| a.0.cmp(&b.0));
 
             let mut diagnostics = Diagnostics::new();
             let dfir_tokens = graph
@@ -644,7 +644,7 @@ impl super::deploy::DeployFlow<'_, EmbeddedDeploy> {
                 .get(location_key)
                 .cloned()
                 .unwrap_or_default();
-            loc_singleton_inputs.sort_by(|a, b| a.0.to_string().cmp(&b.0.to_string()));
+            loc_singleton_inputs.sort_by(|a, b| a.0.cmp(&b.0));
 
             let singleton_input_params: Vec<proc_macro2::TokenStream> = loc_singleton_inputs
                 .iter()

--- a/hydro_lang/src/runtime_support/launch.rs
+++ b/hydro_lang/src/runtime_support/launch.rs
@@ -145,10 +145,7 @@ pub async fn init_no_ack_start<T: DeserializeOwned + Default>() -> DeployPorts<T
             .collect::<Vec<_>>()
     );
 
-    let all_connected = client_conns
-        .into_iter()
-        .chain(server_conns.into_iter())
-        .collect();
+    let all_connected = client_conns.into_iter().chain(server_conns).collect();
 
     DeployPorts {
         ports: RefCell::new(all_connected),

--- a/hydro_lang/src/viz/json.rs
+++ b/hydro_lang/src/viz/json.rs
@@ -624,7 +624,7 @@ impl<W> HydroJson<'_, W> {
         // Create hierarchy structure (single level: locations as parents, nodes as children)
         let mut locs: Vec<(LocationKey, &(String, Vec<VizNodeKey>))> =
             self.locations.iter().collect();
-        locs.sort_by(|a, b| a.0.cmp(&b.0));
+        locs.sort_by_key(|x| x.0);
         let hierarchy: Vec<serde_json::Value> = locs
             .into_iter()
             .map(|(location_key, (label, _))| {

--- a/lattices/src/ght/mod.rs
+++ b/lattices/src/ght/mod.rs
@@ -162,9 +162,7 @@ where
             clippy::disallowed_methods,
             reason = "nondeterministic iteration order, TODO(mingwei)"
         )]
-        self.children
-            .iter()
-            .flat_map(|(_k, vs)| vs.recursive_iter())
+        self.children.values().flat_map(|vs| vs.recursive_iter())
     }
 
     fn find_containing_leaf(

--- a/precheck.bash
+++ b/precheck.bash
@@ -83,7 +83,7 @@ fi
 TARGETS=""
 FEATURES=""
 if [ "$TEST_DFIR" = true ]; then
-    TARGETS="$TARGETS -p dfir_lang -p dfir_pipes -p dfir_rs -p dfir_macro"
+    TARGETS="$TARGETS -p dfir_lang -p dfir_pipes -p dfir_rs -p dfir_macro -p lattices -p variadics"
 fi
 if [ "$TEST_HYDRO" = true ]; then
     TARGETS="$TARGETS -p hydro_lang -p hydro_std -p hydro_test -p hydro_deploy -p hydro_deploy_integration"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.93.1"
+channel = "1.95.0"
 components = [
     "rustfmt",
     "clippy",

--- a/variadics/tests/compile-fail/stable/var_args_spread_middle.stderr
+++ b/variadics/tests/compile-fail/stable/var_args_spread_middle.stderr
@@ -1,25 +1,7 @@
 error: `var_args!` can only have the `...` spread syntax on the last field.
  --> tests/compile-fail/stable/var_args_spread_middle.rs:4:9
   |
-4 |     let var_args!(a, ...b, c) = var_expr!(1, 2.0, "three", false);
-  |         ^^^^^^^^^^^^^^^^^^^^^
+4 |     let var_args!(_a, ..._b, _c) = var_expr!(1, 2.0, "three", false);
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in the macro `$crate::var_args` which comes from the expansion of the macro `var_args` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-warning: variable `a` is assigned to, but never used
- --> tests/compile-fail/stable/var_args_spread_middle.rs:4:19
-  |
-4 |     let var_args!(a, ...b, c) = var_expr!(1, 2.0, "three", false);
-  |                   ^
-  |
-  = note: consider using `_a` instead
-  = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default
-
-warning: value assigned to `a` is never read
- --> tests/compile-fail/stable/var_args_spread_middle.rs:4:19
-  |
-4 |     let var_args!(a, ...b, c) = var_expr!(1, 2.0, "three", false);
-  |                   ^
-  |
-  = help: maybe it is overwritten before being read?
-  = note: `#[warn(unused_assignments)]` (part of `#[warn(unused)]`) on by default

--- a/variadics/tests/compile-fail/stable/var_args_spread_twice.stderr
+++ b/variadics/tests/compile-fail/stable/var_args_spread_twice.stderr
@@ -1,25 +1,7 @@
 error: `var_args!` can only have the `...` spread syntax on the last field.
  --> tests/compile-fail/stable/var_args_spread_twice.rs:4:9
   |
-4 |     let var_args!(a, ...b, ...c) = var_expr!(1, 2.0, "three", false);
-  |         ^^^^^^^^^^^^^^^^^^^^^^^^
+4 |     let var_args!(_a, ..._b, ..._c) = var_expr!(1, 2.0, "three", false);
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in the macro `$crate::var_args` which comes from the expansion of the macro `var_args` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-warning: variable `a` is assigned to, but never used
- --> tests/compile-fail/stable/var_args_spread_twice.rs:4:19
-  |
-4 |     let var_args!(a, ...b, ...c) = var_expr!(1, 2.0, "three", false);
-  |                   ^
-  |
-  = note: consider using `_a` instead
-  = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default
-
-warning: value assigned to `a` is never read
- --> tests/compile-fail/stable/var_args_spread_twice.rs:4:19
-  |
-4 |     let var_args!(a, ...b, ...c) = var_expr!(1, 2.0, "three", false);
-  |                   ^
-  |
-  = help: maybe it is overwritten before being read?
-  = note: `#[warn(unused_assignments)]` (part of `#[warn(unused)]`) on by default

--- a/variadics/tests/compile-fail/var_args_spread_middle.rs
+++ b/variadics/tests/compile-fail/var_args_spread_middle.rs
@@ -1,5 +1,5 @@
 use variadics::*;
 
 fn main() {
-    let var_args!(a, ...b, c) = var_expr!(1, 2.0, "three", false);
+    let var_args!(_a, ..._b, _c) = var_expr!(1, 2.0, "three", false);
 }

--- a/variadics/tests/compile-fail/var_args_spread_twice.rs
+++ b/variadics/tests/compile-fail/var_args_spread_twice.rs
@@ -1,5 +1,5 @@
 use variadics::*;
 
 fn main() {
-    let var_args!(a, ...b, ...c) = var_expr!(1, 2.0, "three", false);
+    let var_args!(_a, ..._b, ..._c) = var_expr!(1, 2.0, "three", false);
 }


### PR DESCRIPTION
- Bump `rust-toolchain.toml` from Rust 1.93.1 to 1.95.0.
- Apply minor iterator/sort refactors to satisfy newer clippy lints and keep deterministic ordering where relevant.
- Refresh trybuild compile-fail `.stderr` snapshots to match Rust 1.95 diagnostic formatting.
- Update `./precheck.bash --dfir` to also run `lattices` and `variadics` tests/snapshots