### PR TITLE
refactor(dfir_pipes,dfir_lang)!: Add two mandatory output ports (`[items]`, `[state]`) to `state`/`state_by` operators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1787,6 +1787,7 @@ dependencies = [
  "futures-util",
  "hydro_build_utils",
  "itertools 0.14.0",
+ "lattices",
  "pin-project-lite",
  "rustc-hash 2.1.1",
  "sealed",

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1210,7 +1210,7 @@ impl DfirGraph {
                             HandoffKind::Option => {
                                 // Singleton slot: store exactly one item, panic on duplicate.
                                 quote_spanned! {port_ident.span()=>
-                                    let #port_ident = #root::dfir_pipes::push::for_each(|__item| {
+                                    let mut #port_ident = #root::dfir_pipes::push::for_each(|__item| {
                                         if #buf_ident.replace(__item).is_some() {
                                             panic!("singleton() received more than one item");
                                         }
@@ -1219,7 +1219,7 @@ impl DfirGraph {
                             }
                             HandoffKind::Vec => {
                                 quote_spanned! {port_ident.span()=>
-                                    let #port_ident = #root::dfir_pipes::push::vec_push(&mut #buf_ident);
+                                    let mut #port_ident = #root::dfir_pipes::push::vec_push(&mut #buf_ident);
                                 }
                             }
                         }

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1210,7 +1210,7 @@ impl DfirGraph {
                             HandoffKind::Option => {
                                 // Singleton slot: store exactly one item, panic on duplicate.
                                 quote_spanned! {port_ident.span()=>
-                                    let mut #port_ident = #root::dfir_pipes::push::for_each(|__item| {
+                                    let #port_ident = #root::dfir_pipes::push::for_each(|__item| {
                                         if #buf_ident.replace(__item).is_some() {
                                             panic!("singleton() received more than one item");
                                         }
@@ -1219,7 +1219,7 @@ impl DfirGraph {
                             }
                             HandoffKind::Vec => {
                                 quote_spanned! {port_ident.span()=>
-                                    let mut #port_ident = #root::dfir_pipes::push::vec_push(&mut #buf_ident);
+                                    let #port_ident = #root::dfir_pipes::push::vec_push(&mut #buf_ident);
                                 }
                             }
                         }

--- a/dfir_lang/src/graph/ops/lattice_bimorphism.rs
+++ b/dfir_lang/src/graph/ops/lattice_bimorphism.rs
@@ -26,8 +26,10 @@ use super::{
 ///     -> map(SetUnionSingletonSet::new_from)
 ///     -> state::<'static, SetUnionHashSet<u32>>();
 ///
-/// lhs -> [0]my_join;
-/// rhs -> [1]my_join;
+/// lhs[items] -> [0]my_join;
+/// rhs[items] -> [1]my_join;
+/// lhs[state] -> null();
+/// rhs[state] -> null();
 ///
 /// my_join = lattice_bimorphism(CartesianProductBimorphism::<HashSet<_>>::default(), #lhs, #rhs)
 ///     -> assert_eq([SetUnionHashSet::new(HashSet::from_iter([

--- a/dfir_lang/src/graph/ops/state.rs
+++ b/dfir_lang/src/graph/ops/state.rs
@@ -1,14 +1,15 @@
 use syn::parse_quote_spanned;
 use super::{
-    OperatorCategory, OperatorConstraints,
+    OperatorCategory, OperatorConstraints, PortListSpec,
     WriteContextArgs, RANGE_1,
 };
 
 // TODO(mingwei): Improve example when things are more stable.
 /// A lattice-based state operator, used for accumulating lattice state
 ///
-/// Emits both a referenceable singleton and (optionally) a pass-through stream. In the future the
-/// pass-through stream may be deduplicated.
+/// Has two output ports:
+/// - `[items]`: emits the input items that actually changed the lattice state (deltas).
+/// - `[state]`: emits a clone of the accumulated lattice value after all items are processed.
 ///
 /// ```dfir
 /// use std::collections::HashSet;
@@ -18,6 +19,8 @@ use super::{
 /// my_state = source_iter(0..3)
 ///     -> map(SetUnionSingletonSet::new_from)
 ///     -> state::<SetUnionHashSet<usize>>();
+/// my_state[items] -> null();
+/// my_state[state] -> null();
 /// ```
 /// The `state` operator is equivalent to `state_by` used with an identity mapping operator with
 /// `Default::default` providing the factory function.
@@ -26,8 +29,8 @@ pub const STATE: OperatorConstraints = OperatorConstraints {
     categories: &[OperatorCategory::Persistence],
     hard_range_inn: RANGE_1,
     soft_range_inn: RANGE_1,
-    hard_range_out: &(0..=1),
-    soft_range_out: &(0..=1),
+    hard_range_out: &(2..=2),
+    soft_range_out: &(2..=2),
     num_args: 0,
     persistence_args: &(0..=1),
     type_args: &(0..=1),
@@ -35,7 +38,7 @@ pub const STATE: OperatorConstraints = OperatorConstraints {
     has_singleton_output: true,
     flo_type: None,
     ports_inn: None,
-    ports_out: None,
+    ports_out: Some(|| PortListSpec::Fixed(parse_quote_spanned!(proc_macro2::Span::call_site()=> items, state))),
     input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs { op_span, .. },
                diagnostics| {

--- a/dfir_lang/src/graph/ops/state.rs
+++ b/dfir_lang/src/graph/ops/state.rs
@@ -1,3 +1,4 @@
+use proc_macro2::Span;
 use syn::parse_quote_spanned;
 use super::{
     OperatorCategory, OperatorConstraints, PortListSpec,
@@ -38,7 +39,7 @@ pub const STATE: OperatorConstraints = OperatorConstraints {
     has_singleton_output: true,
     flo_type: None,
     ports_inn: None,
-    ports_out: Some(|| PortListSpec::Fixed(parse_quote_spanned!(proc_macro2::Span::call_site()=> items, state))),
+    ports_out: Some(|| PortListSpec::Fixed(parse_quote_spanned!(Span::call_site()=> items, state))),
     input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs { op_span, .. },
                diagnostics| {

--- a/dfir_lang/src/graph/ops/state_by.rs
+++ b/dfir_lang/src/graph/ops/state_by.rs
@@ -1,17 +1,22 @@
 use quote::{ToTokens, quote_spanned};
+use syn::parse_quote;
 
 use super::{
     OpInstGenerics, OperatorCategory, OperatorConstraints, OperatorInstance, OperatorWriteOutput,
-    Persistence, RANGE_1, WriteContextArgs,
+    Persistence, PortListSpec, RANGE_1, WriteContextArgs,
 };
 use crate::diagnostic::{Diagnostic, Level};
 
 /// List state operator, but with a closure to map the input to the state lattice and a factory
 /// function to initialize the internal data structure.
 ///
-/// The emitted outputs (both the referencable singleton and the optional pass-through stream) are
-/// of the same type as the inputs to the state_by operator and are not required to be a lattice
-/// type. This is useful receiving pass-through context information on the output side.
+/// Has two output ports:
+/// - `[items]`: emits the input items that actually changed the lattice state (deltas).
+/// - `[state]`: emits a clone of the accumulated lattice value after all items are processed.
+///
+/// The `[items]` output items are of the same type as the inputs to the state_by operator and are
+/// not required to be a lattice type. This is useful for receiving pass-through context information
+/// on the output side.
 ///
 /// ```dfir
 /// use std::collections::HashSet;
@@ -21,6 +26,8 @@ use crate::diagnostic::{Diagnostic, Level};
 ///
 /// my_state = source_iter(0..3)
 ///     -> state_by::<SetUnionHashSet<usize>>(SetUnionSingletonSet::new_from, std::default::Default::default);
+/// my_state[items] -> null();
+/// my_state[state] -> null();
 /// ```
 /// The 2nd argument into `state_by` is a factory function that can be used to supply a custom
 /// initial value for the backing state. The initial value is still expected to be bottom (and will
@@ -35,6 +42,8 @@ use crate::diagnostic::{Diagnostic, Level};
 ///
 /// my_state = source_iter(0..3)
 ///     -> state_by::<SetUnionHashSet<usize>>(SetUnionSingletonSet::new_from, {|| SetUnion::new(HashSet::<usize>::with_capacity(1_000)) });
+/// my_state[items] -> null();
+/// my_state[state] -> null();
 /// ```
 ///
 /// The `state` operator is equivalent to `state_by` used with an identity mapping operator with
@@ -44,8 +53,8 @@ pub const STATE_BY: OperatorConstraints = OperatorConstraints {
     categories: &[OperatorCategory::Persistence],
     hard_range_inn: RANGE_1,
     soft_range_inn: RANGE_1,
-    hard_range_out: &(0..=1),
-    soft_range_out: &(0..=1),
+    hard_range_out: &(2..=2),
+    soft_range_out: &(2..=2),
     num_args: 2,
     persistence_args: &(0..=1),
     type_args: &(0..=1),
@@ -53,13 +62,13 @@ pub const STATE_BY: OperatorConstraints = OperatorConstraints {
     has_singleton_output: true,
     flo_type: None,
     ports_inn: None,
-    ports_out: None,
+    ports_out: Some(|| PortListSpec::Fixed(parse_quote!(items, state))),
     input_delaytype_fn: |_| None,
     write_fn: |&WriteContextArgs {
                    root,
                    op_span,
                    ident,
-                   inputs,
+                   inputs: _,
                    outputs,
                    is_pull,
                    singleton_output_ident,
@@ -116,74 +125,85 @@ pub const STATE_BY: OperatorConstraints = OperatorConstraints {
 
         let by_fn = &arguments[0];
 
-        // TODO(mingwei): deduplicate codegen
-        let write_iterator = if is_pull {
-            let input = &inputs[0];
-            quote_spanned! {op_span=>
-                let #ident = {
-                    fn check_input<'a, Item, MappingFn, MappedItem, Prev, Lat>(
-                        prev: Prev,
-                        mapfn: MappingFn,
-                        state_ref: &'a mut Lat,
-                    ) -> impl 'a + #root::dfir_pipes::pull::Pull<Item = Item, Meta = Prev::Meta>
-                    where
-                        Item: ::std::clone::Clone,
-                        MappingFn: 'a + Fn(Item) -> MappedItem,
-                        Prev: 'a + #root::dfir_pipes::pull::Pull<Item = Item>,
-                        Lat: 'static + #root::lattices::Merge<MappedItem>,
-                    {
-                        #root::dfir_pipes::pull::Pull::filter(
-                            prev,
-                            move |item| {
-                                #root::lattices::Merge::merge(state_ref, (mapfn)(::std::clone::Clone::clone(item)))
-                            },
-                        )
+        // With 2 fixed output ports (items, state), the operator is always push-side.
+        // outputs[0] = items (deltas), outputs[1] = state (accumulated lattice).
+        assert!(!is_pull, "state_by with 2 outputs must be push-side");
+        let items_output = &outputs[0];
+        let state_output = &outputs[1];
+
+        let write_iterator = quote_spanned! {op_span=>
+            let #ident = {
+                #[allow(non_camel_case_types)]
+                struct StatePush<'a, Item, MappingFn, ItemsPsh, StatePsh, Lat> {
+                    items_push: ItemsPsh,
+                    state_push: StatePsh,
+                    mapfn: MappingFn,
+                    state_ref: &'a mut Lat,
+                    _phantom: ::std::marker::PhantomData<fn(Item)>,
+                }
+                impl<'a, Item, MappingFn, MappedItem, ItemsPsh, StatePsh, Lat>
+                    #root::dfir_pipes::push::Push<Item, ()>
+                    for StatePush<'a, Item, MappingFn, ItemsPsh, StatePsh, Lat>
+                where
+                    Item: 'a + ::std::clone::Clone,
+                    MappingFn: 'a + ::std::marker::Unpin + Fn(Item) -> MappedItem,
+                    ItemsPsh: 'a + ::std::marker::Unpin + #root::dfir_pipes::push::Push<Item, ()>,
+                    StatePsh: 'a + ::std::marker::Unpin + #root::dfir_pipes::push::Push<Lat, ()>,
+                    Lat: 'a + 'static + ::std::clone::Clone + #root::lattices::Merge<MappedItem>,
+                {
+                    type Ctx<'ctx> = ();
+                    type CanPend = #root::dfir_pipes::No;
+
+                    fn poll_ready(self: ::core::pin::Pin<&mut Self>, _ctx: &mut ()) -> #root::dfir_pipes::push::PushStep<#root::dfir_pipes::No> {
+                        #root::dfir_pipes::push::PushStep::Done
                     }
-                    check_input::<_, _, _, _, #lattice_type>(#input, #by_fn, &mut #state_ident)
-                };
-            }
-        } else if let Some(output) = outputs.first() {
-            quote_spanned! {op_span=>
-                let #ident = {
-                    fn check_output<'a, Item, MappingFn, MappedItem, Psh, Lat>(
-                        push: Psh,
-                        mapfn: MappingFn,
-                        state_ref: &'a mut Lat,
-                    ) -> impl 'a + #root::dfir_pipes::push::Push<Item, ()>
-                    where
-                        Item: 'a + ::std::clone::Clone,
-                        MappingFn: 'a + Fn(Item) -> MappedItem,
-                        Psh: 'a + #root::dfir_pipes::push::Push<Item, ()>,
-                        Lat: 'static + #root::lattices::Merge<MappedItem>,
-                    {
-                        #root::dfir_pipes::push::filter(move |item| {
-                            #root::lattices::Merge::merge(state_ref, (mapfn)(::std::clone::Clone::clone(item)))
-                        }, push)
+
+                    fn start_send(self: ::core::pin::Pin<&mut Self>, item: Item, _meta: ()) {
+                        // SAFETY: StatePush is Unpin because all fields are Unpin.
+                        let this = unsafe { self.get_unchecked_mut() };
+                        let changed = #root::lattices::Merge::merge(this.state_ref, (this.mapfn)(::std::clone::Clone::clone(&item)));
+                        if changed {
+                            // SAFETY: items_push is Unpin.
+                            unsafe { ::core::pin::Pin::new_unchecked(&mut this.items_push) }.start_send(item, ());
+                        }
                     }
-                    check_output::<_, _, _, _, #lattice_type>(#output, #by_fn, &mut #state_ident)
-                };
-            }
-        } else {
-            quote_spanned! {op_span=>
-                let #ident = {
-                    fn check_output<'a, Item, MappingFn, MappedItem, Lat>(
-                        state_ref: &'a mut Lat,
-                        mapfn: MappingFn,
-                    ) -> impl 'a + #root::dfir_pipes::push::Push<Item, ()>
-                    where
-                        Item: 'a,
-                        MappedItem: 'a,
-                        MappingFn: 'a + Fn(Item) -> MappedItem,
-                        Lat: 'static + #root::lattices::Merge<MappedItem>,
-                    {
-                        #root::dfir_pipes::push::for_each(move |item| {
-                            #root::lattices::Merge::merge(state_ref, (mapfn)(item));
-                        })
+
+                    fn poll_finalize(self: ::core::pin::Pin<&mut Self>, _ctx: &mut ()) -> #root::dfir_pipes::push::PushStep<#root::dfir_pipes::No> {
+                        // SAFETY: StatePush is Unpin because all fields are Unpin.
+                        let this = unsafe { self.get_unchecked_mut() };
+                        // Emit the accumulated state to the state output.
+                        unsafe { ::core::pin::Pin::new_unchecked(&mut this.state_push) }.start_send(::std::clone::Clone::clone(this.state_ref), ());
+                        #root::dfir_pipes::push::PushStep::Done
                     }
-                    check_output::<_, _, _, #lattice_type>(&mut #state_ident, #by_fn)
-                };
-            }
+
+                    fn size_hint(self: ::core::pin::Pin<&mut Self>, _hint: (usize, Option<usize>)) {}
+                }
+
+                fn check_output<'a, Item, MappingFn, MappedItem, ItemsPsh, StatePsh, Lat>(
+                    items_push: ItemsPsh,
+                    state_push: StatePsh,
+                    mapfn: MappingFn,
+                    state_ref: &'a mut Lat,
+                ) -> StatePush<'a, Item, MappingFn, ItemsPsh, StatePsh, Lat>
+                where
+                    Item: 'a + ::std::clone::Clone,
+                    MappingFn: 'a + ::std::marker::Unpin + Fn(Item) -> MappedItem,
+                    ItemsPsh: 'a + ::std::marker::Unpin + #root::dfir_pipes::push::Push<Item, ()>,
+                    StatePsh: 'a + ::std::marker::Unpin + #root::dfir_pipes::push::Push<Lat, ()>,
+                    Lat: 'a + 'static + ::std::clone::Clone + #root::lattices::Merge<MappedItem>,
+                {
+                    StatePush {
+                        items_push,
+                        state_push,
+                        mapfn,
+                        state_ref,
+                        _phantom: ::std::marker::PhantomData,
+                    }
+                }
+                check_output::<_, _, _, _, _, #lattice_type>(#items_output, #state_output, #by_fn, &mut #state_ident)
+            };
         };
+
         Ok(OperatorWriteOutput {
             write_prologue,
             write_iterator,

--- a/dfir_lang/src/graph/ops/state_by.rs
+++ b/dfir_lang/src/graph/ops/state_by.rs
@@ -132,11 +132,10 @@ pub const STATE_BY: OperatorConstraints = OperatorConstraints {
         let state_output = &outputs[1];
 
         let write_iterator = quote_spanned! {op_span=>
-            let #ident = #root::dfir_pipes::push::state_push::<_, _, _, _, _, _, #lattice_type>(
+            let #ident = #root::dfir_pipes::push::state_push::<_, _, _, _, _, #lattice_type>(
                 #items_output,
                 #state_output,
                 #by_fn,
-                #root::lattices::Merge::merge,
                 &mut #state_ident,
             );
         };

--- a/dfir_lang/src/graph/ops/state_by.rs
+++ b/dfir_lang/src/graph/ops/state_by.rs
@@ -132,76 +132,13 @@ pub const STATE_BY: OperatorConstraints = OperatorConstraints {
         let state_output = &outputs[1];
 
         let write_iterator = quote_spanned! {op_span=>
-            let #ident = {
-                #[allow(non_camel_case_types)]
-                struct StatePush<'a, Item, MappingFn, ItemsPsh, StatePsh, Lat> {
-                    items_push: ItemsPsh,
-                    state_push: StatePsh,
-                    mapfn: MappingFn,
-                    state_ref: &'a mut Lat,
-                    _phantom: ::std::marker::PhantomData<fn(Item)>,
-                }
-                impl<'a, Item, MappingFn, MappedItem, ItemsPsh, StatePsh, Lat>
-                    #root::dfir_pipes::push::Push<Item, ()>
-                    for StatePush<'a, Item, MappingFn, ItemsPsh, StatePsh, Lat>
-                where
-                    Item: 'a + ::std::clone::Clone,
-                    MappingFn: 'a + ::std::marker::Unpin + Fn(Item) -> MappedItem,
-                    ItemsPsh: 'a + ::std::marker::Unpin + #root::dfir_pipes::push::Push<Item, ()>,
-                    StatePsh: 'a + ::std::marker::Unpin + #root::dfir_pipes::push::Push<Lat, ()>,
-                    Lat: 'a + 'static + ::std::clone::Clone + #root::lattices::Merge<MappedItem>,
-                {
-                    type Ctx<'ctx> = ();
-                    type CanPend = #root::dfir_pipes::No;
-
-                    fn poll_ready(self: ::core::pin::Pin<&mut Self>, _ctx: &mut ()) -> #root::dfir_pipes::push::PushStep<#root::dfir_pipes::No> {
-                        #root::dfir_pipes::push::PushStep::Done
-                    }
-
-                    fn start_send(self: ::core::pin::Pin<&mut Self>, item: Item, _meta: ()) {
-                        // SAFETY: StatePush is Unpin because all fields are Unpin.
-                        let this = unsafe { self.get_unchecked_mut() };
-                        let changed = #root::lattices::Merge::merge(this.state_ref, (this.mapfn)(::std::clone::Clone::clone(&item)));
-                        if changed {
-                            // SAFETY: items_push is Unpin.
-                            unsafe { ::core::pin::Pin::new_unchecked(&mut this.items_push) }.start_send(item, ());
-                        }
-                    }
-
-                    fn poll_finalize(self: ::core::pin::Pin<&mut Self>, _ctx: &mut ()) -> #root::dfir_pipes::push::PushStep<#root::dfir_pipes::No> {
-                        // SAFETY: StatePush is Unpin because all fields are Unpin.
-                        let this = unsafe { self.get_unchecked_mut() };
-                        // Emit the accumulated state to the state output.
-                        unsafe { ::core::pin::Pin::new_unchecked(&mut this.state_push) }.start_send(::std::clone::Clone::clone(this.state_ref), ());
-                        #root::dfir_pipes::push::PushStep::Done
-                    }
-
-                    fn size_hint(self: ::core::pin::Pin<&mut Self>, _hint: (usize, Option<usize>)) {}
-                }
-
-                fn check_output<'a, Item, MappingFn, MappedItem, ItemsPsh, StatePsh, Lat>(
-                    items_push: ItemsPsh,
-                    state_push: StatePsh,
-                    mapfn: MappingFn,
-                    state_ref: &'a mut Lat,
-                ) -> StatePush<'a, Item, MappingFn, ItemsPsh, StatePsh, Lat>
-                where
-                    Item: 'a + ::std::clone::Clone,
-                    MappingFn: 'a + ::std::marker::Unpin + Fn(Item) -> MappedItem,
-                    ItemsPsh: 'a + ::std::marker::Unpin + #root::dfir_pipes::push::Push<Item, ()>,
-                    StatePsh: 'a + ::std::marker::Unpin + #root::dfir_pipes::push::Push<Lat, ()>,
-                    Lat: 'a + 'static + ::std::clone::Clone + #root::lattices::Merge<MappedItem>,
-                {
-                    StatePush {
-                        items_push,
-                        state_push,
-                        mapfn,
-                        state_ref,
-                        _phantom: ::std::marker::PhantomData,
-                    }
-                }
-                check_output::<_, _, _, _, _, #lattice_type>(#items_output, #state_output, #by_fn, &mut #state_ident)
-            };
+            let #ident = #root::dfir_pipes::push::state_push::<_, _, _, _, _, _, #lattice_type>(
+                #items_output,
+                #state_output,
+                #by_fn,
+                #root::lattices::Merge::merge,
+                &mut #state_ident,
+            );
         };
 
         Ok(OperatorWriteOutput {

--- a/dfir_pipes/Cargo.toml
+++ b/dfir_pipes/Cargo.toml
@@ -9,10 +9,11 @@ repository = { workspace = true }
 license = { workspace = true }
 
 [features]
-default = ["std", "variadics"]
+default = ["std", "variadics", "lattices"]
 std = ["alloc", "futures-core/std", "futures-sink/std", "rustc-hash", "smallvec", "variadics?/std"]
 alloc = ["futures-core/alloc", "futures-sink/alloc"]
 variadics = ["dep:variadics"]
+lattices = ["dep:lattices"]
 
 [dependencies]
 futures-core = { version = "0.3.0", default-features = false }
@@ -23,6 +24,7 @@ rustc-hash = { version = "2.0.0", optional = true }
 sealed = "0.6.0"
 smallvec = { version = "1.0", optional = true }
 variadics = { optional = true, path = "../variadics", default-features = false, version = "^0.1.0" }
+lattices = { optional = true, path = "../lattices", default-features = false, version = "^0.7.0" } # TODO(mingwei): feature-gate std/alloc
 
 # coax cargo-smart-release into publishing this crate.
 # https://github.com/hydro-project/hydro/blob/main/RELEASING.md#addendum-adding-new-crates

--- a/dfir_pipes/src/push/mod.rs
+++ b/dfir_pipes/src/push/mod.rs
@@ -25,6 +25,7 @@ mod persist;
 mod resolve_futures;
 mod sink;
 mod sink_compat;
+mod state_push;
 mod unzip;
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
@@ -58,6 +59,7 @@ pub use persist::Persist;
 pub use resolve_futures::ResolveFutures;
 pub use sink::Sink;
 pub use sink_compat::SinkCompat;
+pub use state_push::StatePush;
 pub use unzip::Unzip;
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
@@ -379,6 +381,29 @@ where
     Psh: Push<Item, ()>,
 {
     SinkCompat::new(push)
+}
+
+/// Creates a [`StatePush`] that merges items into state.
+///
+/// For each item, `mapfn` maps it and `mergefn` merges the result into `state_ref`,
+/// returning `true` if the state changed. Changed items are forwarded to `items_push`.
+/// On finalize, the accumulated state is emitted to `state_push`.
+pub fn state_push<'a, Item, MappingFn, MappedItem, MergeFn, ItemsPsh, StatePsh, Lat>(
+    items_push: ItemsPsh,
+    state_push: StatePsh,
+    mapfn: MappingFn,
+    mergefn: MergeFn,
+    state_ref: &'a mut Lat,
+) -> StatePush<'a, Item, MappingFn, MergeFn, ItemsPsh, StatePsh, Lat>
+where
+    Item: 'a + Clone,
+    MappingFn: 'a + Fn(Item) -> MappedItem,
+    MergeFn: 'a + Fn(&mut Lat, MappedItem) -> bool,
+    ItemsPsh: 'a + Push<Item, ()>,
+    StatePsh: 'a + Push<Lat, ()>,
+    Lat: 'a + 'static + Clone,
+{
+    state_push::state_push(items_push, state_push, mapfn, mergefn, state_ref)
 }
 
 /// Creates an [`Unzip`] push that splits tuple items into two separate pushes.

--- a/dfir_pipes/src/push/mod.rs
+++ b/dfir_pipes/src/push/mod.rs
@@ -59,7 +59,8 @@ pub use persist::Persist;
 pub use resolve_futures::ResolveFutures;
 pub use sink::Sink;
 pub use sink_compat::SinkCompat;
-pub use state_push::StatePush;
+#[cfg(feature = "lattices")]
+pub use state_push::{StatePush, state_push};
 pub use unzip::Unzip;
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
@@ -381,29 +382,6 @@ where
     Psh: Push<Item, ()>,
 {
     SinkCompat::new(push)
-}
-
-/// Creates a [`StatePush`] that merges items into state.
-///
-/// For each item, `mapfn` maps it and `mergefn` merges the result into `state_ref`,
-/// returning `true` if the state changed. Changed items are forwarded to `items_push`.
-/// On finalize, the accumulated state is emitted to `state_push`.
-pub fn state_push<'a, Item, MappingFn, MappedItem, MergeFn, ItemsPsh, StatePsh, Lat>(
-    items_push: ItemsPsh,
-    state_push: StatePsh,
-    mapfn: MappingFn,
-    mergefn: MergeFn,
-    state_ref: &'a mut Lat,
-) -> StatePush<'a, Item, MappingFn, MergeFn, ItemsPsh, StatePsh, Lat>
-where
-    Item: 'a + Clone,
-    MappingFn: 'a + Fn(Item) -> MappedItem,
-    MergeFn: 'a + Fn(&mut Lat, MappedItem) -> bool,
-    ItemsPsh: 'a + Push<Item, ()>,
-    StatePsh: 'a + Push<Lat, ()>,
-    Lat: 'a + 'static + Clone,
-{
-    state_push::state_push(items_push, state_push, mapfn, mergefn, state_ref)
 }
 
 /// Creates an [`Unzip`] push that splits tuple items into two separate pushes.

