### PR TITLE
experiment: use bumpalo for DFIR handoff buffers [ci-bench]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,6 +1051,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow_tests"
+version = "0.1.0"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1807,6 +1807,7 @@ name = "dfir_rs"
 version = "0.16.0"
 dependencies = [
  "bincode",
+ "bumpalo",
  "bytes",
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1790,6 +1790,7 @@ dependencies = [
 name = "dfir_pipes"
 version = "0.0.1"
 dependencies = [
+ "bumpalo",
  "futures-core",
  "futures-sink",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1054,6 +1054,7 @@ dependencies = [
 name = "borrow_tests"
 version = "0.1.0"
 dependencies = [
+ "bumpalo",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
     "sinktools",
     "variadics_macro",
     "variadics",
-    "website_playground",
+    "website_playground", "scratch_borrow_tests",
 ]
 exclude = ["template"]
 

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1255,9 +1255,7 @@ impl DfirGraph {
                             }
                             HandoffKind::Vec => {
                                 quote_spanned! {port_ident.span()=>
-                                    let #port_ident = #root::dfir_pipes::push::for_each(|__item| {
-                                        #buf_ident.push(__item);
-                                    });
+                                    let #port_ident = #root::dfir_pipes::push::VecPush::new(&mut #buf_ident);
                                 }
                             }
                         }

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -937,19 +937,55 @@ impl DfirGraph {
             })
             .collect();
 
+        // Determine which handoff nodes are tick-boundary (defer_tick) back-edges.
+        // These must remain as captured Vec<T> since they persist across ticks.
+        // All other Vec handoffs will be bump-allocated (tick-local).
+        let defer_hoff_ids: BTreeSet<GraphNodeId> = handoff_nodes
+            .iter()
+            .filter(|(node_id, _, _)| self.handoff_delay_type(*node_id).is_some())
+            .map(|&(node_id, _, _)| node_id)
+            .collect();
+
+        // Buffer declarations for defer_tick handoffs (captured, persist across ticks)
+        // and Option singletons (captured).
         let buffer_code: Vec<TokenStream> = handoff_nodes
             .iter()
-            .map(|&(node_id, kind, (src_span, dst_span))| {
+            .filter_map(|&(node_id, kind, (src_span, dst_span))| {
                 let span = src_span.join(dst_span).unwrap_or(src_span);
                 let buf_ident = self.hoff_buf_ident(node_id, span);
                 match kind {
-                    HandoffKind::Vec => quote_spanned! {span=>
-                        let mut #buf_ident = ::std::vec::Vec::new();
-                    },
-                    HandoffKind::Option => quote_spanned! {span=>
+                    HandoffKind::Vec if defer_hoff_ids.contains(&node_id) => {
+                        // defer_tick: captured Vec (persists across ticks)
+                        Some(quote_spanned! {span=>
+                            let mut #buf_ident = ::std::vec::Vec::new();
+                        })
+                    }
+                    HandoffKind::Vec => {
+                        // Regular stream handoff: will be bump-allocated tick-locally.
+                        // No captured buffer needed.
+                        None
+                    }
+                    HandoffKind::Option => Some(quote_spanned! {span=>
                         let mut #buf_ident = ::std::option::Option::None;
-                    },
+                    }),
                 }
+            })
+            .collect();
+
+        // Tick-local bump-allocated Vec handoff declarations (inside the tick closure).
+        let bump_ident = Ident::new("__dfir_bump", Span::call_site());
+
+        let bump_buffer_code: Vec<TokenStream> = handoff_nodes
+            .iter()
+            .filter_map(|&(node_id, kind, (src_span, dst_span))| {
+                if !matches!(kind, HandoffKind::Vec) || defer_hoff_ids.contains(&node_id) {
+                    return None;
+                }
+                let span = src_span.join(dst_span).unwrap_or(src_span);
+                let buf_ident = self.hoff_buf_ident(node_id, span);
+                Some(quote_spanned! {span=>
+                    let mut #buf_ident = #root::bumpalo::collections::Vec::new_in(&#bump_ident);
+                })
             })
             .collect();
 
@@ -1219,7 +1255,9 @@ impl DfirGraph {
                             }
                             HandoffKind::Vec => {
                                 quote_spanned! {port_ident.span()=>
-                                    let #port_ident = #root::dfir_pipes::push::vec_push(&mut #buf_ident);
+                                    let #port_ident = #root::dfir_pipes::push::for_each(|__item| {
+                                        #buf_ident.push(__item);
+                                    });
                                 }
                             }
                         }