--- a/dfir_pipes/src/push/mod.rs
+++ b/dfir_pipes/src/push/mod.rs
@@ -25,6 +25,8 @@ mod persist;
 mod resolve_futures;
 mod sink;
 mod sink_compat;
+#[cfg(feature = "lattices")]
+#[cfg_attr(docsrs, doc(cfg(feature = "lattices")))]
 mod state_push;
 mod unzip;
 #[cfg(feature = "alloc")]
@@ -60,6 +62,7 @@ pub use resolve_futures::ResolveFutures;
 pub use sink::Sink;
 pub use sink_compat::SinkCompat;
 #[cfg(feature = "lattices")]
+#[cfg_attr(docsrs, doc(cfg(feature = "lattices")))]
 pub use state_push::{StatePush, state_push};
 pub use unzip::Unzip;
 #[cfg(feature = "alloc")]

--- a/dfir_pipes/src/push/state_push.rs
+++ b/dfir_pipes/src/push/state_push.rs
@@ -1,0 +1,91 @@
+//! [`StatePush`] push combinator for lattice state operators.
+use core::pin::Pin;
+
+use pin_project_lite::pin_project;
+
+use crate::No;
+use crate::push::{Push, PushStep};
+
+pin_project! {
+    /// Push combinator that merges items into state, forwarding changed items
+    /// to `items_push` and emitting the accumulated state to `state_push` on finalize.
+    ///
+    /// For each item, `mapfn` maps it and `mergefn` merges the mapped value into `state_ref`.
+    /// If the merge returns `true` (indicating a change), the original item is forwarded to
+    /// `items_push`. On finalize, a clone of the accumulated state is sent to `state_push`.
+    #[must_use = "`Push`es do nothing unless items are pushed into them"]
+    pub struct StatePush<'a, Item, MappingFn, MergeFn, ItemsPsh, StatePsh, Lat> {
+        #[pin]
+        items_push: ItemsPsh,
+        #[pin]
+        state_push: StatePsh,
+        mapfn: MappingFn,
+        mergefn: MergeFn,
+        state_ref: &'a mut Lat,
+        _phantom: ::core::marker::PhantomData<fn(Item)>,
+    }
+}
+
+impl<'a, Item, MappingFn, MappedItem, MergeFn, ItemsPsh, StatePsh, Lat> Push<Item, ()>
+    for StatePush<'a, Item, MappingFn, MergeFn, ItemsPsh, StatePsh, Lat>
+where
+    Item: 'a + Clone,
+    MappingFn: 'a + Fn(Item) -> MappedItem,
+    MergeFn: 'a + Fn(&mut Lat, MappedItem) -> bool,
+    ItemsPsh: 'a + Push<Item, ()>,
+    StatePsh: 'a + Push<Lat, ()>,
+    Lat: 'a + 'static + Clone,
+{
+    type Ctx<'ctx> = ();
+    type CanPend = No;
+
+    fn poll_ready(self: Pin<&mut Self>, _ctx: &mut ()) -> PushStep<No> {
+        PushStep::Done
+    }
+
+    fn start_send(self: Pin<&mut Self>, item: Item, _meta: ()) {
+        let this = self.project();
+        let changed = (this.mergefn)(this.state_ref, (this.mapfn)(item.clone()));
+        if changed {
+            this.items_push.start_send(item, ());
+        }
+    }
+
+    fn poll_finalize(self: Pin<&mut Self>, _ctx: &mut ()) -> PushStep<No> {
+        let this = self.project();
+        this.state_push.start_send(this.state_ref.clone(), ());
+        PushStep::Done
+    }
+
+    fn size_hint(self: Pin<&mut Self>, _hint: (usize, Option<usize>)) {}
+}
+
+/// Creates a [`StatePush`] that merges items into state.
+///
+/// For each item, `mapfn` maps it and `mergefn` merges the result into `state_ref`,
+/// returning `true` if the state changed. Changed items are forwarded to `items_push`.
+/// On finalize, the accumulated state is emitted to `state_push`.
+pub fn state_push<'a, Item, MappingFn, MappedItem, MergeFn, ItemsPsh, StatePsh, Lat>(
+    items_push: ItemsPsh,
+    state_push: StatePsh,
+    mapfn: MappingFn,
+    mergefn: MergeFn,
+    state_ref: &'a mut Lat,
+) -> StatePush<'a, Item, MappingFn, MergeFn, ItemsPsh, StatePsh, Lat>
+where
+    Item: 'a + Clone,
+    MappingFn: 'a + Fn(Item) -> MappedItem,
+    MergeFn: 'a + Fn(&mut Lat, MappedItem) -> bool,
+    ItemsPsh: 'a + Push<Item, ()>,
+    StatePsh: 'a + Push<Lat, ()>,
+    Lat: 'a + 'static + Clone,
+{
+    StatePush {
+        items_push,
+        state_push,
+        mapfn,
+        mergefn,
+        state_ref,
+        _phantom: ::core::marker::PhantomData,
+    }
+}

--- a/dfir_pipes/src/push/state_push.rs
+++ b/dfir_pipes/src/push/state_push.rs
@@ -4,14 +4,15 @@ use core::pin::Pin;
 use lattices::Merge;
 use pin_project_lite::pin_project;
 
-use crate::No;
+use super::ready_both;
 use crate::push::{Push, PushStep};
+use crate::{Context, Toggle};
 
 pin_project! {
     /// Push combinator that merges items into state, forwarding changed items
     /// to `items_push` and emitting the accumulated state to `state_push` on finalize.
     ///
-    /// For each item, `map_fn` maps it and `merge_fn` merges the mapped value into `state_ref`.
+    /// For each item, `map_fn` maps it and [`Lat::merge`] merges the mapped value into `state_ref`.
     /// If the merge returns `true` (indicating a change), the original item is forwarded to
     /// `items_push`. On finalize, a clone of the accumulated state is sent to `state_push`.
     #[must_use = "`Push`es do nothing unless items are pushed into them"]
@@ -35,10 +36,17 @@ where
     StatePsh: Push<Lat, ()>,
     Lat: Merge<MappedItem> + Clone,
 {
-    type Ctx<'ctx> = ();
-    type CanPend = No;
+    type Ctx<'ctx> = <ItemsPsh::Ctx<'ctx> as Context<'ctx>>::Merged<StatePsh::Ctx<'ctx>>;
+    type CanPend = <ItemsPsh::CanPend as Toggle>::Or<StatePsh::CanPend>;
 
-    fn poll_ready(self: Pin<&mut Self>, _ctx: &mut ()) -> PushStep<No> {
+    fn poll_ready(self: Pin<&mut Self>, ctx: &mut Self::Ctx<'_>) -> PushStep<Self::CanPend> {
+        let this = self.project();
+        ready_both!(
+            this.items_push
+                .poll_ready(<ItemsPsh::Ctx<'_> as Context<'_>>::unmerge_self(ctx)),
+            this.state_push
+                .poll_ready(<ItemsPsh::Ctx<'_> as Context<'_>>::unmerge_other(ctx)),
+        );
         PushStep::Done
     }
 
@@ -50,9 +58,17 @@ where
         }
     }
 
-    fn poll_finalize(self: Pin<&mut Self>, _ctx: &mut ()) -> PushStep<No> {
-        let this = self.project();
-        this.state_push.start_send(this.state_ref.clone(), ());
+    fn poll_finalize(self: Pin<&mut Self>, ctx: &mut Self::Ctx<'_>) -> PushStep<Self::CanPend> {
+        let mut this = self.project();
+        this.state_push
+            .as_mut()
+            .start_send(this.state_ref.clone(), ());
+        ready_both!(
+            this.items_push
+                .poll_finalize(<ItemsPsh::Ctx<'_> as Context<'_>>::unmerge_self(ctx)),
+            this.state_push
+                .poll_finalize(<ItemsPsh::Ctx<'_> as Context<'_>>::unmerge_other(ctx)),
+        );
         PushStep::Done
     }
 
@@ -61,9 +77,9 @@ where
 
 /// Creates a [`StatePush`] that merges items into state.
 ///
-/// For each item, `map_fn` maps it and `merge_fn` merges the result into `state_ref`,
-/// returning `true` if the state changed. Changed items are forwarded to `items_push`.
-/// On finalize, the accumulated state is emitted to `state_push`.
+/// For each item, `map_fn` maps it and [`Lat::merge`](Merge::merge) merges the result
+/// into `state_ref`, returning `true` if the state changed. Changed items are forwarded
+/// to `items_push`. On finalize, the accumulated state is emitted to `state_push`.
 pub fn state_push<Item, MappingFn, MappedItem, ItemsPsh, StatePsh, Lat>(
     items_push: ItemsPsh,
     state_push: StatePsh,

--- a/dfir_pipes/src/push/state_push.rs
+++ b/dfir_pipes/src/push/state_push.rs
@@ -1,6 +1,7 @@
 //! [`StatePush`] push combinator for lattice state operators.
 use core::pin::Pin;
 
+use lattices::Merge;
 use pin_project_lite::pin_project;
 
 use crate::No;
@@ -10,31 +11,29 @@ pin_project! {
     /// Push combinator that merges items into state, forwarding changed items
     /// to `items_push` and emitting the accumulated state to `state_push` on finalize.
     ///
-    /// For each item, `mapfn` maps it and `mergefn` merges the mapped value into `state_ref`.
+    /// For each item, `map_fn` maps it and `merge_fn` merges the mapped value into `state_ref`.
     /// If the merge returns `true` (indicating a change), the original item is forwarded to
     /// `items_push`. On finalize, a clone of the accumulated state is sent to `state_push`.
     #[must_use = "`Push`es do nothing unless items are pushed into them"]
-    pub struct StatePush<'a, Item, MappingFn, MergeFn, ItemsPsh, StatePsh, Lat> {
+    pub struct StatePush<'a, Item, MappingFn, ItemsPsh, StatePsh, Lat> {
         #[pin]
         items_push: ItemsPsh,
         #[pin]
         state_push: StatePsh,
-        mapfn: MappingFn,
-        mergefn: MergeFn,
+        map_fn: MappingFn,
         state_ref: &'a mut Lat,
         _phantom: ::core::marker::PhantomData<fn(Item)>,
     }
 }
 
-impl<'a, Item, MappingFn, MappedItem, MergeFn, ItemsPsh, StatePsh, Lat> Push<Item, ()>
-    for StatePush<'a, Item, MappingFn, MergeFn, ItemsPsh, StatePsh, Lat>
+impl<'a, Item, MappingFn, MappedItem, ItemsPsh, StatePsh, Lat> Push<Item, ()>
+    for StatePush<'a, Item, MappingFn, ItemsPsh, StatePsh, Lat>
 where
-    Item: 'a + Clone,
-    MappingFn: 'a + Fn(Item) -> MappedItem,
-    MergeFn: 'a + Fn(&mut Lat, MappedItem) -> bool,
-    ItemsPsh: 'a + Push<Item, ()>,
-    StatePsh: 'a + Push<Lat, ()>,
-    Lat: 'a + 'static + Clone,
+    Item: Clone,
+    MappingFn: Fn(Item) -> MappedItem,
+    ItemsPsh: Push<Item, ()>,
+    StatePsh: Push<Lat, ()>,
+    Lat: Merge<MappedItem> + Clone,
 {
     type Ctx<'ctx> = ();
     type CanPend = No;
@@ -45,7 +44,7 @@ where
 
     fn start_send(self: Pin<&mut Self>, item: Item, _meta: ()) {
         let this = self.project();
-        let changed = (this.mergefn)(this.state_ref, (this.mapfn)(item.clone()));
+        let changed = Lat::merge(this.state_ref, (this.map_fn)(item.clone()));
         if changed {
             this.items_push.start_send(item, ());
         }
@@ -62,29 +61,26 @@ where
 
 /// Creates a [`StatePush`] that merges items into state.
 ///
-/// For each item, `mapfn` maps it and `mergefn` merges the result into `state_ref`,
+/// For each item, `map_fn` maps it and `merge_fn` merges the result into `state_ref`,
 /// returning `true` if the state changed. Changed items are forwarded to `items_push`.
 /// On finalize, the accumulated state is emitted to `state_push`.
-pub fn state_push<'a, Item, MappingFn, MappedItem, MergeFn, ItemsPsh, StatePsh, Lat>(
+pub fn state_push<Item, MappingFn, MappedItem, ItemsPsh, StatePsh, Lat>(
     items_push: ItemsPsh,
     state_push: StatePsh,
-    mapfn: MappingFn,
-    mergefn: MergeFn,
-    state_ref: &'a mut Lat,
-) -> StatePush<'a, Item, MappingFn, MergeFn, ItemsPsh, StatePsh, Lat>
+    map_fn: MappingFn,
+    state_ref: &mut Lat,
+) -> StatePush<'_, Item, MappingFn, ItemsPsh, StatePsh, Lat>
 where
-    Item: 'a + Clone,
-    MappingFn: 'a + Fn(Item) -> MappedItem,
-    MergeFn: 'a + Fn(&mut Lat, MappedItem) -> bool,
-    ItemsPsh: 'a + Push<Item, ()>,
-    StatePsh: 'a + Push<Lat, ()>,
-    Lat: 'a + 'static + Clone,
+    Item: Clone,
+    MappingFn: Fn(Item) -> MappedItem,
+    ItemsPsh: Push<Item, ()>,
+    StatePsh: Push<Lat, ()>,
+    Lat: Merge<MappedItem> + Clone,
 {
     StatePush {
         items_push,
         state_push,
-        mapfn,
-        mergefn,
+        map_fn,
         state_ref,
         _phantom: ::core::marker::PhantomData,
     }

--- a/dfir_rs/tests/compile-fail/stable/surface_demuxenum_wrongenum.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_demuxenum_wrongenum.stderr
@@ -87,11 +87,11 @@ error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<std::option:
              `&mut P` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `DemuxEnum<Outputs>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `ResolveFutures<Psh, Queue, QueueInner>` implements `dfir_rs::dfir_pipes::push::Push<Fut, ()>`
+             `StatePush<'a, Item, MappingFn, MergeFn, ItemsPsh, StatePsh, Lat>` implements `dfir_rs::dfir_pipes::push::Push<Item, ()>`
              `VecPush<Buf>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::DemuxVar<Pushes>` implements `dfir_rs::dfir_pipes::push::Push<(usize, Item), Meta>`
              `dfir_rs::dfir_pipes::push::Fanout<P0, P1>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::Filter<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
-             `dfir_rs::dfir_pipes::push::FilterMap<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<In, Meta>`
            and $N others
 note: required by a bound in `pivot_run_sg_1v1`
   --> tests/compile-fail/stable/surface_demuxenum_wrongenum.rs:17:15

--- a/dfir_rs/tests/compile-fail/stable/surface_demuxenum_wrongenum.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_demuxenum_wrongenum.stderr
@@ -87,7 +87,7 @@ error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<std::option:
              `&mut P` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `DemuxEnum<Outputs>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `ResolveFutures<Psh, Queue, QueueInner>` implements `dfir_rs::dfir_pipes::push::Push<Fut, ()>`
-             `StatePush<'a, Item, MappingFn, MergeFn, ItemsPsh, StatePsh, Lat>` implements `dfir_rs::dfir_pipes::push::Push<Item, ()>`
+             `StatePush<'a, Item, MappingFn, ItemsPsh, StatePsh, Lat>` implements `dfir_rs::dfir_pipes::push::Push<Item, ()>`
              `VecPush<Buf>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::DemuxVar<Pushes>` implements `dfir_rs::dfir_pipes::push::Push<(usize, Item), Meta>`
              `dfir_rs::dfir_pipes::push::Fanout<P0, P1>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`

--- a/dfir_rs/tests/compile-fail/stable/surface_demuxenum_wrongfields_1.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_demuxenum_wrongfields_1.stderr
@@ -9,11 +9,11 @@ error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<u32, (), Can
              `&mut P` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `DemuxEnum<Outputs>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `ResolveFutures<Psh, Queue, QueueInner>` implements `dfir_rs::dfir_pipes::push::Push<Fut, ()>`
+             `StatePush<'a, Item, MappingFn, MergeFn, ItemsPsh, StatePsh, Lat>` implements `dfir_rs::dfir_pipes::push::Push<Item, ()>`
              `VecPush<Buf>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::DemuxVar<Pushes>` implements `dfir_rs::dfir_pipes::push::Push<(usize, Item), Meta>`
              `dfir_rs::dfir_pipes::push::Fanout<P0, P1>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::Filter<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
-             `dfir_rs::dfir_pipes::push::FilterMap<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<In, Meta>`
            and $N others
 note: required for `Shape` to implement `DemuxEnumPush<(Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64,)) {std::mem::drop::<(f64,)>}> as dfir_rs::dfir_pipes::push::Push<(f64,), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64, f64), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64, f64)) {std::mem::drop::<(f64, f64)>}> as dfir_rs::dfir_pipes::push::Push<(f64, f64), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<u32, (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<{closure@$DIR/tests/compile-fail/stable/surface_demuxenum_wrongfields_1.rs:20:38: 20:49}> as dfir_rs::dfir_pipes::push::Push<u32, ()>>::CanPend>>), ()>`
   --> tests/compile-fail/stable/surface_demuxenum_wrongfields_1.rs:6:10
@@ -40,11 +40,11 @@ error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<u32, (), Can
              `&mut P` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `DemuxEnum<Outputs>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `ResolveFutures<Psh, Queue, QueueInner>` implements `dfir_rs::dfir_pipes::push::Push<Fut, ()>`
+             `StatePush<'a, Item, MappingFn, MergeFn, ItemsPsh, StatePsh, Lat>` implements `dfir_rs::dfir_pipes::push::Push<Item, ()>`
              `VecPush<Buf>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::DemuxVar<Pushes>` implements `dfir_rs::dfir_pipes::push::Push<(usize, Item), Meta>`
              `dfir_rs::dfir_pipes::push::Fanout<P0, P1>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::Filter<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
-             `dfir_rs::dfir_pipes::push::FilterMap<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<In, Meta>`
            and $N others
 note: required for `Shape` to implement `DemuxEnumPush<(Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64,)) {std::mem::drop::<(f64,)>}> as dfir_rs::dfir_pipes::push::Push<(f64,), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64, f64), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64, f64)) {std::mem::drop::<(f64, f64)>}> as dfir_rs::dfir_pipes::push::Push<(f64, f64), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<u32, (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<{closure@$DIR/tests/compile-fail/stable/surface_demuxenum_wrongfields_1.rs:20:38: 20:49}> as dfir_rs::dfir_pipes::push::Push<u32, ()>>::CanPend>>), ()>`
   --> tests/compile-fail/stable/surface_demuxenum_wrongfields_1.rs:6:10

--- a/dfir_rs/tests/compile-fail/stable/surface_demuxenum_wrongfields_1.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_demuxenum_wrongfields_1.stderr
@@ -9,7 +9,7 @@ error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<u32, (), Can
              `&mut P` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `DemuxEnum<Outputs>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `ResolveFutures<Psh, Queue, QueueInner>` implements `dfir_rs::dfir_pipes::push::Push<Fut, ()>`
-             `StatePush<'a, Item, MappingFn, MergeFn, ItemsPsh, StatePsh, Lat>` implements `dfir_rs::dfir_pipes::push::Push<Item, ()>`
+             `StatePush<'a, Item, MappingFn, ItemsPsh, StatePsh, Lat>` implements `dfir_rs::dfir_pipes::push::Push<Item, ()>`
              `VecPush<Buf>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::DemuxVar<Pushes>` implements `dfir_rs::dfir_pipes::push::Push<(usize, Item), Meta>`
              `dfir_rs::dfir_pipes::push::Fanout<P0, P1>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
@@ -40,7 +40,7 @@ error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<u32, (), Can
              `&mut P` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `DemuxEnum<Outputs>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `ResolveFutures<Psh, Queue, QueueInner>` implements `dfir_rs::dfir_pipes::push::Push<Fut, ()>`
-             `StatePush<'a, Item, MappingFn, MergeFn, ItemsPsh, StatePsh, Lat>` implements `dfir_rs::dfir_pipes::push::Push<Item, ()>`
+             `StatePush<'a, Item, MappingFn, ItemsPsh, StatePsh, Lat>` implements `dfir_rs::dfir_pipes::push::Push<Item, ()>`
              `VecPush<Buf>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::DemuxVar<Pushes>` implements `dfir_rs::dfir_pipes::push::Push<(usize, Item), Meta>`
              `dfir_rs::dfir_pipes::push::Fanout<P0, P1>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`

--- a/dfir_rs/tests/compile-fail/stable/surface_demuxenum_wrongfields_2.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_demuxenum_wrongfields_2.stderr
@@ -9,11 +9,11 @@ error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<(u32,), (), 
              `&mut P` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `DemuxEnum<Outputs>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `ResolveFutures<Psh, Queue, QueueInner>` implements `dfir_rs::dfir_pipes::push::Push<Fut, ()>`
+             `StatePush<'a, Item, MappingFn, MergeFn, ItemsPsh, StatePsh, Lat>` implements `dfir_rs::dfir_pipes::push::Push<Item, ()>`
              `VecPush<Buf>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::DemuxVar<Pushes>` implements `dfir_rs::dfir_pipes::push::Push<(usize, Item), Meta>`
              `dfir_rs::dfir_pipes::push::Fanout<P0, P1>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::Filter<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
-             `dfir_rs::dfir_pipes::push::FilterMap<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<In, Meta>`
            and $N others
 note: required for `Shape` to implement `DemuxEnumPush<(Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64,)) {std::mem::drop::<(f64,)>}> as dfir_rs::dfir_pipes::push::Push<(f64,), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64, f64), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64, f64)) {std::mem::drop::<(f64, f64)>}> as dfir_rs::dfir_pipes::push::Push<(f64, f64), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(u32,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<{closure@$DIR/tests/compile-fail/stable/surface_demuxenum_wrongfields_2.rs:20:38: 20:52}> as dfir_rs::dfir_pipes::push::Push<(u32,), ()>>::CanPend>>), ()>`
   --> tests/compile-fail/stable/surface_demuxenum_wrongfields_2.rs:6:10
@@ -40,11 +40,11 @@ error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<(u32,), (), 
              `&mut P` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `DemuxEnum<Outputs>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `ResolveFutures<Psh, Queue, QueueInner>` implements `dfir_rs::dfir_pipes::push::Push<Fut, ()>`