@@ -1720,6 +1758,7 @@ impl DfirGraph {
 
                 #( #buffer_code )*
                 #( #back_buffer_code )*
+                let mut #bump_ident = #root::bumpalo::Bump::new();
                 #( #op_prologue_code )*
 
                 // Pre-set to true so the first tick always returns true
@@ -1730,6 +1769,10 @@ impl DfirGraph {
                 #[allow(unused_qualifications, unused_mut, unused_variables, clippy::await_holding_refcell_ref, clippy::deref_addrof)]
                 let __dfir_inline_tick = async move |#df: &mut #root::scheduled::context::Context| {
                     let __dfir_metrics = #df.metrics();
+                    // Reset the bump allocator — reclaims all tick-local handoff memory.
+                    #bump_ident.reset();
+                    // Tick-local bump-allocated handoff buffers.
+                    #( #bump_buffer_code )*
                     // Double-buffer swap for defer_tick handoffs: move last tick's
                     // producer output into the back buffer for the consumer to drain.
                     #( #back_edge_swap_code )*

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1145,7 +1145,12 @@ impl DfirGraph {
                 let buf_ident = self.hoff_buf_ident(node_id, span);
                 match kind {
                     HandoffKind::Option => quote_spanned! {span=> #buf_ident.take(); },
-                    HandoffKind::Vec => quote_spanned! {span=> #buf_ident.clear(); },
+                    HandoffKind::Vec if defer_hoff_ids.contains(&node_id) => {
+                        quote_spanned! {span=> #buf_ident.clear(); }
+                    }
+                    HandoffKind::Vec => {
+                        quote_spanned! {span=> drop(#buf_ident); }
+                    }
                 }
             })
             .collect();
@@ -1661,6 +1666,20 @@ impl DfirGraph {
                     })
                     .collect();
 
+                // Drop bump-allocated recv handoffs after subgraph completes.
+                // If the handoff is top-of-stack in the bump, this reclaims memory.
+                let recv_drop_code: Vec<TokenStream> = recv_hoffs
+                    .iter()
+                    .filter(|&&hoff_id| {
+                        matches!(self.node(hoff_id), GraphNode::Handoff { kind: HandoffKind::Vec, .. })
+                            && !defer_hoff_ids.contains(&hoff_id)
+                    })
+                    .map(|&hoff_id| {
+                        let buf_ident = self.hoff_buf_ident(hoff_id, self.nodes[hoff_id].span());
+                        quote! { drop(#buf_ident); }
+                    })
+                    .collect();
+
                 subgraph_blocks.push(quote! {
                     let #sg_fut_ident = async {
                         let #context = &#df;
@@ -1679,6 +1698,7 @@ impl DfirGraph {
                         sg_metrics.total_run_count.update(|x| x + 1);
                     }
                     #( #send_metrics_code )*
+                    #( #recv_drop_code )*
                 });
 
                 // Collect per-subgraph prologues into the main prologue lists.

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1668,8 +1668,10 @@ impl DfirGraph {
 
                 // Drop bump-allocated recv handoffs after subgraph completes.
                 // If the handoff is top-of-stack in the bump, this reclaims memory.
+                // Drop in reverse order (LIFO) so each successive drop is top-of-stack.
                 let recv_drop_code: Vec<TokenStream> = recv_hoffs
                     .iter()
+                    .rev()
                     .filter(|&&hoff_id| {
                         matches!(self.node(hoff_id), GraphNode::Handoff { kind: HandoffKind::Vec, .. })
                             && !defer_hoff_ids.contains(&hoff_id)

--- a/dfir_pipes/Cargo.toml
+++ b/dfir_pipes/Cargo.toml
@@ -13,8 +13,10 @@ default = ["std", "variadics"]
 std = ["alloc", "futures-core/std", "futures-sink/std", "rustc-hash", "smallvec", "variadics?/std"]
 alloc = ["futures-core/alloc", "futures-sink/alloc"]
 variadics = ["dep:variadics"]
+bumpalo = ["dep:bumpalo"]
 
 [dependencies]
+bumpalo = { version = "3", features = ["collections"], optional = true }
 futures-core = { version = "0.3.0", default-features = false }
 futures-sink = { version = "0.3.0", default-features = false }
 itertools = { version = "0.14", default-features = false }

--- a/dfir_pipes/src/pull/send_push.rs
+++ b/dfir_pipes/src/pull/send_push.rs
@@ -17,6 +17,7 @@ pin_project! {
         #[pin]
         push: Psh,
         pull_ended: bool,
+        size_hinted: bool,
     }
 }
 
@@ -30,6 +31,7 @@ where
             pull,
             push,
             pull_ended: false,
+            size_hinted: false,
         }
     }
 }
@@ -47,6 +49,12 @@ where
     fn poll(self: Pin<&mut Self>, cx: &mut core::task::Context<'_>) -> Poll<Self::Output> {
         let mut this = self.project();
         if !*this.pull_ended {
+            // Forward size hint from pull to push once, so the push side
+            // can pre-allocate capacity (e.g., Vec::reserve).
+            if !core::mem::replace(this.size_hinted, true) {
+                let hint = Pull::size_hint(&*this.pull);
+                this.push.as_mut().size_hint(hint);
+            }
             loop {
                 // Ensure push is ready before pulling.
                 match this

--- a/dfir_pipes/src/push/mod.rs
+++ b/dfir_pipes/src/push/mod.rs
@@ -61,7 +61,7 @@ pub use sink_compat::SinkCompat;
 pub use unzip::Unzip;
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-pub use vec_push::VecPush;
+pub use vec_push::{PushBuf, VecPush};
 
 /// The result of pushing an item into a [`Push`].
 ///

--- a/dfir_pipes/src/push/vec_push.rs
+++ b/dfir_pipes/src/push/vec_push.rs
@@ -1,6 +1,4 @@
 //! [`VecPush`] terminal push operator that collects items into a `Vec`.
-use alloc::vec::Vec;
-use core::borrow::BorrowMut;
 use core::pin::Pin;
 
 use pin_project_lite::pin_project;
@@ -8,10 +6,47 @@ use pin_project_lite::pin_project;
 use crate::No;
 use crate::push::{Push, PushStep};
 
+/// Trait for Vec-like buffers that support `push` and `reserve`.
+pub trait PushBuf<Item> {
+    /// Push an item into the buffer.
+    fn push(&mut self, item: Item);
+    /// Reserve capacity for at least `additional` more items.
+    fn reserve(&mut self, additional: usize);
+}
+
+impl<Item, T: PushBuf<Item>> PushBuf<Item> for &mut T {
+    fn push(&mut self, item: Item) {
+        (**self).push(item);
+    }
+    fn reserve(&mut self, additional: usize) {
+        (**self).reserve(additional);
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<Item> PushBuf<Item> for alloc::vec::Vec<Item> {
+    fn push(&mut self, item: Item) {
+        self.push(item);
+    }
+    fn reserve(&mut self, additional: usize) {
+        self.reserve(additional);
+    }
+}
+
+#[cfg(feature = "bumpalo")]
+impl<'bump, Item> PushBuf<Item> for bumpalo::collections::Vec<'bump, Item> {
+    fn push(&mut self, item: Item) {
+        self.push(item);
+    }
+    fn reserve(&mut self, additional: usize) {
+        self.reserve(additional);
+    }
+}
+
 pin_project! {
-    /// Terminal push operator that collects items into a `Vec`.
+    /// Terminal push operator that collects items into a buffer implementing [`PushBuf`].
     ///
-    /// Uses [`Push::size_hint`] to pre-allocate capacity via [`Vec::reserve`].
+    /// Uses [`Push::size_hint`] to pre-allocate capacity via [`PushBuf::reserve`].
     #[must_use = "`Push`es do nothing unless items are pushed into them"]
     pub struct VecPush<Buf> {
         buf: Buf,
@@ -20,17 +55,14 @@ pin_project! {
 
 impl<Buf> VecPush<Buf> {
     /// Creates a new [`VecPush`] writing into the given buffer.
-    pub(crate) const fn new<Item>(buf: Buf) -> Self
-    where
-        Buf: BorrowMut<Vec<Item>>,
-    {
+    pub const fn new(buf: Buf) -> Self {
         Self { buf }
     }
 }
 
 impl<Buf, Item, Meta> Push<Item, Meta> for VecPush<Buf>
 where
-    Buf: BorrowMut<Vec<Item>>,
+    Buf: PushBuf<Item>,
     Meta: Copy,
 {
     type Ctx<'ctx> = ();
@@ -41,7 +73,7 @@ where
     }
 
     fn start_send(self: Pin<&mut Self>, item: Item, _meta: Meta) {
-        self.project().buf.borrow_mut().push(item);
+        self.project().buf.push(item);
     }
 
     fn poll_finalize(self: Pin<&mut Self>, _ctx: &mut Self::Ctx<'_>) -> PushStep<Self::CanPend> {
@@ -49,6 +81,6 @@ where
     }
 
     fn size_hint(self: Pin<&mut Self>, hint: (usize, Option<usize>)) {
-        self.project().buf.borrow_mut().reserve(hint.0);
+        self.project().buf.reserve(hint.0);
     }
 }

--- a/dfir_rs/Cargo.toml
+++ b/dfir_rs/Cargo.toml
@@ -31,7 +31,7 @@ bumpalo = { version = "3", features = ["collections"] }
 bytes = "1.1.0"
 dfir_lang = { path = "../dfir_lang", version = "^0.16.0", default-features = false }
 dfir_macro = { optional = true, path = "../dfir_macro", version = "^0.16.0" }
-dfir_pipes = { path = "../dfir_pipes", version = "^0.0.1" }
+dfir_pipes = { path = "../dfir_pipes", version = "^0.0.1", features = ["bumpalo"] }
 futures = "0.3.0"
 hydro_build_utils = { path = "../hydro_build_utils", version = "^0.1.0", features = [ "insta" ] }
 hydro_deploy_integration = { optional = true, path = "../hydro_deploy/hydro_deploy_integration", version = "^0.16.0" }

--- a/dfir_rs/Cargo.toml
+++ b/dfir_rs/Cargo.toml
@@ -27,6 +27,7 @@ name = "kvs_bench"
 
 [dependencies]
 bincode = "1.3.1"
+bumpalo = { version = "3", features = ["collections"] }
 bytes = "1.1.0"
 dfir_lang = { path = "../dfir_lang", version = "^0.16.0", default-features = false }
 dfir_macro = { optional = true, path = "../dfir_macro", version = "^0.16.0" }

--- a/dfir_rs/src/lib.rs
+++ b/dfir_rs/src/lib.rs
@@ -29,6 +29,7 @@ pub use ::{
 pub use dfir_lang as lang;
 pub use dfir_lang;
 pub use dfir_pipes::itertools;
+pub use bumpalo;
 pub use slotmap;
 pub use variadics::{self, var_args, var_expr, var_type};
 

--- a/dfir_rs/tests/compile-fail/stable/surface_fold_keyed_badtype_int.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_fold_keyed_badtype_int.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, {integer}>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, '_, {integer}>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_fold_keyed_badtype_int.rs:3:9
   |
 3 |         source_iter(0..1)
@@ -14,7 +14,7 @@ note: required by a bound in `check_input`
 4 |             -> reduce_keyed(|old: &mut u32, val: u32| { *old += val; })
   |                ^^^^^^^^^^^^ required by this bound in `check_input`
 
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, {integer}>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, '_, {integer}>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_fold_keyed_badtype_int.rs:4:16
   |
 4 |             -> reduce_keyed(|old: &mut u32, val: u32| { *old += val; })

--- a/dfir_rs/tests/compile-fail/stable/surface_fold_keyed_badtype_option.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_fold_keyed_badtype_option.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, Option<{integer}>>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, '_, Option<{integer}>>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_fold_keyed_badtype_option.rs:3:9
   |
 3 |         source_iter([ Some(5), None, Some(12) ])
@@ -14,7 +14,7 @@ note: required by a bound in `check_input`
 4 |             -> reduce_keyed(|old: &mut u32, val: u32| { *old += val; })
   |                ^^^^^^^^^^^^ required by this bound in `check_input`
 
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, Option<{integer}>>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, '_, Option<{integer}>>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_fold_keyed_badtype_option.rs:4:16
   |
 4 |             -> reduce_keyed(|old: &mut u32, val: u32| { *old += val; })

--- a/dfir_rs/tests/compile-fail/stable/surface_fold_keyed_generics_bad.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_fold_keyed_generics_bad.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, &str>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, '_, &str>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_fold_keyed_generics_bad.rs:3:9
   |
 3 |         source_iter(["hello", "world"])
@@ -14,7 +14,7 @@ note: required by a bound in `check_input`
 4 |             -> fold_keyed::<'tick, &str, usize>(String::new, |old: &mut _, val| {
   |                ^^^^^^^^^^ required by this bound in `check_input`
 
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, &str>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, '_, &str>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_fold_keyed_generics_bad.rs:4:16
   |
 4 |             -> fold_keyed::<'tick, &str, usize>(String::new, |old: &mut _, val| {

--- a/dfir_rs/tests/compile-fail/stable/surface_reduce_keyed_badtype_int.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_reduce_keyed_badtype_int.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, {integer}>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, '_, {integer}>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_reduce_keyed_badtype_int.rs:3:9
   |
 3 |         source_iter(0..1)
@@ -14,7 +14,7 @@ note: required by a bound in `check_input`
 4 |             -> fold_keyed(|| 0, |old: &mut u32, val: u32| { *old += val; })
   |                ^^^^^^^^^^ required by this bound in `check_input`
 
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, {integer}>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, '_, {integer}>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_reduce_keyed_badtype_int.rs:4:16
   |
 4 |             -> fold_keyed(|| 0, |old: &mut u32, val: u32| { *old += val; })

--- a/dfir_rs/tests/compile-fail/stable/surface_reduce_keyed_badtype_option.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_reduce_keyed_badtype_option.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, Option<{integer}>>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, '_, Option<{integer}>>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_reduce_keyed_badtype_option.rs:3:9
   |
 3 |         source_iter([ Some(5), None, Some(12) ])
@@ -14,7 +14,7 @@ note: required by a bound in `check_input`
 4 |             -> fold_keyed(|| 0, |old: &mut u32, val: u32| { *old += val; })
   |                ^^^^^^^^^^ required by this bound in `check_input`
 
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, Option<{integer}>>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, '_, Option<{integer}>>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_reduce_keyed_badtype_option.rs:4:16
   |
 4 |             -> fold_keyed(|| 0, |old: &mut u32, val: u32| { *old += val; })

--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -2555,10 +2555,10 @@ impl HydroNode {
             }
 
             HydroNode::Partition { inner, f, .. } => {
-                f.transform_children(&mut transform, seen_tees);
                 if let Some(transformed) = seen_tees.get(&inner.as_ptr()) {
                     *inner = SharedNode(transformed.clone());
                 } else {
+                    f.transform_children(&mut transform, seen_tees);
                     let transformed_cell = Rc::new(RefCell::new(HydroNode::Placeholder));
                     seen_tees.insert(inner.as_ptr(), transformed_cell.clone());
                     let mut orig = inner.0.replace(HydroNode::Placeholder);
@@ -3459,21 +3459,6 @@ impl HydroNode {
                         let is_true = *is_true; // need to copy early to avoid borrow checking issues with node
                         let ptr = inner.0.as_ref() as *const RefCell<HydroNode>;
                         let ret_ident = if let Some(built_idents) = built_tees.get(&ptr) {
-                            // Pop singleton ref idents (if any) that were pushed by transform_children
-                            // but won't be used since the partition was already built.
-                            //
-                            // When the second Partition branch is processed, transform_children
-                            // recurses into f.singleton_refs, causing each Singleton node's
-                            // transform_bottom_up to push an ident onto ident_stack. Since the
-                            // partition was already built by the first branch, these idents are
-                            // unused and must be popped to maintain stack invariants.
-                            //
-                            // Removing this pop triggers the ident_stack emptiness assertion at
-                            // the end of emit_core (verified by test_singleton_ref_partition_*).
-                            for _ in 0..f.singleton_refs.len() {
-                                ident_stack.pop().unwrap();
-                            }
-
                             match builders_or_callback {
                                 BuildersOrCallback::Builders(_) => {}
                                 BuildersOrCallback::Callback(_, node_callback) => {

--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -69,7 +69,9 @@ impl Clone for ClosureExpr {
 impl Hash for ClosureExpr {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.expr.hash(state);
-        // singleton_refs are not hashed (same as HydroIrMetadata)
+        // singleton_refs are structural children (like HydroIrMetadata), not
+        // identity-defining. Two closures with the same expr but different
+        // captured refs are the same closure text — the refs only affect codegen.
     }
 }
 
@@ -108,12 +110,6 @@ impl Debug for ClosureExpr {
 impl Display for ClosureExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         Display::fmt(&self.expr, f)
-    }
-}
-
-impl ToTokens for ClosureExpr {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        self.expr.to_tokens(tokens);
     }
 }
 
@@ -941,7 +937,7 @@ where
 #[derive(Debug, Hash, serde::Serialize)]
 pub enum HydroRoot {
     ForEach {
-        f: ClosureExpr,
+        f: DebugExpr,
         input: Box<HydroNode>,
         op_metadata: HydroIrOpMetadata,
     },
@@ -1395,7 +1391,7 @@ impl HydroRoot {
                 input,
                 op_metadata,
             } => HydroRoot::ForEach {
-                f: f.deep_clone(seen_tees),
+                f: f.clone(),
                 input: Box::new(input.deep_clone(seen_tees)),
                 op_metadata: op_metadata.clone(),
             },
@@ -1748,11 +1744,8 @@ impl HydroRoot {
 
     pub fn visit_debug_expr(&mut self, mut transform: impl FnMut(&mut DebugExpr)) {
         match self {
-            HydroRoot::ForEach { f, .. } => {
-                transform(&mut f.expr);
-            }
-            HydroRoot::DestSink { sink, .. } => {
-                transform(sink);
+            HydroRoot::ForEach { f, .. } | HydroRoot::DestSink { sink: f, .. } => {
+                transform(f);
             }
             HydroRoot::SendExternal { .. }
             | HydroRoot::CycleSink { .. }
@@ -2548,9 +2541,21 @@ impl HydroNode {
             | HydroNode::CycleSource { .. }
             | HydroNode::ExternalInput { .. } => {}
 
-            HydroNode::Tee { inner, .. }
-            | HydroNode::Singleton { inner, .. }
-            | HydroNode::Partition { inner, .. } => {
+            HydroNode::Tee { inner, .. } | HydroNode::Singleton { inner, .. } => {
+                if let Some(transformed) = seen_tees.get(&inner.as_ptr()) {
+                    *inner = SharedNode(transformed.clone());
+                } else {
+                    let transformed_cell = Rc::new(RefCell::new(HydroNode::Placeholder));
+                    seen_tees.insert(inner.as_ptr(), transformed_cell.clone());
+                    let mut orig = inner.0.replace(HydroNode::Placeholder);
+                    transform(&mut orig, seen_tees);
+                    *transformed_cell.borrow_mut() = orig;
+                    *inner = SharedNode(transformed_cell);
+                }
+            }
+
+            HydroNode::Partition { inner, f, .. } => {
+                f.transform_children(&mut transform, seen_tees);
                 if let Some(transformed) = seen_tees.get(&inner.as_ptr()) {
                     *inner = SharedNode(transformed.clone());
                 } else {
@@ -2718,7 +2723,7 @@ impl HydroNode {
                 if let Some(transformed) = seen_tees.get(&inner.as_ptr()) {
                     HydroNode::Partition {
                         inner: SharedNode(transformed.clone()),
-                        f: f.clone(),
+                        f: f.deep_clone(seen_tees),
                         is_true: *is_true,
                         metadata: metadata.clone(),
                     }
@@ -2729,7 +2734,7 @@ impl HydroNode {
                     *new_rc.borrow_mut() = cloned;
                     HydroNode::Partition {
                         inner: SharedNode(new_rc),
-                        f: f.clone(),
+                        f: f.deep_clone(seen_tees),
                         is_true: *is_true,
                         metadata: metadata.clone(),
                     }
@@ -3454,6 +3459,12 @@ impl HydroNode {
                         let is_true = *is_true; // need to copy early to avoid borrow checking issues with node
                         let ptr = inner.0.as_ref() as *const RefCell<HydroNode>;
                         let ret_ident = if let Some(built_idents) = built_tees.get(&ptr) {
+                            // Pop singleton ref idents (if any) that were pushed by transform_children
+                            // but won't be used since the partition was already built.
+                            for _ in 0..f.singleton_refs.len() {
+                                ident_stack.pop().unwrap();
+                            }
+
                             match builders_or_callback {
                                 BuildersOrCallback::Builders(_) => {}
                                 BuildersOrCallback::Callback(_, node_callback) => {
@@ -3467,6 +3478,7 @@ impl HydroNode {
                             // The inner node was already processed by transform_bottom_up,
                             // so its ident is on the stack
                             let inner_ident = ident_stack.pop().unwrap();
+                            let f_tokens = f.emit_tokens(&mut ident_stack);
 
                             let partition_ident = syn::Ident::new(
                                 &format!("stream_{}_partition", *next_stmt_id),
@@ -3491,7 +3503,7 @@ impl HydroNode {
                                     let builder = graph_builders.get_dfir_mut(&out_location);
                                     builder.add_dfir(
                                         parse_quote! {
-                                            #partition_ident = #inner_ident -> partition(|__item, __num_outputs| if (#f)(__item) { 0_usize } else { 1_usize });
+                                            #partition_ident = #inner_ident -> partition(|__item, __num_outputs| if (#f_tokens)(__item) { 0_usize } else { 1_usize });
                                             #true_ident = #partition_ident[0];
                                             #false_ident = #partition_ident[1];
                                         },
@@ -4225,6 +4237,9 @@ impl HydroNode {
                             unreachable!()
                         };
 
+                        let acc_tokens = acc.emit_tokens(&mut ident_stack);
+                        let init_tokens = init.emit_tokens(&mut ident_stack);
+
                         let fold_ident =
                             syn::Ident::new(&format!("stream_{}", *next_stmt_id), Span::call_site());
 
@@ -4244,9 +4259,9 @@ impl HydroNode {
                                         &node.metadata().op,
                                     );
 
-                                    let (effective_input, acc) = if let Some(ref hooked) = hooked_input_ident {
+                                    let (effective_input, _acc) = if let Some(ref hooked) = hooked_input_ident {
                                         let acc: syn::Expr = parse_quote!({
-                                            let mut __inner = #acc;
+                                            let mut __inner = #acc_tokens;
                                             move |__state, __batch: Vec<_>| {
                                                 if __batch.is_empty() {
                                                     return None;
@@ -4260,7 +4275,7 @@ impl HydroNode {
                                         (hooked, acc)
                                     } else {
                                         let acc: syn::Expr = parse_quote!({
-                                            let mut __inner = #acc;
+                                            let mut __inner = #acc_tokens;
                                             move |__state, __value| {
                                                 __inner(__state, __value);
                                                 Some(__state.clone())
@@ -4272,8 +4287,8 @@ impl HydroNode {
                                     let builder = graph_builders.get_dfir_mut(&out_location);
                                     builder.add_dfir(
                                         parse_quote! {
-                                            source_iter([(#init)()]) -> [0]#fold_ident;
-                                            #effective_input -> scan::<#lifetime>(#init, #acc) -> [1]#fold_ident;
+                                            source_iter([(#init_tokens)()]) -> [0]#fold_ident;
+                                            #effective_input -> scan::<#lifetime>(#init_tokens, #acc_tokens) -> [1]#fold_ident;
                                             #fold_ident = chain();
                                         },
                                         None,
@@ -4298,9 +4313,9 @@ impl HydroNode {
                                     );
                                     let builder = graph_builders.get_dfir_mut(&out_location);
 
-                                    let acc: syn::Expr = parse_quote!({
-                                        let mut __init = #init;
-                                        let mut __inner = #acc;
+                                    let _acc: syn::Expr = parse_quote!({
+                                        let mut __init = #init_tokens;
+                                        let mut __inner = #acc_tokens;
                                         move |__state, __kv: (_, _)| {
                                             // TODO(shadaj): we can avoid the clone when the entry exists
                                             let __state = __state
@@ -4314,7 +4329,7 @@ impl HydroNode {
                                     if let Some(hooked_input_ident) = hooked_input_ident {
                                         builder.add_dfir(
                                             parse_quote! {
-                                                #fold_ident = #hooked_input_ident -> flatten() -> scan::<#lifetime>(|| ::std::collections::HashMap::new(), #acc);
+                                                #fold_ident = #hooked_input_ident -> flatten() -> scan::<#lifetime>(|| ::std::collections::HashMap::new(), #acc_tokens);
                                             },
                                             None,
                                             Some(&next_stmt_id.to_string()),
@@ -4324,7 +4339,7 @@ impl HydroNode {
                                     } else {
                                         builder.add_dfir(
                                             parse_quote! {
-                                                #fold_ident = #input_ident -> scan::<#lifetime>(|| ::std::collections::HashMap::new(), #acc);
+                                                #fold_ident = #input_ident -> scan::<#lifetime>(|| ::std::collections::HashMap::new(), #acc_tokens);
                                             },
                                             None,
                                             Some(&next_stmt_id.to_string()),
@@ -4351,7 +4366,7 @@ impl HydroNode {
                                     let builder = graph_builders.get_dfir_mut(&out_location);
                                     builder.add_dfir(
                                         parse_quote! {
-                                            #fold_ident = #actual_input -> #operator::<#lifetime>(#init, #acc);
+                                            #fold_ident = #actual_input -> #operator::<#lifetime>(#init_tokens, #acc_tokens);
                                         },
                                         None,
                                         Some(&next_stmt_id.to_string()),
@@ -4360,7 +4375,7 @@ impl HydroNode {
                                     let builder = graph_builders.get_dfir_mut(&out_location);
                                     builder.add_dfir(
                                         parse_quote! {
-                                            #fold_ident = #input_ident -> #operator::<#lifetime>(#init, #acc);
+                                            #fold_ident = #input_ident -> #operator::<#lifetime>(#init_tokens, #acc_tokens);
                                         },
                                         None,
                                         Some(&next_stmt_id.to_string()),
@@ -4418,6 +4433,8 @@ impl HydroNode {
                             unreachable!()
                         };
 
+                        let f_tokens = f.emit_tokens(&mut ident_stack);
+
                         let reduce_ident =
                             syn::Ident::new(&format!("stream_{}", *next_stmt_id), Span::call_site());
 
@@ -4445,7 +4462,7 @@ impl HydroNode {
                                     let builder = graph_builders.get_dfir_mut(&out_location);
                                     builder.add_dfir(
                                         parse_quote! {
-                                            #reduce_ident = #input_ident -> #operator::<#lifetime>(#f);
+                                            #reduce_ident = #input_ident -> #operator::<#lifetime>(#f_tokens);
                                         },
                                         None,
                                         Some(&next_stmt_id.to_string()),
@@ -4477,6 +4494,7 @@ impl HydroNode {
                         // watermark is processed second, so it's on top
                         let watermark_ident = ident_stack.pop().unwrap();
                         let input_ident = ident_stack.pop().unwrap();
+                        let f_tokens = f.emit_tokens(&mut ident_stack);
 
                         let chain_ident = syn::Ident::new(
                             &format!("reduce_keyed_watermark_chain_{}", *next_stmt_id),
@@ -4518,7 +4536,7 @@ impl HydroNode {
 
                                             #fold_ident = #chain_ident
                                                 -> #agg_operator::<#lifetime>(|| (::std::collections::HashMap::new(), None), {
-                                                    let __reduce_keyed_fn = #f;
+                                                    let __reduce_keyed_fn = #f_tokens;
                                                     move |(map, opt_curr_watermark), (opt_payload, opt_watermark)| {
                                                         if let Some((k, v)) = opt_payload {
                                                             if let Some(curr_watermark) = *opt_curr_watermark {

--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -34,6 +34,167 @@ use crate::location::{LocationKey, NetworkHint};
 pub mod backtrace;
 use backtrace::Backtrace;
 
+/// A closure expression bundled with any singleton references it captures.
+///
+/// When a `q!()` closure captures a `SingletonRef`, the reference is recorded here
+/// alongside the closure's expression. This allows per-closure tracking of singleton
+/// captures, which is important for nodes with multiple closures (e.g. Fold has `init` and `acc`).
+pub struct ClosureExpr {
+    pub expr: DebugExpr,
+    pub singleton_refs: Vec<(syn::Ident, HydroNode)>,
+}
+
+impl Clone for ClosureExpr {
+    fn clone(&self) -> Self {
+        Self {
+            expr: self.expr.clone(),
+            singleton_refs: self
+                .singleton_refs
+                .iter()
+                .map(|(ident, node)| {
+                    let cloned_node = match node {
+                        HydroNode::Singleton { inner, metadata } => HydroNode::Singleton {
+                            inner: SharedNode(inner.0.clone()),
+                            metadata: metadata.clone(),
+                        },
+                        _ => panic!("singleton_refs should only contain HydroNode::Singleton"),
+                    };
+                    (ident.clone(), cloned_node)
+                })
+                .collect(),
+        }
+    }
+}
+
+impl Hash for ClosureExpr {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.expr.hash(state);
+        // singleton_refs are not hashed (same as HydroIrMetadata)
+    }
+}
+
+impl serde::Serialize for ClosureExpr {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+        let mut s = serializer.serialize_struct("ClosureExpr", 2)?;
+        s.serialize_field("expr", &self.expr)?;
+        s.serialize_field(
+            "singleton_refs",
+            &SerializableSingletonRefs(&self.singleton_refs),
+        )?;
+        s.end()
+    }
+}
+
+struct SerializableSingletonRefs<'a>(&'a [(syn::Ident, HydroNode)]);
+
+impl serde::Serialize for SerializableSingletonRefs<'_> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeSeq;
+        let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
+        for (ident, node) in self.0 {
+            seq.serialize_element(&(ident.to_string(), node))?;
+        }
+        seq.end()
+    }
+}
+
+impl Debug for ClosureExpr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(&self.expr, f)
+    }
+}
+
+impl Display for ClosureExpr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.expr, f)
+    }
+}
+
+impl ToTokens for ClosureExpr {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.expr.to_tokens(tokens);
+    }
+}
+
+impl From<syn::Expr> for ClosureExpr {
+    fn from(expr: syn::Expr) -> Self {
+        Self {
+            expr: DebugExpr(Box::new(expr)),
+            singleton_refs: Vec::new(),
+        }
+    }
+}
+
+impl From<DebugExpr> for ClosureExpr {
+    fn from(expr: DebugExpr) -> Self {
+        Self {
+            expr,
+            singleton_refs: Vec::new(),
+        }
+    }
+}
+
+impl ClosureExpr {
+    pub fn new(expr: DebugExpr, singleton_refs: Vec<(syn::Ident, HydroNode)>) -> Self {
+        Self {
+            expr,
+            singleton_refs,
+        }
+    }
+
+    pub fn deep_clone(&self, seen_tees: &mut SeenSharedNodes) -> Self {
+        Self {
+            expr: self.expr.clone(),
+            singleton_refs: self
+                .singleton_refs
+                .iter()
+                .map(|(ident, node)| (ident.clone(), node.deep_clone(seen_tees)))
+                .collect(),
+        }
+    }
+
+    pub fn transform_children(
+        &mut self,
+        transform: &mut impl FnMut(&mut HydroNode, &mut SeenSharedNodes),
+        seen_tees: &mut SeenSharedNodes,
+    ) {
+        for (_ident, ref_node) in self.singleton_refs.iter_mut() {
+            transform(ref_node, seen_tees);
+        }
+    }
+
+    /// Pop singleton ref idents from the stack and rewrite the closure's token stream,
+    /// replacing local singleton ref idents with `#dfir_ident` references.
+    #[cfg(feature = "build")]
+    pub fn emit_tokens(&self, ident_stack: &mut Vec<syn::Ident>) -> TokenStream {
+        if self.singleton_refs.is_empty() {
+            self.expr.0.to_token_stream()
+        } else {
+            let ref_idents = (0..self.singleton_refs.len())
+                .map(|_| ident_stack.pop().unwrap())
+                .collect::<Vec<_>>()
+                .into_iter()
+                .rev()
+                .collect::<Vec<_>>();
+            let local_idents = self
+                .singleton_refs
+                .iter()
+                .map(|(local_ident, _)| local_ident);
+            let hash = proc_macro2::Punct::new('#', proc_macro2::Spacing::Alone);
+            let expr = &self.expr.0;
+            quote! {
+                {
+                    #(
+                        let #local_idents = #hash #ref_idents;
+                    )*
+                    #expr
+                }
+            }
+        }
+    }
+}
+
 /// Wrapper that displays only the tokens of a parsed expr.
 ///
 /// Boxes `syn::Type` which is ~240 bytes.
@@ -282,18 +443,6 @@ fn serialize_ident<S: serde::Serializer>(
     serializer: S,
 ) -> Result<S::Ok, S::Error> {
     serializer.serialize_str(&ident.to_string())
-}
-
-fn serialize_singleton_refs<S: serde::Serializer>(
-    refs: &[(syn::Ident, HydroNode)],
-    serializer: S,
-) -> Result<S::Ok, S::Error> {
-    use serde::ser::SerializeSeq;
-    let mut seq = serializer.serialize_seq(Some(refs.len()))?;
-    for (ident, node) in refs {
-        seq.serialize_element(&(ident.to_string(), node))?;
-    }
-    seq.end()
 }
 
 pub enum DebugInstantiate {
@@ -792,7 +941,7 @@ where
 #[derive(Debug, Hash, serde::Serialize)]
 pub enum HydroRoot {
     ForEach {
-        f: DebugExpr,
+        f: ClosureExpr,
         input: Box<HydroNode>,
         op_metadata: HydroIrOpMetadata,
     },
@@ -1246,7 +1395,7 @@ impl HydroRoot {
                 input,
                 op_metadata,
             } => HydroRoot::ForEach {
-                f: f.clone(),
+                f: f.deep_clone(seen_tees),
                 input: Box::new(input.deep_clone(seen_tees)),
                 op_metadata: op_metadata.clone(),
             },
@@ -1599,8 +1748,11 @@ impl HydroRoot {
 
     pub fn visit_debug_expr(&mut self, mut transform: impl FnMut(&mut DebugExpr)) {
         match self {
-            HydroRoot::ForEach { f, .. } | HydroRoot::DestSink { sink: f, .. } => {
-                transform(f);
+            HydroRoot::ForEach { f, .. } => {
+                transform(&mut f.expr);
+            }
+            HydroRoot::DestSink { sink, .. } => {
+                transform(sink);
             }
             HydroRoot::SendExternal { .. }
             | HydroRoot::CycleSink { .. }
@@ -2123,7 +2275,7 @@ pub enum HydroNode {
 
     Partition {
         inner: SharedNode,
-        f: DebugExpr,
+        f: ClosureExpr,
         is_true: bool,
         metadata: HydroIrMetadata,
     },
@@ -2219,37 +2371,27 @@ pub enum HydroNode {
     },
 
     Map {
-        f: DebugExpr,
-        /// Singleton references captured by the closure `f` via `SingletonRef`.
-        /// Each entry maps a local ident (used in the closure body) to the IR node
-        /// of the referenced singleton.
-        ///
-        /// TODO: Currently only `Map` has this field. Other closure-bearing variants
-        /// (Filter, FlatMap, Fold, etc.) should be extended similarly. For nodes with
-        /// multiple closures (e.g. Fold has `init` and `acc`), we may need per-closure
-        /// tracking rather than per-node.
-        #[serde(serialize_with = "serialize_singleton_refs")]
-        singleton_refs: Vec<(syn::Ident, HydroNode)>,
+        f: ClosureExpr,
         input: Box<HydroNode>,
         metadata: HydroIrMetadata,
     },
     FlatMap {
-        f: DebugExpr,
+        f: ClosureExpr,
         input: Box<HydroNode>,
         metadata: HydroIrMetadata,
     },
     FlatMapStreamBlocking {
-        f: DebugExpr,
+        f: ClosureExpr,
         input: Box<HydroNode>,
         metadata: HydroIrMetadata,
     },
     Filter {
-        f: DebugExpr,
+        f: ClosureExpr,
         input: Box<HydroNode>,
         metadata: HydroIrMetadata,
     },
     FilterMap {
-        f: DebugExpr,
+        f: ClosureExpr,
         input: Box<HydroNode>,
         metadata: HydroIrMetadata,
     },
@@ -2263,7 +2405,7 @@ pub enum HydroNode {
         metadata: HydroIrMetadata,
     },
     Inspect {
-        f: DebugExpr,
+        f: ClosureExpr,
         input: Box<HydroNode>,
         metadata: HydroIrMetadata,
     },
@@ -2278,43 +2420,43 @@ pub enum HydroNode {
         metadata: HydroIrMetadata,
     },
     Fold {
-        init: DebugExpr,
-        acc: DebugExpr,
+        init: ClosureExpr,
+        acc: ClosureExpr,
         input: Box<HydroNode>,
         metadata: HydroIrMetadata,
     },
 
     Scan {
-        init: DebugExpr,
-        acc: DebugExpr,
+        init: ClosureExpr,
+        acc: ClosureExpr,
         input: Box<HydroNode>,
         metadata: HydroIrMetadata,
     },
     ScanAsyncBlocking {
-        init: DebugExpr,
-        acc: DebugExpr,
+        init: ClosureExpr,
+        acc: ClosureExpr,
         input: Box<HydroNode>,
         metadata: HydroIrMetadata,
     },
     FoldKeyed {
-        init: DebugExpr,
-        acc: DebugExpr,
+        init: ClosureExpr,
+        acc: ClosureExpr,
         input: Box<HydroNode>,
         metadata: HydroIrMetadata,
     },
 
     Reduce {
-        f: DebugExpr,
+        f: ClosureExpr,
         input: Box<HydroNode>,
         metadata: HydroIrMetadata,
     },
     ReduceKeyed {
-        f: DebugExpr,
+        f: ClosureExpr,
         input: Box<HydroNode>,
         metadata: HydroIrMetadata,
     },
     ReduceKeyedWatermark {
-        f: DebugExpr,
+        f: ClosureExpr,
         input: Box<HydroNode>,
         watermark: Box<HydroNode>,
         metadata: HydroIrMetadata,
@@ -2458,43 +2600,54 @@ impl HydroNode {
                 transform(neg.as_mut(), seen_tees);
             }
 
+            HydroNode::Map { f, input, .. } => {
+                f.transform_children(&mut transform, seen_tees);
+                transform(input.as_mut(), seen_tees);
+            }
+            HydroNode::FlatMap { f, input, .. }
+            | HydroNode::FlatMapStreamBlocking { f, input, .. }
+            | HydroNode::Filter { f, input, .. }
+            | HydroNode::FilterMap { f, input, .. }
+            | HydroNode::Inspect { f, input, .. }
+            | HydroNode::Reduce { f, input, .. }
+            | HydroNode::ReduceKeyed { f, input, .. } => {
+                f.transform_children(&mut transform, seen_tees);
+                transform(input.as_mut(), seen_tees);
+            }
             HydroNode::ReduceKeyedWatermark {
-                input, watermark, ..
+                f,
+                input,
+                watermark,
+                ..
             } => {
+                f.transform_children(&mut transform, seen_tees);
                 transform(input.as_mut(), seen_tees);
                 transform(watermark.as_mut(), seen_tees);
             }
-
-            HydroNode::Map {
-                input,
-                singleton_refs,
-                ..
+            HydroNode::Fold {
+                init, acc, input, ..
+            }
+            | HydroNode::Scan {
+                init, acc, input, ..
+            }
+            | HydroNode::ScanAsyncBlocking {
+                init, acc, input, ..
+            }
+            | HydroNode::FoldKeyed {
+                init, acc, input, ..
             } => {
-                // Transform each singleton ref node (these are HydroNode::Singleton wrappers).
-                for (_ident, ref_node) in singleton_refs.iter_mut() {
-                    transform(ref_node, seen_tees);
-                }
+                init.transform_children(&mut transform, seen_tees);
+                acc.transform_children(&mut transform, seen_tees);
                 transform(input.as_mut(), seen_tees);
             }
             HydroNode::ResolveFutures { input, .. }
             | HydroNode::ResolveFuturesBlocking { input, .. }
             | HydroNode::ResolveFuturesOrdered { input, .. }
-            | HydroNode::FlatMap { input, .. }
-            | HydroNode::FlatMapStreamBlocking { input, .. }
-            | HydroNode::Filter { input, .. }
-            | HydroNode::FilterMap { input, .. }
             | HydroNode::Sort { input, .. }
             | HydroNode::DeferTick { input, .. }
             | HydroNode::Enumerate { input, .. }
-            | HydroNode::Inspect { input, .. }
             | HydroNode::Unique { input, .. }
             | HydroNode::Network { input, .. }
-            | HydroNode::Fold { input, .. }
-            | HydroNode::Scan { input, .. }
-            | HydroNode::ScanAsyncBlocking { input, .. }
-            | HydroNode::FoldKeyed { input, .. }
-            | HydroNode::Reduce { input, .. }
-            | HydroNode::ReduceKeyed { input, .. }
             | HydroNode::Counter { input, .. } => {
                 transform(input.as_mut(), seen_tees);
             }
@@ -2687,39 +2840,30 @@ impl HydroNode {
                     metadata: metadata.clone(),
                 }
             }
-            HydroNode::Map {
-                f,
-                singleton_refs,
-                input,
-                metadata,
-            } => HydroNode::Map {
-                f: f.clone(),
-                singleton_refs: singleton_refs
-                    .iter()
-                    .map(|(ident, node)| (ident.clone(), node.deep_clone(seen_tees)))
-                    .collect(),
+            HydroNode::Map { f, input, metadata } => HydroNode::Map {
+                f: f.deep_clone(seen_tees),
                 input: Box::new(input.deep_clone(seen_tees)),
                 metadata: metadata.clone(),
             },
             HydroNode::FlatMap { f, input, metadata } => HydroNode::FlatMap {
-                f: f.clone(),
+                f: f.deep_clone(seen_tees),
                 input: Box::new(input.deep_clone(seen_tees)),
                 metadata: metadata.clone(),
             },
             HydroNode::FlatMapStreamBlocking { f, input, metadata } => {
                 HydroNode::FlatMapStreamBlocking {
-                    f: f.clone(),
+                    f: f.deep_clone(seen_tees),
                     input: Box::new(input.deep_clone(seen_tees)),
                     metadata: metadata.clone(),
                 }
             }
             HydroNode::Filter { f, input, metadata } => HydroNode::Filter {
-                f: f.clone(),
+                f: f.deep_clone(seen_tees),
                 input: Box::new(input.deep_clone(seen_tees)),
                 metadata: metadata.clone(),
             },
             HydroNode::FilterMap { f, input, metadata } => HydroNode::FilterMap {
-                f: f.clone(),
+                f: f.deep_clone(seen_tees),
                 input: Box::new(input.deep_clone(seen_tees)),
                 metadata: metadata.clone(),
             },
@@ -2732,7 +2876,7 @@ impl HydroNode {
                 metadata: metadata.clone(),
             },
             HydroNode::Inspect { f, input, metadata } => HydroNode::Inspect {
-                f: f.clone(),
+                f: f.deep_clone(seen_tees),
                 input: Box::new(input.deep_clone(seen_tees)),
                 metadata: metadata.clone(),
             },
@@ -2750,8 +2894,8 @@ impl HydroNode {
                 input,
                 metadata,
             } => HydroNode::Fold {
-                init: init.clone(),
-                acc: acc.clone(),
+                init: init.deep_clone(seen_tees),
+                acc: acc.deep_clone(seen_tees),
                 input: Box::new(input.deep_clone(seen_tees)),
                 metadata: metadata.clone(),
             },
@@ -2761,8 +2905,8 @@ impl HydroNode {
                 input,
                 metadata,
             } => HydroNode::Scan {
-                init: init.clone(),
-                acc: acc.clone(),
+                init: init.deep_clone(seen_tees),
+                acc: acc.deep_clone(seen_tees),
                 input: Box::new(input.deep_clone(seen_tees)),
                 metadata: metadata.clone(),
             },
@@ -2772,8 +2916,8 @@ impl HydroNode {
                 input,
                 metadata,
             } => HydroNode::ScanAsyncBlocking {
-                init: init.clone(),
-                acc: acc.clone(),
+                init: init.deep_clone(seen_tees),
+                acc: acc.deep_clone(seen_tees),
                 input: Box::new(input.deep_clone(seen_tees)),
                 metadata: metadata.clone(),
             },
@@ -2783,8 +2927,8 @@ impl HydroNode {
                 input,
                 metadata,
             } => HydroNode::FoldKeyed {
-                init: init.clone(),
-                acc: acc.clone(),
+                init: init.deep_clone(seen_tees),
+                acc: acc.deep_clone(seen_tees),
                 input: Box::new(input.deep_clone(seen_tees)),
                 metadata: metadata.clone(),
             },
@@ -2794,18 +2938,18 @@ impl HydroNode {
                 watermark,
                 metadata,
             } => HydroNode::ReduceKeyedWatermark {
-                f: f.clone(),
+                f: f.deep_clone(seen_tees),
                 input: Box::new(input.deep_clone(seen_tees)),
                 watermark: Box::new(watermark.deep_clone(seen_tees)),
                 metadata: metadata.clone(),
             },
             HydroNode::Reduce { f, input, metadata } => HydroNode::Reduce {
-                f: f.clone(),
+                f: f.deep_clone(seen_tees),
                 input: Box::new(input.deep_clone(seen_tees)),
                 metadata: metadata.clone(),
             },
             HydroNode::ReduceKeyed { f, input, metadata } => HydroNode::ReduceKeyed {
-                f: f.clone(),
+                f: f.deep_clone(seen_tees),
                 input: Box::new(input.deep_clone(seen_tees)),
                 metadata: metadata.clone(),
             },
@@ -3744,42 +3888,16 @@ impl HydroNode {
                         ident_stack.push(futures_ident);
                     }
 
-                    HydroNode::Map { f, singleton_refs, .. } => {
+                    HydroNode::Map { f, .. } => {
                         // Pop input ident (pushed last by transform_children).
                         let input_ident = ident_stack.pop().unwrap();
-                        // Pop singleton ref idents in reverse order (pushed before input).
-                        let ref_idents = (0..singleton_refs.len())
-                            .map(|_| ident_stack.pop().unwrap())
-                            .collect::<Vec<_>>()
-                            .into_iter()
-                            .rev()
-                            .collect::<Vec<_>>();
+                        let f_tokens = f.emit_tokens(&mut ident_stack);
 
                         let map_ident =
                             syn::Ident::new(&format!("stream_{}", *next_stmt_id), Span::call_site());
 
                         match builders_or_callback {
                             BuildersOrCallback::Builders(graph_builders) => {
-                                // Wrap the closure: assign local singleton ref idents to
-                                // `#ref_ident` (the `singleton()` node's DFIR variable name).
-                                let f_tokens = if singleton_refs.is_empty() {
-                                    f.0.to_token_stream()
-                                } else {
-                                    let local_idents = singleton_refs
-                                        .iter()
-                                        .map(|(local_ident, _)| local_ident);
-                                    let hash = proc_macro2::Punct::new('#', proc_macro2::Spacing::Alone);
-                                    let expr = &f.0;
-                                    quote! {
-                                        {
-                                            #(
-                                                let #local_idents = #hash #ref_idents;
-                                            )*
-                                            #expr
-                                        }
-                                    }
-                                };
-
                                 let builder = graph_builders.get_dfir_mut(&out_location);
                                 builder.add_dfir(
                                     parse_quote! {
@@ -3801,6 +3919,7 @@ impl HydroNode {
 
                     HydroNode::FlatMap { f, .. } => {
                         let input_ident = ident_stack.pop().unwrap();
+                        let f_tokens = f.emit_tokens(&mut ident_stack);
 
                         let flat_map_ident =
                             syn::Ident::new(&format!("stream_{}", *next_stmt_id), Span::call_site());
@@ -3810,7 +3929,7 @@ impl HydroNode {
                                 let builder = graph_builders.get_dfir_mut(&out_location);
                                 builder.add_dfir(
                                     parse_quote! {
-                                        #flat_map_ident = #input_ident -> flat_map(#f);
+                                        #flat_map_ident = #input_ident -> flat_map(#f_tokens);
                                     },
                                     None,
                                     Some(&next_stmt_id.to_string()),
@@ -3828,6 +3947,7 @@ impl HydroNode {
 
                     HydroNode::FlatMapStreamBlocking { f, .. } => {
                         let input_ident = ident_stack.pop().unwrap();
+                        let f_tokens = f.emit_tokens(&mut ident_stack);
 
                         let flat_map_stream_blocking_ident =
                             syn::Ident::new(&format!("stream_{}", *next_stmt_id), Span::call_site());
@@ -3837,7 +3957,7 @@ impl HydroNode {
                                 let builder = graph_builders.get_dfir_mut(&out_location);
                                 builder.add_dfir(
                                     parse_quote! {
-                                        #flat_map_stream_blocking_ident = #input_ident -> flat_map_stream_blocking(#f);
+                                        #flat_map_stream_blocking_ident = #input_ident -> flat_map_stream_blocking(#f_tokens);
                                     },
                                     None,
                                     Some(&next_stmt_id.to_string()),
@@ -3855,6 +3975,7 @@ impl HydroNode {
 
                     HydroNode::Filter { f, .. } => {
                         let input_ident = ident_stack.pop().unwrap();
+                        let f_tokens = f.emit_tokens(&mut ident_stack);
 
                         let filter_ident =
                             syn::Ident::new(&format!("stream_{}", *next_stmt_id), Span::call_site());
@@ -3864,7 +3985,7 @@ impl HydroNode {
                                 let builder = graph_builders.get_dfir_mut(&out_location);
                                 builder.add_dfir(
                                     parse_quote! {
-                                        #filter_ident = #input_ident -> filter(#f);
+                                        #filter_ident = #input_ident -> filter(#f_tokens);
                                     },
                                     None,
                                     Some(&next_stmt_id.to_string()),
@@ -3882,6 +4003,7 @@ impl HydroNode {
 
                     HydroNode::FilterMap { f, .. } => {
                         let input_ident = ident_stack.pop().unwrap();
+                        let f_tokens = f.emit_tokens(&mut ident_stack);
 
                         let filter_map_ident =
                             syn::Ident::new(&format!("stream_{}", *next_stmt_id), Span::call_site());
@@ -3891,7 +4013,7 @@ impl HydroNode {
                                 let builder = graph_builders.get_dfir_mut(&out_location);
                                 builder.add_dfir(
                                     parse_quote! {
-                                        #filter_map_ident = #input_ident -> filter_map(#f);
+                                        #filter_map_ident = #input_ident -> filter_map(#f_tokens);
                                     },
                                     None,
                                     Some(&next_stmt_id.to_string()),
@@ -3995,6 +4117,7 @@ impl HydroNode {
 
                     HydroNode::Inspect { f, .. } => {
                         let input_ident = ident_stack.pop().unwrap();
+                        let f_tokens = f.emit_tokens(&mut ident_stack);
 
                         let inspect_ident =
                             syn::Ident::new(&format!("stream_{}", *next_stmt_id), Span::call_site());
@@ -4004,7 +4127,7 @@ impl HydroNode {
                                 let builder = graph_builders.get_dfir_mut(&out_location);
                                 builder.add_dfir(
                                     parse_quote! {
-                                        #inspect_ident = #input_ident -> inspect(#f);
+                                        #inspect_ident = #input_ident -> inspect(#f_tokens);
                                     },
                                     None,
                                     Some(&next_stmt_id.to_string()),
@@ -4621,14 +4744,14 @@ impl HydroNode {
             | HydroNode::Reduce { f, .. }
             | HydroNode::ReduceKeyed { f, .. }
             | HydroNode::ReduceKeyedWatermark { f, .. } => {
-                transform(f);
+                transform(&mut f.expr);
             }
             HydroNode::Fold { init, acc, .. }
             | HydroNode::Scan { init, acc, .. }
             | HydroNode::ScanAsyncBlocking { init, acc, .. }
             | HydroNode::FoldKeyed { init, acc, .. } => {
-                transform(init);
-                transform(acc);
+                transform(&mut init.expr);
+                transform(&mut acc.expr);
             }
             HydroNode::Network {
                 serialize_fn,
@@ -5122,7 +5245,7 @@ mod test {
         ignore = "expects inclusion of feature-gated fields"
     )]
     fn hydro_node_size() {
-        assert_eq!(size_of::<HydroNode>(), 248);
+        assert_eq!(size_of::<HydroNode>(), 256);
     }
 
     #[test]

--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -3461,6 +3461,15 @@ impl HydroNode {
                         let ret_ident = if let Some(built_idents) = built_tees.get(&ptr) {
                             // Pop singleton ref idents (if any) that were pushed by transform_children
                             // but won't be used since the partition was already built.
+                            //
+                            // When the second Partition branch is processed, transform_children
+                            // recurses into f.singleton_refs, causing each Singleton node's
+                            // transform_bottom_up to push an ident onto ident_stack. Since the
+                            // partition was already built by the first branch, these idents are
+                            // unused and must be popped to maintain stack invariants.
+                            //
+                            // Removing this pop triggers the ident_stack emptiness assertion at
+                            // the end of emit_core (verified by test_singleton_ref_partition_*).
                             for _ in 0..f.singleton_refs.len() {
                                 ident_stack.pop().unwrap();
                             }
@@ -4707,9 +4716,16 @@ impl HydroNode {
             false,
         );
 
-        ident_stack
+        let ret = ident_stack
             .pop()
-            .expect("ident_stack should have exactly one element after traversal")
+            .expect("ident_stack should have exactly one element after traversal");
+        assert!(
+            ident_stack.is_empty(),
+            "ident_stack should be empty after popping the final ident, but has {} remaining element(s). \
+             This indicates a bug in the code gen: some node pushed idents that were never consumed.",
+            ident_stack.len()
+        );
+        ret
     }
 
     pub fn visit_debug_expr(&mut self, mut transform: impl FnMut(&mut DebugExpr)) {

--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -4259,7 +4259,7 @@ impl HydroNode {
                                         &node.metadata().op,
                                     );
 
-                                    let (effective_input, _acc) = if let Some(ref hooked) = hooked_input_ident {
+                                    let (effective_input, wrapped_acc) = if let Some(ref hooked) = hooked_input_ident {
                                         let acc: syn::Expr = parse_quote!({
                                             let mut __inner = #acc_tokens;
                                             move |__state, __batch: Vec<_>| {
@@ -4288,7 +4288,7 @@ impl HydroNode {
                                     builder.add_dfir(
                                         parse_quote! {
                                             source_iter([(#init_tokens)()]) -> [0]#fold_ident;
-                                            #effective_input -> scan::<#lifetime>(#init_tokens, #acc_tokens) -> [1]#fold_ident;
+                                            #effective_input -> scan::<#lifetime>(#init_tokens, #wrapped_acc) -> [1]#fold_ident;
                                             #fold_ident = chain();
                                         },
                                         None,
@@ -4313,7 +4313,7 @@ impl HydroNode {
                                     );
                                     let builder = graph_builders.get_dfir_mut(&out_location);
 
-                                    let _acc: syn::Expr = parse_quote!({
+                                    let wrapped_acc: syn::Expr = parse_quote!({
                                         let mut __init = #init_tokens;
                                         let mut __inner = #acc_tokens;
                                         move |__state, __kv: (_, _)| {
@@ -4329,7 +4329,7 @@ impl HydroNode {
                                     if let Some(hooked_input_ident) = hooked_input_ident {
                                         builder.add_dfir(
                                             parse_quote! {
-                                                #fold_ident = #hooked_input_ident -> flatten() -> scan::<#lifetime>(|| ::std::collections::HashMap::new(), #acc_tokens);
+                                                #fold_ident = #hooked_input_ident -> flatten() -> scan::<#lifetime>(|| ::std::collections::HashMap::new(), #wrapped_acc);
                                             },
                                             None,
                                             Some(&next_stmt_id.to_string()),
@@ -4339,7 +4339,7 @@ impl HydroNode {
                                     } else {
                                         builder.add_dfir(
                                             parse_quote! {
-                                                #fold_ident = #input_ident -> scan::<#lifetime>(|| ::std::collections::HashMap::new(), #acc_tokens);
+                                                #fold_ident = #input_ident -> scan::<#lifetime>(|| ::std::collections::HashMap::new(), #wrapped_acc);
                                             },
                                             None,
                                             Some(&next_stmt_id.to_string()),

--- a/hydro_lang/src/compile/ir/snapshots/hydro_lang__compile__ir__serde_test__tests__ir_json_snapshot.snap
+++ b/hydro_lang/src/compile/ir/snapshots/hydro_lang__compile__ir__serde_test__tests__ir_json_snapshot.snap
@@ -5,15 +5,20 @@ expression: json
 [
   {
     "ForEach": {
-      "f": "q!(| v | println ! (\"{}\" , v))",
+      "f": {
+        "expr": "q!(| v | println ! (\"{}\" , v))",
+        "singleton_refs": []
+      },
       "input": {
         "Tee": {
           "inner": {
             "$shared": 0,
             "node": {
               "Map": {
-                "f": "q!(| x | x * 2)",
-                "singleton_refs": [],
+                "f": {
+                  "expr": "q!(| x | x * 2)",
+                  "singleton_refs": []
+                },
                 "input": {
                   "Source": {
                     "source": {
@@ -108,7 +113,10 @@ expression: json
   },
   {
     "ForEach": {
-      "f": "q!(| v | eprintln ! (\"{}\" , v))",
+      "f": {
+        "expr": "q!(| v | eprintln ! (\"{}\" , v))",
+        "singleton_refs": []
+      },
       "input": {
         "Tee": {
           "inner": {

--- a/hydro_lang/src/compile/ir/snapshots/hydro_lang__compile__ir__serde_test__tests__ir_json_snapshot.snap
+++ b/hydro_lang/src/compile/ir/snapshots/hydro_lang__compile__ir__serde_test__tests__ir_json_snapshot.snap
@@ -5,10 +5,7 @@ expression: json
 [
   {
     "ForEach": {
-      "f": {
-        "expr": "q!(| v | println ! (\"{}\" , v))",
-        "singleton_refs": []
-      },
+      "f": "q!(| v | println ! (\"{}\" , v))",
       "input": {
         "Tee": {
           "inner": {
@@ -113,10 +110,7 @@ expression: json
   },
   {
     "ForEach": {
-      "f": {
-        "expr": "q!(| v | eprintln ! (\"{}\" , v))",
-        "singleton_refs": []
-      },
+      "f": "q!(| v | eprintln ! (\"{}\" , v))",
       "input": {
         "Tee": {
           "inner": {

--- a/hydro_lang/src/live_collections/keyed_singleton.rs
+++ b/hydro_lang/src/live_collections/keyed_singleton.rs
@@ -378,7 +378,6 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound> KeyedSingleton<K, V, L, 
             self.location.clone(),
             HydroNode::Map {
                 f: map_f,
-                singleton_refs: Vec::new(),
                 input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.new_node_metadata(KeyedSingleton::<
                     K,
@@ -443,7 +442,6 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound> KeyedSingleton<K, V, L, 
             self.location.clone(),
             HydroNode::Map {
                 f: map_f,
-                singleton_refs: Vec::new(),
                 input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.new_node_metadata(KeyedSingleton::<
                     K,
@@ -942,7 +940,6 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound<ValueBound = Bounded>>
             self.location.clone(),
             HydroNode::Map {
                 f: map_f,
-                singleton_refs: Vec::new(),
                 input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.new_node_metadata(Stream::<
                     V,

--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -688,7 +688,6 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
             self.location.clone(),
             HydroNode::Map {
                 f: map_f,
-                singleton_refs: Vec::new(),
                 input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
@@ -748,7 +747,6 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
             self.location.clone(),
             HydroNode::Map {
                 f: map_f,
-                singleton_refs: Vec::new(),
                 input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
@@ -805,7 +803,6 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
             self.location.clone(),
             HydroNode::Map {
                 f: map_f,
-                singleton_refs: Vec::new(),
                 input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location

--- a/hydro_lang/src/live_collections/optional.rs
+++ b/hydro_lang/src/live_collections/optional.rs
@@ -357,7 +357,6 @@ where
             self.location.clone(),
             HydroNode::Map {
                 f,
-                singleton_refs: Vec::new(),
                 input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location

--- a/hydro_lang/src/live_collections/singleton.rs
+++ b/hydro_lang/src/live_collections/singleton.rs
@@ -438,7 +438,6 @@ where
             self.location.clone(),
             HydroNode::Map {
                 f,
-                singleton_refs: Vec::new(),
                 input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -1135,9 +1135,7 @@ where
         O: IsOrdered,
         R: IsExactlyOnce,
     {
-        let f = crate::singleton_ref::with_singleton_capture(|| {
-            f.splice_fn1_ctx(&self.location).into()
-        });
+        let f = f.splice_fn1_ctx(&self.location).into();
         self.location
             .flow_state()
             .borrow_mut()

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -456,14 +456,13 @@ where
     where
         F: Fn(T) -> U + 'a,
     {
-        let (f, singleton_refs) = crate::singleton_ref::with_singleton_capture(|| {
+        let f = crate::singleton_ref::with_singleton_capture(|| {
             f.splice_fn1_ctx(&self.location).into()
         });
         Stream::new(
             self.location.clone(),
             HydroNode::Map {
                 f,
-                singleton_refs,
                 input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
@@ -501,7 +500,9 @@ where
         I: IntoIterator<Item = U>,
         F: Fn(T) -> I + 'a,
     {
-        let f = f.splice_fn1_ctx(&self.location).into();
+        let f = crate::singleton_ref::with_singleton_capture(|| {
+            f.splice_fn1_ctx(&self.location).into()
+        });
         Stream::new(
             self.location.clone(),
             HydroNode::FlatMap {
@@ -548,7 +549,9 @@ where
         I: IntoIterator<Item = U>,
         F: Fn(T) -> I + 'a,
     {
-        let f = f.splice_fn1_ctx(&self.location).into();
+        let f = crate::singleton_ref::with_singleton_capture(|| {
+            f.splice_fn1_ctx(&self.location).into()
+        });
         Stream::new(
             self.location.clone(),
             HydroNode::FlatMap {
@@ -685,7 +688,9 @@ where
     where
         F: Fn(&T) -> bool + 'a,
     {
-        let f = f.splice_fn1_borrow_ctx(&self.location).into();
+        let f = crate::singleton_ref::with_singleton_capture(|| {
+            f.splice_fn1_borrow_ctx(&self.location).into()
+        });
         Stream::new(
             self.location.clone(),
             HydroNode::Filter {
@@ -741,7 +746,9 @@ where
     where
         F: Fn(&T) -> bool + 'a,
     {
-        let f: crate::compile::ir::DebugExpr = f.splice_fn1_borrow_ctx(&self.location).into();
+        let f = crate::singleton_ref::with_singleton_capture(|| {
+            f.splice_fn1_borrow_ctx(&self.location).into()
+        });
         let shared = SharedNode(Rc::new(RefCell::new(
             self.ir_node.replace(HydroNode::Placeholder),
         )));
@@ -1103,7 +1110,9 @@ where
     where
         F: Fn(&T) + 'a,
     {
-        let f = f.splice_fn1_borrow_ctx(&self.location).into();
+        let f = crate::singleton_ref::with_singleton_capture(|| {
+            f.splice_fn1_borrow_ctx(&self.location).into()
+        });
 
         Stream::new(
             self.location.clone(),
@@ -1126,7 +1135,9 @@ where
         O: IsOrdered,
         R: IsExactlyOnce,
     {
-        let f = f.splice_fn1_ctx(&self.location).into();
+        let f = crate::singleton_ref::with_singleton_capture(|| {
+            f.splice_fn1_ctx(&self.location).into()
+        });
         self.location
             .flow_state()
             .borrow_mut()

--- a/hydro_lang/src/singleton_ref.rs
+++ b/hydro_lang/src/singleton_ref.rs
@@ -168,4 +168,82 @@ mod tests {
 
         let _built = flow.finalize();
     }
+
+    /// Compile-only: singleton ref inside filter closure.
+    #[test]
+    fn singleton_by_ref_filter() {
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<P1>();
+
+        let threshold = node
+            .source_iter(q!(0..5i32))
+            .fold(q!(|| 0i32), q!(|acc: &mut i32, x| *acc += x));
+        let threshold_ref = threshold.by_ref();
+
+        node.source_iter(q!(1..=10i32))
+            .filter(q!(|x| *x > *threshold_ref))
+            .for_each(q!(|_| {}));
+
+        threshold.into_stream().for_each(q!(|_| {}));
+        let _built = flow.finalize();
+    }
+
+    /// Compile-only: singleton ref inside flat_map closure.
+    #[test]
+    fn singleton_by_ref_flat_map() {
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<P1>();
+
+        let count = node
+            .source_iter(q!(0..3i32))
+            .fold(q!(|| 0i32), q!(|acc: &mut i32, _| *acc += 1));
+        let count_ref = count.by_ref();
+
+        node.source_iter(q!(1..=2i32))
+            .flat_map_ordered(q!(|x| (0..*count_ref).map(move |i| x + i)))
+            .for_each(q!(|_| {}));
+
+        count.into_stream().for_each(q!(|_| {}));
+        let _built = flow.finalize();
+    }
+
+    /// Compile-only: singleton ref inside inspect closure.
+    #[test]
+    fn singleton_by_ref_inspect() {
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<P1>();
+
+        let count = node
+            .source_iter(q!(0..5i32))
+            .fold(q!(|| 0i32), q!(|acc: &mut i32, _| *acc += 1));
+        let count_ref = count.by_ref();
+
+        node.source_iter(q!(1..=3i32))
+            .inspect(q!(|x| println!("count={}, x={}", *count_ref, x)))
+            .for_each(q!(|_| {}));
+
+        count.into_stream().for_each(q!(|_| {}));
+        let _built = flow.finalize();
+    }
+
+    /// Compile-only: singleton ref inside partition predicate.
+    #[test]
+    fn singleton_by_ref_partition() {
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<P1>();
+
+        let threshold = node
+            .source_iter(q!(0..5i32))
+            .fold(q!(|| 0i32), q!(|acc: &mut i32, x| *acc += x));
+        let threshold_ref = threshold.by_ref();
+
+        let (above, below) = node
+            .source_iter(q!(1..=10i32))
+            .partition(q!(|x| *x > *threshold_ref));
+
+        above.for_each(q!(|_| {}));
+        below.for_each(q!(|_| {}));
+        threshold.into_stream().for_each(q!(|_| {}));
+        let _built = flow.finalize();
+    }
 }

--- a/hydro_lang/src/singleton_ref.rs
+++ b/hydro_lang/src/singleton_ref.rs
@@ -246,4 +246,30 @@ mod tests {
         threshold.into_stream().for_each(q!(|_| {}));
         let _built = flow.finalize();
     }
+
+    /// Compile-only: singleton ref inside partition with downstream operators on both branches.
+    ///
+    /// This exercises the ident_stack pop logic in the "already built" path of Partition
+    /// code generation. When the second branch is processed, singleton ref idents pushed by
+    /// transform_children must be popped to keep the stack consistent for downstream ops.
+    #[test]
+    fn singleton_by_ref_partition_with_downstream_ops() {
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<P1>();
+
+        let threshold = node
+            .source_iter(q!(0..5i32))
+            .fold(q!(|| 0i32), q!(|acc: &mut i32, x| *acc += x));
+        let threshold_ref = threshold.by_ref();
+
+        let (above, below) = node
+            .source_iter(q!(1..=10i32))
+            .partition(q!(|x| *x > *threshold_ref));
+
+        // Downstream operators on both branches — if the pop is missing, these will fail
+        above.map(q!(|x| x * 2)).for_each(q!(|_| {}));
+        below.map(q!(|x| x + 100)).for_each(q!(|_| {}));
+        threshold.into_stream().for_each(q!(|_| {}));
+        let _built = flow.finalize();
+    }
 }

--- a/hydro_lang/src/singleton_ref.rs
+++ b/hydro_lang/src/singleton_ref.rs
@@ -51,8 +51,11 @@ thread_local! {
 }
 
 /// Activate the singleton reference capture context. Must be called before `q!()` expansion
-/// that may capture singletons. Returns the captured references when the scope ends.
-pub fn with_singleton_capture<R>(f: impl FnOnce() -> R) -> (R, Vec<(syn::Ident, HydroNode)>) {
+/// that may capture singletons. Returns a `ClosureExpr` bundling the expression with any
+/// captured singleton references.
+pub fn with_singleton_capture(
+    f: impl FnOnce() -> crate::compile::ir::DebugExpr,
+) -> crate::compile::ir::ClosureExpr {
     SINGLETON_REFS.with(|cell| {
         let prev = cell.borrow_mut().replace(Vec::new());
         assert!(
@@ -60,9 +63,9 @@ pub fn with_singleton_capture<R>(f: impl FnOnce() -> R) -> (R, Vec<(syn::Ident, 
             "nested singleton capture scopes are not supported"
         );
     });
-    let result = f();
-    let captured = SINGLETON_REFS.with(|cell| cell.borrow_mut().take().unwrap());
-    (result, captured)
+    let expr = f();
+    let singleton_refs = SINGLETON_REFS.with(|cell| cell.borrow_mut().take().unwrap());
+    crate::compile::ir::ClosureExpr::new(expr, singleton_refs)
 }
 
 static SINGLETON_REF_COUNTER: std::sync::atomic::AtomicUsize =

--- a/hydro_lang/src/viz/render.rs
+++ b/hydro_lang/src/viz/render.rs
@@ -876,7 +876,7 @@ impl HydroRoot {
                 config,
                 input,
                 None,
-                NodeLabel::with_exprs("for_each".to_owned(), vec![f.expr.clone()]),
+                NodeLabel::with_exprs("for_each".to_owned(), vec![f.clone()]),
             ),
 
             HydroRoot::SendExternal {

--- a/hydro_lang/src/viz/render.rs
+++ b/hydro_lang/src/viz/render.rs
@@ -876,7 +876,7 @@ impl HydroRoot {
                 config,
                 input,
                 None,
-                NodeLabel::with_exprs("for_each".to_owned(), vec![f.clone()]),
+                NodeLabel::with_exprs("for_each".to_owned(), vec![f.expr.clone()]),
             ),
 
             HydroRoot::SendExternal {
@@ -1274,7 +1274,7 @@ impl HydroNode {
                     op_name: extract_op_name(self.print_root()),
                     node_type: HydroNodeType::Transform,
                 },
-                f,
+                &f.expr,
             ),
 
             // Single-expression Aggregation operations - grouped by node type
@@ -1289,7 +1289,7 @@ impl HydroNode {
                     op_name: extract_op_name(self.print_root()),
                     node_type: HydroNodeType::Aggregation,
                 },
-                f,
+                &f.expr,
             ),
 
             // Join-like operations with left/right edge labels - grouped by edge labeling
@@ -1429,8 +1429,8 @@ impl HydroNode {
                         op_name: extract_op_name(self.print_root()),
                         node_type,
                     },
-                    init,
-                    acc,
+                    &init.expr,
+                    &acc.expr,
                 )
             }
 
@@ -1474,7 +1474,7 @@ impl HydroNode {
                 );
 
                 let node_id = structure.add_node_with_backtrace(
-                    NodeLabel::with_exprs(extract_op_name(self.print_root()), vec![f.clone()]),
+                    NodeLabel::with_exprs(extract_op_name(self.print_root()), vec![f.expr.clone()]),
                     HydroNodeType::Aggregation,
                     location_key,
                     Some(metadata.op.backtrace.clone()),

--- a/hydro_test/src/cluster/snapshots/compute_pi_ir.snap
+++ b/hydro_test/src/cluster/snapshots/compute_pi_ir.snap
@@ -213,7 +213,7 @@ expression: built.ir()
                                                 first: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                                     input: Map {
-                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                         input: Reduce {
                                                             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
                                                             input: FlatMap {

--- a/hydro_test/src/cluster/snapshots/compute_pi_ir.snap
+++ b/hydro_test/src/cluster/snapshots/compute_pi_ir.snap
@@ -11,7 +11,6 @@ expression: built.ir()
                     inner: Cast {
                         inner: Map {
                             f: stageleft :: runtime_support :: fn1_type_hint :: < ((u64 , u64) , bool) , (u64 , u64) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | (d , _) | d }),
-                            singleton_refs: [],
                             input: CrossSingleton {
                                 left: Batch {
                                     inner: Reduce {
@@ -19,7 +18,6 @@ expression: built.ir()
                                         input: ObserveNonDet {
                                             inner: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: compute_pi :: Worker > , (u64 , u64)) , (u64 , u64) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                                singleton_refs: [],
                                                 input: Cast {
                                                     inner: Cast {
                                                         inner: Network {
@@ -41,14 +39,11 @@ expression: built.ir()
                                                                         acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (u64 , u64) , bool , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: compute_pi :: * ; | (inside , total) , sample_inside | { if sample_inside { * inside += 1 ; } * total += 1 ; } }),
                                                                         input: Map {
                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (f64 , f64) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: compute_pi :: * ; | (x , y) | x * x + y * y < 1.0 }),
-                                                                            singleton_refs: [],
                                                                             input: Map {
                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , (f64 , f64) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: compute_pi :: * ; | _ | rand :: random :: < (f64 , f64) > () }),
-                                                                                singleton_refs: [],
                                                                                 input: Batch {
                                                                                     inner: Map {
                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: tick :: * ; | _ | () }),
-                                                                                        singleton_refs: [],
                                                                                         input: FlatMap {
                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < () , std :: ops :: Range < usize > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: tick :: * ; let batch_size__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: compute_pi :: * ; let batch_size__free = 8192usize ; batch_size__free } ; move | _ | 0 .. batch_size__free }),
                                                                                             input: Source {
@@ -213,15 +208,12 @@ expression: built.ir()
                                     f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | b | * b }),
                                     input: Map {
                                         f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_some () }),
-                                        singleton_refs: [],
                                         input: Cast {
                                             inner: ChainFirst {
                                                 first: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                    singleton_refs: [],
                                                     input: Map {
-                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                        singleton_refs: [],
+                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                         input: Reduce {
                                                             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
                                                             input: FlatMap {

--- a/hydro_test/src/cluster/snapshots/many_to_many_ir.snap
+++ b/hydro_test/src/cluster/snapshots/many_to_many_ir.snap
@@ -27,7 +27,6 @@ expression: built.ir()
                                 left: ObserveNonDet {
                                     inner: Map {
                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                        singleton_refs: [],
                                         input: Cast {
                                             inner: Cast {
                                                 inner: Filter {
@@ -39,7 +38,6 @@ expression: built.ir()
                                                             input: Cast {
                                                                 inner: Map {
                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | (k , v) | (MemberId :: from_tagless (k) , v) }),
-                                                                    singleton_refs: [],
                                                                     input: Source {
                                                                         source: ClusterMembers(
                                                                             Cluster(loc1v1),

--- a/hydro_test/src/cluster/snapshots/map_reduce_ir.snap
+++ b/hydro_test/src/cluster/snapshots/map_reduce_ir.snap
@@ -16,7 +16,6 @@ expression: built.ir()
                                     inner: Cast {
                                         inner: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: map_reduce :: Worker > , (std :: string :: String , i32)) , (std :: string :: String , i32) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                            singleton_refs: [],
                                             input: Cast {
                                                 inner: Cast {
                                                     inner: Network {
@@ -43,7 +42,6 @@ expression: built.ir()
                                                                                 inner: Cast {
                                                                                     inner: Map {
                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < std :: string :: String , (std :: string :: String , ()) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: map_reduce :: * ; | string | (string , ()) }),
-                                                                                        singleton_refs: [],
                                                                                         input: Network {
                                                                                             name: None,
                                                                                             networking_info: Tcp {
@@ -65,7 +63,6 @@ expression: built.ir()
                                                                                                                 inner: Enumerate {
                                                                                                                     input: Map {
                                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < & str , std :: string :: String > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: map_reduce :: * ; | s | s . to_owned () }),
-                                                                                                                        singleton_refs: [],
                                                                                                                         input: Source {
                                                                                                                             source: Iter(
                                                                                                                                 stageleft :: runtime_support :: type_hint :: < std :: vec :: Vec < & str > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: map_reduce :: * ; vec ! ["abc" , "abc" , "xyz" , "abc"] }),
@@ -117,7 +114,6 @@ expression: built.ir()
                                                                                                                     input: ObserveNonDet {
                                                                                                                         inner: Map {
                                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: map_reduce :: Worker > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: map_reduce :: Worker > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                                                                                            singleton_refs: [],
                                                                                                                             input: Cast {
                                                                                                                                 inner: Cast {
                                                                                                                                     inner: Filter {
@@ -129,7 +125,6 @@ expression: built.ir()
                                                                                                                                                 input: Cast {
                                                                                                                                                     inner: Map {
                                                                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: map_reduce :: Worker > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | (k , v) | (MemberId :: from_tagless (k) , v) }),
-                                                                                                                                                        singleton_refs: [],
                                                                                                                                                         input: Source {
                                                                                                                                                             source: ClusterMembers(
                                                                                                                                                                 Cluster(loc2v1),

--- a/hydro_test/src/cluster/snapshots/paxos_ir.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir.snap
@@ -35,7 +35,6 @@ expression: built.ir()
                         },
                         second: Map {
                             f: stageleft :: runtime_support :: fn1_type_hint :: < ((u32 , core :: option :: Option < i32 >) , bool) , (u32 , core :: option :: Option < i32 >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | (d , _) | d }),
-                            singleton_refs: [],
                             input: CrossSingleton {
                                 left: Cast {
                                     inner: SingletonSource {
@@ -61,15 +60,12 @@ expression: built.ir()
                                     f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | b | * b }),
                                     input: Map {
                                         f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_some () }),
-                                        singleton_refs: [],
                                         input: Cast {
                                             inner: ChainFirst {
                                                 first: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                    singleton_refs: [],
                                                     input: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                        singleton_refs: [],
                                                         input: SingletonSource {
                                                             value: { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; () },
                                                             first_tick_only: true,
@@ -271,7 +267,6 @@ expression: built.ir()
         input: Tee {
             inner: <shared 1>: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , u32) , u32 > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless ((__hydro_lang_cluster_self_id_loc1v1) . clone ()) ; move | (received_max_ballot , ballot_num) | { if received_max_ballot > (Ballot { num : ballot_num , proposer_id : CLUSTER_SELF_ID__free . clone () , }) { received_max_ballot . num + 1 } else { ballot_num } } }),
-                singleton_refs: [],
                 input: Cast {
                     inner: CrossSingleton {
                         left: Tee {
@@ -591,7 +586,6 @@ expression: built.ir()
         input: Tee {
             inner: <shared 3>: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                singleton_refs: [],
                 input: Cast {
                     inner: Network {
                         name: None,
@@ -612,7 +606,6 @@ expression: built.ir()
                                         inner: Cast {
                                             inner: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                singleton_refs: [],
                                                 input: Cast {
                                                     inner: Cast {
                                                         inner: Filter {
@@ -624,7 +617,6 @@ expression: built.ir()
                                                                     input: Cast {
                                                                         inner: Map {
                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | (k , v) | (MemberId :: from_tagless (k) , v) }),
-                                                                            singleton_refs: [],
                                                                             input: Source {
                                                                                 source: ClusterMembers(
                                                                                     Cluster(loc1v1),
@@ -746,13 +738,11 @@ expression: built.ir()
                                                 inner: Cast {
                                                     inner: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , bool) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | (d , _) | d }),
-                                                        singleton_refs: [],
                                                         input: CrossSingleton {
                                                             left: Batch {
                                                                 inner: YieldConcat {
                                                                     inner: Map {
                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , bool) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                                                                        singleton_refs: [],
                                                                         input: CrossSingleton {
                                                                             left: Tee {
                                                                                 inner: <shared 4>: Batch {
@@ -760,7 +750,6 @@ expression: built.ir()
                                                                                         inner: Tee {
                                                                                             inner: <shared 5>: Map {
                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < u32 , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless ((__hydro_lang_cluster_self_id_loc1v1) . clone ()) ; move | num | Ballot { num , proposer_id : CLUSTER_SELF_ID__free . clone () } }),
-                                                                                                singleton_refs: [],
                                                                                                 input: Tee {
                                                                                                     inner: <shared 1>,
                                                                                                     metadata: HydroIrMetadata {
@@ -878,15 +867,12 @@ expression: built.ir()
                                                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | b | * b }),
                                                                 input: Map {
                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_some () }),
-                                                                    singleton_refs: [],
                                                                     input: Cast {
                                                                         inner: ChainFirst {
                                                                             first: Map {
                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                                                singleton_refs: [],
                                                                                 input: Map {
-                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                                                    singleton_refs: [],
+                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                                                     input: Reduce {
                                                                                         f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
                                                                                         input: FlatMap {
@@ -1184,7 +1170,6 @@ expression: built.ir()
                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | p1b | println ! ("Proposer received P1b: {:?}" , p1b) }),
                                 input: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                    singleton_refs: [],
                                     input: Cast {
                                         inner: Network {
                                             name: None,
@@ -1202,14 +1187,12 @@ expression: built.ir()
                                                 inner: YieldConcat {
                                                     inner: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < ((hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | ((ballot , max_ballot) , log) | (ballot . proposer_id . clone () , (ballot . clone () , if ballot == max_ballot { Ok (log) } else { Err (max_ballot) })) }),
-                                                        singleton_refs: [],
                                                         input: CrossSingleton {
                                                             left: CrossSingleton {
                                                                 left: Tee {
                                                                     inner: <shared 9>: Batch {
                                                                         inner: Map {
                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                                                            singleton_refs: [],
                                                                             input: Cast {
                                                                                 inner: Network {
                                                                                     name: None,
@@ -1229,7 +1212,6 @@ expression: built.ir()
                                                                                                 left: ObserveNonDet {
                                                                                                     inner: Map {
                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                                                                        singleton_refs: [],
                                                                                                         input: Cast {
                                                                                                             inner: Cast {
                                                                                                                 inner: Filter {
@@ -1241,7 +1223,6 @@ expression: built.ir()
                                                                                                                             input: Cast {
                                                                                                                                 inner: Map {
                                                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | (k , v) | (MemberId :: from_tagless (k) , v) }),
-                                                                                                                                    singleton_refs: [],
                                                                                                                                     input: Source {
                                                                                                                                         source: ClusterMembers(
                                                                                                                                             Cluster(loc2v1),
@@ -1354,7 +1335,6 @@ expression: built.ir()
                                                                                                             inner: Cast {
                                                                                                                 inner: Map {
                                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , bool) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                                                                                                                    singleton_refs: [],
                                                                                                                     input: CrossSingleton {
                                                                                                                         left: Tee {
                                                                                                                             inner: <shared 4>,
@@ -1370,23 +1350,18 @@ expression: built.ir()
                                                                                                                             f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
                                                                                                                             input: Map {
                                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (bool , bool) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (a , b) | a && b }),
-                                                                                                                                singleton_refs: [],
                                                                                                                                 input: Cast {
                                                                                                                                     inner: CrossSingleton {
                                                                                                                                         left: Map {
                                                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_some () }),
-                                                                                                                                            singleton_refs: [],
                                                                                                                                             input: Cast {
                                                                                                                                                 inner: ChainFirst {
                                                                                                                                                     first: Map {
                                                                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                                                                                                                        singleton_refs: [],
                                                                                                                                                         input: Map {
                                                                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                                                                                                                            singleton_refs: [],
                                                                                                                                                             input: Map {
                                                                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (() , bool) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | (d , _) | d }),
-                                                                                                                                                                singleton_refs: [],
                                                                                                                                                                 input: CrossSingleton {
                                                                                                                                                                     left: Batch {
                                                                                                                                                                         inner: YieldConcat {
@@ -1464,7 +1439,6 @@ expression: built.ir()
                                                                                                                                                                         f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | b | * b }),
                                                                                                                                                                         input: Map {
                                                                                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | ! b }),
-                                                                                                                                                                            singleton_refs: [],
                                                                                                                                                                             input: Tee {
                                                                                                                                                                                 inner: <shared 6>,
                                                                                                                                                                                 metadata: HydroIrMetadata {
@@ -1569,15 +1543,12 @@ expression: built.ir()
                                                                                                                                         },
                                                                                                                                         right: Map {
                                                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_some () }),
-                                                                                                                                            singleton_refs: [],
                                                                                                                                             input: Cast {
                                                                                                                                                 inner: ChainFirst {
                                                                                                                                                     first: Map {
                                                                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                                                                                                                        singleton_refs: [],
                                                                                                                                                         input: Map {
-                                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                                                                                                                            singleton_refs: [],
+                                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                                                                                                                             input: Reduce {
                                                                                                                                                                 f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
                                                                                                                                                                 input: FlatMap {
@@ -2147,7 +2118,6 @@ expression: built.ir()
             neg: Tee {
                 inner: <shared 11>: Map {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                    singleton_refs: [],
                     input: Cast {
                         inner: Cast {
                             inner: Filter {
@@ -2267,7 +2237,6 @@ expression: built.ir()
         input: Difference {
             pos: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                singleton_refs: [],
                 input: Cast {
                     inner: Cast {
                         inner: Filter {
@@ -2354,20 +2323,16 @@ expression: built.ir()
         input: Tee {
             inner: <shared 13>: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (bool , bool) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (a , b) | a && b }),
-                singleton_refs: [],
                 input: Cast {
                     inner: CrossSingleton {
                         left: Map {
                             f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_some () }),
-                            singleton_refs: [],
                             input: Cast {
                                 inner: ChainFirst {
                                     first: Map {
                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                        singleton_refs: [],
                                         input: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                            singleton_refs: [],
                                             input: Tee {
                                                 inner: <shared 14>: FilterMap {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < ((hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; move | ((quorum_ballot , quorum_accepted) , my_ballot) | if quorum_ballot == my_ballot { Some (quorum_accepted) } else { None } }),
@@ -2405,7 +2370,6 @@ expression: built.ir()
                                                                                                                 },
                                                                                                                 neg: Map {
                                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                                                                                    singleton_refs: [],
                                                                                                                     input: Cast {
                                                                                                                         inner: Cast {
                                                                                                                             inner: Filter {
@@ -2734,7 +2698,6 @@ expression: built.ir()
                             inner: YieldConcat {
                                 inner: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (received_max_ballot , cur_ballot) | received_max_ballot <= cur_ballot }),
-                                    singleton_refs: [],
                                     input: Cast {
                                         inner: CrossSingleton {
                                             left: Tee {
@@ -2837,7 +2800,6 @@ expression: built.ir()
         ),
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (_ , ballot) | ballot }),
-            singleton_refs: [],
             input: FilterMap {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | (key , res) | match res { Ok (_) => None , Err (e) => Some ((key , e)) , } }),
                 input: Tee {
@@ -2880,7 +2842,6 @@ expression: built.ir()
         ),
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , bool) , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | (d , _) | d }),
-            singleton_refs: [],
             input: CrossSingleton {
                 left: Tee {
                     inner: <shared 15>: Chain {
@@ -2913,12 +2874,10 @@ expression: built.ir()
                             inner: ObserveNonDet {
                                 inner: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , i32) , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos_bench :: Client > :: from_tagless ((__hydro_lang_cluster_self_id_loc3v1) . clone ()) ; move | (virtual_id , payload) | { (virtual_id , (CLUSTER_SELF_ID__free . clone () , payload)) } }),
-                                    singleton_refs: [],
                                     input: Cast {
                                         inner: Tee {
                                             inner: <shared 16>: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , core :: option :: Option < i32 >) , (u32 , i32) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < i32 > , i32 > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; move | payload | { if let Some (counter) = payload { counter + 1 } else { 0 } } }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
-                                                singleton_refs: [],
                                                 input: Chain {
                                                     first: YieldConcat {
                                                         inner: Cast {
@@ -2967,7 +2926,6 @@ expression: built.ir()
                                                     },
                                                     second: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , i32) , (u32 , core :: option :: Option < i32 >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < i32 , core :: option :: Option < i32 > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | payload | Some (payload) }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
-                                                        singleton_refs: [],
                                                         input: CycleSource {
                                                             cycle_id: CycleId(
                                                                 1,
@@ -3092,20 +3050,16 @@ expression: built.ir()
                     f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | b | * b }),
                     input: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_none () }),
-                        singleton_refs: [],
                         input: Cast {
                             inner: ChainFirst {
                                 first: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                    singleton_refs: [],
                                     input: Map {
                                         f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                        singleton_refs: [],
                                         input: Tee {
                                             inner: <shared 17>: Batch {
                                                 inner: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | ballot | ballot . proposer_id }),
-                                                    singleton_refs: [],
                                                     input: Reduce {
                                                         f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | curr , new | { if new > * curr { * curr = new ; } } }),
                                                         input: ObserveNonDet {
@@ -3113,7 +3067,6 @@ expression: built.ir()
                                                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_with_client :: * ; | ballot | println ! ("Client notified that leader was elected: {:?}" , ballot) }),
                                                                 input: Map {
                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                                                    singleton_refs: [],
                                                                     input: Cast {
                                                                         inner: Network {
                                                                             name: None,
@@ -3133,7 +3086,6 @@ expression: built.ir()
                                                                                         left: ObserveNonDet {
                                                                                             inner: Map {
                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                                                                singleton_refs: [],
                                                                                                 input: Cast {
                                                                                                     inner: Cast {
                                                                                                         inner: Filter {
@@ -3145,7 +3097,6 @@ expression: built.ir()
                                                                                                                     input: Cast {
                                                                                                                         inner: Map {
                                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | (k , v) | (MemberId :: from_tagless (k) , v) }),
-                                                                                                                            singleton_refs: [],
                                                                                                                             input: Source {
                                                                                                                                 source: ClusterMembers(
                                                                                                                                     Cluster(loc3v1),
@@ -3256,7 +3207,6 @@ expression: built.ir()
                                                                                                 inner: Cast {
                                                                                                     inner: Map {
                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , bool) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                                                                                                        singleton_refs: [],
                                                                                                         input: CrossSingleton {
                                                                                                             left: Tee {
                                                                                                                 inner: <shared 4>,
@@ -3273,7 +3223,6 @@ expression: built.ir()
                                                                                                                 input: Tee {
                                                                                                                     inner: <shared 18>: Map {
                                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (bool , bool) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (a , b) | a && b }),
-                                                                                                                        singleton_refs: [],
                                                                                                                         input: Cast {
                                                                                                                             inner: CrossSingleton {
                                                                                                                                 left: Tee {
@@ -3288,21 +3237,17 @@ expression: built.ir()
                                                                                                                                 },
                                                                                                                                 right: Map {
                                                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_none () }),
-                                                                                                                                    singleton_refs: [],
                                                                                                                                     input: Cast {
                                                                                                                                         inner: ChainFirst {
                                                                                                                                             first: Map {
                                                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                                                                                                                singleton_refs: [],
                                                                                                                                                 input: Map {
                                                                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                                                                                                                    singleton_refs: [],
                                                                                                                                                     input: DeferTick {
                                                                                                                                                         input: FilterMap {
                                                                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | v | v }),
                                                                                                                                                             input: Map {
                                                                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < bool , core :: option :: Option < () > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | is_leader | is_leader . then_some (()) }),
-                                                                                                                                                                singleton_refs: [],
                                                                                                                                                                 input: Tee {
                                                                                                                                                                     inner: <shared 13>,
                                                                                                                                                                     metadata: HydroIrMetadata {
@@ -3695,7 +3640,6 @@ expression: built.ir()
         ),
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , usize) , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (num_payloads , base_slot) | base_slot + num_payloads }),
-            singleton_refs: [],
             input: Cast {
                 inner: CrossSingleton {
                     left: Fold {
@@ -3704,20 +3648,17 @@ expression: built.ir()
                         input: Tee {
                             inner: <shared 19>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , usize) , (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | ((index , payload) , base_slot) | (base_slot + index , payload) }),
-                                singleton_refs: [],
                                 input: CrossSingleton {
                                     left: Enumerate {
                                         input: Batch {
                                             inner: YieldConcat {
                                                 inner: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , bool) , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | (d , _) | d }),
-                                                    singleton_refs: [],
                                                     input: CrossSingleton {
                                                         left: Batch {
                                                             inner: ObserveNonDet {
                                                                 inner: Map {
                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                                                    singleton_refs: [],
                                                                     input: Cast {
                                                                         inner: Network {
                                                                             name: None,
@@ -3734,7 +3675,6 @@ expression: built.ir()
                                                                             input: Cast {
                                                                                 inner: Map {
                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_with_client :: * ; move | (payload , leader_id) | (leader_id , payload) }),
-                                                                                    singleton_refs: [],
                                                                                     input: YieldConcat {
                                                                                         inner: CrossSingleton {
                                                                                             left: Tee {
@@ -3928,7 +3868,6 @@ expression: built.ir()
                                                 inner: ChainFirst {
                                                     first: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < usize , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | s | s + 1 }),
-                                                        singleton_refs: [],
                                                         input: Batch {
                                                             inner: YieldConcat {
                                                                 inner: Tee {
@@ -3937,13 +3876,11 @@ expression: built.ir()
                                                                         input: ObserveNonDet {
                                                                             inner: Map {
                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                                                singleton_refs: [],
                                                                                 input: Cast {
                                                                                     inner: Cast {
                                                                                         inner: Tee {
                                                                                             inner: <shared 22>: Map {
                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)) , (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (count , entry) | (count , entry . unwrap ()) }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
-                                                                                                singleton_refs: [],
                                                                                                 input: FoldKeyed {
                                                                                                     init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | | (0 , None) }),
                                                                                                     acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | curr_entry , new_entry | { if let Some (curr_entry_payload) = & mut curr_entry . 1 { let same_values = new_entry . value == curr_entry_payload . value ; let higher_ballot = new_entry . ballot > curr_entry_payload . ballot ; if same_values { curr_entry . 0 += 1 ; } if higher_ballot { curr_entry_payload . ballot = new_entry . ballot ; if ! same_values { curr_entry . 0 = 1 ; curr_entry_payload . value = new_entry . value ; } } } else { * curr_entry = (1 , Some (new_entry)) ; } } }),
@@ -3952,7 +3889,6 @@ expression: built.ir()
                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | d | d }),
                                                                                                             input: Map {
                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (_checkpoint , log) | log }),
-                                                                                                                singleton_refs: [],
                                                                                                                 input: Tee {
                                                                                                                     inner: <shared 23>: FlatMap {
                                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | v }),
@@ -4347,7 +4283,6 @@ expression: built.ir()
                         inner: Tee {
                             inner: <shared 25>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                singleton_refs: [],
                                 input: Cast {
                                     inner: Network {
                                         name: None,
@@ -4365,13 +4300,11 @@ expression: built.ir()
                                             inner: YieldConcat {
                                                 inner: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (p2a , max_ballot) | (p2a . sender , ((p2a . slot , p2a . ballot . clone ()) , if p2a . ballot == max_ballot { Ok (()) } else { Err (max_ballot) })) }),
-                                                    singleton_refs: [],
                                                     input: CrossSingleton {
                                                         left: Tee {
                                                             inner: <shared 26>: Batch {
                                                                 inner: Map {
                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >) , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                                                    singleton_refs: [],
                                                                     input: Cast {
                                                                         inner: Network {
                                                                             name: None,
@@ -4391,7 +4324,6 @@ expression: built.ir()
                                                                                         left: ObserveNonDet {
                                                                                             inner: Map {
                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                                                                singleton_refs: [],
                                                                                                 input: Cast {
                                                                                                     inner: Cast {
                                                                                                         inner: Filter {
@@ -4403,7 +4335,6 @@ expression: built.ir()
                                                                                                                     input: Cast {
                                                                                                                         inner: Map {
                                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | (k , v) | (MemberId :: from_tagless (k) , v) }),
-                                                                                                                            singleton_refs: [],
                                                                                                                             input: Source {
                                                                                                                                 source: ClusterMembers(
                                                                                                                                     Cluster(loc2v1),
@@ -4512,18 +4443,15 @@ expression: built.ir()
                                                                                         right: Batch {
                                                                                             inner: Map {
                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless ((__hydro_lang_cluster_self_id_loc1v1) . clone ()) ; move | ((slot , ballot) , value) | P2a { sender : CLUSTER_SELF_ID__free . clone () , ballot , slot , value } }),
-                                                                                                singleton_refs: [],
                                                                                                 input: EndAtomic {
                                                                                                     inner: Tee {
                                                                                                         inner: <shared 27>: YieldConcat {
                                                                                                             inner: Map {
                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , bool) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | (d , _) | d }),
-                                                                                                                singleton_refs: [],
                                                                                                                 input: CrossSingleton {
                                                                                                                     left: Chain {
                                                                                                                         first: Map {
                                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | ((slot , payload) , ballot) | ((slot , ballot) , Some (payload)) }),
-                                                                                                                            singleton_refs: [],
                                                                                                                             input: CrossSingleton {
                                                                                                                                 left: Batch {
                                                                                                                                     inner: YieldConcat {
@@ -4672,7 +4600,6 @@ expression: built.ir()
                                                                                                                                                 inner: ChainFirst {
                                                                                                                                                     first: Map {
                                                                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < usize , core :: option :: Option < usize > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                                                                                                                        singleton_refs: [],
                                                                                                                                                         input: Reduce {
                                                                                                                                                             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | curr , new | { if new > * curr { * curr = new ; } } }),
                                                                                                                                                             input: ObserveNonDet {
@@ -4801,7 +4728,6 @@ expression: built.ir()
                                                                                                                             },
                                                                                                                             second: Map {
                                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; move | (slot , ballot) | ((slot , ballot) , None) }),
-                                                                                                                                singleton_refs: [],
                                                                                                                                 input: CrossSingleton {
                                                                                                                                     left: Difference {
                                                                                                                                         pos: FlatMap {
@@ -4867,7 +4793,6 @@ expression: built.ir()
                                                                                                                                         },
                                                                                                                                         neg: Map {
                                                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                                                                                                            singleton_refs: [],
                                                                                                                                             input: Cast {
                                                                                                                                                 inner: Cast {
                                                                                                                                                     inner: Tee {
@@ -5288,7 +5213,6 @@ expression: built.ir()
             neg: Tee {
                 inner: <shared 29>: Map {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (usize , usize)) , (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                    singleton_refs: [],
                     input: Cast {
                         inner: Cast {
                             inner: Filter {
@@ -5586,12 +5510,10 @@ expression: built.ir()
             },
             neg: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ()) , (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: request_response :: * ; | (key , _) | key }),
-                singleton_refs: [],
                 input: Tee {
                     inner: <shared 33>: Batch {
                         inner: Map {
                             f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ()) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | k | (k , ()) }),
-                            singleton_refs: [],
                             input: YieldConcat {
                                 inner: Difference {
                                     pos: Tee {
@@ -5715,7 +5637,6 @@ expression: built.ir()
                             inner: ChainFirst {
                                 first: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < usize , core :: option :: Option < usize > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                    singleton_refs: [],
                                     input: Tee {
                                         inner: <shared 34>: Batch {
                                             inner: CycleSource {
@@ -5985,7 +5906,6 @@ expression: built.ir()
         ),
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (_ , ballot) | ballot }),
-            singleton_refs: [],
             input: FilterMap {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , core :: option :: Option < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | (key , res) | match res { Ok (_) => None , Err (e) => Some ((key , e)) , } }),
                 input: Tee {
@@ -6027,7 +5947,6 @@ expression: built.ir()
             inner: Cast {
                 inner: Map {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , bool) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                    singleton_refs: [],
                     input: CrossSingleton {
                         left: Tee {
                             inner: <shared 4>,
@@ -6103,7 +6022,6 @@ expression: built.ir()
         ),
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; | (sorted_payload , _) | { sorted_payload } }),
-            singleton_refs: [],
             input: Filter {
                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; | (sorted_payload , highest_seq) | sorted_payload . seq > * highest_seq }),
                 input: CrossSingleton {
@@ -6113,13 +6031,10 @@ expression: built.ir()
                                 first: Batch {
                                     inner: Map {
                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > >) , hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; | (slot , kv) | SequencedKv { seq : slot , kv } }),
-                                        singleton_refs: [],
                                         input: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; | (index , payload) | (index , payload . map (| (key , value) | KvPayload { key , value })) }),
-                                            singleton_refs: [],
                                             input: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (usize , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , (usize , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                                singleton_refs: [],
                                                 input: Cast {
                                                     inner: Network {
                                                         name: None,
@@ -6139,7 +6054,6 @@ expression: built.ir()
                                                                     left: ObserveNonDet {
                                                                         inner: Map {
                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                                            singleton_refs: [],
                                                                             input: Cast {
                                                                                 inner: Cast {
                                                                                     inner: Filter {
@@ -6151,7 +6065,6 @@ expression: built.ir()
                                                                                                 input: Cast {
                                                                                                     inner: Map {
                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | (k , v) | (MemberId :: from_tagless (k) , v) }),
-                                                                                                        singleton_refs: [],
                                                                                                         input: Source {
                                                                                                             source: ClusterMembers(
                                                                                                                 Cluster(loc5v1),
@@ -6260,11 +6173,9 @@ expression: built.ir()
                                                                     right: Batch {
                                                                         inner: Map {
                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , ())) , (usize , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | ((slot , _ballot) , (value , _)) | (slot , value) }),
-                                                                            singleton_refs: [],
                                                                             input: YieldConcat {
                                                                                 inner: Map {
                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , ())) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , ())) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: request_response :: * ; | (key , (meta , resp)) | (key , (meta , resp)) }),
-                                                                                    singleton_refs: [],
                                                                                     input: JoinHalf {
                                                                                         left: Tee {
                                                                                             inner: <shared 32>,
@@ -6647,7 +6558,6 @@ expression: built.ir()
         input: Tee {
             inner: <shared 37>: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: collections :: hash_map :: HashMap < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; | (_kv_store , next_slot) | next_slot }),
-                singleton_refs: [],
                 input: Batch {
                     inner: Fold {
                         init: stageleft :: runtime_support :: fn0_type_hint :: < (std :: collections :: hash_map :: HashMap < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; | | (HashMap :: new () , 0) }),
@@ -6656,7 +6566,6 @@ expression: built.ir()
                             inner: Tee {
                                 inner: <shared 38>: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; | (sorted_payload , _) | { sorted_payload } }),
-                                    singleton_refs: [],
                                     input: Filter {
                                         f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; | (sorted_payload , highest_seq) | sorted_payload . seq < * highest_seq }),
                                         input: CrossSingleton {
@@ -6788,7 +6697,6 @@ expression: built.ir()
                             inner: ChainFirst {
                                 first: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < usize , core :: option :: Option < usize > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                    singleton_refs: [],
                                     input: Batch {
                                         inner: Reduce {
                                             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | curr , new | { if new > * curr { * curr = new ; } } }),
@@ -7005,10 +6913,8 @@ expression: built.ir()
                 input: ObserveNonDet {
                     inner: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica > , usize) , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; | (_sender , seq) | seq }),
-                        singleton_refs: [],
                         input: Map {
                             f: stageleft :: runtime_support :: fn1_type_hint :: < ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica > , usize) , bool) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica > , usize) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | (d , _) | d }),
-                            singleton_refs: [],
                             input: CrossSingleton {
                                 left: Cast {
                                     inner: Cast {
@@ -7034,7 +6940,6 @@ expression: built.ir()
                                                                     left: ObserveNonDet {
                                                                         inner: Map {
                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                                            singleton_refs: [],
                                                                             input: Cast {
                                                                                 inner: Cast {
                                                                                     inner: Filter {
@@ -7046,7 +6951,6 @@ expression: built.ir()
                                                                                                 input: Cast {
                                                                                                     inner: Map {
                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | (k , v) | (MemberId :: from_tagless (k) , v) }),
-                                                                                                        singleton_refs: [],
                                                                                                         input: Source {
                                                                                                             source: ClusterMembers(
                                                                                                                 Cluster(loc2v1),
@@ -7290,7 +7194,6 @@ expression: built.ir()
                                     f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | b | * b }),
                                     input: Map {
                                         f: stageleft :: runtime_support :: fn1_type_hint :: < usize , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; let f__free = 1usize ; move | num_received | num_received == f__free + 1 }),
-                                        singleton_refs: [],
                                         input: Fold {
                                             init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | | 0usize }),
                                             acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica > , usize) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | count , _ | * count += 1 }),
@@ -7459,7 +7362,6 @@ expression: built.ir()
                         inner: Tee {
                             inner: <shared 42>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica > , ((u32 , i32) , core :: result :: Result < () , () >)) , ((u32 , i32) , core :: result :: Result < () , () >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                singleton_refs: [],
                                 input: Cast {
                                     inner: Network {
                                         name: None,
@@ -7476,7 +7378,6 @@ expression: built.ir()
                                         input: Cast {
                                             inner: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , ((u32 , i32) , core :: result :: Result < () , () >)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; | payload | (payload . value . 0 , ((payload . key , payload . value . 1) , Ok (()))) }),
-                                                singleton_refs: [],
                                                 input: YieldConcat {
                                                     inner: FilterMap {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; | payload | payload . kv }),
@@ -7827,7 +7728,6 @@ expression: built.ir()
             inner: ChainFirst {
                 first: Map {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (new , old) | { old . borrow_mut () . add (new) . expect ("Error adding value to histogram") ; old } }),
-                    singleton_refs: [],
                     input: CrossSingleton {
                         left: Tee {
                             inner: <shared 46>: Fold {
@@ -7837,14 +7737,12 @@ expression: built.ir()
                                     inner: <shared 47>: Batch {
                                         inner: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , (i32 , core :: time :: Duration)) , core :: time :: Duration > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; | (_virtual_client_id , (_output , latency)) | latency }),
-                                            singleton_refs: [],
                                             input: Cast {
                                                 inner: YieldConcat {
                                                     inner: Cast {
                                                         inner: Cast {
                                                             inner: Map {
                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , (std :: time :: Instant , (std :: time :: Instant , i32))) , (u32 , (i32 , core :: time :: Duration)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < (std :: time :: Instant , (std :: time :: Instant , i32)) , (i32 , core :: time :: Duration) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (start_time , (end_time , output)) | (output , end_time . duration_since (start_time)) }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
-                                                                singleton_refs: [],
                                                                 input: Cast {
                                                                     inner: Cast {
                                                                         inner: JoinHalf {
@@ -7920,7 +7818,6 @@ expression: built.ir()
                                                                                 inner: Cast {
                                                                                     inner: Map {
                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , i32) , (u32 , (std :: time :: Instant , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < i32 , (std :: time :: Instant , i32) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | output | (Instant :: now () , output) }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
-                                                                                        singleton_refs: [],
                                                                                         input: ReduceKeyed {
                                                                                             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < i32 , i32 , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | curr , new | { * curr = new ; } }),
                                                                                             input: ObserveNonDet {
@@ -8131,7 +8028,6 @@ expression: built.ir()
                         right: Tee {
                             inner: <shared 48>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                                singleton_refs: [],
                                 input: CrossSingleton {
                                     left: Tee {
                                         inner: <shared 49>: Cast {
@@ -8205,15 +8101,12 @@ expression: built.ir()
                                         f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
                                         input: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_none () }),
-                                            singleton_refs: [],
                                             input: Cast {
                                                 inner: ChainFirst {
                                                     first: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                        singleton_refs: [],
                                                         input: Map {
-                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                            singleton_refs: [],
+                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                             input: Tee {
                                                                 inner: <shared 50>: Reduce {
                                                                     f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
@@ -8394,7 +8287,6 @@ expression: built.ir()
                 second: Cast {
                     inner: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | histogram | Rc :: new (RefCell :: new (histogram)) }),
-                        singleton_refs: [],
                         input: Tee {
                             inner: <shared 46>,
                             metadata: HydroIrMetadata {
@@ -8447,7 +8339,6 @@ expression: built.ir()
             inner: ChainFirst {
                 first: Map {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , usize) , usize > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (new , old) | new + old }),
-                    singleton_refs: [],
                     input: CrossSingleton {
                         left: Tee {
                             inner: <shared 51>: Fold {
@@ -8496,7 +8387,6 @@ expression: built.ir()
                         right: Tee {
                             inner: <shared 52>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                                singleton_refs: [],
                                 input: CrossSingleton {
                                     left: Tee {
                                         inner: <shared 53>: Cast {
@@ -8570,15 +8460,12 @@ expression: built.ir()
                                         f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
                                         input: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_none () }),
-                                            singleton_refs: [],
                                             input: Cast {
                                                 inner: ChainFirst {
                                                     first: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                        singleton_refs: [],
                                                         input: Map {
-                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                            singleton_refs: [],
+                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                             input: Tee {
                                                                 inner: <shared 50>,
                                                                 metadata: HydroIrMetadata {
@@ -8739,8 +8626,7 @@ expression: built.ir()
             23,
         ),
         input: Map {
-            f: stageleft :: runtime_support :: fn1_type_hint :: < ((std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > >) , core :: option :: Option < () >) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | ((old , new) , reset) | { if reset . is_some () { old . replace (Histogram :: < u64 > :: new (3) . unwrap ()) ; } if let Some (new) = new { old . borrow_mut () . add (& * new . borrow_mut ()) . expect ("Error adding value to histogram") ; } old } }),
-            singleton_refs: [],
+            f: stageleft :: runtime_support :: fn1_type_hint :: < ((std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > >) , core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant >) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | ((old , new) , reset) | { if reset . is_some () { old . replace (Histogram :: < u64 > :: new (3) . unwrap ()) ; } if let Some (new) = new { old . borrow_mut () . add (& * new . borrow_mut ()) . expect ("Error adding value to histogram") ; } old } }),
             input: Cast {
                 inner: CrossSingleton {
                     left: Cast {
@@ -8817,17 +8703,14 @@ expression: built.ir()
                                 inner: ChainFirst {
                                     first: Map {
                                         f: stageleft :: runtime_support :: fn1_type_hint :: < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                        singleton_refs: [],
                                         input: Reduce {
                                             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | curr , new | { curr . borrow_mut () . add (& * new . borrow_mut ()) . expect ("Error adding value to histogram") ; } }),
                                             input: ObserveNonDet {
                                                 inner: Batch {
                                                     inner: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | wrapper | wrapper . histogram }),
-                                                        singleton_refs: [],
                                                         input: Map {
                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper) , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                                            singleton_refs: [],
                                                             input: Cast {
                                                                 inner: Cast {
                                                                     inner: Network {
@@ -8844,12 +8727,10 @@ expression: built.ir()
                                                                         ),
                                                                         input: Map {
                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | latencies | { SerializableHistogramWrapper { histogram : latencies , } } }),
-                                                                            singleton_refs: [],
                                                                             input: YieldConcat {
                                                                                 inner: Cast {
                                                                                     inner: Map {
                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                                                                                        singleton_refs: [],
                                                                                         input: CrossSingleton {
                                                                                             left: Tee {
                                                                                                 inner: <shared 49>,
@@ -8865,15 +8746,12 @@ expression: built.ir()
                                                                                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
                                                                                                 input: Map {
                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_some () }),
-                                                                                                    singleton_refs: [],
                                                                                                     input: Cast {
                                                                                                         inner: ChainFirst {
                                                                                                             first: Map {
                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                                                                                singleton_refs: [],
                                                                                                                 input: Map {
-                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                                                                                    singleton_refs: [],
+                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                                                                                     input: Tee {
                                                                                                                         inner: <shared 50>,
                                                                                                                         metadata: HydroIrMetadata {
@@ -9141,8 +9019,7 @@ expression: built.ir()
                     right: Cast {
                         inner: ChainFirst {
                             first: Map {
-                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                singleton_refs: [],
+                                f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                 input: DeferTick {
                                     input: Tee {
                                         inner: <shared 55>: Reduce {
@@ -9302,7 +9179,6 @@ expression: built.ir()
                 first: Batch {
                     inner: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , usize) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                        singleton_refs: [],
                         input: Cast {
                             inner: Cast {
                                 inner: Network {
@@ -9321,7 +9197,6 @@ expression: built.ir()
                                         inner: Cast {
                                             inner: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                                                singleton_refs: [],
                                                 input: CrossSingleton {
                                                     left: Tee {
                                                         inner: <shared 53>,
@@ -9337,15 +9212,12 @@ expression: built.ir()
                                                         f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
                                                         input: Map {
                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_some () }),
-                                                            singleton_refs: [],
                                                             input: Cast {
                                                                 inner: ChainFirst {
                                                                     first: Map {
                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                                        singleton_refs: [],
                                                                         input: Map {
-                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                                            singleton_refs: [],
+                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                                             input: Tee {
                                                                                 inner: <shared 50>,
                                                                                 metadata: HydroIrMetadata {
@@ -9514,7 +9386,6 @@ expression: built.ir()
                 second: Cast {
                     inner: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                        singleton_refs: [],
                         input: CrossSingleton {
                             left: Tee {
                                 inner: <shared 56>: Cast {
@@ -9588,15 +9459,12 @@ expression: built.ir()
                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
                                 input: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_none () }),
-                                    singleton_refs: [],
                                     input: Cast {
                                         inner: ChainFirst {
                                             first: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                singleton_refs: [],
                                                 input: Map {
-                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                    singleton_refs: [],
+                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                     input: Tee {
                                                         inner: <shared 55>,
                                                         metadata: HydroIrMetadata {
@@ -9727,7 +9595,6 @@ expression: built.ir()
             inner: Cast {
                 inner: Map {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                    singleton_refs: [],
                     input: CrossSingleton {
                         left: Tee {
                             inner: <shared 56>,
@@ -9743,15 +9610,12 @@ expression: built.ir()
                             f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
                             input: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_some () }),
-                                singleton_refs: [],
                                 input: Cast {
                                     inner: ChainFirst {
                                         first: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                            singleton_refs: [],
                                             input: Map {
-                                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                singleton_refs: [],
+                                                f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                 input: Tee {
                                                     inner: <shared 55>,
                                                     metadata: HydroIrMetadata {
@@ -9872,12 +9736,10 @@ expression: built.ir()
         f: stageleft :: runtime_support :: fn1_type_hint :: < (f64 , f64 , f64 , u64) , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; move | (p50 , p99 , p999 , num_samples) | { println ! ("Latency p50: {:.3} | p99 {:.3} | p999 {:.3} ms ({:} samples)" , p50 , p99 , p999 , num_samples) ; } }),
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , (f64 , f64 , f64 , u64) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; move | latencies | (Duration :: from_nanos (latencies . borrow () . value_at_quantile (0.5)) . as_micros () as f64 / 1000.0 , Duration :: from_nanos (latencies . borrow () . value_at_quantile (0.99)) . as_micros () as f64 / 1000.0 , Duration :: from_nanos (latencies . borrow () . value_at_quantile (0.999)) . as_micros () as f64 / 1000.0 , latencies . borrow () . len () ,) }),
-            singleton_refs: [],
             input: YieldConcat {
                 inner: Cast {
                     inner: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                        singleton_refs: [],
                         input: CrossSingleton {
                             left: Tee {
                                 inner: <shared 54>,
@@ -9893,15 +9755,12 @@ expression: built.ir()
                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
                                 input: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_some () }),
-                                    singleton_refs: [],
                                     input: Cast {
                                         inner: ChainFirst {
                                             first: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                singleton_refs: [],
                                                 input: Map {
-                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                    singleton_refs: [],
+                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                     input: Tee {
                                                         inner: <shared 55>,
                                                         metadata: HydroIrMetadata {

--- a/hydro_test/src/cluster/snapshots/paxos_ir.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir.snap
@@ -872,7 +872,7 @@ expression: built.ir()
                                                                             first: Map {
                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                                                                 input: Map {
-                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                                                     input: Reduce {
                                                                                         f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
                                                                                         input: FlatMap {
@@ -1548,7 +1548,7 @@ expression: built.ir()
                                                                                                                                                     first: Map {
                                                                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                                                                                                                                         input: Map {
-                                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                                                                                                                             input: Reduce {
                                                                                                                                                                 f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
                                                                                                                                                                 input: FlatMap {
@@ -8106,7 +8106,7 @@ expression: built.ir()
                                                     first: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                                         input: Map {
-                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                             input: Tee {
                                                                 inner: <shared 50>: Reduce {
                                                                     f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
@@ -8465,7 +8465,7 @@ expression: built.ir()
                                                     first: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                                         input: Map {
-                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                             input: Tee {
                                                                 inner: <shared 50>,
                                                                 metadata: HydroIrMetadata {
@@ -8626,7 +8626,7 @@ expression: built.ir()
             23,
         ),
         input: Map {
-            f: stageleft :: runtime_support :: fn1_type_hint :: < ((std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > >) , core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant >) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | ((old , new) , reset) | { if reset . is_some () { old . replace (Histogram :: < u64 > :: new (3) . unwrap ()) ; } if let Some (new) = new { old . borrow_mut () . add (& * new . borrow_mut ()) . expect ("Error adding value to histogram") ; } old } }),
+            f: stageleft :: runtime_support :: fn1_type_hint :: < ((std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > >) , core :: option :: Option < () >) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | ((old , new) , reset) | { if reset . is_some () { old . replace (Histogram :: < u64 > :: new (3) . unwrap ()) ; } if let Some (new) = new { old . borrow_mut () . add (& * new . borrow_mut ()) . expect ("Error adding value to histogram") ; } old } }),
             input: Cast {
                 inner: CrossSingleton {
                     left: Cast {
@@ -8751,7 +8751,7 @@ expression: built.ir()
                                                                                                             first: Map {
                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                                                                                                 input: Map {
-                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                                                                                     input: Tee {
                                                                                                                         inner: <shared 50>,
                                                                                                                         metadata: HydroIrMetadata {
@@ -9019,7 +9019,7 @@ expression: built.ir()
                     right: Cast {
                         inner: ChainFirst {
                             first: Map {
-                                f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
+                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                 input: DeferTick {
                                     input: Tee {
                                         inner: <shared 55>: Reduce {
@@ -9217,7 +9217,7 @@ expression: built.ir()
                                                                     first: Map {
                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                                                         input: Map {
-                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                                             input: Tee {
                                                                                 inner: <shared 50>,
                                                                                 metadata: HydroIrMetadata {
@@ -9464,7 +9464,7 @@ expression: built.ir()
                                             first: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                                 input: Map {
-                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                     input: Tee {
                                                         inner: <shared 55>,
                                                         metadata: HydroIrMetadata {
@@ -9615,7 +9615,7 @@ expression: built.ir()
                                         first: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                             input: Map {
-                                                f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                 input: Tee {
                                                     inner: <shared 55>,
                                                     metadata: HydroIrMetadata {
@@ -9760,7 +9760,7 @@ expression: built.ir()
                                             first: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                                 input: Map {
-                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                     input: Tee {
                                                         inner: <shared 55>,
                                                         metadata: HydroIrMetadata {

--- a/hydro_test/src/cluster/snapshots/simple_cluster_ir.snap
+++ b/hydro_test/src/cluster/snapshots/simple_cluster_ir.snap
@@ -37,21 +37,17 @@ expression: built.ir()
                                 input: Cast {
                                     inner: Map {
                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: simple_cluster :: * ; | (id , n) | (id . clone () , (id , n)) }),
-                                        singleton_refs: [],
                                         input: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (() , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32)) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | (() , (v1 , v2)) | (v1 , v2) }),
-                                            singleton_refs: [],
                                             input: JoinHalf {
                                                 left: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , (() , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | v | (() , v) }),
-                                                    singleton_refs: [],
                                                     input: FilterMap {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , core :: option :: Option < hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: simple_cluster :: * ; | (i , e) | match e { MembershipEvent :: Joined => Some (i) , MembershipEvent :: Left => None , } }),
                                                         input: Cast {
                                                             inner: Cast {
                                                                 inner: Map {
                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | (k , v) | (MemberId :: from_tagless (k) , v) }),
-                                                                    singleton_refs: [],
                                                                     input: Source {
                                                                         source: ClusterMembers(
                                                                             Cluster(loc2v1),
@@ -120,7 +116,6 @@ expression: built.ir()
                                                 },
                                                 right: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < i32 , (() , i32) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | v | (() , v) }),
-                                                    singleton_refs: [],
                                                     input: Source {
                                                         source: Iter(
                                                             stageleft :: runtime_support :: type_hint :: < std :: ops :: Range < i32 > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: simple_cluster :: * ; 0 .. 5 }),

--- a/hydro_test/src/cluster/snapshots/two_pc_ir.snap
+++ b/hydro_test/src/cluster/snapshots/two_pc_ir.snap
@@ -35,7 +35,6 @@ expression: built.ir()
                         },
                         second: Map {
                             f: stageleft :: runtime_support :: fn1_type_hint :: < ((u32 , core :: option :: Option < i32 >) , bool) , (u32 , core :: option :: Option < i32 >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | (d , _) | d }),
-                            singleton_refs: [],
                             input: CrossSingleton {
                                 left: Cast {
                                     inner: SingletonSource {
@@ -61,15 +60,12 @@ expression: built.ir()
                                     f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | b | * b }),
                                     input: Map {
                                         f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_some () }),
-                                        singleton_refs: [],
                                         input: Cast {
                                             inner: ChainFirst {
                                                 first: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                    singleton_refs: [],
                                                     input: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                        singleton_refs: [],
                                                         input: SingletonSource {
                                                             value: { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; () },
                                                             first_tick_only: true,
@@ -264,10 +260,8 @@ expression: built.ir()
                         inner: Tee {
                             inner: <shared 2>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) , ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) , core :: result :: Result < () , () >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: two_pc :: * ; | kv | (kv , Ok :: < () , () > (())) }),
-                                singleton_refs: [],
                                 input: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32))) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                    singleton_refs: [],
                                     input: Cast {
                                         inner: Cast {
                                             inner: Network {
@@ -300,7 +294,6 @@ expression: built.ir()
                                                                 left: ObserveNonDet {
                                                                     inner: Map {
                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                                        singleton_refs: [],
                                                                         input: Cast {
                                                                             inner: Cast {
                                                                                 inner: Filter {
@@ -312,7 +305,6 @@ expression: built.ir()
                                                                                             input: Cast {
                                                                                                 inner: Map {
                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | (k , v) | (MemberId :: from_tagless (k) , v) }),
-                                                                                                    singleton_refs: [],
                                                                                                     input: Source {
                                                                                                         source: ClusterMembers(
                                                                                                             Cluster(loc2v1),
@@ -437,7 +429,6 @@ expression: built.ir()
                                                                                     inner: Tee {
                                                                                         inner: <shared 3>: Map {
                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , core :: option :: Option < i32 >) , (u32 , i32) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < i32 > , i32 > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; move | payload | { if let Some (counter) = payload { counter + 1 } else { 0 } } }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
-                                                                                            singleton_refs: [],
                                                                                             input: Chain {
                                                                                                 first: YieldConcat {
                                                                                                     inner: Cast {
@@ -486,7 +477,6 @@ expression: built.ir()
                                                                                                 },
                                                                                                 second: Map {
                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , i32) , (u32 , core :: option :: Option < i32 >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < i32 , core :: option :: Option < i32 > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | payload | Some (payload) }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
-                                                                                                    singleton_refs: [],
                                                                                                     input: CycleSource {
                                                                                                         cycle_id: CycleId(
                                                                                                             1,
@@ -928,10 +918,8 @@ expression: built.ir()
                         inner: Tee {
                             inner: <shared 7>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) , ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) , core :: result :: Result < () , () >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: two_pc :: * ; | kv | (kv , Ok :: < () , () > (())) }),
-                                singleton_refs: [],
                                 input: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32))) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                    singleton_refs: [],
                                     input: Cast {
                                         inner: Cast {
                                             inner: Network {
@@ -964,7 +952,6 @@ expression: built.ir()
                                                                 left: ObserveNonDet {
                                                                     inner: Map {
                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                                        singleton_refs: [],
                                                                         input: Cast {
                                                                             inner: Cast {
                                                                                 inner: Filter {
@@ -976,7 +963,6 @@ expression: built.ir()
                                                                                             input: Cast {
                                                                                                 inner: Map {
                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | (k , v) | (MemberId :: from_tagless (k) , v) }),
-                                                                                                    singleton_refs: [],
                                                                                                     input: Source {
                                                                                                         source: ClusterMembers(
                                                                                                             Cluster(loc2v1),
@@ -1506,7 +1492,6 @@ expression: built.ir()
             inner: ChainFirst {
                 first: Map {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (new , old) | { old . borrow_mut () . add (new) . expect ("Error adding value to histogram") ; old } }),
-                    singleton_refs: [],
                     input: CrossSingleton {
                         left: Tee {
                             inner: <shared 11>: Fold {
@@ -1516,14 +1501,12 @@ expression: built.ir()
                                     inner: <shared 12>: Batch {
                                         inner: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , (i32 , core :: time :: Duration)) , core :: time :: Duration > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: two_pc_bench :: * ; | (_virtual_client_id , (_output , latency)) | latency }),
-                                            singleton_refs: [],
                                             input: Cast {
                                                 inner: YieldConcat {
                                                     inner: Cast {
                                                         inner: Cast {
                                                             inner: Map {
                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , (std :: time :: Instant , (std :: time :: Instant , i32))) , (u32 , (i32 , core :: time :: Duration)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < (std :: time :: Instant , (std :: time :: Instant , i32)) , (i32 , core :: time :: Duration) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (start_time , (end_time , output)) | (output , end_time . duration_since (start_time)) }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
-                                                                singleton_refs: [],
                                                                 input: Cast {
                                                                     inner: Cast {
                                                                         inner: JoinHalf {
@@ -1599,7 +1582,6 @@ expression: built.ir()
                                                                                 inner: Cast {
                                                                                     inner: Map {
                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , i32) , (u32 , (std :: time :: Instant , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < i32 , (std :: time :: Instant , i32) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | output | (Instant :: now () , output) }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
-                                                                                        singleton_refs: [],
                                                                                         input: ReduceKeyed {
                                                                                             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < i32 , i32 , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | curr , new | { * curr = new ; } }),
                                                                                             input: ObserveNonDet {
@@ -1810,7 +1792,6 @@ expression: built.ir()
                         right: Tee {
                             inner: <shared 13>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                                singleton_refs: [],
                                 input: CrossSingleton {
                                     left: Tee {
                                         inner: <shared 14>: Cast {
@@ -1884,15 +1865,12 @@ expression: built.ir()
                                         f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
                                         input: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_none () }),
-                                            singleton_refs: [],
                                             input: Cast {
                                                 inner: ChainFirst {
                                                     first: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                        singleton_refs: [],
                                                         input: Map {
-                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                            singleton_refs: [],
+                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                             input: Tee {
                                                                 inner: <shared 15>: Reduce {
                                                                     f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
@@ -2073,7 +2051,6 @@ expression: built.ir()
                 second: Cast {
                     inner: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | histogram | Rc :: new (RefCell :: new (histogram)) }),
-                        singleton_refs: [],
                         input: Tee {
                             inner: <shared 11>,
                             metadata: HydroIrMetadata {
@@ -2126,7 +2103,6 @@ expression: built.ir()
             inner: ChainFirst {
                 first: Map {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , usize) , usize > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (new , old) | new + old }),
-                    singleton_refs: [],
                     input: CrossSingleton {
                         left: Tee {
                             inner: <shared 16>: Fold {
@@ -2175,7 +2151,6 @@ expression: built.ir()
                         right: Tee {
                             inner: <shared 17>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                                singleton_refs: [],
                                 input: CrossSingleton {
                                     left: Tee {
                                         inner: <shared 18>: Cast {
@@ -2249,15 +2224,12 @@ expression: built.ir()
                                         f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
                                         input: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_none () }),
-                                            singleton_refs: [],
                                             input: Cast {
                                                 inner: ChainFirst {
                                                     first: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                        singleton_refs: [],
                                                         input: Map {
-                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                            singleton_refs: [],
+                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                             input: Tee {
                                                                 inner: <shared 15>,
                                                                 metadata: HydroIrMetadata {
@@ -2418,8 +2390,7 @@ expression: built.ir()
             8,
         ),
         input: Map {
-            f: stageleft :: runtime_support :: fn1_type_hint :: < ((std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > >) , core :: option :: Option < () >) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | ((old , new) , reset) | { if reset . is_some () { old . replace (Histogram :: < u64 > :: new (3) . unwrap ()) ; } if let Some (new) = new { old . borrow_mut () . add (& * new . borrow_mut ()) . expect ("Error adding value to histogram") ; } old } }),
-            singleton_refs: [],
+            f: stageleft :: runtime_support :: fn1_type_hint :: < ((std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > >) , core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant >) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | ((old , new) , reset) | { if reset . is_some () { old . replace (Histogram :: < u64 > :: new (3) . unwrap ()) ; } if let Some (new) = new { old . borrow_mut () . add (& * new . borrow_mut ()) . expect ("Error adding value to histogram") ; } old } }),
             input: Cast {
                 inner: CrossSingleton {
                     left: Cast {
@@ -2496,17 +2467,14 @@ expression: built.ir()
                                 inner: ChainFirst {
                                     first: Map {
                                         f: stageleft :: runtime_support :: fn1_type_hint :: < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                        singleton_refs: [],
                                         input: Reduce {
                                             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | curr , new | { curr . borrow_mut () . add (& * new . borrow_mut ()) . expect ("Error adding value to histogram") ; } }),
                                             input: ObserveNonDet {
                                                 inner: Batch {
                                                     inner: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | wrapper | wrapper . histogram }),
-                                                        singleton_refs: [],
                                                         input: Map {
                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper) , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                                            singleton_refs: [],
                                                             input: Cast {
                                                                 inner: Cast {
                                                                     inner: Network {
@@ -2523,12 +2491,10 @@ expression: built.ir()
                                                                         ),
                                                                         input: Map {
                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | latencies | { SerializableHistogramWrapper { histogram : latencies , } } }),
-                                                                            singleton_refs: [],
                                                                             input: YieldConcat {
                                                                                 inner: Cast {
                                                                                     inner: Map {
                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                                                                                        singleton_refs: [],
                                                                                         input: CrossSingleton {
                                                                                             left: Tee {
                                                                                                 inner: <shared 14>,
@@ -2544,15 +2510,12 @@ expression: built.ir()
                                                                                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
                                                                                                 input: Map {
                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_some () }),
-                                                                                                    singleton_refs: [],
                                                                                                     input: Cast {
                                                                                                         inner: ChainFirst {
                                                                                                             first: Map {
                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                                                                                singleton_refs: [],
                                                                                                                 input: Map {
-                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                                                                                    singleton_refs: [],
+                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                                                                                     input: Tee {
                                                                                                                         inner: <shared 15>,
                                                                                                                         metadata: HydroIrMetadata {
@@ -2820,8 +2783,7 @@ expression: built.ir()
                     right: Cast {
                         inner: ChainFirst {
                             first: Map {
-                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                singleton_refs: [],
+                                f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                 input: DeferTick {
                                     input: Tee {
                                         inner: <shared 20>: Reduce {
@@ -2981,7 +2943,6 @@ expression: built.ir()
                 first: Batch {
                     inner: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , usize) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                        singleton_refs: [],
                         input: Cast {
                             inner: Cast {
                                 inner: Network {
@@ -3000,7 +2961,6 @@ expression: built.ir()
                                         inner: Cast {
                                             inner: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                                                singleton_refs: [],
                                                 input: CrossSingleton {
                                                     left: Tee {
                                                         inner: <shared 18>,
@@ -3016,15 +2976,12 @@ expression: built.ir()
                                                         f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
                                                         input: Map {
                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_some () }),
-                                                            singleton_refs: [],
                                                             input: Cast {
                                                                 inner: ChainFirst {
                                                                     first: Map {
                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                                        singleton_refs: [],
                                                                         input: Map {
-                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                                            singleton_refs: [],
+                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                                             input: Tee {
                                                                                 inner: <shared 15>,
                                                                                 metadata: HydroIrMetadata {
@@ -3193,7 +3150,6 @@ expression: built.ir()
                 second: Cast {
                     inner: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                        singleton_refs: [],
                         input: CrossSingleton {
                             left: Tee {
                                 inner: <shared 21>: Cast {
@@ -3267,15 +3223,12 @@ expression: built.ir()
                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
                                 input: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_none () }),
-                                    singleton_refs: [],
                                     input: Cast {
                                         inner: ChainFirst {
                                             first: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                singleton_refs: [],
                                                 input: Map {
-                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                    singleton_refs: [],
+                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                     input: Tee {
                                                         inner: <shared 20>,
                                                         metadata: HydroIrMetadata {
@@ -3406,7 +3359,6 @@ expression: built.ir()
             inner: Cast {
                 inner: Map {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                    singleton_refs: [],
                     input: CrossSingleton {
                         left: Tee {
                             inner: <shared 21>,
@@ -3422,15 +3374,12 @@ expression: built.ir()
                             f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
                             input: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_some () }),
-                                singleton_refs: [],
                                 input: Cast {
                                     inner: ChainFirst {
                                         first: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                            singleton_refs: [],
                                             input: Map {
-                                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                singleton_refs: [],
+                                                f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                 input: Tee {
                                                     inner: <shared 20>,
                                                     metadata: HydroIrMetadata {
@@ -3551,12 +3500,10 @@ expression: built.ir()
         f: stageleft :: runtime_support :: fn1_type_hint :: < (f64 , f64 , f64 , u64) , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; move | (p50 , p99 , p999 , num_samples) | { println ! ("Latency p50: {:.3} | p99 {:.3} | p999 {:.3} ms ({:} samples)" , p50 , p99 , p999 , num_samples) ; } }),
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , (f64 , f64 , f64 , u64) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; move | latencies | (Duration :: from_nanos (latencies . borrow () . value_at_quantile (0.5)) . as_micros () as f64 / 1000.0 , Duration :: from_nanos (latencies . borrow () . value_at_quantile (0.99)) . as_micros () as f64 / 1000.0 , Duration :: from_nanos (latencies . borrow () . value_at_quantile (0.999)) . as_micros () as f64 / 1000.0 , latencies . borrow () . len () ,) }),
-            singleton_refs: [],
             input: YieldConcat {
                 inner: Cast {
                     inner: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                        singleton_refs: [],
                         input: CrossSingleton {
                             left: Tee {
                                 inner: <shared 19>,
@@ -3572,15 +3519,12 @@ expression: built.ir()
                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
                                 input: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_some () }),
-                                    singleton_refs: [],
                                     input: Cast {
                                         inner: ChainFirst {
                                             first: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                singleton_refs: [],
                                                 input: Map {
-                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                    singleton_refs: [],
+                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                     input: Tee {
                                                         inner: <shared 20>,
                                                         metadata: HydroIrMetadata {

--- a/hydro_test/src/cluster/snapshots/two_pc_ir.snap
+++ b/hydro_test/src/cluster/snapshots/two_pc_ir.snap
@@ -1870,7 +1870,7 @@ expression: built.ir()
                                                     first: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                                         input: Map {
-                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                             input: Tee {
                                                                 inner: <shared 15>: Reduce {
                                                                     f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
@@ -2229,7 +2229,7 @@ expression: built.ir()
                                                     first: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                                         input: Map {
-                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                             input: Tee {
                                                                 inner: <shared 15>,
                                                                 metadata: HydroIrMetadata {
@@ -2390,7 +2390,7 @@ expression: built.ir()
             8,
         ),
         input: Map {
-            f: stageleft :: runtime_support :: fn1_type_hint :: < ((std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > >) , core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant >) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | ((old , new) , reset) | { if reset . is_some () { old . replace (Histogram :: < u64 > :: new (3) . unwrap ()) ; } if let Some (new) = new { old . borrow_mut () . add (& * new . borrow_mut ()) . expect ("Error adding value to histogram") ; } old } }),
+            f: stageleft :: runtime_support :: fn1_type_hint :: < ((std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > >) , core :: option :: Option < () >) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | ((old , new) , reset) | { if reset . is_some () { old . replace (Histogram :: < u64 > :: new (3) . unwrap ()) ; } if let Some (new) = new { old . borrow_mut () . add (& * new . borrow_mut ()) . expect ("Error adding value to histogram") ; } old } }),
             input: Cast {
                 inner: CrossSingleton {
                     left: Cast {
@@ -2515,7 +2515,7 @@ expression: built.ir()
                                                                                                             first: Map {
                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                                                                                                 input: Map {
-                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                                                                                     input: Tee {
                                                                                                                         inner: <shared 15>,
                                                                                                                         metadata: HydroIrMetadata {
@@ -2783,7 +2783,7 @@ expression: built.ir()
                     right: Cast {
                         inner: ChainFirst {
                             first: Map {
-                                f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
+                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                 input: DeferTick {
                                     input: Tee {
                                         inner: <shared 20>: Reduce {
@@ -2981,7 +2981,7 @@ expression: built.ir()
                                                                     first: Map {
                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                                                         input: Map {
-                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                                             input: Tee {
                                                                                 inner: <shared 15>,
                                                                                 metadata: HydroIrMetadata {
@@ -3228,7 +3228,7 @@ expression: built.ir()
                                             first: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                                 input: Map {
-                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                     input: Tee {
                                                         inner: <shared 20>,
                                                         metadata: HydroIrMetadata {
@@ -3379,7 +3379,7 @@ expression: built.ir()
                                         first: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                             input: Map {
-                                                f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                 input: Tee {
                                                     inner: <shared 20>,
                                                     metadata: HydroIrMetadata {
@@ -3524,7 +3524,7 @@ expression: built.ir()
                                             first: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                                 input: Map {
-                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                     input: Tee {
                                                         inner: <shared 20>,
                                                         metadata: HydroIrMetadata {

--- a/hydro_test/src/distributed/snapshots/first_ten_distributed_ir.snap
+++ b/hydro_test/src/distributed/snapshots/first_ten_distributed_ir.snap
@@ -107,7 +107,6 @@ expression: builder.finalize().ir()
             ),
             input: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < u32 , hydro_test :: __staged :: distributed :: first_ten :: SendOverNetwork > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: distributed :: first_ten :: * ; | n | SendOverNetwork { n } }),
-                singleton_refs: [],
                 input: Source {
                     source: Iter(
                         stageleft :: runtime_support :: type_hint :: < std :: ops :: Range < u32 > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: distributed :: first_ten :: * ; 0 .. 10 }),

--- a/hydro_test/src/local/singleton_ref.rs
+++ b/hydro_test/src/local/singleton_ref.rs
@@ -290,6 +290,196 @@ mod tests {
         assert_eq!(results, vec![11, 15]);
     }
 
+    /// Test: singleton ref inside a partition closure.
+    /// partition is unique because it has a closure but produces two consumer streams,
+    /// so the singleton ref must be correctly shared across both output branches.
+    #[tokio::test]
+    async fn test_singleton_ref_partition() {
+        let mut deployment = Deployment::new();
+
+        let mut builder = FlowBuilder::new();
+        let external = builder.external::<()>();
+        let p1 = builder.process::<()>();
+
+        // Singleton: fold 0..5 => 10 (threshold)
+        let threshold = p1
+            .source_iter(q!(0..5i32))
+            .fold(q!(|| 0i32), q!(|acc: &mut i32, x| *acc += x));
+        let threshold_ref = threshold.by_ref();
+
+        // Partition: elements > threshold go to true branch, others to false branch
+        let (above, below) = p1
+            .source_iter(q!(vec![5i32, 8, 10, 11, 15, 3]))
+            .partition(q!(|x| *x > *threshold_ref));
+
+        let out_above = above.send_bincode_external(&external);
+        let out_below = below.send_bincode_external(&external);
+
+        threshold.into_stream().for_each(q!(|_| {}));
+
+        let nodes = builder
+            .with_default_optimize()
+            .with_process(&p1, deployment.Localhost())
+            .with_external(&external, deployment.Localhost())
+            .deploy(&mut deployment);
+
+        deployment.deploy().await.unwrap();
+
+        let mut recv_above = nodes.connect(out_above).await;
+        let mut recv_below = nodes.connect(out_below).await;
+
+        deployment.start().await.unwrap();
+
+        let mut results_above = Vec::new();
+        for _ in 0..2 {
+            results_above.push(recv_above.next().await.unwrap());
+        }
+        results_above.sort();
+        // threshold = 10, elements strictly > 10 are 11 and 15
+        assert_eq!(results_above, vec![11, 15]);
+
+        let mut results_below = Vec::new();
+        for _ in 0..4 {
+            results_below.push(recv_below.next().await.unwrap());
+        }
+        results_below.sort();
+        // elements <= 10 are 3, 5, 8, 10
+        assert_eq!(results_below, vec![3, 5, 8, 10]);
+    }
+
+    /// Test: singleton ref in partition with downstream map operators on both branches.
+    ///
+    /// This specifically exercises the ident_stack pop logic in the "already built" path
+    /// of Partition code generation (lines 3462-3466 in ir/mod.rs). When the second branch
+    /// of a partition is processed, transform_children pushes singleton ref idents onto the
+    /// stack, but since the partition was already built by the first branch, those idents
+    /// must be popped to keep the stack consistent for downstream operators.
+    ///
+    /// Without the pop, the ident_stack would be corrupted and downstream operators (the
+    /// maps on each branch) would read wrong idents, causing a compile/runtime failure.
+    #[tokio::test]
+    async fn test_singleton_ref_partition_with_downstream_ops() {
+        let mut deployment = Deployment::new();
+
+        let mut builder = FlowBuilder::new();
+        let external = builder.external::<()>();
+        let p1 = builder.process::<()>();
+
+        // Singleton: fold 0..5 => 10
+        let threshold = p1
+            .source_iter(q!(0..5i32))
+            .fold(q!(|| 0i32), q!(|acc: &mut i32, x| *acc += x));
+        let threshold_ref = threshold.by_ref();
+
+        // Partition using the singleton ref
+        let (above, below) = p1
+            .source_iter(q!(vec![5i32, 8, 11, 15]))
+            .partition(q!(|x| *x > *threshold_ref));
+
+        // Apply downstream operators on BOTH branches — this is the key part.
+        // If the ident_stack pop is missing, these maps will get wrong idents.
+        let out_above = above
+            .map(q!(|x| x * 2))
+            .send_bincode_external(&external);
+        let out_below = below
+            .map(q!(|x| x + 100))
+            .send_bincode_external(&external);
+
+        threshold.into_stream().for_each(q!(|_| {}));
+
+        let nodes = builder
+            .with_default_optimize()
+            .with_process(&p1, deployment.Localhost())
+            .with_external(&external, deployment.Localhost())
+            .deploy(&mut deployment);
+
+        deployment.deploy().await.unwrap();
+
+        let mut recv_above = nodes.connect(out_above).await;
+        let mut recv_below = nodes.connect(out_below).await;
+
+        deployment.start().await.unwrap();
+
+        let mut results_above = Vec::new();
+        for _ in 0..2 {
+            results_above.push(recv_above.next().await.unwrap());
+        }
+        results_above.sort();
+        // threshold = 10, above = [11, 15], mapped: [22, 30]
+        assert_eq!(results_above, vec![22, 30]);
+
+        let mut results_below = Vec::new();
+        for _ in 0..2 {
+            results_below.push(recv_below.next().await.unwrap());
+        }
+        results_below.sort();
+        // below = [5, 8], mapped: [105, 108]
+        assert_eq!(results_below, vec![105, 108]);
+    }
+
+    /// Test: singleton ref in partition where the false branch is chained with another stream.
+    ///
+    /// This creates a scenario where the stale singleton ref ident left on the ident_stack
+    /// (if the pop is missing) would be incorrectly consumed by the chain operator,
+    /// causing a compilation or runtime failure.
+    #[tokio::test]
+    async fn test_singleton_ref_partition_chain_false_branch() {
+        let mut deployment = Deployment::new();
+
+        let mut builder = FlowBuilder::new();
+        let external = builder.external::<()>();
+        let p1 = builder.process::<()>();
+
+        // Singleton: fold 0..5 => 10
+        let threshold = p1
+            .source_iter(q!(0..5i32))
+            .fold(q!(|| 0i32), q!(|acc: &mut i32, x| *acc += x));
+        let threshold_ref = threshold.by_ref();
+
+        // Partition using the singleton ref
+        let (above, below) = p1
+            .source_iter(q!(vec![5i32, 8, 11, 15]))
+            .partition(q!(|x| *x > *threshold_ref));
+
+        // Chain the false branch with another stream — this forces the chain operator
+        // to pop two idents from the stack. If the singleton ref ident wasn't popped,
+        // the chain would get the wrong ident.
+        let extra_stream = p1.source_iter(q!(vec![99i32]));
+        let out_above = above.send_bincode_external(&external);
+        let out_below = below.chain(extra_stream).send_bincode_external(&external);
+
+        threshold.into_stream().for_each(q!(|_| {}));
+
+        let nodes = builder
+            .with_default_optimize()
+            .with_process(&p1, deployment.Localhost())
+            .with_external(&external, deployment.Localhost())
+            .deploy(&mut deployment);
+
+        deployment.deploy().await.unwrap();
+
+        let mut recv_above = nodes.connect(out_above).await;
+        let mut recv_below = nodes.connect(out_below).await;
+
+        deployment.start().await.unwrap();
+
+        let mut results_above = Vec::new();
+        for _ in 0..2 {
+            results_above.push(recv_above.next().await.unwrap());
+        }
+        results_above.sort();
+        // threshold = 10, above = [11, 15]
+        assert_eq!(results_above, vec![11, 15]);
+
+        let mut results_below = Vec::new();
+        for _ in 0..3 {
+            results_below.push(recv_below.next().await.unwrap());
+        }
+        results_below.sort();
+        // below = [5, 8] chained with [99]
+        assert_eq!(results_below, vec![5, 8, 99]);
+    }
+
     /// Test: singleton ref inside a flat_map closure.
     #[tokio::test]
     async fn test_singleton_ref_flat_map() {

--- a/hydro_test/src/local/singleton_ref.rs
+++ b/hydro_test/src/local/singleton_ref.rs
@@ -245,4 +245,99 @@ mod tests {
         // ref_a = 10, ref_b = 33, so results = 1+10+33=44, 2+10+33=45
         assert_eq!(results, vec![44, 45]);
     }
+
+    /// Test: singleton ref inside a filter closure.
+    #[tokio::test]
+    async fn test_singleton_ref_filter() {
+        let mut deployment = Deployment::new();
+
+        let mut builder = FlowBuilder::new();
+        let external = builder.external::<()>();
+        let p1 = builder.process::<()>();
+
+        // Singleton: fold 0..5 => 10 (threshold)
+        let threshold = p1
+            .source_iter(q!(0..5i32))
+            .fold(q!(|| 0i32), q!(|acc: &mut i32, x| *acc += x));
+        let threshold_ref = threshold.by_ref();
+
+        // Filter: keep only elements > threshold (10)
+        let out_port = p1
+            .source_iter(q!(vec![5i32, 8, 11, 15, 3]))
+            .filter(q!(|x| *x > *threshold_ref))
+            .send_bincode_external(&external);
+
+        threshold.into_stream().for_each(q!(|_| {}));
+
+        let nodes = builder
+            .with_default_optimize()
+            .with_process(&p1, deployment.Localhost())
+            .with_external(&external, deployment.Localhost())
+            .deploy(&mut deployment);
+
+        deployment.deploy().await.unwrap();
+
+        let mut out_recv = nodes.connect(out_port).await;
+
+        deployment.start().await.unwrap();
+
+        let mut results = Vec::new();
+        for _ in 0..2 {
+            results.push(out_recv.next().await.unwrap());
+        }
+        results.sort();
+        // threshold = 10, so only 11 and 15 pass
+        assert_eq!(results, vec![11, 15]);
+    }
+
+    /// Test: singleton ref inside a flat_map closure.
+    #[tokio::test]
+    async fn test_singleton_ref_flat_map() {
+        let mut deployment = Deployment::new();
+
+        let mut builder = FlowBuilder::new();
+        let external = builder.external::<()>();
+        let p1 = builder.process::<()>();
+
+        // Singleton: fold 0..3 => 3 (repeat count)
+        let count = p1
+            .source_iter(q!(0..3i32))
+            .fold(q!(|| 0i32), q!(|acc: &mut i32, _| *acc += 1));
+        let count_ref = count.by_ref();
+
+        // flat_map: for each element, produce a vec of `count` copies
+        let out_port = p1
+            .source_iter(q!(vec![10i32, 20]))
+            .flat_map_ordered(q!(|x| {
+                let n = *count_ref as usize;
+                let mut v = Vec::new();
+                for _ in 0..n {
+                    v.push(x);
+                }
+                v
+            }))
+            .send_bincode_external(&external);
+
+        count.into_stream().for_each(q!(|_| {}));
+
+        let nodes = builder
+            .with_default_optimize()
+            .with_process(&p1, deployment.Localhost())
+            .with_external(&external, deployment.Localhost())
+            .deploy(&mut deployment);
+
+        deployment.deploy().await.unwrap();
+
+        let mut out_recv = nodes.connect(out_port).await;
+
+        deployment.start().await.unwrap();
+
+        let mut results = Vec::new();
+        for _ in 0..6 {
+            results.push(out_recv.next().await.unwrap());
+        }
+        results.sort();
+        // count = 3, so [10, 10, 10, 20, 20, 20]
+        assert_eq!(results, vec![10, 10, 10, 20, 20, 20]);
+    }
 }

--- a/hydro_test/src/local/singleton_ref.rs
+++ b/hydro_test/src/local/singleton_ref.rs
@@ -378,12 +378,8 @@ mod tests {
 
         // Apply downstream operators on BOTH branches — this is the key part.
         // If the ident_stack pop is missing, these maps will get wrong idents.
-        let out_above = above
-            .map(q!(|x| x * 2))
-            .send_bincode_external(&external);
-        let out_below = below
-            .map(q!(|x| x + 100))
-            .send_bincode_external(&external);
+        let out_above = above.map(q!(|x| x * 2)).send_bincode_external(&external);
+        let out_below = below.map(q!(|x| x + 100)).send_bincode_external(&external);
 
         threshold.into_stream().for_each(q!(|_| {}));
 

--- a/scratch_borrow_tests/Cargo.toml
+++ b/scratch_borrow_tests/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+bumpalo = { version = "3", features = ["collections"] }
 tokio = { version = "1", features = ["full"] }
 
 [[bin]]
@@ -111,3 +112,9 @@ path = "src/test34.rs"
 [[bin]]
 name = "test35"
 path = "src/test35.rs"
+[[bin]]
+name = "test36"
+path = "src/test36.rs"
+[[bin]]
+name = "test37"
+path = "src/test37.rs"

--- a/scratch_borrow_tests/Cargo.toml
+++ b/scratch_borrow_tests/Cargo.toml
@@ -1,0 +1,86 @@
+[package]
+name = "borrow_tests"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+tokio = { version = "1", features = ["full"] }
+
+[[bin]]
+name = "test1"
+path = "src/test1.rs"
+[[bin]]
+name = "test2"
+path = "src/test2.rs"
+[[bin]]
+name = "test3"
+path = "src/test3.rs"
+[[bin]]
+name = "test4"
+path = "src/test4.rs"
+[[bin]]
+name = "test5"
+path = "src/test5.rs"
+[[bin]]
+name = "test6"
+path = "src/test6.rs"
+[[bin]]
+name = "test7"
+path = "src/test7.rs"
+[[bin]]
+name = "test8"
+path = "src/test8.rs"
+[[bin]]
+name = "test9"
+path = "src/test9.rs"
+[[bin]]
+name = "test10"
+path = "src/test10.rs"
+[[bin]]
+name = "test11"
+path = "src/test11.rs"
+[[bin]]
+name = "test12"
+path = "src/test12.rs"
+[[bin]]
+name = "test13"
+path = "src/test13.rs"
+[[bin]]
+name = "test14"
+path = "src/test14.rs"
+[[bin]]
+name = "test15"
+path = "src/test15.rs"
+[[bin]]
+name = "test16"
+path = "src/test16.rs"
+[[bin]]
+name = "test17"
+path = "src/test17.rs"
+[[bin]]
+name = "test18"
+path = "src/test18.rs"
+[[bin]]
+name = "test19"
+path = "src/test19.rs"
+[[bin]]
+name = "test20"
+path = "src/test20.rs"
+[[bin]]
+name = "test21"
+path = "src/test21.rs"
+[[bin]]
+name = "test22"
+path = "src/test22.rs"
+[[bin]]
+name = "test23"
+path = "src/test23.rs"
+[[bin]]
+name = "test24"
+path = "src/test24.rs"
+[[bin]]
+name = "test25"
+path = "src/test25.rs"
+[[bin]]
+name = "test26"
+path = "src/test26.rs"

--- a/scratch_borrow_tests/Cargo.toml
+++ b/scratch_borrow_tests/Cargo.toml
@@ -84,3 +84,30 @@ path = "src/test25.rs"
 [[bin]]
 name = "test26"
 path = "src/test26.rs"
+[[bin]]
+name = "test27"
+path = "src/test27.rs"
+[[bin]]
+name = "test28"
+path = "src/test28.rs"
+[[bin]]
+name = "test29"
+path = "src/test29.rs"
+[[bin]]
+name = "test30"
+path = "src/test30.rs"
+[[bin]]
+name = "test31"
+path = "src/test31.rs"
+[[bin]]
+name = "test32"
+path = "src/test32.rs"
+[[bin]]
+name = "test33"
+path = "src/test33.rs"
+[[bin]]
+name = "test34"
+path = "src/test34.rs"
+[[bin]]
+name = "test35"
+path = "src/test35.rs"

--- a/scratch_borrow_tests/src/test1.rs
+++ b/scratch_borrow_tests/src/test1.rs
@@ -1,0 +1,28 @@
+//! Test 1: async move || with direct borrow of captured state across plain blocks.
+//! Question: Can stratum 1 borrow fold_state that stratum 0 mutated?
+//! RESULT: ✅ PASS
+
+#[tokio::main]
+async fn main() {
+    let mut fold_state: i64 = 0;
+    let input_buf: Vec<i64> = vec![1, 2, 3];
+
+    let mut tick = async move |_: &mut ()| -> bool {
+        // Stratum 0: mutate fold_state
+        {
+            for item in input_buf.iter() {
+                fold_state += item;
+            }
+        }
+        // Stratum 1: borrow fold_state immutably
+        {
+            let r: &i64 = &fold_state;
+            println!("fold_state = {}", r);
+        }
+        true
+    };
+
+    tick(&mut ()).await;
+    tick(&mut ()).await;
+    println!("done");
+}

--- a/scratch_borrow_tests/src/test10.rs
+++ b/scratch_borrow_tests/src/test10.rs
@@ -1,0 +1,35 @@
+//! Test 10: Hybrid - captured Vec handoff (for perf, avoids realloc)
+//! alongside local reference slots.
+//! The Vec holds owned T, the local slot holds &T.
+//! RESULT: ✅ PASS
+
+#[tokio::main]
+async fn main() {
+    let mut fold_state: i64 = 0;
+    // Captured handoff - persists for reuse, holds OWNED values
+    let mut stream_hoff: Vec<i64> = Vec::new();
+
+    let mut tick = async move |_: &mut ()| -> bool {
+        // Stratum 0: produce owned values into captured handoff
+        {
+            fold_state += 1;
+            stream_hoff.push(fold_state);
+            stream_hoff.push(fold_state * 2);
+        }
+
+        // Local singleton ref
+        let fold_ref: &i64 = &fold_state;
+
+        // Stratum 1: drain captured handoff while borrowing fold_state
+        {
+            for val in stream_hoff.drain(..) {
+                println!("val={}, fold_ref={}", val, fold_ref);
+            }
+        }
+
+        true
+    };
+
+    tick(&mut ()).await;
+    tick(&mut ()).await;
+}

--- a/scratch_borrow_tests/src/test11.rs
+++ b/scratch_borrow_tests/src/test11.rs
@@ -1,0 +1,40 @@
+//! Test 11: Captured fixed-size buffer (ArrayVec-style) with owned values,
+//! plus local reference to captured state. Best of both worlds for no_std?
+//! RESULT: ✅ PASS
+
+#[tokio::main]
+async fn main() {
+    let mut fold_state: i64 = 0;
+    // Captured fixed-size handoff - no alloc, persists across ticks
+    let mut stream_hoff: [Option<i64>; 8] = [None; 8];
+    let mut stream_len: usize = 0;
+
+    let mut tick = async move |_: &mut ()| -> bool {
+        // Stratum 0: produce owned values into captured fixed buffer
+        {
+            fold_state += 1;
+            stream_hoff[stream_len] = Some(fold_state);
+            stream_len += 1;
+            stream_hoff[stream_len] = Some(fold_state * 2);
+            stream_len += 1;
+        }
+
+        // Local singleton ref to captured state
+        let fold_ref: &i64 = &fold_state;
+
+        // Stratum 1: drain captured buffer while borrowing fold_state
+        {
+            for i in 0..stream_len {
+                if let Some(val) = stream_hoff[i].take() {
+                    println!("val={}, fold_ref={}", val, fold_ref);
+                }
+            }
+            stream_len = 0;
+        }
+
+        true
+    };
+
+    tick(&mut ()).await;
+    tick(&mut ()).await;
+}

--- a/scratch_borrow_tests/src/test12.rs
+++ b/scratch_borrow_tests/src/test12.rs
@@ -1,0 +1,32 @@
+//! Test 12: Can fold's pipe output be &mut Acc flowing into a downstream operator?
+//! This is the 'static fold case where we want zero-copy output.
+//! RESULT: ✅ PASS
+
+#[tokio::main]
+async fn main() {
+    let mut fold_state: Vec<i64> = Vec::new();
+
+    let mut tick = async move |_: &mut ()| -> bool {
+        // Stratum 0: fold accumulates (mutates captured state)
+        {
+            fold_state.push(1);
+        }
+
+        // The fold's "output" is &mut Vec<i64> - can downstream use it?
+        let fold_output: &mut Vec<i64> = &mut fold_state;
+
+        // Stratum 1: downstream operator receives &mut Acc
+        {
+            // e.g., map over the accumulated vec
+            let sum: i64 = fold_output.iter().sum();
+            println!("sum of fold state = {}", sum);
+            // Can even mutate it (for state() operator semantics)
+            fold_output.retain(|x| *x > 0);
+        }
+
+        true
+    };
+
+    tick(&mut ()).await;
+    tick(&mut ()).await;
+}

--- a/scratch_borrow_tests/src/test13.rs
+++ b/scratch_borrow_tests/src/test13.rs
@@ -1,0 +1,32 @@
+//! Test 13: Stream of references through a TICK-LOCAL Vec handoff.
+//! persist() collects items into a captured Vec, then downstream iterates &T.
+//! RESULT: ✅ PASS
+
+#[tokio::main]
+async fn main() {
+    // Cross-tick: persisted collection
+    let mut persist_buf: Vec<i64> = Vec::new();
+
+    let mut tick = async move |input: &[i64]| -> bool {
+        // Stratum 0: persist (append to cross-tick buffer)
+        {
+            persist_buf.extend_from_slice(input);
+        }
+
+        // Tick-local handoff carrying references to persist_buf
+        let ref_handoff: Vec<&i64> = persist_buf.iter().collect();
+
+        // Stratum 1: process references
+        {
+            for r in ref_handoff.iter() {
+                println!("ref item: {}", r);
+            }
+        }
+
+        true
+    };
+
+    tick(&[1, 2, 3]).await;
+    println!("---");
+    tick(&[4, 5]).await;
+}

--- a/scratch_borrow_tests/src/test14.rs
+++ b/scratch_borrow_tests/src/test14.rs
@@ -1,0 +1,41 @@
+//! Test 14: Fixed-size handoff carrying &T references. No alloc.
+//! RESULT: ✅ PASS
+
+#[tokio::main]
+async fn main() {
+    let mut persist_buf: [i64; 16] = [0; 16];
+    let mut persist_len: usize = 0;
+
+    let mut tick = async move |input: &[i64]| -> bool {
+        // Stratum 0: persist
+        {
+            for &val in input {
+                persist_buf[persist_len] = val;
+                persist_len += 1;
+            }
+        }
+
+        // Tick-local fixed handoff carrying references
+        let mut ref_handoff: [Option<&i64>; 16] = [None; 16];
+        {
+            for i in 0..persist_len {
+                ref_handoff[i] = Some(&persist_buf[i]);
+            }
+        }
+
+        // Stratum 1: consume references
+        {
+            for slot in ref_handoff.iter() {
+                if let Some(r) = slot {
+                    println!("ref: {}", r);
+                }
+            }
+        }
+
+        true
+    };
+
+    tick(&[1, 2, 3]).await;
+    println!("---");
+    tick(&[4, 5]).await;
+}

--- a/scratch_borrow_tests/src/test15.rs
+++ b/scratch_borrow_tests/src/test15.rs
@@ -1,0 +1,41 @@
+//! Test 15: Fixed-size ref handoff with async { }.await between strata.
+//! RESULT: ✅ PASS
+
+#[tokio::main]
+async fn main() {
+    let mut persist_buf: [i64; 16] = [0; 16];
+    let mut persist_len: usize = 0;
+
+    let mut tick = async move |input: &[i64]| -> bool {
+        // Stratum 0 (async block)
+        async {
+            for &val in input {
+                persist_buf[persist_len] = val;
+                persist_len += 1;
+            }
+        }.await;
+
+        // Tick-local ref handoff
+        let mut ref_handoff: [Option<&i64>; 16] = [None; 16];
+        async {
+            for i in 0..persist_len {
+                ref_handoff[i] = Some(&persist_buf[i]);
+            }
+        }.await;
+
+        // Stratum 1 (async block)
+        async {
+            for slot in ref_handoff.iter() {
+                if let Some(r) = slot {
+                    println!("ref: {}", r);
+                }
+            }
+        }.await;
+
+        true
+    };
+
+    tick(&[1, 2, 3]).await;
+    println!("---");
+    tick(&[4, 5]).await;
+}

--- a/scratch_borrow_tests/src/test16.rs
+++ b/scratch_borrow_tests/src/test16.rs
@@ -1,0 +1,42 @@
+//! Test 16: Can we have a CAPTURED fixed buffer that we refill with &T each tick?
+//! RESULT: ❌ FAIL — same FnMut wall as test 4
+
+#[tokio::main]
+async fn main() {
+    let mut persist_buf: [i64; 16] = [0; 16];
+    let mut persist_len: usize = 0;
+    // Captured handoff - but wants to hold &i64 pointing into persist_buf
+    let mut ref_handoff: [Option<&i64>; 16] = [None; 16];
+
+    let mut tick = async move |input: &[i64]| -> bool {
+        // Stratum 0
+        {
+            for &val in input {
+                persist_buf[persist_len] = val;
+                persist_len += 1;
+            }
+        }
+
+        // Fill captured ref handoff with refs to captured persist_buf
+        {
+            for i in 0..persist_len {
+                ref_handoff[i] = Some(&persist_buf[i]);
+            }
+        }
+
+        // Stratum 1
+        {
+            for slot in ref_handoff.iter_mut() {
+                if let Some(r) = slot.take() {
+                    println!("ref: {}", r);
+                }
+            }
+        }
+
+        true
+    };
+
+    tick(&[1, 2, 3]).await;
+    println!("---");
+    tick(&[4, 5]).await;
+}

--- a/scratch_borrow_tests/src/test17.rs
+++ b/scratch_borrow_tests/src/test17.rs
@@ -1,0 +1,84 @@
+//! Test 17: Full realistic no_std DFIR tick combining:
+//! - Captured 'static fold state
+//! - Captured defer_tick buffer (owned values, cross-tick)
+//! - Tick-local stream handoff (owned values, within-tick)
+//! - Tick-local singleton ref slot (&T to fold state)
+//! - Tick-local ref handoff (&T to persist buffer)
+//! All within async move ||, with async { }.await subgraph blocks.
+//! RESULT: ✅ PASS
+
+#[tokio::main]
+async fn main() {
+    // === CAPTURED (cross-tick) state ===
+    let mut fold_state: i64 = 0;
+    let mut persist_buf: [i64; 16] = [0; 16];
+    let mut persist_len: usize = 0;
+    let mut defer_buf: [Option<i64>; 4] = [None; 4];
+    let mut defer_back: [Option<i64>; 4] = [None; 4];
+
+    let mut tick = async move |input: &[i64]| -> bool {
+        // Double-buffer swap (start of tick)
+        std::mem::swap(&mut defer_buf, &mut defer_back);
+
+        // === TICK-LOCAL buffers ===
+        let mut stream_hoff: [Option<i64>; 8] = [None; 8];
+        let mut stream_len: usize = 0;
+
+        // Stratum 0: source + fold + persist + forward to stream handoff
+        async {
+            // Drain deferred input from last tick
+            for slot in defer_back.iter_mut() {
+                if let Some(val) = slot.take() {
+                    fold_state += val;
+                }
+            }
+            // Process new input
+            for &val in input {
+                fold_state += val;
+                persist_buf[persist_len] = val;
+                persist_len += 1;
+                stream_hoff[stream_len] = Some(val);
+                stream_len += 1;
+            }
+        }.await;
+
+        // Tick-local singleton ref
+        let fold_ref: &i64 = &fold_state;
+
+        // Tick-local ref handoff (references into persist_buf)
+        let mut ref_hoff: [Option<&i64>; 16] = [None; 16];
+        for i in 0..persist_len {
+            ref_hoff[i] = Some(&persist_buf[i]);
+        }
+
+        // Stratum 1: use singleton ref + stream handoff + ref handoff
+        async {
+            print!("stream items (fold={}): ", fold_ref);
+            for i in 0..stream_len {
+                if let Some(val) = stream_hoff[i].take() {
+                    print!("{} ", val);
+                }
+            }
+            println!();
+
+            print!("persisted refs: ");
+            for slot in ref_hoff.iter() {
+                if let Some(r) = slot {
+                    print!("{} ", r);
+                }
+            }
+            println!();
+        }.await;
+
+        // defer_tick: send fold_state to next tick
+        defer_buf[0] = Some(*fold_ref);
+
+        true
+    };
+
+    tick(&[1, 2, 3]).await;
+    println!("---");
+    tick(&[10]).await;
+    println!("---");
+    tick(&[]).await;
+}

--- a/scratch_borrow_tests/src/test18.rs
+++ b/scratch_borrow_tests/src/test18.rs
@@ -1,0 +1,36 @@
+//! Test 18: Direct iteration of &T from captured buffer (no intermediate ref handoff).
+//! This is the simplest model: persist_buf is captured, downstream just borrows it.
+//! RESULT: ✅ PASS
+
+#[tokio::main]
+async fn main() {
+    let mut persist_buf: [i64; 16] = [0; 16];
+    let mut persist_len: usize = 0;
+    let mut fold_state: i64 = 0;
+
+    let mut tick = async move |input: &[i64]| -> bool {
+        // Stratum 0: accumulate
+        {
+            for &val in input {
+                persist_buf[persist_len] = val;
+                persist_len += 1;
+                fold_state += val;
+            }
+        }
+
+        // Stratum 1: directly borrow captured persist_buf (no handoff needed!)
+        {
+            let fold_ref = &fold_state;
+            let slice = &persist_buf[..persist_len];
+            for item in slice {
+                println!("item={}, fold={}", item, fold_ref);
+            }
+        }
+
+        true
+    };
+
+    tick(&[1, 2, 3]).await;
+    println!("---");
+    tick(&[4]).await;
+}

--- a/scratch_borrow_tests/src/test19.rs
+++ b/scratch_borrow_tests/src/test19.rs
@@ -1,0 +1,33 @@
+//! Test 19: Mutable reference to captured state flowing to downstream.
+//! Simulates state() operator where downstream can mutate the lattice.
+//! RESULT: ✅ PASS
+
+#[tokio::main]
+async fn main() {
+    let mut lattice_state: Vec<i64> = Vec::new();
+
+    let mut tick = async move |input: &[i64]| -> bool {
+        // Stratum 0: merge into lattice
+        {
+            for &val in input {
+                if !lattice_state.contains(&val) {
+                    lattice_state.push(val);
+                }
+            }
+        }
+
+        // Downstream gets &mut to the state
+        let state_ref: &mut Vec<i64> = &mut lattice_state;
+
+        // Stratum 1: can read AND mutate
+        {
+            state_ref.sort();
+            println!("sorted state: {:?}", state_ref);
+        }
+
+        true
+    };
+
+    tick(&[3, 1, 2]).await;
+    tick(&[5, 1, 4]).await;
+}

--- a/scratch_borrow_tests/src/test2.rs
+++ b/scratch_borrow_tests/src/test2.rs
@@ -1,0 +1,25 @@
+//! Test 2: Store &T reference in a local variable within one tick call.
+//! Simulates: fold produces value, downstream borrows it via a local binding.
+//! RESULT: ✅ PASS
+
+#[tokio::main]
+async fn main() {
+    let mut fold_state: i64 = 0;
+
+    let mut tick = async move |_: &mut ()| -> bool {
+        // Stratum 0: mutate
+        fold_state += 1;
+
+        // "singleton slot" - local to this call
+        let singleton_ref: &i64 = &fold_state;
+
+        // Stratum 1: consume the reference
+        {
+            println!("via ref: {}", singleton_ref);
+        }
+        true
+    };
+
+    tick(&mut ()).await;
+    tick(&mut ()).await;
+}

--- a/scratch_borrow_tests/src/test20.rs
+++ b/scratch_borrow_tests/src/test20.rs
@@ -1,0 +1,31 @@
+//! Test 20: Multiple downstream consumers borrowing the same singleton.
+//! Simulates tee on a singleton reference.
+//! RESULT: ✅ PASS
+
+#[tokio::main]
+async fn main() {
+    let mut fold_state: i64 = 0;
+
+    let mut tick = async move |input: &[i64]| -> bool {
+        // Stratum 0
+        for &v in input { fold_state += v; }
+
+        // Multiple borrows of the same singleton
+        let ref1: &i64 = &fold_state;
+        let ref2: &i64 = &fold_state;
+
+        // Stratum 1a: consumer A
+        {
+            println!("consumer A: fold = {}", ref1);
+        }
+        // Stratum 1b: consumer B (same stratum, different subgraph)
+        {
+            println!("consumer B: fold = {}", ref2);
+        }
+
+        true
+    };
+
+    tick(&[1, 2, 3]).await;
+    tick(&[10]).await;
+}

--- a/scratch_borrow_tests/src/test21.rs
+++ b/scratch_borrow_tests/src/test21.rs
@@ -1,0 +1,43 @@
+//! Test 21: Struct approach - can async fn hold references to self fields
+//! in a buffer that's ALSO a field of self?
+//! RESULT: ✅ PASS (using locals, not self-referential fields)
+
+struct Dataflow {
+    fold_state: i64,
+    persist_buf: [i64; 16],
+    persist_len: usize,
+}
+
+impl Dataflow {
+    fn new() -> Self {
+        Self { fold_state: 0, persist_buf: [0; 16], persist_len: 0 }
+    }
+
+    async fn run_tick(&mut self, input: &[i64]) {
+        // Stratum 0
+        for &v in input {
+            self.fold_state += v;
+            self.persist_buf[self.persist_len] = v;
+            self.persist_len += 1;
+        }
+
+        // Local ref buffer (same as closure approach)
+        let fold_ref = &self.fold_state;
+        let persist_slice = &self.persist_buf[..self.persist_len];
+
+        // Stratum 1
+        async {}.await; // await point
+
+        for item in persist_slice {
+            println!("item={}, fold={}", item, fold_ref);
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let mut df = Dataflow::new();
+    df.run_tick(&[1, 2, 3]).await;
+    println!("---");
+    df.run_tick(&[4]).await;
+}

--- a/scratch_borrow_tests/src/test22.rs
+++ b/scratch_borrow_tests/src/test22.rs
@@ -1,0 +1,40 @@
+//! Test 22: Index-based ref handoff. Captured Vec<usize> holds indices,
+//! resolved to &T at consumption time. Reuses allocation, no unsafe.
+//! RESULT: ✅ PASS
+
+#[tokio::main]
+async fn main() {
+    let mut persist_buf: [i64; 16] = [0; 16];
+    let mut persist_len: usize = 0;
+    // Captured "ref handoff" — but stores indices, not references
+    let mut ref_handoff_indices: Vec<usize> = Vec::new();
+
+    let mut tick = async move |input: &[i64]| -> bool {
+        // Stratum 0: persist
+        {
+            for &val in input {
+                persist_buf[persist_len] = val;
+                persist_len += 1;
+            }
+            // "Emit references" = emit indices
+            ref_handoff_indices.clear();
+            for i in 0..persist_len {
+                ref_handoff_indices.push(i);
+            }
+        }
+
+        // Stratum 1: resolve indices to &T
+        {
+            for &idx in ref_handoff_indices.iter() {
+                let r: &i64 = &persist_buf[idx];
+                println!("ref via index: {}", r);
+            }
+        }
+
+        true
+    };
+
+    tick(&[1, 2, 3]).await;
+    println!("---");
+    tick(&[4]).await;
+}

--- a/scratch_borrow_tests/src/test23.rs
+++ b/scratch_borrow_tests/src/test23.rs
@@ -1,0 +1,51 @@
+//! Test 23: raw_parts approach for reusing Vec<&T> allocation across ticks.
+//! Sound because: vec is always empty between tick calls.
+//! RESULT: ✅ PASS (requires unsafe)
+
+#[tokio::main]
+async fn main() {
+    let mut persist_buf: [i64; 16] = [0; 16];
+    let mut persist_len: usize = 0;
+
+    // Store raw parts of a Vec<&i64> — erases the lifetime
+    let (mut ptr, mut len, mut cap) = Vec::<&i64>::new().into_raw_parts();
+
+    let mut tick = async move |input: &[i64]| -> bool {
+        // Reconstruct Vec with tick-local lifetime
+        let mut ref_handoff: Vec<&i64> = unsafe {
+            debug_assert_eq!(len, 0, "ref handoff should be empty between ticks");
+            Vec::from_raw_parts(ptr, len, cap)
+        };
+
+        // Stratum 0: persist + fill ref handoff
+        {
+            for &val in input {
+                persist_buf[persist_len] = val;
+                persist_len += 1;
+            }
+            for i in 0..persist_len {
+                ref_handoff.push(&persist_buf[i]);
+            }
+        }
+
+        // Stratum 1: consume refs
+        {
+            for r in ref_handoff.iter() {
+                println!("ref: {}", r);
+            }
+        }
+
+        // Clear and save raw parts back (refs are dead, vec is empty)
+        ref_handoff.clear();
+        let new_parts = ref_handoff.into_raw_parts();
+        ptr = new_parts.0 as *mut &i64; // cast erases lifetime
+        len = new_parts.1;
+        cap = new_parts.2;
+
+        true
+    };
+
+    tick(&[1, 2, 3]).await;
+    println!("---");
+    tick(&[4]).await;
+}

--- a/scratch_borrow_tests/src/test24.rs
+++ b/scratch_borrow_tests/src/test24.rs
@@ -1,0 +1,44 @@
+//! Test 24: Captured Vec<&'static T> with lifetime transmute.
+//! Simpler than raw_parts but equally unsafe.
+//! RESULT: ✅ PASS (requires unsafe)
+
+#[tokio::main]
+async fn main() {
+    let mut persist_buf: [i64; 16] = [0; 16];
+    let mut persist_len: usize = 0;
+    // Captured with 'static lifetime — we'll transmute real refs into this
+    let mut ref_handoff: Vec<&'static i64> = Vec::new();
+
+    let mut tick = async move |input: &[i64]| -> bool {
+        ref_handoff.clear();
+
+        // Stratum 0
+        {
+            for &val in input {
+                persist_buf[persist_len] = val;
+                persist_len += 1;
+            }
+            for i in 0..persist_len {
+                let r: &i64 = &persist_buf[i];
+                // SAFETY: ref is valid for the duration of this tick call,
+                // and we clear the vec before returning.
+                let r_static: &'static i64 = unsafe { std::mem::transmute(r) };
+                ref_handoff.push(r_static);
+            }
+        }
+
+        // Stratum 1
+        {
+            for r in ref_handoff.iter() {
+                println!("ref: {}", r);
+            }
+        }
+
+        ref_handoff.clear(); // MUST clear before tick returns
+        true
+    };
+
+    tick(&[1, 2, 3]).await;
+    println!("---");
+    tick(&[4]).await;
+}

--- a/scratch_borrow_tests/src/test25.rs
+++ b/scratch_borrow_tests/src/test25.rs
@@ -1,0 +1,36 @@
+//! Test 25: No handoff at all — producer writes to captured buffer,
+//! consumer borrows a slice of it. The "handoff" is just knowing the range.
+//! RESULT: ✅ PASS
+
+#[tokio::main]
+async fn main() {
+    let mut persist_buf: [i64; 16] = [0; 16];
+    let mut persist_len: usize = 0;
+
+    let mut tick = async move |input: &[i64]| -> bool {
+        // Stratum 0: write into captured buffer
+        let start = persist_len;
+        {
+            for &val in input {
+                persist_buf[persist_len] = val;
+                persist_len += 1;
+            }
+        }
+        let end = persist_len;
+
+        // Stratum 1: borrow the slice that was just written
+        // (plus all historical data)
+        {
+            let new_items: &[i64] = &persist_buf[start..end];
+            let all_items: &[i64] = &persist_buf[..end];
+            println!("new: {:?}", new_items);
+            println!("all: {:?}", all_items);
+        }
+
+        true
+    };
+
+    tick(&[1, 2, 3]).await;
+    println!("---");
+    tick(&[4, 5]).await;
+}

--- a/scratch_borrow_tests/src/test26.rs
+++ b/scratch_borrow_tests/src/test26.rs
@@ -1,0 +1,42 @@
+//! Test 26: Captured fixed array used as stream handoff (owned values).
+//! Cleared at start of tick. No lifetime issues since it holds owned T.
+//! This is the no_std stream handoff pattern.
+//! RESULT: ✅ PASS
+
+#[tokio::main]
+async fn main() {
+    let mut fold_state: i64 = 0;
+    // Captured fixed-size stream handoff (owned values, no refs)
+    let mut stream_hoff: [i64; 8] = [0; 8];
+    let mut stream_hoff_len: usize = 0;
+
+    let mut tick = async move |input: &[i64]| -> bool {
+        // Clear from last tick
+        stream_hoff_len = 0;
+
+        // Stratum 0: produce owned values
+        {
+            for &val in input {
+                fold_state += val;
+                stream_hoff[stream_hoff_len] = val;
+                stream_hoff_len += 1;
+            }
+        }
+
+        // Singleton ref (tick-local borrow of captured state)
+        let fold_ref: &i64 = &fold_state;
+
+        // Stratum 1: consume owned values from handoff + borrow singleton
+        {
+            for i in 0..stream_hoff_len {
+                println!("item={}, fold={}", stream_hoff[i], fold_ref);
+            }
+        }
+
+        true
+    };
+
+    tick(&[1, 2, 3]).await;
+    println!("---");
+    tick(&[10, 20]).await;
+}

--- a/scratch_borrow_tests/src/test27.rs
+++ b/scratch_borrow_tests/src/test27.rs
@@ -1,0 +1,55 @@
+//! Test 27: Unified codegen path — raw_parts as a GENERAL mechanism for all handoffs.
+//! The idea: every handoff stores its allocation as raw parts (ptr, len, cap).
+//! Each tick, reconstruct the Vec<T> locally. T can be anything — owned, &'a, etc.
+//! The codegen doesn't need to know whether T contains references.
+//! RESULT: ✅ PASS
+//!
+//! This is the "one codegen path" approach: same code whether T = i64 or T = &'a i64.
+
+#[tokio::main]
+async fn main() {
+    let mut fold_state: i64 = 0;
+
+    // Handoff stored as raw parts — type-erased at the lifetime level.
+    // For owned types (i64), this is just a Vec that persists.
+    // For ref types (&i64), this reuses the allocation without capturing the lifetime.
+    let mut hoff_parts: (*mut u8, usize, usize) = {
+        let v = Vec::<i64>::new();
+        let (ptr, len, cap) = v.into_raw_parts();
+        (ptr as *mut u8, len, cap)
+    };
+
+    let mut tick = async move |input: &[i64]| -> bool {
+        // Reconstruct the Vec locally each tick.
+        // SAFETY: parts came from a Vec<i64>, len is always 0 between ticks.
+        let mut handoff: Vec<i64> = unsafe {
+            Vec::from_raw_parts(hoff_parts.0 as *mut i64, hoff_parts.1, hoff_parts.2)
+        };
+
+        // Stratum 0: produce
+        {
+            for &val in input {
+                fold_state += val;
+                handoff.push(val);
+            }
+        }
+
+        // Stratum 1: consume
+        {
+            let fold_ref = &fold_state;
+            for val in handoff.drain(..) {
+                println!("item={}, fold={}", val, fold_ref);
+            }
+        }
+
+        // Save parts back (vec is empty, allocation preserved)
+        let (ptr, len, cap) = handoff.into_raw_parts();
+        hoff_parts = (ptr as *mut u8, len, cap);
+
+        true
+    };
+
+    tick(&[1, 2, 3]).await;
+    println!("---");
+    tick(&[10]).await;
+}

--- a/scratch_borrow_tests/src/test28.rs
+++ b/scratch_borrow_tests/src/test28.rs
@@ -1,0 +1,53 @@
+//! Test 28: Same unified raw_parts approach, but T = &'tick i64 (reference type).
+//! Demonstrates that the SAME codegen pattern works for reference-containing types.
+//! RESULT: ✅ PASS
+
+#[tokio::main]
+async fn main() {
+    let mut persist_buf: [i64; 16] = [0; 16];
+    let mut persist_len: usize = 0;
+
+    // Same raw_parts pattern — but this time the Vec will hold &i64.
+    // The codegen is identical; it doesn't need to know T contains a lifetime.
+    let mut hoff_parts: (*mut u8, usize, usize) = {
+        let v = Vec::<&i64>::new();
+        let (ptr, len, cap) = v.into_raw_parts();
+        (ptr as *mut u8, len, cap)
+    };
+
+    let mut tick = async move |input: &[i64]| -> bool {
+        // Reconstruct Vec<&i64> locally — lifetime is tick-scoped
+        let mut handoff: Vec<&i64> = unsafe {
+            Vec::from_raw_parts(hoff_parts.0 as *mut &i64, hoff_parts.1, hoff_parts.2)
+        };
+
+        // Stratum 0: persist + fill ref handoff
+        {
+            for &val in input {
+                persist_buf[persist_len] = val;
+                persist_len += 1;
+            }
+            for i in 0..persist_len {
+                handoff.push(&persist_buf[i]);
+            }
+        }
+
+        // Stratum 1: consume references
+        {
+            for r in handoff.iter() {
+                println!("ref: {}", r);
+            }
+        }
+
+        // Clear and save parts (refs are dead, vec is empty)
+        handoff.clear();
+        let (ptr, len, cap) = handoff.into_raw_parts();
+        hoff_parts = (ptr as *mut u8, len, cap);
+
+        true
+    };
+
+    tick(&[1, 2, 3]).await;
+    println!("---");
+    tick(&[4]).await;
+}

--- a/scratch_borrow_tests/src/test29.rs
+++ b/scratch_borrow_tests/src/test29.rs
@@ -1,0 +1,103 @@
+//! Test 29: Can we wrap the raw_parts pattern in a safe abstraction?
+//! A "TickVec" that stores allocation across ticks but reconstructs each tick.
+//! The key: the type parameter T is only present during the tick, not in storage.
+//! RESULT: ✅ PASS
+
+use std::marker::PhantomData;
+
+/// Stores a Vec's allocation across tick boundaries without capturing T's lifetime.
+/// Between ticks, this is just (ptr, cap) — no live T values exist.
+struct HandoffAlloc {
+    ptr: *mut u8,
+    cap: usize,
+    // Layout info for dealloc on drop
+    align: usize,
+    elem_size: usize,
+}
+
+impl HandoffAlloc {
+    fn new<T>() -> Self {
+        let v = Vec::<T>::new();
+        let (ptr, _len, cap) = v.into_raw_parts();
+        Self {
+            ptr: ptr as *mut u8,
+            cap,
+            align: std::mem::align_of::<T>(),
+            elem_size: std::mem::size_of::<T>(),
+        }
+    }
+
+    /// Reconstruct a Vec<T> for this tick. Must be called with the same T
+    /// that was used to create this HandoffAlloc (or same size/align).
+    /// SAFETY: caller must ensure T matches the original layout and that
+    /// the returned Vec is cleared before the tick ends.
+    unsafe fn take_vec<T>(&mut self) -> Vec<T> {
+        debug_assert_eq!(std::mem::size_of::<T>(), self.elem_size);
+        debug_assert_eq!(std::mem::align_of::<T>(), self.align);
+        Vec::from_raw_parts(self.ptr as *mut T, 0, self.cap)
+    }
+
+    /// Return the Vec's allocation after use. Vec must be empty.
+    fn return_vec<T>(&mut self, v: Vec<T>) {
+        assert!(v.is_empty(), "HandoffAlloc: vec must be empty when returned");
+        let (ptr, _len, cap) = v.into_raw_parts();
+        self.ptr = ptr as *mut u8;
+        self.cap = cap;
+    }
+}
+
+impl Drop for HandoffAlloc {
+    fn drop(&mut self) {
+        if self.cap > 0 && self.elem_size > 0 {
+            unsafe {
+                let layout = std::alloc::Layout::from_size_align_unchecked(
+                    self.elem_size * self.cap,
+                    self.align,
+                );
+                std::alloc::dealloc(self.ptr, layout);
+            }
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let mut persist_buf: [i64; 16] = [0; 16];
+    let mut persist_len: usize = 0;
+
+    // One HandoffAlloc — doesn't know about lifetimes in T
+    let mut alloc = HandoffAlloc::new::<&i64>();
+
+    let mut tick = async move |input: &[i64]| -> bool {
+        // Reconstruct Vec<&i64> for this tick
+        let mut handoff: Vec<&i64> = unsafe { alloc.take_vec() };
+
+        // Stratum 0
+        {
+            for &val in input {
+                persist_buf[persist_len] = val;
+                persist_len += 1;
+            }
+            for i in 0..persist_len {
+                handoff.push(&persist_buf[i]);
+            }
+        }
+
+        // Stratum 1
+        {
+            for r in handoff.iter() {
+                println!("ref: {}", r);
+            }
+        }
+
+        // Return allocation
+        handoff.clear();
+        alloc.return_vec(handoff);
+
+        true
+    };
+
+    tick(&[1, 2, 3]).await;
+    println!("---");
+    tick(&[4]).await;
+}

--- a/scratch_borrow_tests/src/test3.rs
+++ b/scratch_borrow_tests/src/test3.rs
@@ -1,0 +1,26 @@
+//! Test 3: Store &mut T in a local slot, use it in a later block.
+//! Simulates mutable singleton reference.
+//! RESULT: ✅ PASS
+
+#[tokio::main]
+async fn main() {
+    let mut fold_state: Vec<i64> = Vec::new();
+
+    let mut tick = async move |_: &mut ()| -> bool {
+        // Stratum 0: fold accumulates
+        fold_state.push(1);
+
+        // Pass mutable ref to stratum 1
+        let singleton_mut: &mut Vec<i64> = &mut fold_state;
+
+        // Stratum 1: uses mutable ref
+        {
+            singleton_mut.push(99);
+            println!("len = {}", singleton_mut.len());
+        }
+        true
+    };
+
+    tick(&mut ()).await;
+    tick(&mut ()).await;
+}

--- a/scratch_borrow_tests/src/test30.rs
+++ b/scratch_borrow_tests/src/test30.rs
@@ -1,0 +1,63 @@
+//! Test 30: The simplest unified approach — just make ALL handoffs tick-local.
+//! For no_std: fixed arrays (zero cost to recreate).
+//! For std: Vec::new() each tick (re-allocates, but simple and safe).
+//! 
+//! Question: is Vec::new() + push actually expensive? With small buffer
+//! optimization or arena allocators it might be fine. And the compiler
+//! might optimize it away entirely for small/known sizes.
+//!
+//! This test measures: does making the Vec tick-local actually prevent
+//! allocation reuse? (Spoiler: yes, but it's the baseline safe approach.)
+//! RESULT: ✅ PASS
+
+#[tokio::main]
+async fn main() {
+    let mut fold_state: i64 = 0;
+    let mut persist_buf: [i64; 16] = [0; 16];
+    let mut persist_len: usize = 0;
+
+    let mut tick = async move |input: &[i64]| -> bool {
+        // ALL handoffs are tick-local. Simple. Safe. No lifetime issues.
+        let mut stream_hoff: Vec<i64> = Vec::new();       // owned stream
+        let mut ref_hoff: Vec<&i64> = Vec::new();         // ref stream
+
+        // Stratum 0
+        {
+            for &val in input {
+                fold_state += val;
+                persist_buf[persist_len] = val;
+                persist_len += 1;
+                stream_hoff.push(val);
+            }
+            for i in 0..persist_len {
+                ref_hoff.push(&persist_buf[i]);
+            }
+        }
+
+        // Singleton ref (always tick-local, always works)
+        let fold_ref: &i64 = &fold_state;
+
+        // Stratum 1
+        {
+            println!("fold = {}", fold_ref);
+            print!("stream: ");
+            for val in stream_hoff.drain(..) {
+                print!("{} ", val);
+            }
+            println!();
+            print!("refs: ");
+            for r in ref_hoff.iter() {
+                print!("{} ", r);
+            }
+            println!();
+        }
+
+        // Vecs are dropped here — allocation freed each tick.
+        // For no_std, replace with fixed arrays (zero-cost).
+        true
+    };
+
+    tick(&[1, 2, 3]).await;
+    println!("---");
+    tick(&[4]).await;
+}

--- a/scratch_borrow_tests/src/test31.rs
+++ b/scratch_borrow_tests/src/test31.rs
@@ -1,0 +1,155 @@
+//! Test 31: Bump arena that provides Vec-like buffers within a tick.
+//! 
+//! The arena persists across ticks (captured). Each tick, it resets its bump pointer.
+//! Buffers allocated from it are tick-local (can hold references).
+//! On drop (end of tick), buffers are just forgotten — the arena reclaims everything.
+//!
+//! For no_std: back the arena with a fixed `[u8; N]` array.
+//! For std: back it with a heap-allocated `Vec<u8>` that grows as needed.
+//!
+//! RESULT: ✅ PASS
+
+use std::cell::Cell;
+use std::marker::PhantomData;
+use std::mem::{self, MaybeUninit};
+use std::ptr;
+
+/// A simple bump allocator that resets each tick.
+/// Captured across ticks — the backing memory persists.
+struct TickArena {
+    buf: Vec<u8>,       // For no_std: replace with [u8; N]
+    offset: usize,      // Bump pointer — reset to 0 each tick
+}
+
+impl TickArena {
+    fn new(capacity: usize) -> Self {
+        let mut buf = Vec::with_capacity(capacity);
+        // SAFETY: we manage initialization ourselves
+        unsafe { buf.set_len(capacity); }
+        Self { buf, offset: 0 }
+    }
+
+    /// Reset the arena for a new tick. All previous allocations are invalidated.
+    /// SAFETY: caller must ensure no references to arena memory are live.
+    fn reset(&mut self) {
+        self.offset = 0;
+    }
+
+    /// Allocate space for `count` elements of type T. Returns a raw slice pointer.
+    /// Panics if arena is full.
+    fn alloc_slice_raw<T>(&mut self, count: usize) -> *mut T {
+        let align = mem::align_of::<T>();
+        let size = mem::size_of::<T>() * count;
+
+        // Align up
+        let aligned_offset = (self.offset + align - 1) & !(align - 1);
+        let new_offset = aligned_offset + size;
+
+        if new_offset > self.buf.len() {
+            // For std: could grow. For no_std: panic.
+            self.buf.resize(new_offset * 2, 0);
+        }
+
+        let ptr = unsafe { self.buf.as_mut_ptr().add(aligned_offset) as *mut T };
+        self.offset = new_offset;
+        ptr
+    }
+}
+
+/// A Vec-like buffer allocated from a TickArena.
+/// Tick-local — can hold any T including references.
+/// Does NOT free on drop (arena reclaims on reset).
+struct ArenaVec<'arena, T> {
+    ptr: *mut T,
+    len: usize,
+    cap: usize,
+    _marker: PhantomData<&'arena mut [T]>,
+}
+
+impl<'arena, T> ArenaVec<'arena, T> {
+    /// Create a new ArenaVec with capacity `cap` from the arena.
+    fn new(arena: &'arena mut TickArena, cap: usize) -> Self {
+        let ptr = arena.alloc_slice_raw::<T>(cap);
+        Self { ptr, len: 0, cap, _marker: PhantomData }
+    }
+
+    fn push(&mut self, val: T) {
+        assert!(self.len < self.cap, "ArenaVec full");
+        unsafe {
+            ptr::write(self.ptr.add(self.len), val);
+        }
+        self.len += 1;
+    }
+
+    fn as_slice(&self) -> &[T] {
+        unsafe { std::slice::from_raw_parts(self.ptr, self.len) }
+    }
+
+    fn drain(&mut self) -> impl Iterator<Item = T> + '_ {
+        let len = self.len;
+        self.len = 0;
+        (0..len).map(move |i| unsafe { ptr::read(self.ptr.add(i)) })
+    }
+
+    fn clear(&mut self) {
+        // Drop elements
+        for i in 0..self.len {
+            unsafe { ptr::drop_in_place(self.ptr.add(i)); }
+        }
+        self.len = 0;
+    }
+}
+
+impl<'arena, T> Drop for ArenaVec<'arena, T> {
+    fn drop(&mut self) {
+        self.clear(); // Drop elements, but don't free memory (arena owns it)
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let mut fold_state: i64 = 0;
+    let mut persist_buf: [i64; 16] = [0; 16];
+    let mut persist_len: usize = 0;
+
+    // Arena persists across ticks (captured) — backing memory reused
+    let mut arena = TickArena::new(1024);
+
+    let mut tick = async move |input: &[i64]| -> bool {
+        // Reset arena — all previous tick's allocations are gone
+        arena.reset();
+
+        // Allocate tick-local buffers FROM the arena
+        // These can hold any T, including &'tick references
+        let mut stream_hoff = ArenaVec::<i64>::new(&mut arena, 16);
+        // Can't do ref handoff from same arena borrow... need to rethink.
+        // Let's just test the owned case first.
+
+        // Stratum 0
+        {
+            for &val in input {
+                fold_state += val;
+                persist_buf[persist_len] = val;
+                persist_len += 1;
+                stream_hoff.push(val);
+            }
+        }
+
+        let fold_ref = &fold_state;
+
+        // Stratum 1
+        {
+            print!("stream (fold={}): ", fold_ref);
+            for val in stream_hoff.drain() {
+                print!("{} ", val);
+            }
+            println!();
+        }
+
+        true
+    };
+
+    tick(&[1, 2, 3]).await;
+    println!("---");
+    tick(&[10]).await;
+}

--- a/scratch_borrow_tests/src/test32.rs
+++ b/scratch_borrow_tests/src/test32.rs
@@ -1,0 +1,129 @@
+//! Test 32: Simpler approach — a "SlabVec" that's just a pre-allocated Vec
+//! that gets cleared and reused, but the Vec itself is reconstructed tick-locally
+//! from a captured raw allocation. No arena needed — each handoff owns its slab.
+//!
+//! Key insight: we don't need a shared arena. Each handoff can independently
+//! store its own allocation as raw parts. The "allocator" is just the pattern of:
+//! 1. Captured: (ptr, cap) — the raw allocation, no type/lifetime info
+//! 2. Tick-local: reconstruct Vec<T> from (ptr, 0, cap), use it, clear it, save back
+//!
+//! This is test 27/28 but wrapped in a clean abstraction.
+//! RESULT: ✅ PASS
+
+/// Stores a Vec's heap allocation across tick boundaries.
+/// T is erased — only size/align/ptr/cap are stored.
+/// Between ticks, no T values exist (len is always 0).
+struct Slab {
+    ptr: *mut u8,
+    cap: usize,
+    elem_size: usize,
+    elem_align: usize,
+}
+
+impl Slab {
+    /// Create a new empty slab for elements of type T.
+    fn new<T>() -> Self {
+        Self {
+            ptr: std::ptr::null_mut(),
+            cap: 0,
+            elem_size: std::mem::size_of::<T>(),
+            elem_align: std::mem::align_of::<T>(),
+        }
+    }
+
+    /// Reconstruct a Vec<T> for this tick. The Vec starts empty but may have
+    /// pre-allocated capacity from previous ticks.
+    /// SAFETY: T must match the original type's size and alignment.
+    /// The returned Vec must be cleared before being passed back to `reclaim`.
+    unsafe fn take<T>(&mut self) -> Vec<T> {
+        debug_assert_eq!(std::mem::size_of::<T>(), self.elem_size);
+        debug_assert_eq!(std::mem::align_of::<T>(), self.elem_align);
+        if self.ptr.is_null() {
+            Vec::new()
+        } else {
+            let v = Vec::from_raw_parts(self.ptr as *mut T, 0, self.cap);
+            self.ptr = std::ptr::null_mut();
+            self.cap = 0;
+            v
+        }
+    }
+
+    /// Return a Vec's allocation to the slab. Vec must be empty.
+    fn reclaim<T>(&mut self, v: Vec<T>) {
+        debug_assert!(v.is_empty());
+        let (ptr, _len, cap) = v.into_raw_parts();
+        self.ptr = ptr as *mut u8;
+        self.cap = cap;
+    }
+}
+
+impl Drop for Slab {
+    fn drop(&mut self) {
+        if !self.ptr.is_null() && self.cap > 0 && self.elem_size > 0 {
+            unsafe {
+                let layout = std::alloc::Layout::from_size_align_unchecked(
+                    self.elem_size * self.cap,
+                    self.elem_align,
+                );
+                std::alloc::dealloc(self.ptr, layout);
+            }
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let mut fold_state: i64 = 0;
+    let mut persist_buf: [i64; 16] = [0; 16];
+    let mut persist_len: usize = 0;
+
+    // Captured slabs — one per handoff. Type-erased, no lifetime in storage.
+    let mut stream_slab = Slab::new::<i64>();
+    let mut ref_slab = Slab::new::<&i64>(); // same Slab type works for refs!
+
+    let mut tick = async move |input: &[i64]| -> bool {
+        // Reconstruct tick-local Vecs from slabs
+        let mut stream_hoff: Vec<i64> = unsafe { stream_slab.take() };
+        let mut ref_hoff: Vec<&i64> = unsafe { ref_slab.take() };
+
+        // Stratum 0
+        {
+            for &val in input {
+                fold_state += val;
+                persist_buf[persist_len] = val;
+                persist_len += 1;
+                stream_hoff.push(val);
+            }
+            for i in 0..persist_len {
+                ref_hoff.push(&persist_buf[i]);
+            }
+        }
+
+        let fold_ref = &fold_state;
+
+        // Stratum 1
+        {
+            print!("stream (fold={}): ", fold_ref);
+            for val in stream_hoff.drain(..) {
+                print!("{} ", val);
+            }
+            println!();
+            print!("refs: ");
+            for r in ref_hoff.iter() {
+                print!("{} ", r);
+            }
+            println!();
+        }
+
+        // Return allocations to slabs
+        ref_hoff.clear();
+        stream_slab.reclaim(stream_hoff);
+        ref_slab.reclaim(ref_hoff);
+
+        true
+    };
+
+    tick(&[1, 2, 3]).await;
+    println!("---");
+    tick(&[4]).await;
+}

--- a/scratch_borrow_tests/src/test33.rs
+++ b/scratch_borrow_tests/src/test33.rs
@@ -1,0 +1,71 @@
+//! Test 33: The no_std version of the Slab — backed by a fixed array.
+//! Same interface, no heap allocation at all.
+//! RESULT: ✅ PASS
+
+use std::mem::MaybeUninit;
+use std::ptr;
+
+/// Fixed-capacity slab for no_std. Stores N elements of type T.
+/// Between ticks, len is 0 (no live values). The backing array persists.
+/// 
+/// Unlike the heap Slab, this one CAN be generic over T because for no_std
+/// we know the type at compile time (the proc macro generates it).
+/// But the key question is: can it hold T = &'tick Something?
+///
+/// Answer: NO if it's captured. YES if it's tick-local.
+/// So for no_std, the fixed array must be tick-local (stack-allocated each tick).
+/// The "slab" concept doesn't help for no_std — fixed arrays are already free to create.
+///
+/// This test confirms: for no_std, just use tick-local arrays directly.
+/// The Slab abstraction is only useful for std (heap allocation reuse).
+
+#[tokio::main]
+async fn main() {
+    let mut fold_state: i64 = 0;
+    let mut persist_buf: [i64; 16] = [0; 16];
+    let mut persist_len: usize = 0;
+
+    let mut tick = async move |input: &[i64]| -> bool {
+        // no_std: tick-local fixed arrays. Zero cost. Can hold refs.
+        let mut stream_hoff: [MaybeUninit<i64>; 16] = [const { MaybeUninit::uninit() }; 16];
+        let mut stream_len: usize = 0;
+        let mut ref_hoff: [Option<&i64>; 16] = [None; 16];
+
+        // Stratum 0
+        {
+            for &val in input {
+                fold_state += val;
+                persist_buf[persist_len] = val;
+                persist_len += 1;
+                stream_hoff[stream_len] = MaybeUninit::new(val);
+                stream_len += 1;
+            }
+            for i in 0..persist_len {
+                ref_hoff[i] = Some(&persist_buf[i]);
+            }
+        }
+
+        let fold_ref = &fold_state;
+
+        // Stratum 1
+        {
+            print!("stream (fold={}): ", fold_ref);
+            for i in 0..stream_len {
+                let val = unsafe { stream_hoff[i].assume_init() };
+                print!("{} ", val);
+            }
+            println!();
+            print!("refs: ");
+            for slot in ref_hoff.iter().flatten() {
+                print!("{} ", slot);
+            }
+            println!();
+        }
+
+        true
+    };
+
+    tick(&[1, 2, 3]).await;
+    println!("---");
+    tick(&[4]).await;
+}

--- a/scratch_borrow_tests/src/test34.rs
+++ b/scratch_borrow_tests/src/test34.rs
@@ -1,0 +1,172 @@
+//! Test 34: Bump arena with pre-allocated slots.
+//! Instead of allocating from the arena at runtime, pre-allocate all handoff
+//! slots at arena creation time. Each tick just resets the lengths.
+//! This avoids the multiple-mutable-borrow problem.
+//!
+//! Key insight: the proc macro KNOWS how many handoffs exist and their max sizes.
+//! So it can pre-allocate all slots upfront. The "arena" is really just a struct
+//! of pre-sized buffers — which is what the codegen already produces!
+//!
+//! The real question becomes: can we have a SINGLE captured allocation
+//! (one big [u8; N]) that we slice into multiple tick-local Vecs?
+//! RESULT: ✅ PASS
+
+use std::mem::MaybeUninit;
+
+/// A pre-partitioned arena. The proc macro computes the layout at compile time.
+/// Each "slot" is a region of the arena assigned to one handoff.
+struct PrePartitionedArena {
+    // One contiguous allocation, partitioned at known offsets.
+    // For no_std: [u8; TOTAL_SIZE] (compile-time constant)
+    // For std: Vec<u8> (heap, allocated once)
+    buf: Vec<u8>,
+}
+
+/// A handle to a pre-assigned region in the arena.
+/// Captured across ticks — just stores offset and capacity.
+/// The actual typed access happens tick-locally.
+struct SlotHandle {
+    offset: usize,
+    cap: usize,  // in elements
+    elem_size: usize,
+    elem_align: usize,
+}
+
+impl PrePartitionedArena {
+    fn new(size: usize) -> Self {
+        let mut buf = vec![0u8; size];
+        Self { buf }
+    }
+
+    /// Get a raw pointer to a slot's memory region.
+    fn slot_ptr(&mut self, handle: &SlotHandle) -> *mut u8 {
+        unsafe { self.buf.as_mut_ptr().add(handle.offset) }
+    }
+
+    /// Allocate a slot for `cap` elements of type T. Returns a handle.
+    fn alloc_slot<T>(&mut self, cap: usize, current_offset: &mut usize) -> SlotHandle {
+        let align = std::mem::align_of::<T>();
+        let size = std::mem::size_of::<T>();
+        let aligned = (*current_offset + align - 1) & !(align - 1);
+        let end = aligned + size * cap;
+        assert!(end <= self.buf.len(), "arena too small");
+        let handle = SlotHandle {
+            offset: aligned,
+            cap,
+            elem_size: size,
+            elem_align: align,
+        };
+        *current_offset = end;
+        handle
+    }
+}
+
+/// Tick-local typed view into a slot. Can hold any T including references.
+struct SlotVec<'a, T> {
+    ptr: *mut T,
+    len: usize,
+    cap: usize,
+    _marker: std::marker::PhantomData<&'a mut [T]>,
+}
+
+impl<'a, T> SlotVec<'a, T> {
+    /// Create from arena + handle. Tick-local — T can contain references.
+    fn from_slot(arena: &'a mut PrePartitionedArena, handle: &SlotHandle) -> Self {
+        let ptr = arena.slot_ptr(handle) as *mut T;
+        Self {
+            ptr,
+            len: 0,
+            cap: handle.cap,
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    fn push(&mut self, val: T) {
+        assert!(self.len < self.cap, "SlotVec full");
+        unsafe { std::ptr::write(self.ptr.add(self.len), val); }
+        self.len += 1;
+    }
+
+    fn iter(&self) -> impl Iterator<Item = &T> {
+        (0..self.len).map(move |i| unsafe { &*self.ptr.add(i) })
+    }
+
+    fn drain(&mut self) -> impl Iterator<Item = T> + '_ {
+        let len = self.len;
+        self.len = 0;
+        (0..len).map(move |i| unsafe { std::ptr::read(self.ptr.add(i)) })
+    }
+}
+
+impl<'a, T> Drop for SlotVec<'a, T> {
+    fn drop(&mut self) {
+        for i in 0..self.len {
+            unsafe { std::ptr::drop_in_place(self.ptr.add(i)); }
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let mut fold_state: i64 = 0;
+    let mut persist_buf: [i64; 16] = [0; 16];
+    let mut persist_len: usize = 0;
+
+    // Pre-allocate arena with known layout (proc macro would compute this)
+    let mut arena = PrePartitionedArena::new(4096);
+    let mut offset = 0;
+    let stream_slot = arena.alloc_slot::<i64>(16, &mut offset);
+    let ref_slot = arena.alloc_slot::<&i64>(16, &mut offset);
+
+    let mut tick = async move |input: &[i64]| -> bool {
+        // Create tick-local typed views — these CAN hold references
+        // Problem: can't create two SlotVecs from the same &mut arena...
+        // Need to use raw pointers or split borrows.
+        
+        // Workaround: compute raw pointers upfront, then create SlotVecs
+        let stream_ptr = arena.slot_ptr(&stream_slot) as *mut i64;
+        let ref_ptr = arena.slot_ptr(&ref_slot) as *mut &i64;
+
+        let mut stream_len = 0usize;
+        let mut ref_len = 0usize;
+
+        // Stratum 0
+        {
+            for &val in input {
+                fold_state += val;
+                persist_buf[persist_len] = val;
+                persist_len += 1;
+                unsafe { std::ptr::write(stream_ptr.add(stream_len), val); }
+                stream_len += 1;
+            }
+            for i in 0..persist_len {
+                unsafe { std::ptr::write(ref_ptr.add(ref_len), &persist_buf[i]); }
+                ref_len += 1;
+            }
+        }
+
+        let fold_ref = &fold_state;
+
+        // Stratum 1
+        {
+            print!("stream (fold={}): ", fold_ref);
+            for i in 0..stream_len {
+                let val = unsafe { std::ptr::read(stream_ptr.add(i)) };
+                print!("{} ", val);
+            }
+            println!();
+            print!("refs: ");
+            for i in 0..ref_len {
+                let r = unsafe { std::ptr::read(ref_ptr.add(i)) };
+                print!("{} ", r);
+            }
+            println!();
+        }
+
+        true
+    };
+
+    tick(&[1, 2, 3]).await;
+    println!("---");
+    tick(&[4]).await;
+}

--- a/scratch_borrow_tests/src/test35.rs
+++ b/scratch_borrow_tests/src/test35.rs
@@ -1,0 +1,154 @@
+//! Test 35: The cleanest unified approach — "Slab" per handoff.
+//!
+//! Summary of findings:
+//! - For std: each handoff has a captured `Slab` (stores raw allocation).
+//!   Each tick, reconstruct Vec<T> from the slab, use it, clear it, return it.
+//!   T can be anything — owned or reference-containing. One codegen path.
+//!
+//! - For no_std: each handoff is a tick-local fixed array.
+//!   No captured state needed (arrays are free to create on stack).
+//!   T can be anything. One codegen path.
+//!
+//! - The codegen difference between std and no_std is just the buffer type:
+//!   std:    `let mut hoff = slab.take::<T>();` ... `slab.reclaim(hoff);`
+//!   no_std: `let mut hoff = [MaybeUninit::<T>::uninit(); N];`
+//!
+//! - Singleton refs are always just `let fold_ref = &fold_state;` — no buffer.
+//!
+//! This test shows the full picture with the Slab approach for std.
+//! RESULT: ✅ PASS
+
+/// Reusable allocation for a single handoff buffer.
+/// Captured across ticks. Type-erased (no lifetime in storage).
+/// 
+/// For no_std, this type doesn't exist — replaced by tick-local arrays.
+struct Slab {
+    ptr: *mut u8,
+    cap: usize,
+    elem_layout: std::alloc::Layout,
+}
+
+impl Slab {
+    fn new<T>() -> Self {
+        Self {
+            ptr: std::ptr::null_mut(),
+            cap: 0,
+            elem_layout: std::alloc::Layout::new::<T>(),
+        }
+    }
+
+    /// Take the allocation as a Vec<T>. Vec starts empty, has previous capacity.
+    /// SAFETY: T must have same Layout as the T used to create this Slab.
+    unsafe fn take<T>(&mut self) -> Vec<T> {
+        if self.ptr.is_null() {
+            Vec::new()
+        } else {
+            let ptr = self.ptr as *mut T;
+            let cap = self.cap;
+            self.ptr = std::ptr::null_mut();
+            self.cap = 0;
+            unsafe { Vec::from_raw_parts(ptr, 0, cap) }
+        }
+    }
+
+    /// Return the allocation. Vec must be empty (all elements consumed/dropped).
+    fn reclaim<T>(&mut self, v: Vec<T>) {
+        debug_assert!(v.is_empty());
+        let (ptr, _, cap) = v.into_raw_parts();
+        self.ptr = ptr as *mut u8;
+        self.cap = cap;
+    }
+}
+
+impl Drop for Slab {
+    fn drop(&mut self) {
+        if !self.ptr.is_null() && self.cap > 0 && self.elem_layout.size() > 0 {
+            unsafe {
+                let layout = std::alloc::Layout::from_size_align_unchecked(
+                    self.elem_layout.size() * self.cap,
+                    self.elem_layout.align(),
+                );
+                std::alloc::dealloc(self.ptr, layout);
+            }
+        }
+    }
+}
+
+// ============================================================
+// Simulated generated code (what the proc macro would produce)
+// ============================================================
+
+#[tokio::main]
+async fn main() {
+    // === Cross-tick state (captured) ===
+    let mut fold_state: i64 = 0;                        // 'static fold
+    let mut persist_buf: Vec<i64> = Vec::new();         // 'static persist
+    let mut defer_buf: Vec<i64> = Vec::new();           // defer_tick (owned)
+    let mut defer_back: Vec<i64> = Vec::new();          // defer_tick back-buffer
+
+    // === Handoff slabs (captured, type-erased allocations) ===
+    let mut slab_stream: Slab = Slab::new::<i64>();     // stream handoff
+    let mut slab_refs: Slab = Slab::new::<&i64>();      // ref handoff (same Slab type!)
+
+    // === Tick closure ===
+    let mut tick = async move |input: &[i64]| -> bool {
+        // --- Start of tick ---
+        std::mem::swap(&mut defer_buf, &mut defer_back);
+
+        // Reconstruct tick-local buffers from slabs (reuses allocation!)
+        let mut stream_hoff: Vec<i64> = unsafe { slab_stream.take() };
+        let mut ref_hoff: Vec<&i64> = unsafe { slab_refs.take() };
+
+        // Stratum 0: source + fold + persist
+        {
+            // Drain deferred
+            for val in defer_back.drain(..) {
+                fold_state += val;
+            }
+            // Process input
+            for &val in input {
+                fold_state += val;
+                persist_buf.push(val);
+                stream_hoff.push(val);
+            }
+            // Fill ref handoff
+            for item in persist_buf.iter() {
+                ref_hoff.push(item);
+            }
+        }
+
+        // Singleton ref (tick-local borrow, zero cost)
+        let fold_ref: &i64 = &fold_state;
+
+        // Stratum 1: consume handoffs + use singleton ref
+        {
+            print!("[tick] stream (fold={}): ", fold_ref);
+            for val in stream_hoff.drain(..) {
+                print!("{} ", val);
+            }
+            println!();
+
+            print!("[tick] all persisted: ");
+            for r in ref_hoff.iter() {
+                print!("{} ", r);
+            }
+            println!();
+        }
+
+        // defer_tick output
+        defer_buf.push(*fold_ref);
+
+        // --- End of tick: return allocations to slabs ---
+        ref_hoff.clear();
+        slab_stream.reclaim(stream_hoff);
+        slab_refs.reclaim(ref_hoff);
+
+        true
+    };
+
+    tick(&[1, 2, 3]).await;
+    println!("---");
+    tick(&[10]).await;
+    println!("---");
+    tick(&[]).await; // empty input, defer_tick feeds
+}

--- a/scratch_borrow_tests/src/test36.rs
+++ b/scratch_borrow_tests/src/test36.rs
@@ -1,0 +1,58 @@
+//! Test 36: bumpalo as the tick-scoped allocator.
+//! Bump is captured across ticks. Each tick, reset() and allocate fresh Vecs.
+//! Question: does the 'bump lifetime work with async move ||?
+
+use bumpalo::Bump;
+
+#[tokio::main]
+async fn main() {
+    let mut fold_state: i64 = 0;
+    let mut persist_buf: Vec<i64> = Vec::new();
+
+    // Captured across ticks — backing memory reused
+    let mut bump = Bump::new();
+
+    let mut tick = async move |input: &[i64]| -> bool {
+        // Reset arena — O(1), all previous allocations invalidated
+        bump.reset();
+
+        // Allocate tick-local Vecs from the bump
+        let mut stream_hoff = bumpalo::vec![in &bump; ];
+        let mut ref_hoff: bumpalo::collections::Vec<&i64> = bumpalo::vec![in &bump; ];
+
+        // Stratum 0
+        {
+            for &val in input {
+                fold_state += val;
+                persist_buf.push(val);
+                stream_hoff.push(val);
+            }
+            for item in persist_buf.iter() {
+                ref_hoff.push(item);
+            }
+        }
+
+        // Singleton ref
+        let fold_ref: &i64 = &fold_state;
+
+        // Stratum 1
+        {
+            print!("stream (fold={}): ", fold_ref);
+            for val in stream_hoff.drain(..) {
+                print!("{} ", val);
+            }
+            println!();
+            print!("refs: ");
+            for r in ref_hoff.iter() {
+                print!("{} ", r);
+            }
+            println!();
+        }
+
+        true
+    };
+
+    tick(&[1, 2, 3]).await;
+    println!("---");
+    tick(&[10]).await;
+}

--- a/scratch_borrow_tests/src/test37.rs
+++ b/scratch_borrow_tests/src/test37.rs
@@ -1,0 +1,52 @@
+//! Test 37: bumpalo with async { }.await subgraph blocks.
+//! Does the 'bump lifetime survive across await points?
+
+use bumpalo::Bump;
+
+#[tokio::main]
+async fn main() {
+    let mut fold_state: i64 = 0;
+    let mut persist_buf: Vec<i64> = Vec::new();
+    let mut bump = Bump::new();
+
+    let mut tick = async move |input: &[i64]| -> bool {
+        bump.reset();
+
+        let mut stream_hoff: bumpalo::collections::Vec<i64> = bumpalo::vec![in &bump; ];
+        let mut ref_hoff: bumpalo::collections::Vec<&i64> = bumpalo::vec![in &bump; ];
+
+        // Stratum 0 (async block)
+        async {
+            for &val in input {
+                fold_state += val;
+                persist_buf.push(val);
+                stream_hoff.push(val);
+            }
+            for item in persist_buf.iter() {
+                ref_hoff.push(item);
+            }
+        }.await;
+
+        let fold_ref: &i64 = &fold_state;
+
+        // Stratum 1 (async block)
+        async {
+            print!("stream (fold={}): ", fold_ref);
+            for val in stream_hoff.drain(..) {
+                print!("{} ", val);
+            }
+            println!();
+            print!("refs: ");
+            for r in ref_hoff.iter() {
+                print!("{} ", r);
+            }
+            println!();
+        }.await;
+
+        true
+    };
+
+    tick(&[1, 2, 3]).await;
+    println!("---");
+    tick(&[10]).await;
+}

--- a/scratch_borrow_tests/src/test4.rs
+++ b/scratch_borrow_tests/src/test4.rs
@@ -1,0 +1,27 @@
+//! Test 4: A handoff buffer that PERSISTS across ticks tries to hold &T.
+//! This is the scenario from the last comment on #2713.
+//! RESULT: ❌ FAIL — "closure implements FnMut, so references to captured variables can't escape"
+
+#[tokio::main]
+async fn main() {
+    let mut fold_state: i64 = 0;
+    let mut handoff: [Option<&i64>; 1] = [None]; // fixed-size "handoff"
+
+    let mut tick = async move |_: &mut ()| -> bool {
+        // Stratum 0: fold, then put ref in handoff
+        {
+            fold_state += 1;
+            handoff[0] = Some(&fold_state);
+        }
+        // Stratum 1: read from handoff
+        {
+            if let Some(r) = handoff[0].take() {
+                println!("got: {}", r);
+            }
+        }
+        true
+    };
+
+    tick(&mut ()).await;
+    tick(&mut ()).await;
+}

--- a/scratch_borrow_tests/src/test5.rs
+++ b/scratch_borrow_tests/src/test5.rs
@@ -1,0 +1,29 @@
+//! Test 5: Handoff buffer is LOCAL to each tick call (not captured across ticks).
+//! For no_std: could we allocate fixed buffers on the stack each tick?
+//! RESULT: ✅ PASS
+
+#[tokio::main]
+async fn main() {
+    let mut fold_state: i64 = 0;
+
+    let mut tick = async move |_: &mut ()| -> bool {
+        // Local to this tick call - not captured
+        let mut handoff: [Option<&i64>; 1] = [None];
+
+        // Stratum 0
+        {
+            fold_state += 1;
+            handoff[0] = Some(&fold_state);
+        }
+        // Stratum 1
+        {
+            if let Some(r) = handoff[0].take() {
+                println!("got: {}", r);
+            }
+        }
+        true
+    };
+
+    tick(&mut ()).await;
+    tick(&mut ()).await;
+}

--- a/scratch_borrow_tests/src/test6.rs
+++ b/scratch_borrow_tests/src/test6.rs
@@ -1,0 +1,30 @@
+//! Test 6: Same as test5 but with async { }.await around subgraph blocks.
+//! Does the async boundary break the borrowing?
+//! RESULT: ✅ PASS
+
+#[tokio::main]
+async fn main() {
+    let mut fold_state: i64 = 0;
+
+    let mut tick = async move |_: &mut ()| -> bool {
+        let mut handoff: [Option<&i64>; 1] = [None];
+
+        // Stratum 0 (async)
+        async {
+            fold_state += 1;
+            handoff[0] = Some(&fold_state);
+        }.await;
+
+        // Stratum 1 (async)
+        async {
+            if let Some(r) = handoff[0].take() {
+                println!("got: {}", r);
+            }
+        }.await;
+
+        true
+    };
+
+    tick(&mut ()).await;
+    tick(&mut ()).await;
+}

--- a/scratch_borrow_tests/src/test7.rs
+++ b/scratch_borrow_tests/src/test7.rs
@@ -1,0 +1,37 @@
+//! Test 7: Generated struct with run_tick. No closure lifetime issues.
+//! Also tests: can we hold &fold_state while iterating stream_handoff?
+//! RESULT: ✅ PASS
+
+struct Dataflow {
+    fold_state: i64,
+    stream_handoff: [i64; 8],
+    stream_len: usize,
+}
+
+impl Dataflow {
+    fn new() -> Self {
+        Self { fold_state: 0, stream_handoff: [0; 8], stream_len: 0 }
+    }
+
+    fn run_tick(&mut self) {
+        // Stratum 0: fold
+        self.fold_state += 1;
+
+        // Stratum 1: borrow fold_state while reading stream_handoff
+        let fold_ref: &i64 = &self.fold_state;
+        for i in 0..self.stream_len {
+            println!("{} + {} = {}", self.stream_handoff[i], fold_ref,
+                     self.stream_handoff[i] + fold_ref);
+        }
+        self.stream_len = 0;
+    }
+}
+
+fn main() {
+    let mut df = Dataflow::new();
+    df.stream_handoff[0] = 10;
+    df.stream_handoff[1] = 20;
+    df.stream_len = 2;
+    df.run_tick();
+    df.run_tick();
+}

--- a/scratch_borrow_tests/src/test8.rs
+++ b/scratch_borrow_tests/src/test8.rs
@@ -1,0 +1,42 @@
+//! Test 8: Struct-based with async run_tick.
+//! Tests borrowing across .await points.
+//! RESULT: ✅ PASS
+
+struct Dataflow {
+    fold_state: i64,
+    stream_handoff: [i64; 8],
+    stream_len: usize,
+}
+
+impl Dataflow {
+    fn new() -> Self {
+        Self { fold_state: 0, stream_handoff: [0; 8], stream_len: 0 }
+    }
+
+    async fn run_tick(&mut self) {
+        // Stratum 0: fold
+        self.fold_state += 1;
+
+        // Borrow fold_state
+        let fold_ref: &i64 = &self.fold_state;
+
+        // Simulate async subgraph (await point)
+        async {}.await;
+
+        // Stratum 1: still using the reference after await
+        for i in 0..self.stream_len {
+            println!("{} + {} = {}", self.stream_handoff[i], fold_ref,
+                     self.stream_handoff[i] + fold_ref);
+        }
+        self.stream_len = 0;
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let mut df = Dataflow::new();
+    df.stream_handoff[0] = 10;
+    df.stream_len = 1;
+    df.run_tick().await;
+    df.run_tick().await;
+}

--- a/scratch_borrow_tests/src/test9.rs
+++ b/scratch_borrow_tests/src/test9.rs
@@ -1,0 +1,49 @@
+//! Test 9: Realistic no_std scenario with external input via parameter.
+//! RESULT: ✅ PASS
+
+#[tokio::main]
+async fn main() {
+    // Cross-tick state
+    let mut fold_state: i64 = 0;
+    let mut defer_buf: [Option<i64>; 4] = [None; 4];
+
+    let mut tick = async move |input: &mut [Option<i64>; 4]| -> bool {
+        // Tick-local handoff (fixed-size, no alloc)
+        let mut stream_hoff: [Option<i64>; 4] = [None; 4];
+
+        // Stratum 0: drain input, accumulate fold, forward to stream handoff
+        {
+            let mut idx = 0;
+            for slot in input.iter_mut() {
+                if let Some(val) = slot.take() {
+                    fold_state += val;
+                    stream_hoff[idx] = Some(val);
+                    idx += 1;
+                }
+            }
+        }
+
+        // Singleton slot: borrow fold_state
+        let singleton_ref: &i64 = &fold_state;
+
+        // Stratum 1: cross_singleton equivalent - use ref alongside stream
+        {
+            for slot in stream_hoff.iter_mut() {
+                if let Some(val) = slot.take() {
+                    println!("item={}, fold_ref={}", val, singleton_ref);
+                }
+            }
+        }
+
+        // defer_tick: owned value into cross-tick buffer
+        defer_buf[0] = Some(*singleton_ref);
+
+        true
+    };
+
+    let mut input1 = [Some(1), Some(2), Some(3), None];
+    tick(&mut input1).await;
+    println!("---");
+    let mut input2 = [Some(10), None, None, None];
+    tick(&mut input2).await;
+}


### PR DESCRIPTION
Replace captured Vec<T> handoff buffers with tick-local
bumpalo::collections::Vec allocated from a captured Bump arena.
The bump is reset at the start of each tick, reclaiming all memory.

- Regular (non-defer_tick) Vec handoffs: bump-allocated, tick-local
- defer_tick back buffers: remain as captured Vec<T> (cross-tick)
- Option (singleton) handoffs: unchanged
- Send port code uses for_each(push) instead of VecPush

All dfir_rs tests pass. Trybuild snapshots updated.

This enables future work where handoff buffers can hold reference types
(T = &'tick Something) since the buffer is tick-local from the borrow
checker's perspective, while reusing memory across ticks via the bump.

Co-authored-by: Infinity 🤖 <infinity@hydro.run>