+             `StatePush<'a, Item, MappingFn, MergeFn, ItemsPsh, StatePsh, Lat>` implements `dfir_rs::dfir_pipes::push::Push<Item, ()>`
              `VecPush<Buf>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::DemuxVar<Pushes>` implements `dfir_rs::dfir_pipes::push::Push<(usize, Item), Meta>`
              `dfir_rs::dfir_pipes::push::Fanout<P0, P1>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::Filter<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
-             `dfir_rs::dfir_pipes::push::FilterMap<Next, Func>` implements `dfir_rs::dfir_pipes::push::Push<In, Meta>`
            and $N others
 note: required for `Shape` to implement `DemuxEnumPush<(Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64,)) {std::mem::drop::<(f64,)>}> as dfir_rs::dfir_pipes::push::Push<(f64,), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(f64, f64), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<fn((f64, f64)) {std::mem::drop::<(f64, f64)>}> as dfir_rs::dfir_pipes::push::Push<(f64, f64), ()>>::CanPend>>, Pin<&mut impl dfir_rs::dfir_pipes::push::Push<(u32,), (), CanPend = <dfir_rs::dfir_pipes::push::ForEach<{closure@$DIR/tests/compile-fail/stable/surface_demuxenum_wrongfields_2.rs:20:38: 20:52}> as dfir_rs::dfir_pipes::push::Push<(u32,), ()>>::CanPend>>), ()>`
   --> tests/compile-fail/stable/surface_demuxenum_wrongfields_2.rs:6:10

--- a/dfir_rs/tests/compile-fail/stable/surface_demuxenum_wrongfields_2.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_demuxenum_wrongfields_2.stderr
@@ -9,7 +9,7 @@ error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<(u32,), (), 
              `&mut P` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `DemuxEnum<Outputs>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `ResolveFutures<Psh, Queue, QueueInner>` implements `dfir_rs::dfir_pipes::push::Push<Fut, ()>`
-             `StatePush<'a, Item, MappingFn, MergeFn, ItemsPsh, StatePsh, Lat>` implements `dfir_rs::dfir_pipes::push::Push<Item, ()>`
+             `StatePush<'a, Item, MappingFn, ItemsPsh, StatePsh, Lat>` implements `dfir_rs::dfir_pipes::push::Push<Item, ()>`
              `VecPush<Buf>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::DemuxVar<Pushes>` implements `dfir_rs::dfir_pipes::push::Push<(usize, Item), Meta>`
              `dfir_rs::dfir_pipes::push::Fanout<P0, P1>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
@@ -40,7 +40,7 @@ error[E0277]: the trait bound `impl dfir_rs::dfir_pipes::push::Push<(u32,), (), 
              `&mut P` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `DemuxEnum<Outputs>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `ResolveFutures<Psh, Queue, QueueInner>` implements `dfir_rs::dfir_pipes::push::Push<Fut, ()>`
-             `StatePush<'a, Item, MappingFn, MergeFn, ItemsPsh, StatePsh, Lat>` implements `dfir_rs::dfir_pipes::push::Push<Item, ()>`
+             `StatePush<'a, Item, MappingFn, ItemsPsh, StatePsh, Lat>` implements `dfir_rs::dfir_pipes::push::Push<Item, ()>`
              `VecPush<Buf>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`
              `dfir_rs::dfir_pipes::push::DemuxVar<Pushes>` implements `dfir_rs::dfir_pipes::push::Push<(usize, Item), Meta>`
              `dfir_rs::dfir_pipes::push::Fanout<P0, P1>` implements `dfir_rs::dfir_pipes::push::Push<Item, Meta>`

--- a/dfir_rs/tests/snapshots/surface_lattice_bimorphism__cartesian_product@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_lattice_bimorphism__cartesian_product@graphvis_dot.snap
@@ -7,30 +7,35 @@ digraph {
     edge [fontname="Monaco,Menlo,Consolas,&quot;Droid Sans Mono&quot;,Inconsolata,&quot;Courier New&quot;,monospace"];
     n1v1 [label="(n1v1) source_iter(0..3)", shape=invhouse, fillcolor="#88aaff"]
     n2v1 [label="(n2v1) map(SetUnionSingletonSet::new_from)", shape=invhouse, fillcolor="#88aaff"]
-    n3v1 [label="(n3v1) state::<'static, SetUnionHashSet<u32>>()", shape=invhouse, fillcolor="#88aaff"]
+    n3v1 [label="(n3v1) state::<'static, SetUnionHashSet<u32>>()", shape=house, fillcolor="#ffff88"]
     n4v1 [label="(n4v1) source_iter(3..5)", shape=invhouse, fillcolor="#88aaff"]
     n5v1 [label="(n5v1) map(SetUnionSingletonSet::new_from)", shape=invhouse, fillcolor="#88aaff"]
-    n6v1 [label="(n6v1) state::<'static, SetUnionHashSet<u32>>()", shape=invhouse, fillcolor="#88aaff"]
-    n7v1 [label="(n7v1) lattice_bimorphism(CartesianProductBimorphism::<HashSet<_>>::default(), lhs, rhs)", shape=invhouse, fillcolor="#88aaff"]
-    n8v1 [label="(n8v1) for_each(|x| out_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
-    n9v1 [label="(n9v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n10v1 [label="(n10v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
+    n6v1 [label="(n6v1) state::<'static, SetUnionHashSet<u32>>()", shape=house, fillcolor="#ffff88"]
+    n7v1 [label="(n7v1) null()", shape=house, fillcolor="#ffff88"]
+    n8v1 [label="(n8v1) null()", shape=house, fillcolor="#ffff88"]
+    n9v1 [label="(n9v1) lattice_bimorphism(CartesianProductBimorphism::<HashSet<_>>::default(), lhs, rhs)", shape=invhouse, fillcolor="#88aaff"]
+    n10v1 [label="(n10v1) for_each(|x| out_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
+    n11v1 [label="(n11v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
+    n12v1 [label="(n12v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n2v1 -> n3v1
     n1v1 -> n2v1
     n5v1 -> n6v1
     n4v1 -> n5v1
-    n3v1 -> n9v1
-    n6v1 -> n10v1
-    n7v1 -> n8v1
-    n9v1 -> n7v1 [label="0"]
-    n10v1 -> n7v1 [label="1"]
-    n3v1 -> n7v1 [color=red]
-    n6v1 -> n7v1 [color=red]
+    n3v1 -> n11v1 [label="items"]
+    n6v1 -> n12v1 [label="items"]
+    n3v1 -> n7v1 [label="state"]
+    n6v1 -> n8v1 [label="state"]
+    n9v1 -> n10v1
+    n11v1 -> n9v1 [label="0"]
+    n12v1 -> n9v1 [label="1"]
+    n3v1 -> n9v1 [color=red]
+    n6v1 -> n9v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
         style=filled
         label = "sg_1v1"
+        n7v1
         subgraph sg_1v1_var_lhs {
             cluster=true
             label="var lhs"
@@ -44,6 +49,7 @@ digraph {
         fillcolor="#dddddd"
         style=filled
         label = "sg_2v1"
+        n8v1
         subgraph sg_2v1_var_rhs {
             cluster=true
             label="var rhs"
@@ -60,8 +66,8 @@ digraph {
         subgraph sg_3v1_var_my_join {
             cluster=true
             label="var my_join"
-            n7v1
-            n8v1
+            n9v1
+            n10v1
         }
     }
 }

--- a/dfir_rs/tests/snapshots/surface_lattice_bimorphism__cartesian_product@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_lattice_bimorphism__cartesian_product@graphvis_mermaid.snap
@@ -10,26 +10,31 @@ classDef otherClass fill:#fdc,stroke:#000,text-align:left,white-space:pre
 linkStyle default stroke:#aaa
 1v1[\"(1v1) <code>source_iter(0..3)</code>"/]:::pullClass
 2v1[\"(2v1) <code>map(SetUnionSingletonSet::new_from)</code>"/]:::pullClass
-3v1[\"(3v1) <code>state::&lt;'static, SetUnionHashSet&lt;u32&gt;&gt;()</code>"/]:::pullClass
+3v1[/"(3v1) <code>state::&lt;'static, SetUnionHashSet&lt;u32&gt;&gt;()</code>"\]:::pushClass
 4v1[\"(4v1) <code>source_iter(3..5)</code>"/]:::pullClass
 5v1[\"(5v1) <code>map(SetUnionSingletonSet::new_from)</code>"/]:::pullClass
-6v1[\"(6v1) <code>state::&lt;'static, SetUnionHashSet&lt;u32&gt;&gt;()</code>"/]:::pullClass
-7v1[\"(7v1) <code>lattice_bimorphism(CartesianProductBimorphism::&lt;HashSet&lt;_&gt;&gt;::default(), lhs, rhs)</code>"/]:::pullClass
-8v1[/"(8v1) <code>for_each(|x| out_send.send(x).unwrap())</code>"\]:::pushClass
-9v1["(9v1) <code>handoff</code>"]:::otherClass
-10v1["(10v1) <code>handoff</code>"]:::otherClass
+6v1[/"(6v1) <code>state::&lt;'static, SetUnionHashSet&lt;u32&gt;&gt;()</code>"\]:::pushClass
+7v1[/"(7v1) <code>null()</code>"\]:::pushClass
+8v1[/"(8v1) <code>null()</code>"\]:::pushClass
+9v1[\"(9v1) <code>lattice_bimorphism(CartesianProductBimorphism::&lt;HashSet&lt;_&gt;&gt;::default(), lhs, rhs)</code>"/]:::pullClass
+10v1[/"(10v1) <code>for_each(|x| out_send.send(x).unwrap())</code>"\]:::pushClass
+11v1["(11v1) <code>handoff</code>"]:::otherClass
+12v1["(12v1) <code>handoff</code>"]:::otherClass
 2v1-->3v1
 1v1-->2v1
 5v1-->6v1
 4v1-->5v1
-3v1-->9v1
-6v1-->10v1
-7v1-->8v1
-9v1-->|0|7v1
-10v1-->|1|7v1
-3v1--x7v1; linkStyle 9 stroke:red
-6v1--x7v1; linkStyle 10 stroke:red
+3v1-->|items|11v1
+6v1-->|items|12v1
+3v1-->|state|7v1
+6v1-->|state|8v1
+9v1-->10v1
+11v1-->|0|9v1
+12v1-->|1|9v1
+3v1--x9v1; linkStyle 11 stroke:red
+6v1--x9v1; linkStyle 12 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
+    7v1
     subgraph sg_1v1_var_lhs ["var <tt>lhs</tt>"]
         1v1
         2v1
@@ -37,6 +42,7 @@ subgraph sg_1v1 ["sg_1v1"]
     end
 end
 subgraph sg_2v1 ["sg_2v1"]
+    8v1
     subgraph sg_2v1_var_rhs ["var <tt>rhs</tt>"]
         4v1
         5v1
@@ -45,7 +51,7 @@ subgraph sg_2v1 ["sg_2v1"]
 end
 subgraph sg_3v1 ["sg_3v1"]
     subgraph sg_3v1_var_my_join ["var <tt>my_join</tt>"]
-        7v1
-        8v1
+        9v1
+        10v1
     end
 end

--- a/dfir_rs/tests/snapshots/surface_lattice_bimorphism__cartesian_product_1401@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_lattice_bimorphism__cartesian_product_1401@graphvis_dot.snap
@@ -7,30 +7,35 @@ digraph {
     edge [fontname="Monaco,Menlo,Consolas,&quot;Droid Sans Mono&quot;,Inconsolata,&quot;Courier New&quot;,monospace"];
     n1v1 [label="(n1v1) source_iter(0..1)", shape=invhouse, fillcolor="#88aaff"]
     n2v1 [label="(n2v1) map(SetUnionSingletonSet::new_from)", shape=invhouse, fillcolor="#88aaff"]
-    n3v1 [label="(n3v1) state::<'static, SetUnionHashSet<u32>>()", shape=invhouse, fillcolor="#88aaff"]
+    n3v1 [label="(n3v1) state::<'static, SetUnionHashSet<u32>>()", shape=house, fillcolor="#ffff88"]
     n4v1 [label="(n4v1) source_iter(1..2)", shape=invhouse, fillcolor="#88aaff"]
     n5v1 [label="(n5v1) map(SetUnionSingletonSet::new_from)", shape=invhouse, fillcolor="#88aaff"]
-    n6v1 [label="(n6v1) state::<'static, SetUnionHashSet<u32>>()", shape=invhouse, fillcolor="#88aaff"]
-    n7v1 [label="(n7v1) lattice_bimorphism(CartesianProductBimorphism::<HashSet<_>>::default(), lhs, rhs)", shape=invhouse, fillcolor="#88aaff"]
-    n8v1 [label="(n8v1) for_each(|x| out_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
-    n9v1 [label="(n9v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n10v1 [label="(n10v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
+    n6v1 [label="(n6v1) state::<'static, SetUnionHashSet<u32>>()", shape=house, fillcolor="#ffff88"]
+    n7v1 [label="(n7v1) null()", shape=house, fillcolor="#ffff88"]
+    n8v1 [label="(n8v1) null()", shape=house, fillcolor="#ffff88"]
+    n9v1 [label="(n9v1) lattice_bimorphism(CartesianProductBimorphism::<HashSet<_>>::default(), lhs, rhs)", shape=invhouse, fillcolor="#88aaff"]
+    n10v1 [label="(n10v1) for_each(|x| out_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
+    n11v1 [label="(n11v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
+    n12v1 [label="(n12v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n2v1 -> n3v1
     n1v1 -> n2v1
     n5v1 -> n6v1
     n4v1 -> n5v1
-    n3v1 -> n9v1
-    n6v1 -> n10v1
-    n7v1 -> n8v1
-    n9v1 -> n7v1 [label="0"]
-    n10v1 -> n7v1 [label="1"]
-    n3v1 -> n7v1 [color=red]
-    n6v1 -> n7v1 [color=red]
+    n3v1 -> n11v1 [label="items"]
+    n6v1 -> n12v1 [label="items"]
+    n3v1 -> n7v1 [label="state"]
+    n6v1 -> n8v1 [label="state"]
+    n9v1 -> n10v1
+    n11v1 -> n9v1 [label="0"]
+    n12v1 -> n9v1 [label="1"]
+    n3v1 -> n9v1 [color=red]
+    n6v1 -> n9v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
         style=filled
         label = "sg_1v1"
+        n7v1
         subgraph sg_1v1_var_lhs {
             cluster=true
             label="var lhs"
@@ -44,6 +49,7 @@ digraph {
         fillcolor="#dddddd"
         style=filled
         label = "sg_2v1"
+        n8v1
         subgraph sg_2v1_var_rhs {
             cluster=true
             label="var rhs"
@@ -60,8 +66,8 @@ digraph {
         subgraph sg_3v1_var_my_join {
             cluster=true
             label="var my_join"
-            n7v1
-            n8v1
+            n9v1
+            n10v1
         }
     }
 }

--- a/dfir_rs/tests/snapshots/surface_lattice_bimorphism__cartesian_product_1401@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_lattice_bimorphism__cartesian_product_1401@graphvis_mermaid.snap
@@ -10,26 +10,31 @@ classDef otherClass fill:#fdc,stroke:#000,text-align:left,white-space:pre
 linkStyle default stroke:#aaa
 1v1[\"(1v1) <code>source_iter(0..1)</code>"/]:::pullClass
 2v1[\"(2v1) <code>map(SetUnionSingletonSet::new_from)</code>"/]:::pullClass
-3v1[\"(3v1) <code>state::&lt;'static, SetUnionHashSet&lt;u32&gt;&gt;()</code>"/]:::pullClass
+3v1[/"(3v1) <code>state::&lt;'static, SetUnionHashSet&lt;u32&gt;&gt;()</code>"\]:::pushClass
 4v1[\"(4v1) <code>source_iter(1..2)</code>"/]:::pullClass
 5v1[\"(5v1) <code>map(SetUnionSingletonSet::new_from)</code>"/]:::pullClass
-6v1[\"(6v1) <code>state::&lt;'static, SetUnionHashSet&lt;u32&gt;&gt;()</code>"/]:::pullClass
-7v1[\"(7v1) <code>lattice_bimorphism(CartesianProductBimorphism::&lt;HashSet&lt;_&gt;&gt;::default(), lhs, rhs)</code>"/]:::pullClass
-8v1[/"(8v1) <code>for_each(|x| out_send.send(x).unwrap())</code>"\]:::pushClass
-9v1["(9v1) <code>handoff</code>"]:::otherClass
-10v1["(10v1) <code>handoff</code>"]:::otherClass
+6v1[/"(6v1) <code>state::&lt;'static, SetUnionHashSet&lt;u32&gt;&gt;()</code>"\]:::pushClass
+7v1[/"(7v1) <code>null()</code>"\]:::pushClass
+8v1[/"(8v1) <code>null()</code>"\]:::pushClass
+9v1[\"(9v1) <code>lattice_bimorphism(CartesianProductBimorphism::&lt;HashSet&lt;_&gt;&gt;::default(), lhs, rhs)</code>"/]:::pullClass
+10v1[/"(10v1) <code>for_each(|x| out_send.send(x).unwrap())</code>"\]:::pushClass
+11v1["(11v1) <code>handoff</code>"]:::otherClass
+12v1["(12v1) <code>handoff</code>"]:::otherClass
 2v1-->3v1
 1v1-->2v1
 5v1-->6v1
 4v1-->5v1
-3v1-->9v1
-6v1-->10v1
-7v1-->8v1
-9v1-->|0|7v1
-10v1-->|1|7v1
-3v1--x7v1; linkStyle 9 stroke:red
-6v1--x7v1; linkStyle 10 stroke:red
+3v1-->|items|11v1
+6v1-->|items|12v1
+3v1-->|state|7v1
+6v1-->|state|8v1
+9v1-->10v1
+11v1-->|0|9v1
+12v1-->|1|9v1
+3v1--x9v1; linkStyle 11 stroke:red
+6v1--x9v1; linkStyle 12 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
+    7v1
     subgraph sg_1v1_var_lhs ["var <tt>lhs</tt>"]
         1v1
         2v1
@@ -37,6 +42,7 @@ subgraph sg_1v1 ["sg_1v1"]
     end
 end
 subgraph sg_2v1 ["sg_2v1"]
+    8v1
     subgraph sg_2v1_var_rhs ["var <tt>rhs</tt>"]
         4v1
         5v1
@@ -45,7 +51,7 @@ subgraph sg_2v1 ["sg_2v1"]
 end
 subgraph sg_3v1 ["sg_3v1"]
     subgraph sg_3v1_var_my_join ["var <tt>my_join</tt>"]
-        7v1
-        8v1
+        9v1
+        10v1
     end
 end

--- a/dfir_rs/tests/snapshots/surface_lattice_bimorphism__cartesian_product_tick_state@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_lattice_bimorphism__cartesian_product_tick_state@graphvis_dot.snap
@@ -7,32 +7,37 @@ digraph {
     edge [fontname="Monaco,Menlo,Consolas,&quot;Droid Sans Mono&quot;,Inconsolata,&quot;Courier New&quot;,monospace"];
     n1v1 [label="(n1v1) source_stream(lhs_recv)", shape=invhouse, fillcolor="#88aaff"]
     n2v1 [label="(n2v1) map(SetUnionSingletonSet::new_from)", shape=invhouse, fillcolor="#88aaff"]
-    n3v1 [label="(n3v1) state::<'tick, SetUnionHashSet<u32>>()", shape=invhouse, fillcolor="#88aaff"]
+    n3v1 [label="(n3v1) state::<'tick, SetUnionHashSet<u32>>()", shape=house, fillcolor="#ffff88"]
     n4v1 [label="(n4v1) source_stream(rhs_recv)", shape=invhouse, fillcolor="#88aaff"]
     n5v1 [label="(n5v1) map(SetUnionSingletonSet::new_from)", shape=invhouse, fillcolor="#88aaff"]
-    n6v1 [label="(n6v1) state::<'tick, SetUnionHashSet<u32>>()", shape=invhouse, fillcolor="#88aaff"]
-    n7v1 [label="(n7v1) lattice_bimorphism(CartesianProductBimorphism::<HashSet<_>>::default(), lhs, rhs)", shape=invhouse, fillcolor="#88aaff"]
-    n8v1 [label="(n8v1) inspect(|x| println!(\"{:?}: {:?}\", context.current_tick(), x))", shape=invhouse, fillcolor="#88aaff"]
-    n9v1 [label="(n9v1) for_each(|x| out_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
-    n10v1 [label="(n10v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n11v1 [label="(n11v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
+    n6v1 [label="(n6v1) state::<'tick, SetUnionHashSet<u32>>()", shape=house, fillcolor="#ffff88"]
+    n7v1 [label="(n7v1) null()", shape=house, fillcolor="#ffff88"]
+    n8v1 [label="(n8v1) null()", shape=house, fillcolor="#ffff88"]
+    n9v1 [label="(n9v1) lattice_bimorphism(CartesianProductBimorphism::<HashSet<_>>::default(), lhs, rhs)", shape=invhouse, fillcolor="#88aaff"]
+    n10v1 [label="(n10v1) inspect(|x| println!(\"{:?}: {:?}\", context.current_tick(), x))", shape=invhouse, fillcolor="#88aaff"]
+    n11v1 [label="(n11v1) for_each(|x| out_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
+    n12v1 [label="(n12v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
+    n13v1 [label="(n13v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n2v1 -> n3v1
     n1v1 -> n2v1
     n5v1 -> n6v1
     n4v1 -> n5v1
-    n3v1 -> n10v1 [label="items"]
-    n6v1 -> n11v1 [label="items"]
-    n8v1 -> n9v1
-    n7v1 -> n8v1
-    n10v1 -> n7v1 [label="0"]
-    n11v1 -> n7v1 [label="1"]
-    n3v1 -> n7v1 [color=red]
-    n6v1 -> n7v1 [color=red]
+    n3v1 -> n12v1 [label="items"]
+    n6v1 -> n13v1 [label="items"]
+    n3v1 -> n7v1 [label="state"]
+    n6v1 -> n8v1 [label="state"]
+    n10v1 -> n11v1
+    n9v1 -> n10v1
+    n12v1 -> n9v1 [label="0"]
+    n13v1 -> n9v1 [label="1"]
+    n3v1 -> n9v1 [color=red]
+    n6v1 -> n9v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
         style=filled
         label = "sg_1v1"
+        n7v1
         subgraph sg_1v1_var_lhs {
             cluster=true
             label="var lhs"
@@ -46,6 +51,7 @@ digraph {
         fillcolor="#dddddd"
         style=filled
         label = "sg_2v1"
+        n8v1
         subgraph sg_2v1_var_rhs {
             cluster=true
             label="var rhs"
@@ -62,9 +68,9 @@ digraph {
         subgraph sg_3v1_var_my_join {
             cluster=true
             label="var my_join"
-            n7v1
-            n8v1
             n9v1
+            n10v1
+            n11v1
         }
     }
 }

--- a/dfir_rs/tests/snapshots/surface_lattice_bimorphism__cartesian_product_tick_state@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_lattice_bimorphism__cartesian_product_tick_state@graphvis_mermaid.snap
@@ -10,28 +10,33 @@ classDef otherClass fill:#fdc,stroke:#000,text-align:left,white-space:pre
 linkStyle default stroke:#aaa
 1v1[\"(1v1) <code>source_stream(lhs_recv)</code>"/]:::pullClass
 2v1[\"(2v1) <code>map(SetUnionSingletonSet::new_from)</code>"/]:::pullClass
-3v1[\"(3v1) <code>state::&lt;'tick, SetUnionHashSet&lt;u32&gt;&gt;()</code>"/]:::pullClass
+3v1[/"(3v1) <code>state::&lt;'tick, SetUnionHashSet&lt;u32&gt;&gt;()</code>"\]:::pushClass
 4v1[\"(4v1) <code>source_stream(rhs_recv)</code>"/]:::pullClass
 5v1[\"(5v1) <code>map(SetUnionSingletonSet::new_from)</code>"/]:::pullClass
-6v1[\"(6v1) <code>state::&lt;'tick, SetUnionHashSet&lt;u32&gt;&gt;()</code>"/]:::pullClass
-7v1[\"(7v1) <code>lattice_bimorphism(CartesianProductBimorphism::&lt;HashSet&lt;_&gt;&gt;::default(), lhs, rhs)</code>"/]:::pullClass
-8v1[\"(8v1) <code>inspect(|x| println!(&quot;{:?}: {:?}&quot;, context.current_tick(), x))</code>"/]:::pullClass
-9v1[/"(9v1) <code>for_each(|x| out_send.send(x).unwrap())</code>"\]:::pushClass
-10v1["(10v1) <code>handoff</code>"]:::otherClass
-11v1["(11v1) <code>handoff</code>"]:::otherClass
+6v1[/"(6v1) <code>state::&lt;'tick, SetUnionHashSet&lt;u32&gt;&gt;()</code>"\]:::pushClass
+7v1[/"(7v1) <code>null()</code>"\]:::pushClass
+8v1[/"(8v1) <code>null()</code>"\]:::pushClass
+9v1[\"(9v1) <code>lattice_bimorphism(CartesianProductBimorphism::&lt;HashSet&lt;_&gt;&gt;::default(), lhs, rhs)</code>"/]:::pullClass
+10v1[\"(10v1) <code>inspect(|x| println!(&quot;{:?}: {:?}&quot;, context.current_tick(), x))</code>"/]:::pullClass
+11v1[/"(11v1) <code>for_each(|x| out_send.send(x).unwrap())</code>"\]:::pushClass
+12v1["(12v1) <code>handoff</code>"]:::otherClass
+13v1["(13v1) <code>handoff</code>"]:::otherClass
 2v1-->3v1
 1v1-->2v1
 5v1-->6v1
 4v1-->5v1
-3v1-->|items|10v1
-6v1-->|items|11v1
-8v1-->9v1
-7v1-->8v1
-10v1-->|0|7v1
-11v1-->|1|7v1
-3v1--x7v1; linkStyle 10 stroke:red
-6v1--x7v1; linkStyle 11 stroke:red
+3v1-->|items|12v1
+6v1-->|items|13v1
+3v1-->|state|7v1
+6v1-->|state|8v1
+10v1-->11v1
+9v1-->10v1
+12v1-->|0|9v1
+13v1-->|1|9v1
+3v1--x9v1; linkStyle 12 stroke:red
+6v1--x9v1; linkStyle 13 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
+    7v1
     subgraph sg_1v1_var_lhs ["var <tt>lhs</tt>"]
         1v1
         2v1
@@ -39,6 +44,7 @@ subgraph sg_1v1 ["sg_1v1"]
     end
 end
 subgraph sg_2v1 ["sg_2v1"]
+    8v1
     subgraph sg_2v1_var_rhs ["var <tt>rhs</tt>"]
         4v1
         5v1
@@ -47,8 +53,8 @@ subgraph sg_2v1 ["sg_2v1"]
 end
 subgraph sg_3v1 ["sg_3v1"]
     subgraph sg_3v1_var_my_join ["var <tt>my_join</tt>"]
-        7v1
-        8v1
         9v1
+        10v1
+        11v1
     end
 end

--- a/dfir_rs/tests/snapshots/surface_lattice_bimorphism__join@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_lattice_bimorphism__join@graphvis_dot.snap
@@ -7,30 +7,35 @@ digraph {
     edge [fontname="Monaco,Menlo,Consolas,&quot;Droid Sans Mono&quot;,Inconsolata,&quot;Courier New&quot;,monospace"];
     n1v1 [label="(n1v1) source_iter([(7, 1), (7, 2)])", shape=invhouse, fillcolor="#88aaff"]
     n2v1 [label="(n2v1) map(|(k, v)| MapUnionSingletonMap::new_from((k, SetUnionSingletonSet::new_from(v))))", shape=invhouse, fillcolor="#88aaff"]
-    n3v1 [label="(n3v1) state::<'static, MapUnionHashMap<usize, SetUnionHashSet<usize>>>()", shape=invhouse, fillcolor="#88aaff"]
+    n3v1 [label="(n3v1) state::<'static, MapUnionHashMap<usize, SetUnionHashSet<usize>>>()", shape=house, fillcolor="#ffff88"]
     n4v1 [label="(n4v1) source_iter([(7, 0), (7, 1), (7, 2)])", shape=invhouse, fillcolor="#88aaff"]
     n5v1 [label="(n5v1) map(|(k, v)| MapUnionSingletonMap::new_from((k, SetUnionSingletonSet::new_from(v))))", shape=invhouse, fillcolor="#88aaff"]
-    n6v1 [label="(n6v1) state::<'static, MapUnionHashMap<usize, SetUnionHashSet<usize>>>()", shape=invhouse, fillcolor="#88aaff"]
-    n7v1 [label="(n7v1) lattice_bimorphism(\l    KeyedBimorphism::<\l        HashMap<_, _>,\l        _,\l    >::new(CartesianProductBimorphism::<HashSet<_>>::default()),\l    lhs,\l    rhs,\l)\l", shape=invhouse, fillcolor="#88aaff"]
-    n8v1 [label="(n8v1) for_each(|x| out_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
-    n9v1 [label="(n9v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n10v1 [label="(n10v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
+    n6v1 [label="(n6v1) state::<'static, MapUnionHashMap<usize, SetUnionHashSet<usize>>>()", shape=house, fillcolor="#ffff88"]
+    n7v1 [label="(n7v1) null()", shape=house, fillcolor="#ffff88"]
+    n8v1 [label="(n8v1) null()", shape=house, fillcolor="#ffff88"]
+    n9v1 [label="(n9v1) lattice_bimorphism(\l    KeyedBimorphism::<\l        HashMap<_, _>,\l        _,\l    >::new(CartesianProductBimorphism::<HashSet<_>>::default()),\l    lhs,\l    rhs,\l)\l", shape=invhouse, fillcolor="#88aaff"]
+    n10v1 [label="(n10v1) for_each(|x| out_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
+    n11v1 [label="(n11v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
+    n12v1 [label="(n12v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n2v1 -> n3v1
     n1v1 -> n2v1
     n5v1 -> n6v1
     n4v1 -> n5v1
-    n3v1 -> n9v1
-    n6v1 -> n10v1
-    n7v1 -> n8v1
-    n9v1 -> n7v1 [label="0"]
-    n10v1 -> n7v1 [label="1"]
-    n3v1 -> n7v1 [color=red]
-    n6v1 -> n7v1 [color=red]
+    n3v1 -> n11v1 [label="items"]
+    n6v1 -> n12v1 [label="items"]
+    n3v1 -> n7v1 [label="state"]
+    n6v1 -> n8v1 [label="state"]
+    n9v1 -> n10v1
+    n11v1 -> n9v1 [label="0"]
+    n12v1 -> n9v1 [label="1"]
+    n3v1 -> n9v1 [color=red]
+    n6v1 -> n9v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
         style=filled
         label = "sg_1v1"
+        n7v1
         subgraph sg_1v1_var_lhs {
             cluster=true
             label="var lhs"
@@ -44,6 +49,7 @@ digraph {
         fillcolor="#dddddd"
         style=filled
         label = "sg_2v1"
+        n8v1
         subgraph sg_2v1_var_rhs {
             cluster=true
             label="var rhs"
@@ -60,8 +66,8 @@ digraph {
         subgraph sg_3v1_var_my_join {
             cluster=true
             label="var my_join"
-            n7v1
-            n8v1
+            n9v1
+            n10v1
         }
     }
 }

--- a/dfir_rs/tests/snapshots/surface_lattice_bimorphism__join@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_lattice_bimorphism__join@graphvis_mermaid.snap
@@ -10,26 +10,31 @@ classDef otherClass fill:#fdc,stroke:#000,text-align:left,white-space:pre
 linkStyle default stroke:#aaa
 1v1[\"(1v1) <code>source_iter([(7, 1), (7, 2)])</code>"/]:::pullClass
 2v1[\"(2v1) <code>map(|(k, v)| MapUnionSingletonMap::new_from((k, SetUnionSingletonSet::new_from(v))))</code>"/]:::pullClass
-3v1[\"(3v1) <code>state::&lt;'static, MapUnionHashMap&lt;usize, SetUnionHashSet&lt;usize&gt;&gt;&gt;()</code>"/]:::pullClass
+3v1[/"(3v1) <code>state::&lt;'static, MapUnionHashMap&lt;usize, SetUnionHashSet&lt;usize&gt;&gt;&gt;()</code>"\]:::pushClass
 4v1[\"(4v1) <code>source_iter([(7, 0), (7, 1), (7, 2)])</code>"/]:::pullClass
 5v1[\"(5v1) <code>map(|(k, v)| MapUnionSingletonMap::new_from((k, SetUnionSingletonSet::new_from(v))))</code>"/]:::pullClass
-6v1[\"(6v1) <code>state::&lt;'static, MapUnionHashMap&lt;usize, SetUnionHashSet&lt;usize&gt;&gt;&gt;()</code>"/]:::pullClass
-7v1[\"<div style=text-align:center>(7v1)</div> <code>lattice_bimorphism(<br>    KeyedBimorphism::&lt;<br>        HashMap&lt;_, _&gt;,<br>        _,<br>    &gt;::new(CartesianProductBimorphism::&lt;HashSet&lt;_&gt;&gt;::default()),<br>    lhs,<br>    rhs,<br>)</code>"/]:::pullClass
-8v1[/"(8v1) <code>for_each(|x| out_send.send(x).unwrap())</code>"\]:::pushClass
-9v1["(9v1) <code>handoff</code>"]:::otherClass
-10v1["(10v1) <code>handoff</code>"]:::otherClass
+6v1[/"(6v1) <code>state::&lt;'static, MapUnionHashMap&lt;usize, SetUnionHashSet&lt;usize&gt;&gt;&gt;()</code>"\]:::pushClass
+7v1[/"(7v1) <code>null()</code>"\]:::pushClass
+8v1[/"(8v1) <code>null()</code>"\]:::pushClass
+9v1[\"<div style=text-align:center>(9v1)</div> <code>lattice_bimorphism(<br>    KeyedBimorphism::&lt;<br>        HashMap&lt;_, _&gt;,<br>        _,<br>    &gt;::new(CartesianProductBimorphism::&lt;HashSet&lt;_&gt;&gt;::default()),<br>    lhs,<br>    rhs,<br>)</code>"/]:::pullClass
+10v1[/"(10v1) <code>for_each(|x| out_send.send(x).unwrap())</code>"\]:::pushClass
+11v1["(11v1) <code>handoff</code>"]:::otherClass
+12v1["(12v1) <code>handoff</code>"]:::otherClass
 2v1-->3v1
 1v1-->2v1
 5v1-->6v1
 4v1-->5v1
-3v1-->9v1
-6v1-->10v1
-7v1-->8v1
-9v1-->|0|7v1
-10v1-->|1|7v1
-3v1--x7v1; linkStyle 9 stroke:red
-6v1--x7v1; linkStyle 10 stroke:red
+3v1-->|items|11v1
+6v1-->|items|12v1
+3v1-->|state|7v1
+6v1-->|state|8v1
+9v1-->10v1
+11v1-->|0|9v1
+12v1-->|1|9v1
+3v1--x9v1; linkStyle 11 stroke:red
+6v1--x9v1; linkStyle 12 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
+    7v1
     subgraph sg_1v1_var_lhs ["var <tt>lhs</tt>"]
         1v1
         2v1
@@ -37,6 +42,7 @@ subgraph sg_1v1 ["sg_1v1"]
     end
 end
 subgraph sg_2v1 ["sg_2v1"]
+    8v1
     subgraph sg_2v1_var_rhs ["var <tt>rhs</tt>"]
         4v1
         5v1
@@ -45,7 +51,7 @@ subgraph sg_2v1 ["sg_2v1"]
 end
 subgraph sg_3v1 ["sg_3v1"]
     subgraph sg_3v1_var_my_join ["var <tt>my_join</tt>"]
-        7v1
-        8v1
+        9v1
+        10v1
     end
 end

--- a/dfir_rs/tests/snapshots/surface_lattice_bimorphism_persist_insertion__cartesian_product_multi_tick@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_lattice_bimorphism_persist_insertion__cartesian_product_multi_tick@graphvis_dot.snap
@@ -7,34 +7,39 @@ digraph {
     edge [fontname="Monaco,Menlo,Consolas,&quot;Droid Sans Mono&quot;,Inconsolata,&quot;Courier New&quot;,monospace"];
     n1v1 [label="(n1v1) source_stream(lhs_recv)", shape=invhouse, fillcolor="#88aaff"]
     n2v1 [label="(n2v1) map(SetUnionSingletonSet::new_from)", shape=invhouse, fillcolor="#88aaff"]
-    n3v1 [label="(n3v1) state::<'static, SetUnionHashSet<u32>>()", shape=invhouse, fillcolor="#88aaff"]
+    n3v1 [label="(n3v1) state::<'static, SetUnionHashSet<u32>>()", shape=house, fillcolor="#ffff88"]
     n4v1 [label="(n4v1) source_stream(rhs_recv)", shape=invhouse, fillcolor="#88aaff"]
     n5v1 [label="(n5v1) map(SetUnionSingletonSet::new_from)", shape=invhouse, fillcolor="#88aaff"]
-    n6v1 [label="(n6v1) state::<'static, SetUnionHashSet<u32>>()", shape=invhouse, fillcolor="#88aaff"]
-    n7v1 [label="(n7v1) lattice_bimorphism(CartesianProductBimorphism::<HashSet<_>>::default(), lhs, rhs)", shape=invhouse, fillcolor="#88aaff"]
-    n8v1 [label="(n8v1) lattice_reduce()", shape=invhouse, fillcolor="#88aaff"]
-    n9v1 [label="(n9v1) for_each(|x| out_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
-    n10v1 [label="(n10v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n11v1 [label="(n11v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
+    n6v1 [label="(n6v1) state::<'static, SetUnionHashSet<u32>>()", shape=house, fillcolor="#ffff88"]
+    n7v1 [label="(n7v1) null()", shape=house, fillcolor="#ffff88"]
+    n8v1 [label="(n8v1) null()", shape=house, fillcolor="#ffff88"]
+    n9v1 [label="(n9v1) lattice_bimorphism(CartesianProductBimorphism::<HashSet<_>>::default(), lhs, rhs)", shape=invhouse, fillcolor="#88aaff"]
+    n10v1 [label="(n10v1) lattice_reduce()", shape=invhouse, fillcolor="#88aaff"]
+    n11v1 [label="(n11v1) for_each(|x| out_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
     n12v1 [label="(n12v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
+    n13v1 [label="(n13v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
+    n14v1 [label="(n14v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n2v1 -> n3v1
     n1v1 -> n2v1
     n5v1 -> n6v1
     n4v1 -> n5v1
-    n3v1 -> n10v1
-    n6v1 -> n11v1
-    n8v1 -> n9v1
-    n7v1 -> n12v1
-    n10v1 -> n7v1 [label="0"]
-    n11v1 -> n7v1 [label="1"]
-    n12v1 -> n8v1 [color=red]
-    n3v1 -> n7v1 [color=red]
-    n6v1 -> n7v1 [color=red]
+    n3v1 -> n12v1 [label="items"]
+    n6v1 -> n13v1 [label="items"]
+    n3v1 -> n7v1 [label="state"]
+    n6v1 -> n8v1 [label="state"]
+    n10v1 -> n11v1
+    n9v1 -> n14v1
+    n12v1 -> n9v1 [label="0"]
+    n13v1 -> n9v1 [label="1"]
+    n14v1 -> n10v1 [color=red]
+    n3v1 -> n9v1 [color=red]
+    n6v1 -> n9v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
         style=filled
         label = "sg_1v1"
+        n7v1
         subgraph sg_1v1_var_lhs {
             cluster=true
             label="var lhs"
@@ -48,6 +53,7 @@ digraph {
         fillcolor="#dddddd"
         style=filled
         label = "sg_2v1"
+        n8v1
         subgraph sg_2v1_var_rhs {
             cluster=true
             label="var rhs"
@@ -64,7 +70,7 @@ digraph {
         subgraph sg_3v1_var_my_join {
             cluster=true
             label="var my_join"
-            n7v1
+            n9v1
         }
     }
     subgraph sg_4v1 {
@@ -75,8 +81,8 @@ digraph {
         subgraph sg_4v1_var_my_join {
             cluster=true
             label="var my_join"
-            n8v1
-            n9v1
+            n10v1
+            n11v1
         }
     }
 }

--- a/dfir_rs/tests/snapshots/surface_lattice_bimorphism_persist_insertion__cartesian_product_multi_tick@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_lattice_bimorphism_persist_insertion__cartesian_product_multi_tick@graphvis_mermaid.snap
@@ -10,30 +10,35 @@ classDef otherClass fill:#fdc,stroke:#000,text-align:left,white-space:pre
 linkStyle default stroke:#aaa
 1v1[\"(1v1) <code>source_stream(lhs_recv)</code>"/]:::pullClass
 2v1[\"(2v1) <code>map(SetUnionSingletonSet::new_from)</code>"/]:::pullClass
-3v1[\"(3v1) <code>state::&lt;'static, SetUnionHashSet&lt;u32&gt;&gt;()</code>"/]:::pullClass
+3v1[/"(3v1) <code>state::&lt;'static, SetUnionHashSet&lt;u32&gt;&gt;()</code>"\]:::pushClass
 4v1[\"(4v1) <code>source_stream(rhs_recv)</code>"/]:::pullClass
 5v1[\"(5v1) <code>map(SetUnionSingletonSet::new_from)</code>"/]:::pullClass
-6v1[\"(6v1) <code>state::&lt;'static, SetUnionHashSet&lt;u32&gt;&gt;()</code>"/]:::pullClass
-7v1[\"(7v1) <code>lattice_bimorphism(CartesianProductBimorphism::&lt;HashSet&lt;_&gt;&gt;::default(), lhs, rhs)</code>"/]:::pullClass
-8v1[\"(8v1) <code>lattice_reduce()</code>"/]:::pullClass
-9v1[/"(9v1) <code>for_each(|x| out_send.send(x).unwrap())</code>"\]:::pushClass
-10v1["(10v1) <code>handoff</code>"]:::otherClass
-11v1["(11v1) <code>handoff</code>"]:::otherClass
+6v1[/"(6v1) <code>state::&lt;'static, SetUnionHashSet&lt;u32&gt;&gt;()</code>"\]:::pushClass
+7v1[/"(7v1) <code>null()</code>"\]:::pushClass
+8v1[/"(8v1) <code>null()</code>"\]:::pushClass
+9v1[\"(9v1) <code>lattice_bimorphism(CartesianProductBimorphism::&lt;HashSet&lt;_&gt;&gt;::default(), lhs, rhs)</code>"/]:::pullClass
+10v1[\"(10v1) <code>lattice_reduce()</code>"/]:::pullClass
+11v1[/"(11v1) <code>for_each(|x| out_send.send(x).unwrap())</code>"\]:::pushClass
 12v1["(12v1) <code>handoff</code>"]:::otherClass
+13v1["(13v1) <code>handoff</code>"]:::otherClass
+14v1["(14v1) <code>handoff</code>"]:::otherClass
 2v1-->3v1
 1v1-->2v1
 5v1-->6v1
 4v1-->5v1
-3v1-->10v1
-6v1-->11v1
-8v1-->9v1
-7v1-->12v1
-10v1-->|0|7v1
-11v1-->|1|7v1
-12v1-->8v1; linkStyle 10 stroke:#060
-3v1--x7v1; linkStyle 11 stroke:red
-6v1--x7v1; linkStyle 12 stroke:red
+3v1-->|items|12v1
+6v1-->|items|13v1
+3v1-->|state|7v1
+6v1-->|state|8v1
+10v1-->11v1
+9v1-->14v1
+12v1-->|0|9v1
+13v1-->|1|9v1
+14v1-->10v1; linkStyle 12 stroke:#060
+3v1--x9v1; linkStyle 13 stroke:red
+6v1--x9v1; linkStyle 14 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
+    7v1
     subgraph sg_1v1_var_lhs ["var <tt>lhs</tt>"]
         1v1
         2v1
@@ -41,6 +46,7 @@ subgraph sg_1v1 ["sg_1v1"]
     end
 end
 subgraph sg_2v1 ["sg_2v1"]
+    8v1
     subgraph sg_2v1_var_rhs ["var <tt>rhs</tt>"]
         4v1
         5v1
@@ -49,12 +55,12 @@ subgraph sg_2v1 ["sg_2v1"]
 end
 subgraph sg_3v1 ["sg_3v1"]
     subgraph sg_3v1_var_my_join ["var <tt>my_join</tt>"]
-        7v1
+        9v1
     end
 end
 subgraph sg_4v1 ["sg_4v1"]
     subgraph sg_4v1_var_my_join ["var <tt>my_join</tt>"]
-        8v1
-        9v1
+        10v1
+        11v1
     end
 end

--- a/dfir_rs/tests/snapshots/surface_lattice_bimorphism_persist_insertion__cartesian_product_multi_tick_identity@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_lattice_bimorphism_persist_insertion__cartesian_product_multi_tick_identity@graphvis_dot.snap
@@ -7,36 +7,41 @@ digraph {
     edge [fontname="Monaco,Menlo,Consolas,&quot;Droid Sans Mono&quot;,Inconsolata,&quot;Courier New&quot;,monospace"];
     n1v1 [label="(n1v1) source_stream(lhs_recv)", shape=invhouse, fillcolor="#88aaff"]
     n2v1 [label="(n2v1) map(SetUnionSingletonSet::new_from)", shape=invhouse, fillcolor="#88aaff"]
-    n3v1 [label="(n3v1) state::<'static, SetUnionHashSet<u32>>()", shape=invhouse, fillcolor="#88aaff"]
+    n3v1 [label="(n3v1) state::<'static, SetUnionHashSet<u32>>()", shape=house, fillcolor="#ffff88"]
     n4v1 [label="(n4v1) source_stream(rhs_recv)", shape=invhouse, fillcolor="#88aaff"]
     n5v1 [label="(n5v1) map(SetUnionSingletonSet::new_from)", shape=invhouse, fillcolor="#88aaff"]
-    n6v1 [label="(n6v1) state::<'static, SetUnionHashSet<u32>>()", shape=invhouse, fillcolor="#88aaff"]
-    n7v1 [label="(n7v1) identity()", shape=invhouse, fillcolor="#88aaff"]
-    n8v1 [label="(n8v1) lattice_bimorphism(CartesianProductBimorphism::<HashSet<_>>::default(), lhs, rhs)", shape=invhouse, fillcolor="#88aaff"]
-    n9v1 [label="(n9v1) lattice_reduce()", shape=invhouse, fillcolor="#88aaff"]
-    n10v1 [label="(n10v1) for_each(|x| out_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
-    n11v1 [label="(n11v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n12v1 [label="(n12v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
+    n6v1 [label="(n6v1) state::<'static, SetUnionHashSet<u32>>()", shape=house, fillcolor="#ffff88"]
+    n7v1 [label="(n7v1) identity()", shape=house, fillcolor="#ffff88"]
+    n8v1 [label="(n8v1) null()", shape=house, fillcolor="#ffff88"]
+    n9v1 [label="(n9v1) null()", shape=house, fillcolor="#ffff88"]
+    n10v1 [label="(n10v1) lattice_bimorphism(CartesianProductBimorphism::<HashSet<_>>::default(), lhs, rhs)", shape=invhouse, fillcolor="#88aaff"]
+    n11v1 [label="(n11v1) lattice_reduce()", shape=invhouse, fillcolor="#88aaff"]
+    n12v1 [label="(n12v1) for_each(|x| out_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
     n13v1 [label="(n13v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
+    n14v1 [label="(n14v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
+    n15v1 [label="(n15v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n2v1 -> n3v1
     n1v1 -> n2v1
     n5v1 -> n6v1
     n4v1 -> n5v1
-    n6v1 -> n11v1
-    n3v1 -> n12v1
-    n7v1 -> n8v1 [label="1"]
-    n9v1 -> n10v1
-    n8v1 -> n13v1
-    n11v1 -> n7v1
-    n12v1 -> n8v1 [label="0"]
-    n13v1 -> n9v1 [color=red]
-    n3v1 -> n8v1 [color=red]
-    n6v1 -> n8v1 [color=red]
+    n6v1 -> n7v1 [label="items"]
+    n3v1 -> n8v1 [label="state"]
+    n6v1 -> n9v1 [label="state"]
+    n3v1 -> n13v1 [label="items"]
+    n7v1 -> n14v1
+    n11v1 -> n12v1
+    n10v1 -> n15v1
+    n13v1 -> n10v1 [label="0"]
+    n14v1 -> n10v1 [label="1"]
+    n15v1 -> n11v1 [color=red]
+    n3v1 -> n10v1 [color=red]
+    n6v1 -> n10v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
         style=filled
         label = "sg_1v1"
+        n8v1
         subgraph sg_1v1_var_lhs {
             cluster=true
             label="var lhs"
@@ -50,12 +55,18 @@ digraph {
         fillcolor="#dddddd"
         style=filled
         label = "sg_2v1"
+        n9v1
         subgraph sg_2v1_var_rhs {
             cluster=true
             label="var rhs"
             n4v1
             n5v1
             n6v1
+        }
+        subgraph sg_2v1_var_rhs_id {
+            cluster=true
+            label="var rhs_id"
+            n7v1
         }
     }
     subgraph sg_3v1 {
@@ -66,12 +77,7 @@ digraph {
         subgraph sg_3v1_var_my_join {
             cluster=true
             label="var my_join"
-            n8v1
-        }
-        subgraph sg_3v1_var_rhs_id {
-            cluster=true
-            label="var rhs_id"
-            n7v1
+            n10v1
         }
     }
     subgraph sg_4v1 {
@@ -82,8 +88,8 @@ digraph {
         subgraph sg_4v1_var_my_join {
             cluster=true
             label="var my_join"
-            n9v1
-            n10v1
+            n11v1
+            n12v1
         }
     }
 }

--- a/dfir_rs/tests/snapshots/surface_lattice_bimorphism_persist_insertion__cartesian_product_multi_tick_identity@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_lattice_bimorphism_persist_insertion__cartesian_product_multi_tick_identity@graphvis_mermaid.snap
@@ -10,32 +10,37 @@ classDef otherClass fill:#fdc,stroke:#000,text-align:left,white-space:pre
 linkStyle default stroke:#aaa
 1v1[\"(1v1) <code>source_stream(lhs_recv)</code>"/]:::pullClass
 2v1[\"(2v1) <code>map(SetUnionSingletonSet::new_from)</code>"/]:::pullClass
-3v1[\"(3v1) <code>state::&lt;'static, SetUnionHashSet&lt;u32&gt;&gt;()</code>"/]:::pullClass
+3v1[/"(3v1) <code>state::&lt;'static, SetUnionHashSet&lt;u32&gt;&gt;()</code>"\]:::pushClass
 4v1[\"(4v1) <code>source_stream(rhs_recv)</code>"/]:::pullClass
 5v1[\"(5v1) <code>map(SetUnionSingletonSet::new_from)</code>"/]:::pullClass
-6v1[\"(6v1) <code>state::&lt;'static, SetUnionHashSet&lt;u32&gt;&gt;()</code>"/]:::pullClass
-7v1[\"(7v1) <code>identity()</code>"/]:::pullClass
-8v1[\"(8v1) <code>lattice_bimorphism(CartesianProductBimorphism::&lt;HashSet&lt;_&gt;&gt;::default(), lhs, rhs)</code>"/]:::pullClass
-9v1[\"(9v1) <code>lattice_reduce()</code>"/]:::pullClass
-10v1[/"(10v1) <code>for_each(|x| out_send.send(x).unwrap())</code>"\]:::pushClass
-11v1["(11v1) <code>handoff</code>"]:::otherClass
-12v1["(12v1) <code>handoff</code>"]:::otherClass
+6v1[/"(6v1) <code>state::&lt;'static, SetUnionHashSet&lt;u32&gt;&gt;()</code>"\]:::pushClass
+7v1[/"(7v1) <code>identity()</code>"\]:::pushClass
+8v1[/"(8v1) <code>null()</code>"\]:::pushClass
+9v1[/"(9v1) <code>null()</code>"\]:::pushClass
+10v1[\"(10v1) <code>lattice_bimorphism(CartesianProductBimorphism::&lt;HashSet&lt;_&gt;&gt;::default(), lhs, rhs)</code>"/]:::pullClass
+11v1[\"(11v1) <code>lattice_reduce()</code>"/]:::pullClass
+12v1[/"(12v1) <code>for_each(|x| out_send.send(x).unwrap())</code>"\]:::pushClass
 13v1["(13v1) <code>handoff</code>"]:::otherClass
+14v1["(14v1) <code>handoff</code>"]:::otherClass
+15v1["(15v1) <code>handoff</code>"]:::otherClass
 2v1-->3v1
 1v1-->2v1
 5v1-->6v1
 4v1-->5v1
-6v1-->11v1
-3v1-->12v1
-7v1-->|1|8v1
-9v1-->10v1
-8v1-->13v1
-11v1-->7v1
-12v1-->|0|8v1
-13v1-->9v1; linkStyle 11 stroke:#060
-3v1--x8v1; linkStyle 12 stroke:red
-6v1--x8v1; linkStyle 13 stroke:red
+6v1-->|items|7v1
+3v1-->|state|8v1
+6v1-->|state|9v1
+3v1-->|items|13v1
+7v1-->14v1
+11v1-->12v1
+10v1-->15v1
+13v1-->|0|10v1
+14v1-->|1|10v1
+15v1-->11v1; linkStyle 13 stroke:#060
+3v1--x10v1; linkStyle 14 stroke:red
+6v1--x10v1; linkStyle 15 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
+    8v1
     subgraph sg_1v1_var_lhs ["var <tt>lhs</tt>"]
         1v1
         2v1
@@ -43,23 +48,24 @@ subgraph sg_1v1 ["sg_1v1"]
     end
 end
 subgraph sg_2v1 ["sg_2v1"]
+    9v1
     subgraph sg_2v1_var_rhs ["var <tt>rhs</tt>"]
         4v1
         5v1
         6v1
     end
+    subgraph sg_2v1_var_rhs_id ["var <tt>rhs_id</tt>"]
+        7v1
+    end
 end
 subgraph sg_3v1 ["sg_3v1"]
     subgraph sg_3v1_var_my_join ["var <tt>my_join</tt>"]
-        8v1
-    end
-    subgraph sg_3v1_var_rhs_id ["var <tt>rhs_id</tt>"]
-        7v1
+        10v1
     end
 end
 subgraph sg_4v1 ["sg_4v1"]
     subgraph sg_4v1_var_my_join ["var <tt>my_join</tt>"]
-        9v1
-        10v1
+        11v1
+        12v1
     end
 end

--- a/dfir_rs/tests/snapshots/surface_lattice_bimorphism_persist_insertion__cartesian_product_multi_tick_tee@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_lattice_bimorphism_persist_insertion__cartesian_product_multi_tick_tee@graphvis_dot.snap
@@ -7,38 +7,43 @@ digraph {
     edge [fontname="Monaco,Menlo,Consolas,&quot;Droid Sans Mono&quot;,Inconsolata,&quot;Courier New&quot;,monospace"];
     n1v1 [label="(n1v1) source_stream(lhs_recv)", shape=invhouse, fillcolor="#88aaff"]
     n2v1 [label="(n2v1) map(SetUnionSingletonSet::new_from)", shape=invhouse, fillcolor="#88aaff"]
-    n3v1 [label="(n3v1) state::<'static, SetUnionHashSet<u32>>()", shape=invhouse, fillcolor="#88aaff"]
+    n3v1 [label="(n3v1) state::<'static, SetUnionHashSet<u32>>()", shape=house, fillcolor="#ffff88"]
     n4v1 [label="(n4v1) source_stream(rhs_recv)", shape=invhouse, fillcolor="#88aaff"]
     n5v1 [label="(n5v1) map(SetUnionSingletonSet::new_from)", shape=invhouse, fillcolor="#88aaff"]
-    n6v1 [label="(n6v1) state::<'static, SetUnionHashSet<u32>>()", shape=invhouse, fillcolor="#88aaff"]
+    n6v1 [label="(n6v1) state::<'static, SetUnionHashSet<u32>>()", shape=house, fillcolor="#ffff88"]
     n7v1 [label="(n7v1) tee()", shape=house, fillcolor="#ffff88"]
     n8v1 [label="(n8v1) for_each(|x| println!(\"tee: {:?}\", x))", shape=house, fillcolor="#ffff88"]
-    n9v1 [label="(n9v1) lattice_bimorphism(CartesianProductBimorphism::<HashSet<_>>::default(), lhs, rhs)", shape=invhouse, fillcolor="#88aaff"]
-    n10v1 [label="(n10v1) lattice_reduce()", shape=invhouse, fillcolor="#88aaff"]
-    n11v1 [label="(n11v1) for_each(|x| out_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
-    n12v1 [label="(n12v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n13v1 [label="(n13v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
+    n9v1 [label="(n9v1) null()", shape=house, fillcolor="#ffff88"]
+    n10v1 [label="(n10v1) null()", shape=house, fillcolor="#ffff88"]
+    n11v1 [label="(n11v1) lattice_bimorphism(CartesianProductBimorphism::<HashSet<_>>::default(), lhs, rhs)", shape=invhouse, fillcolor="#88aaff"]
+    n12v1 [label="(n12v1) lattice_reduce()", shape=invhouse, fillcolor="#88aaff"]
+    n13v1 [label="(n13v1) for_each(|x| out_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
     n14v1 [label="(n14v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
+    n15v1 [label="(n15v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
+    n16v1 [label="(n16v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
     n2v1 -> n3v1
     n1v1 -> n2v1
     n5v1 -> n6v1
     n4v1 -> n5v1
-    n6v1 -> n7v1
+    n6v1 -> n7v1 [label="items"]
     n7v1 -> n8v1
-    n3v1 -> n12v1
-    n7v1 -> n13v1
-    n10v1 -> n11v1
-    n9v1 -> n14v1
-    n12v1 -> n9v1 [label="0"]
-    n13v1 -> n9v1 [label="1"]
-    n14v1 -> n10v1 [color=red]
-    n3v1 -> n9v1 [color=red]
-    n6v1 -> n9v1 [color=red]
+    n3v1 -> n9v1 [label="state"]
+    n6v1 -> n10v1 [label="state"]
+    n3v1 -> n14v1 [label="items"]
+    n7v1 -> n15v1
+    n12v1 -> n13v1
+    n11v1 -> n16v1
+    n14v1 -> n11v1 [label="0"]
+    n15v1 -> n11v1 [label="1"]
+    n16v1 -> n12v1 [color=red]
+    n3v1 -> n11v1 [color=red]
+    n6v1 -> n11v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
         style=filled
         label = "sg_1v1"
+        n9v1
         subgraph sg_1v1_var_lhs {
             cluster=true
             label="var lhs"
@@ -53,6 +58,7 @@ digraph {
         style=filled
         label = "sg_2v1"
         n8v1
+        n10v1
         subgraph sg_2v1_var_rhs {
             cluster=true
             label="var rhs"
@@ -74,7 +80,7 @@ digraph {
         subgraph sg_3v1_var_my_join {
             cluster=true
             label="var my_join"
-            n9v1
+            n11v1
         }
     }
     subgraph sg_4v1 {
@@ -85,8 +91,8 @@ digraph {
         subgraph sg_4v1_var_my_join {
             cluster=true
             label="var my_join"
-            n10v1
-            n11v1
+            n12v1
+            n13v1
         }
     }
 }

--- a/dfir_rs/tests/snapshots/surface_lattice_bimorphism_persist_insertion__cartesian_product_multi_tick_tee@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_lattice_bimorphism_persist_insertion__cartesian_product_multi_tick_tee@graphvis_mermaid.snap
@@ -10,34 +10,39 @@ classDef otherClass fill:#fdc,stroke:#000,text-align:left,white-space:pre
 linkStyle default stroke:#aaa
 1v1[\"(1v1) <code>source_stream(lhs_recv)</code>"/]:::pullClass
 2v1[\"(2v1) <code>map(SetUnionSingletonSet::new_from)</code>"/]:::pullClass
-3v1[\"(3v1) <code>state::&lt;'static, SetUnionHashSet&lt;u32&gt;&gt;()</code>"/]:::pullClass
+3v1[/"(3v1) <code>state::&lt;'static, SetUnionHashSet&lt;u32&gt;&gt;()</code>"\]:::pushClass
 4v1[\"(4v1) <code>source_stream(rhs_recv)</code>"/]:::pullClass
 5v1[\"(5v1) <code>map(SetUnionSingletonSet::new_from)</code>"/]:::pullClass
-6v1[\"(6v1) <code>state::&lt;'static, SetUnionHashSet&lt;u32&gt;&gt;()</code>"/]:::pullClass
+6v1[/"(6v1) <code>state::&lt;'static, SetUnionHashSet&lt;u32&gt;&gt;()</code>"\]:::pushClass
 7v1[/"(7v1) <code>tee()</code>"\]:::pushClass
 8v1[/"(8v1) <code>for_each(|x| println!(&quot;tee: {:?}&quot;, x))</code>"\]:::pushClass
-9v1[\"(9v1) <code>lattice_bimorphism(CartesianProductBimorphism::&lt;HashSet&lt;_&gt;&gt;::default(), lhs, rhs)</code>"/]:::pullClass
-10v1[\"(10v1) <code>lattice_reduce()</code>"/]:::pullClass
-11v1[/"(11v1) <code>for_each(|x| out_send.send(x).unwrap())</code>"\]:::pushClass
-12v1["(12v1) <code>handoff</code>"]:::otherClass
-13v1["(13v1) <code>handoff</code>"]:::otherClass
+9v1[/"(9v1) <code>null()</code>"\]:::pushClass
+10v1[/"(10v1) <code>null()</code>"\]:::pushClass
+11v1[\"(11v1) <code>lattice_bimorphism(CartesianProductBimorphism::&lt;HashSet&lt;_&gt;&gt;::default(), lhs, rhs)</code>"/]:::pullClass
+12v1[\"(12v1) <code>lattice_reduce()</code>"/]:::pullClass
+13v1[/"(13v1) <code>for_each(|x| out_send.send(x).unwrap())</code>"\]:::pushClass
 14v1["(14v1) <code>handoff</code>"]:::otherClass
+15v1["(15v1) <code>handoff</code>"]:::otherClass
+16v1["(16v1) <code>handoff</code>"]:::otherClass
 2v1-->3v1
 1v1-->2v1
 5v1-->6v1
 4v1-->5v1
-6v1-->7v1
+6v1-->|items|7v1
 7v1-->8v1
-3v1-->12v1
-7v1-->13v1
-10v1-->11v1
-9v1-->14v1
-12v1-->|0|9v1
-13v1-->|1|9v1
-14v1-->10v1; linkStyle 12 stroke:#060
-3v1--x9v1; linkStyle 13 stroke:red
-6v1--x9v1; linkStyle 14 stroke:red
+3v1-->|state|9v1
+6v1-->|state|10v1
+3v1-->|items|14v1
+7v1-->15v1
+12v1-->13v1
+11v1-->16v1
+14v1-->|0|11v1
+15v1-->|1|11v1
+16v1-->12v1; linkStyle 14 stroke:#060
+3v1--x11v1; linkStyle 15 stroke:red
+6v1--x11v1; linkStyle 16 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
+    9v1
     subgraph sg_1v1_var_lhs ["var <tt>lhs</tt>"]
         1v1
         2v1
@@ -46,6 +51,7 @@ subgraph sg_1v1 ["sg_1v1"]
 end
 subgraph sg_2v1 ["sg_2v1"]
     8v1
+    10v1
     subgraph sg_2v1_var_rhs ["var <tt>rhs</tt>"]
         4v1
         5v1
@@ -57,12 +63,12 @@ subgraph sg_2v1 ["sg_2v1"]
 end
 subgraph sg_3v1 ["sg_3v1"]
     subgraph sg_3v1_var_my_join ["var <tt>my_join</tt>"]
-        9v1
+        11v1
     end
 end
 subgraph sg_4v1 ["sg_4v1"]
     subgraph sg_4v1_var_my_join ["var <tt>my_join</tt>"]
-        10v1
-        11v1
+        12v1
+        13v1
     end
 end

--- a/dfir_rs/tests/snapshots/surface_singleton__multi_tick@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_singleton__multi_tick@graphvis_dot.snap
@@ -8,19 +8,21 @@ digraph {
     n1v1 [label="(n1v1) source_iter(1..=10)", shape=invhouse, fillcolor="#88aaff"]
     n2v1 [label="(n2v1) source_iter(3..=5)", shape=invhouse, fillcolor="#88aaff"]
     n3v1 [label="(n3v1) map(Max::new)", shape=invhouse, fillcolor="#88aaff"]
-    n4v1 [label="(n4v1) state::<'static, Max<_>>()", shape=invhouse, fillcolor="#88aaff"]
+    n4v1 [label="(n4v1) state::<'static, Max<_>>()", shape=house, fillcolor="#ffff88"]
     n5v1 [label="(n5v1) filter(|value| { value <= max_of_stream2.as_reveal_ref() })", shape=invhouse, fillcolor="#88aaff"]
     n6v1 [label="(n6v1) map(|x| (context.current_tick(), x))", shape=invhouse, fillcolor="#88aaff"]
     n7v1 [label="(n7v1) for_each(|x| filter_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
-    n8v1 [label="(n8v1) map(|x| (context.current_tick(), x.into_reveal()))", shape=invhouse, fillcolor="#88aaff"]
+    n8v1 [label="(n8v1) map(|x: Max<_>| (context.current_tick(), x.into_reveal()))", shape=house, fillcolor="#ffff88"]
     n9v1 [label="(n9v1) for_each(|x| max_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
+    n10v1 [label="(n10v1) null()", shape=house, fillcolor="#ffff88"]
     n2v1 -> n3v1
     n3v1 -> n4v1
     n6v1 -> n7v1
     n5v1 -> n6v1
     n1v1 -> n5v1
     n8v1 -> n9v1
-    n4v1 -> n8v1
+    n4v1 -> n8v1 [label="items"]
+    n4v1 -> n10v1 [label="state"]
     n4v1 -> n5v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
@@ -47,6 +49,7 @@ digraph {
         label = "sg_2v1"
         n8v1
         n9v1
+        n10v1
         subgraph sg_2v1_var_max_of_stream2 {
             cluster=true
             label="var max_of_stream2"

--- a/dfir_rs/tests/snapshots/surface_singleton__multi_tick@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_singleton__multi_tick@graphvis_mermaid.snap
@@ -11,20 +11,22 @@ linkStyle default stroke:#aaa
 1v1[\"(1v1) <code>source_iter(1..=10)</code>"/]:::pullClass
 2v1[\"(2v1) <code>source_iter(3..=5)</code>"/]:::pullClass
 3v1[\"(3v1) <code>map(Max::new)</code>"/]:::pullClass
-4v1[\"(4v1) <code>state::&lt;'static, Max&lt;_&gt;&gt;()</code>"/]:::pullClass
+4v1[/"(4v1) <code>state::&lt;'static, Max&lt;_&gt;&gt;()</code>"\]:::pushClass
 5v1[\"(5v1) <code>filter(|value| { value &lt;= max_of_stream2.as_reveal_ref() })</code>"/]:::pullClass
 6v1[\"(6v1) <code>map(|x| (context.current_tick(), x))</code>"/]:::pullClass
 7v1[/"(7v1) <code>for_each(|x| filter_send.send(x).unwrap())</code>"\]:::pushClass
-8v1[\"(8v1) <code>map(|x| (context.current_tick(), x.into_reveal()))</code>"/]:::pullClass
+8v1[/"(8v1) <code>map(|x: Max&lt;_&gt;| (context.current_tick(), x.into_reveal()))</code>"\]:::pushClass
 9v1[/"(9v1) <code>for_each(|x| max_send.send(x).unwrap())</code>"\]:::pushClass
+10v1[/"(10v1) <code>null()</code>"\]:::pushClass
 2v1-->3v1
 3v1-->4v1
 6v1-->7v1
 5v1-->6v1
 1v1-->5v1
 8v1-->9v1
-4v1-->8v1
-4v1--x5v1; linkStyle 7 stroke:red
+4v1-->|items|8v1
+4v1-->|state|10v1
+4v1--x5v1; linkStyle 8 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
     subgraph sg_1v1_var_filtered_stream1 ["var <tt>filtered_stream1</tt>"]
         5v1
@@ -38,6 +40,7 @@ end
 subgraph sg_2v1 ["sg_2v1"]
     8v1
     9v1
+    10v1
     subgraph sg_2v1_var_max_of_stream2 ["var <tt>max_of_stream2</tt>"]
         4v1
     end

--- a/dfir_rs/tests/snapshots/surface_singleton__state@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_singleton__state@graphvis_dot.snap
@@ -8,13 +8,14 @@ digraph {
     n1v1 [label="(n1v1) source_iter(1..=10)", shape=invhouse, fillcolor="#88aaff"]
     n2v1 [label="(n2v1) source_iter(3..=5)", shape=invhouse, fillcolor="#88aaff"]
     n3v1 [label="(n3v1) map(Max::new)", shape=invhouse, fillcolor="#88aaff"]
-    n4v1 [label="(n4v1) state::<'static, Max<_>>()", shape=invhouse, fillcolor="#88aaff"]
+    n4v1 [label="(n4v1) state::<'static, Max<_>>()", shape=house, fillcolor="#ffff88"]
     n5v1 [label="(n5v1) persist::<'static>()", shape=invhouse, fillcolor="#88aaff"]
     n6v1 [label="(n6v1) filter(|value| { value <= max_of_stream2.as_reveal_ref() })", shape=invhouse, fillcolor="#88aaff"]
     n7v1 [label="(n7v1) map(|x| (context.current_tick(), x))", shape=invhouse, fillcolor="#88aaff"]
     n8v1 [label="(n8v1) for_each(|x| filter_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
-    n9v1 [label="(n9v1) map(|x| (context.current_tick(), x.into_reveal()))", shape=invhouse, fillcolor="#88aaff"]
+    n9v1 [label="(n9v1) map(|x: Max<_>| (context.current_tick(), x.into_reveal()))", shape=house, fillcolor="#ffff88"]
     n10v1 [label="(n10v1) for_each(|x| max_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
+    n11v1 [label="(n11v1) null()", shape=house, fillcolor="#ffff88"]
     n2v1 -> n3v1
     n3v1 -> n4v1
     n7v1 -> n8v1
@@ -22,7 +23,8 @@ digraph {
     n5v1 -> n6v1
     n1v1 -> n5v1
     n9v1 -> n10v1
-    n4v1 -> n9v1
+    n4v1 -> n9v1 [label="items"]
+    n4v1 -> n11v1 [label="state"]
     n4v1 -> n6v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
@@ -50,6 +52,7 @@ digraph {
         label = "sg_2v1"
         n9v1
         n10v1
+        n11v1
         subgraph sg_2v1_var_max_of_stream2 {
             cluster=true
             label="var max_of_stream2"

--- a/dfir_rs/tests/snapshots/surface_singleton__state@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_singleton__state@graphvis_mermaid.snap
@@ -11,13 +11,14 @@ linkStyle default stroke:#aaa
 1v1[\"(1v1) <code>source_iter(1..=10)</code>"/]:::pullClass
 2v1[\"(2v1) <code>source_iter(3..=5)</code>"/]:::pullClass
 3v1[\"(3v1) <code>map(Max::new)</code>"/]:::pullClass
-4v1[\"(4v1) <code>state::&lt;'static, Max&lt;_&gt;&gt;()</code>"/]:::pullClass
+4v1[/"(4v1) <code>state::&lt;'static, Max&lt;_&gt;&gt;()</code>"\]:::pushClass
 5v1[\"(5v1) <code>persist::&lt;'static&gt;()</code>"/]:::pullClass
 6v1[\"(6v1) <code>filter(|value| { value &lt;= max_of_stream2.as_reveal_ref() })</code>"/]:::pullClass
 7v1[\"(7v1) <code>map(|x| (context.current_tick(), x))</code>"/]:::pullClass
 8v1[/"(8v1) <code>for_each(|x| filter_send.send(x).unwrap())</code>"\]:::pushClass
-9v1[\"(9v1) <code>map(|x| (context.current_tick(), x.into_reveal()))</code>"/]:::pullClass
+9v1[/"(9v1) <code>map(|x: Max&lt;_&gt;| (context.current_tick(), x.into_reveal()))</code>"\]:::pushClass
 10v1[/"(10v1) <code>for_each(|x| max_send.send(x).unwrap())</code>"\]:::pushClass
+11v1[/"(11v1) <code>null()</code>"\]:::pushClass
 2v1-->3v1
 3v1-->4v1
 7v1-->8v1
@@ -25,8 +26,9 @@ linkStyle default stroke:#aaa
 5v1-->6v1
 1v1-->5v1
 9v1-->10v1
-4v1-->9v1
-4v1--x6v1; linkStyle 8 stroke:red
+4v1-->|items|9v1
+4v1-->|state|11v1
+4v1--x6v1; linkStyle 9 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
     subgraph sg_1v1_var_filtered_stream1 ["var <tt>filtered_stream1</tt>"]
         5v1
@@ -41,6 +43,7 @@ end
 subgraph sg_2v1 ["sg_2v1"]
     9v1
     10v1
+    11v1
     subgraph sg_2v1_var_max_of_stream2 ["var <tt>max_of_stream2</tt>"]
         4v1
     end

--- a/dfir_rs/tests/snapshots/surface_singleton__state_unused@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_singleton__state_unused@graphvis_dot.snap
@@ -8,13 +8,19 @@ digraph {
     n1v1 [label="(n1v1) source_iter(15..=25)", shape=invhouse, fillcolor="#88aaff"]
     n2v1 [label="(n2v1) map(Max::new)", shape=invhouse, fillcolor="#88aaff"]
     n3v1 [label="(n3v1) state::<'static, Max<_>>()", shape=house, fillcolor="#ffff88"]
+    n4v1 [label="(n4v1) null()", shape=house, fillcolor="#ffff88"]
+    n5v1 [label="(n5v1) null()", shape=house, fillcolor="#ffff88"]
     n1v1 -> n2v1
     n2v1 -> n3v1
+    n3v1 -> n4v1 [label="items"]
+    n3v1 -> n5v1 [label="state"]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
         style=filled
         label = "sg_1v1"
+        n4v1
+        n5v1
         subgraph sg_1v1_var_max_of_stream2 {
             cluster=true
             label="var max_of_stream2"

--- a/dfir_rs/tests/snapshots/surface_singleton__state_unused@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_singleton__state_unused@graphvis_mermaid.snap
@@ -11,9 +11,15 @@ linkStyle default stroke:#aaa
 1v1[\"(1v1) <code>source_iter(15..=25)</code>"/]:::pullClass
 2v1[\"(2v1) <code>map(Max::new)</code>"/]:::pullClass
 3v1[/"(3v1) <code>state::&lt;'static, Max&lt;_&gt;&gt;()</code>"\]:::pushClass
+4v1[/"(4v1) <code>null()</code>"\]:::pushClass
+5v1[/"(5v1) <code>null()</code>"\]:::pushClass
 1v1-->2v1
 2v1-->3v1
+3v1-->|items|4v1
+3v1-->|state|5v1
 subgraph sg_1v1 ["sg_1v1"]
+    4v1
+    5v1
     subgraph sg_1v1_var_max_of_stream2 ["var <tt>max_of_stream2</tt>"]
         3v1
     end

--- a/dfir_rs/tests/surface_lattice_bimorphism.rs
+++ b/dfir_rs/tests/surface_lattice_bimorphism.rs
@@ -23,8 +23,10 @@ pub fn test_cartesian_product() {
             -> map(SetUnionSingletonSet::new_from)
             -> state::<'static, SetUnionHashSet<u32>>();
 
-        lhs -> [0]my_join;
-        rhs -> [1]my_join;
+        lhs[items] -> [0]my_join;
+        rhs[items] -> [1]my_join;
+        lhs[state] -> null();
+        rhs[state] -> null();
 
         my_join = lattice_bimorphism(CartesianProductBimorphism::<HashSet<_>>::default(), #lhs, #rhs)
             -> for_each(|x| out_send.send(x).unwrap());
@@ -58,8 +60,10 @@ pub fn test_cartesian_product_1401() {
             -> map(SetUnionSingletonSet::new_from)
             -> state::<'static, SetUnionHashSet<u32>>();
 
-        lhs -> [0]my_join;
-        rhs -> [1]my_join;
+        lhs[items] -> [0]my_join;
+        rhs[items] -> [1]my_join;
+        lhs[state] -> null();
+        rhs[state] -> null();
 
         my_join = lattice_bimorphism(CartesianProductBimorphism::<HashSet<_>>::default(), #lhs, #rhs)
             -> for_each(|x| out_send.send(x).unwrap());
@@ -85,8 +89,10 @@ pub fn test_join() {
             -> map(|(k, v)| MapUnionSingletonMap::new_from((k, SetUnionSingletonSet::new_from(v))))
             -> state::<'static, MapUnionHashMap<usize, SetUnionHashSet<usize>>>();
 
-        lhs -> [0]my_join;
-        rhs -> [1]my_join;
+        lhs[items] -> [0]my_join;
+        rhs[items] -> [1]my_join;
+        lhs[state] -> null();
+        rhs[state] -> null();
 
         my_join = lattice_bimorphism(KeyedBimorphism::<HashMap<_, _>, _>::new(CartesianProductBimorphism::<HashSet<_>>::default()), #lhs, #rhs)
             -> for_each(|x| out_send.send(x).unwrap());
@@ -128,6 +134,8 @@ pub fn test_cartesian_product_tick_state() {
 
         lhs[items] -> [0]my_join;
         rhs[items] -> [1]my_join;
+        lhs[state] -> null();
+        rhs[state] -> null();
 
         my_join = lattice_bimorphism(CartesianProductBimorphism::<HashSet<_>>::default(), #lhs, #rhs)
             -> inspect(|x| println!("{:?}: {:?}", context.current_tick(), x))
@@ -197,6 +205,8 @@ fn test_ght_join_bimorphism() {
 
         lhs[items] -> [0]my_join;
         rhs[items] -> [1]my_join;
+        lhs[state] -> null();
+        rhs[state] -> null();
 
 
         my_join = lattice_bimorphism(MyBim::default(), #lhs, #rhs)

--- a/dfir_rs/tests/surface_lattice_bimorphism_persist_insertion.rs
+++ b/dfir_rs/tests/surface_lattice_bimorphism_persist_insertion.rs
@@ -55,8 +55,10 @@ pub fn test_cartesian_product_multi_tick() {
             -> map(SetUnionSingletonSet::new_from)
             -> state::<'static, SetUnionHashSet<u32>>();
 
-        lhs -> [0]my_join;
-        rhs -> [1]my_join;
+        lhs[items] -> [0]my_join;
+        rhs[items] -> [1]my_join;
+        lhs[state] -> null();
+        rhs[state] -> null();
 
         my_join = lattice_bimorphism(CartesianProductBimorphism::<HashSet<_>>::default(), #lhs, #rhs)
             -> lattice_reduce()
@@ -80,10 +82,12 @@ pub fn test_cartesian_product_multi_tick_tee() {
         rhs = source_stream(rhs_recv)
             -> map(SetUnionSingletonSet::new_from)
             -> state::<'static, SetUnionHashSet<u32>>();
-        rhs_tee = rhs -> tee();
+        rhs_tee = rhs[items] -> tee();
         rhs_tee -> for_each(|x| println!("tee: {:?}", x));
+        lhs[state] -> null();
+        rhs[state] -> null();
 
-        lhs -> [0]my_join;
+        lhs[items] -> [0]my_join;
         rhs_tee -> [1]my_join;
 
         my_join = lattice_bimorphism(CartesianProductBimorphism::<HashSet<_>>::default(), #lhs, #rhs)
@@ -108,9 +112,11 @@ pub fn test_cartesian_product_multi_tick_identity() {
         rhs = source_stream(rhs_recv)
             -> map(SetUnionSingletonSet::new_from)
             -> state::<'static, SetUnionHashSet<u32>>();
-        rhs_id = rhs -> identity();
+        rhs_id = rhs[items] -> identity();
+        lhs[state] -> null();
+        rhs[state] -> null();
 
-        lhs -> [0]my_join;
+        lhs[items] -> [0]my_join;
         rhs_id -> [1]my_join;
 
         my_join = lattice_bimorphism(CartesianProductBimorphism::<HashSet<_>>::default(), #lhs, #rhs)

--- a/dfir_rs/tests/surface_lattice_generalized_hash_trie.rs
+++ b/dfir_rs/tests/surface_lattice_generalized_hash_trie.rs
@@ -60,6 +60,8 @@ fn test_join() {
             -> state::<MyGht>();
         R[items] -> [0]my_join;
         S[items] -> [1]my_join;
+        R[state] -> null();
+        S[state] -> null();
         my_join = lattice_bimorphism(MyBim::default(), #R, #S)
             -> lattice_reduce()
             -> for_each(|x| out_send.send(x).unwrap());

--- a/dfir_rs/tests/surface_singleton.rs
+++ b/dfir_rs/tests/surface_singleton.rs
@@ -23,10 +23,10 @@ pub fn test_state() {
             -> map(|x| (context.current_tick(), x))
             -> for_each(|x| filter_send.send(x).unwrap());
 
-        // Optional:
-        max_of_stream2
-            -> map(|x| (context.current_tick(), x.into_reveal()))
+        max_of_stream2[items]
+            -> map(|x: Max<_>| (context.current_tick(), x.into_reveal()))
             -> for_each(|x| max_send.send(x).unwrap());
+        max_of_stream2[state] -> null();
     };
     assert_graphvis_snapshots!(df);
 
@@ -72,6 +72,8 @@ pub fn test_state_unused() {
     let mut df = dfir_rs::dfir_syntax! {
         stream2 = source_iter(15..=25) -> map(Max::new);
         max_of_stream2 = stream2 -> state::<'static, Max<_>>();
+        max_of_stream2[items] -> null();
+        max_of_stream2[state] -> null();
     };
     assert_graphvis_snapshots!(df);
 
@@ -87,9 +89,10 @@ pub fn test_state_tick() {
         stream2 = source_stream(input_recv) -> map(Max::new);
         max_of_stream2 = stream2 -> state::<'tick, Max<_>>();
 
-        max_of_stream2
-            -> map(|x| (context.current_tick(), x.into_reveal()))
+        max_of_stream2[items]
+            -> map(|x: Max<_>| (context.current_tick(), x.into_reveal()))
             -> for_each(|x| max_send.send(x).unwrap());
+        max_of_stream2[state] -> null();
     };
 
     input_send.send(3).unwrap();
@@ -375,10 +378,10 @@ pub fn test_multi_tick() {
             -> map(|x| (context.current_tick(), x))
             -> for_each(|x| filter_send.send(x).unwrap());
 
-        // Optional:
-        max_of_stream2
-            -> map(|x| (context.current_tick(), x.into_reveal()))
+        max_of_stream2[items]
+            -> map(|x: Max<_>| (context.current_tick(), x.into_reveal()))
             -> for_each(|x| max_send.send(x).unwrap());
+        max_of_stream2[state] -> null();
     };
     assert_graphvis_snapshots!(df);
 


### PR DESCRIPTION
This is part of a small detour to remove the old DFIR singleton system while keeping these operators around. Alternative would be to just delete them.

The `state` and `state_by` lattice operators now have two fixed output ports:
- `[items]`: emits the input items that actually changed the lattice (deltas), same as the old single output
- `[state]`: emits a clone of the accumulated lattice value after all items are processed

This separates the two semantically different outputs that were previously conflated:
the delta stream (for downstream dataflow) and the accumulated state (for singleton
references). The `[state]` port can now be piped into `singleton()` for the new
reference system, decoupling the lattice state operator from the old
`has_singleton_output` mechanism.

Key implementation details:
- `state_by` uses a custom inline `StatePush` struct implementing the `Push` trait
  to handle both outputs in a single push combinator
- Items are filtered to `[items]` on each `start_send`; state is emitted to `[state]`
  during `poll_finalize`
- `ports_out` is set to `Fixed(parse_quote!(items, state))` enforcing both ports
- `has_singleton_output: true` is kept so the old `#var` reference system still works
- Push sink `let` bindings in `meta_graph.rs` changed to `let mut` (needed for pin projection)

All existing tests updated to use the new port syntax. Unused `[state]` ports are
directed to `null()`.

Co-authored-by: Infinity 🤖 <infinity@hydro.run>