### PR TITLE
feat(dfir_lang): add `#mut` and `#{N}` syntax for mutable/ordered singleton references

### DIFF
--- a/dfir_lang/src/graph/flat_graph_builder.rs
+++ b/dfir_lang/src/graph/flat_graph_builder.rs
@@ -907,8 +907,7 @@ impl FlatGraphBuilder {
 
             for refs in refs_by_target.values() {
                 // Group refs by access group: Option<u32> -> (shared_spans, mut_spans)
-                let mut by_group: BTreeMap<Option<u32>, (Vec<Span>, Vec<Span>)> =
-                    BTreeMap::new();
+                let mut by_group: BTreeMap<Option<u32>, (Vec<Span>, Vec<Span>)> = BTreeMap::new();
                 for &(is_mut, access_group, span) in refs {
                     let entry = by_group.entry(access_group).or_default();
                     if is_mut {
@@ -918,9 +917,9 @@ impl FlatGraphBuilder {
                     }
                 }
 
-                let ungrouped_shared = by_group
+                let (ungrouped_shared, ungrouped_mut) = by_group
                     .get(&None)
-                    .map_or(&[][..], |(s, _)| s.as_slice());
+                    .map_or((&[][..], &[][..]), |(s, m)| (s.as_slice(), m.as_slice()));
                 let all_mut_spans: Vec<Span> = by_group
                     .values()
                     .flat_map(|(_, m)| m.iter().copied())
@@ -941,19 +940,9 @@ impl FlatGraphBuilder {
                     continue;
                 }
 
-                // Ungrouped mutable refs cannot coexist with any other mutable refs (grouped or ungrouped).
-                let ungrouped_mut = by_group
-                    .get(&None)
-                    .map_or(&[][..], |(_, m)| m.as_slice());
-                let grouped_mut_spans: Vec<Span> = by_group
-                    .iter()
-                    .filter(|(k, _)| k.is_some())
-                    .flat_map(|(_, (_, m))| m.iter().copied())
-                    .collect();
-                if !ungrouped_mut.is_empty()
-                    && (!grouped_mut_spans.is_empty() || ungrouped_mut.len() > 1)
-                {
-                    for &span in ungrouped_mut.iter().chain(grouped_mut_spans.iter()) {
+                // Ungrouped mutable refs cannot coexist with any other mutable refs.
+                if !ungrouped_mut.is_empty() && all_mut_spans.len() > 1 {
+                    for &span in &all_mut_spans {
                         self.diagnostics.push(Diagnostic::spanned(
                             span,
                             Level::Error,
@@ -966,26 +955,23 @@ impl FlatGraphBuilder {
                     continue;
                 }
 
-                // Per-group checks.
-                for (&group, (shared_spans, mut_spans)) in &by_group {
+                // Per-group checks (ungrouped cases fully handled above).
+                for (group, (shared_spans, mut_spans)) in &by_group {
+                    if group.is_none() {
+                        continue;
+                    }
                     if !shared_spans.is_empty() && !mut_spans.is_empty() {
-                        let msg = if group.is_none() {
-                            "Cannot mix ungrouped shared (`#var`) and mutable (`#mut var`) \
-                             references to the same singleton. Use access groups `#{N}` to \
-                             specify ordering."
-                        } else {
-                            "Cannot mix shared (`#`) and mutable (`#mut`) references \
-                             in the same access group."
-                        };
                         for &span in shared_spans.iter().chain(mut_spans.iter()) {
                             self.diagnostics.push(Diagnostic::spanned(
                                 span,
                                 Level::Error,
-                                msg.to_owned(),
+                                "Cannot mix shared (`#`) and mutable (`#mut`) references \
+                                 in the same access group."
+                                    .to_owned(),
                             ));
                         }
                     }
-                    if group.is_some() && mut_spans.len() > 1 {
+                    if mut_spans.len() > 1 {
                         for &span in mut_spans {
                             self.diagnostics.push(Diagnostic::spanned(
                                 span,

--- a/dfir_lang/src/graph/flat_graph_builder.rs
+++ b/dfir_lang/src/graph/flat_graph_builder.rs
@@ -428,7 +428,7 @@ impl FlatGraphBuilder {
                             Some(node_id)
                         } else {
                             self.diagnostics.push(Diagnostic::spanned(
-                                singleton_ref.ident.span(),
+                                singleton_ref.span(),
                                 Level::Error,
                                 format!(
                                     "Cannot find referenced name `{}`; name was never assigned.",
@@ -855,7 +855,7 @@ impl FlatGraphBuilder {
                             let ref_op_constraints = ref_op_inst.op_constraints;
                             if !ref_op_constraints.has_singleton_output {
                                 self.diagnostics.push(Diagnostic::spanned(
-                                    singleton_ref_token.ident.span(),
+                                    singleton_ref_token.span(),
                                     Level::Error,
                                     format!(
                                         "Cannot reference operator `{}`. Only operators with singleton state can be referenced.",

--- a/dfir_lang/src/graph/flat_graph_builder.rs
+++ b/dfir_lang/src/graph/flat_graph_builder.rs
@@ -941,7 +941,32 @@ impl FlatGraphBuilder {
                     continue;
                 }
 
-                // Per-group checks (including ungrouped mutable-only).
+                // Ungrouped mutable refs cannot coexist with any other mutable refs (grouped or ungrouped).
+                let ungrouped_mut = by_group
+                    .get(&None)
+                    .map_or(&[][..], |(_, m)| m.as_slice());
+                let grouped_mut_spans: Vec<Span> = by_group
+                    .iter()
+                    .filter(|(k, _)| k.is_some())
+                    .flat_map(|(_, (_, m))| m.iter().copied())
+                    .collect();
+                if !ungrouped_mut.is_empty()
+                    && (!grouped_mut_spans.is_empty() || ungrouped_mut.len() > 1)
+                {
+                    for &span in ungrouped_mut.iter().chain(grouped_mut_spans.iter()) {
+                        self.diagnostics.push(Diagnostic::spanned(
+                            span,
+                            Level::Error,
+                            "Ungrouped `#mut` references cannot coexist with other mutable \
+                             references to the same singleton. Use access groups `#{N} mut var` \
+                             to specify ordering."
+                                .to_owned(),
+                        ));
+                    }
+                    continue;
+                }
+
+                // Per-group checks.
                 for (&group, (shared_spans, mut_spans)) in &by_group {
                     if !shared_spans.is_empty() && !mut_spans.is_empty() {
                         let msg = if group.is_none() {
@@ -960,19 +985,14 @@ impl FlatGraphBuilder {
                             ));
                         }
                     }
-                    if mut_spans.len() > 1 {
-                        let msg = if group.is_none() {
-                            "Multiple ungrouped `#mut` references to the same singleton. \
-                             Use access groups `#{N} mut var` to specify ordering."
-                        } else {
-                            "Multiple `#mut` references in the same access group. \
-                             Each mutable reference must be in its own access group."
-                        };
+                    if group.is_some() && mut_spans.len() > 1 {
                         for &span in mut_spans {
                             self.diagnostics.push(Diagnostic::spanned(
                                 span,
                                 Level::Error,
-                                msg.to_owned(),
+                                "Multiple `#mut` references in the same access group. \
+                                 Each mutable reference must be in its own access group."
+                                    .to_owned(),
                             ));
                         }
                     }

--- a/dfir_lang/src/graph/flat_graph_builder.rs
+++ b/dfir_lang/src/graph/flat_graph_builder.rs
@@ -429,7 +429,7 @@ impl FlatGraphBuilder {
                         };
                         crate::graph::meta_graph::ResolvedSingletonRef {
                             node_id: resolved_node_id,
-                            is_mut: singleton_ref.is_mut,
+                            is_mut: singleton_ref.token_mut.is_some(),
                             access_group: singleton_ref.access_group.as_ref().map(|(_, n)| *n),
                         }
                     })
@@ -896,7 +896,7 @@ impl FlatGraphBuilder {
                     {
                         if let Some(target_id) = resolved_ref.node_id {
                             refs_by_target.entry(target_id).or_default().push((
-                                ref_token.is_mut,
+                                ref_token.token_mut.is_some(),
                                 ref_token.access_group.as_ref().map(|(_, n)| *n),
                                 ref_token.ident.span(),
                             ));

--- a/dfir_lang/src/graph/flat_graph_builder.rs
+++ b/dfir_lang/src/graph/flat_graph_builder.rs
@@ -430,7 +430,7 @@ impl FlatGraphBuilder {
                         crate::graph::meta_graph::ResolvedSingletonRef {
                             node_id: resolved_node_id,
                             is_mut: singleton_ref.is_mut,
-                            access_group: singleton_ref.access_group,
+                            access_group: singleton_ref.access_group.as_ref().map(|(_, n)| *n),
                         }
                     })
                     .collect();
@@ -897,7 +897,7 @@ impl FlatGraphBuilder {
                         if let Some(target_id) = resolved_ref.node_id {
                             refs_by_target.entry(target_id).or_default().push((
                                 ref_token.is_mut,
-                                ref_token.access_group,
+                                ref_token.access_group.as_ref().map(|(_, n)| *n),
                                 ref_token.ident.span(),
                             ));
                         }
@@ -918,6 +918,24 @@ impl FlatGraphBuilder {
                             Level::Error,
                             "Multiple ungrouped `#mut` references to the same singleton. \
                              Use access groups `#{N} mut var` to specify ordering."
+                                .to_owned(),
+                        ));
+                    }
+                }
+
+                // Check ungrouped mutable + ungrouped shared coexistence.
+                let ungrouped_shared: Vec<_> = refs
+                    .iter()
+                    .filter(|(is_mut, group, _)| !*is_mut && group.is_none())
+                    .collect();
+                if !ungrouped_mut.is_empty() && !ungrouped_shared.is_empty() {
+                    for &&(_, _, span) in ungrouped_mut.iter().chain(ungrouped_shared.iter()) {
+                        self.diagnostics.push(Diagnostic::spanned(
+                            span,
+                            Level::Error,
+                            "Cannot mix ungrouped shared (`#var`) and mutable (`#mut var`) \
+                             references to the same singleton. Use access groups `#{N}` to \
+                             specify ordering."
                                 .to_owned(),
                         ));
                     }

--- a/dfir_lang/src/graph/flat_graph_builder.rs
+++ b/dfir_lang/src/graph/flat_graph_builder.rs
@@ -878,6 +878,92 @@ impl FlatGraphBuilder {
                 }
             }
         }
+
+        // Validate mutable singleton references:
+        // - Multiple ungrouped `#mut var` to the same singleton is an error.
+        // - `#var` and `#mut var` in the same access group is an error.
+        {
+            use std::collections::HashMap;
+            // Collect all refs: target_node_id -> Vec<(consumer_node_id, is_mut, access_group, span)>
+            let mut refs_by_target: HashMap<
+                GraphNodeId,
+                Vec<(GraphNodeId, bool, Option<u32>, Span)>,
+            > = HashMap::new();
+            for node_id in self.flat_graph.node_ids() {
+                if let GraphNode::Operator(operator) = self.flat_graph.node(node_id) {
+                    let resolved = self.flat_graph.node_singleton_references(node_id);
+                    for (resolved_ref, ref_token) in
+                        resolved.iter().zip(operator.singletons_referenced.iter())
+                    {
+                        if let Some(target_id) = resolved_ref.node_id {
+                            refs_by_target.entry(target_id).or_default().push((
+                                node_id,
+                                ref_token.is_mut,
+                                ref_token.access_group,
+                                ref_token.ident.span(),
+                            ));
+                        }
+                    }
+                }
+            }
+
+            for (_target_id, refs) in &refs_by_target {
+                // Check ungrouped mutable refs.
+                let ungrouped_mut: Vec<_> = refs
+                    .iter()
+                    .filter(|(_, is_mut, group, _)| *is_mut && group.is_none())
+                    .collect();
+                if ungrouped_mut.len() > 1 {
+                    for &&(_, _, _, span) in &ungrouped_mut {
+                        self.diagnostics.push(Diagnostic::spanned(
+                            span,
+                            Level::Error,
+                            "Multiple ungrouped `#mut` references to the same singleton. \
+                             Use access groups `#{N} mut var` to specify ordering."
+                                .to_owned(),
+                        ));
+                    }
+                }
+
+                // Check mixed shared + mutable in the same access group.
+                let mut grouped: HashMap<u32, (Vec<Span>, Vec<Span>)> = HashMap::new();
+                for &(_, is_mut, access_group, span) in refs {
+                    if let Some(group) = access_group {
+                        let entry = grouped.entry(group).or_default();
+                        if is_mut {
+                            entry.1.push(span);
+                        } else {
+                            entry.0.push(span);
+                        }
+                    }
+                }
+                for (_group, (shared_spans, mut_spans)) in &grouped {
+                    if !shared_spans.is_empty() && !mut_spans.is_empty() {
+                        for &span in shared_spans.iter().chain(mut_spans.iter()) {
+                            self.diagnostics.push(Diagnostic::spanned(
+                                span,
+                                Level::Error,
+                                "Cannot mix shared (`#`) and mutable (`#mut`) references \
+                                 in the same access group."
+                                    .to_owned(),
+                            ));
+                        }
+                    }
+                    // Multiple mutable refs in the same group is also an error.
+                    if mut_spans.len() > 1 {
+                        for &span in mut_spans {
+                            self.diagnostics.push(Diagnostic::spanned(
+                                span,
+                                Level::Error,
+                                "Multiple `#mut` references in the same access group. \
+                                 Each mutable reference must be in its own access group."
+                                    .to_owned(),
+                            ));
+                        }
+                    }
+                }
+            }
+        }
     }
 
     /// Warns about unused port indexing referenced in [`Self::varname_ends`].

--- a/dfir_lang/src/graph/flat_graph_builder.rs
+++ b/dfir_lang/src/graph/flat_graph_builder.rs
@@ -910,36 +910,14 @@ impl FlatGraphBuilder {
         // 1. If any singleton reference has an explicit group number, they all must have one.
         // 2. Every `#mut` must be in its own group.
         {
-            // Collect all refs, grouped by the singleton they're pointing at, then by the access group idx `Option<u32>`.
-            let mut refs_by_target = BTreeMap::<
-                GraphNodeId,
-                BTreeMap<Option<u32>, Vec<(&ResolvedSingletonRef, Span)>>,
-            >::new();
-            for node_id in self.flat_graph.node_ids() {
-                if let GraphNode::Operator(operator) = self.flat_graph.node(node_id) {
-                    let resolved = self.flat_graph.node_singleton_references(node_id);
-                    for (resolved_ref, ref_token) in
-                        resolved.iter().zip(operator.singletons_referenced.iter())
-                    {
-                        if let Some(target_id) = resolved_ref.node_id {
-                            refs_by_target
-                                .entry(target_id)
-                                .or_default()
-                                .entry(resolved_ref.access_group)
-                                .or_default()
-                                .push((resolved_ref, ref_token.span()));
-                        }
-                    }
-                }
-            }
-
+            let refs_by_target = self.flat_graph.node_singleton_reference_groups();
             // For each singleton, check the groups.
             for (_singleton, groups) in refs_by_target {
                 // Rule 1. If any singleton reference has an explicit group number, they all must have one.
                 if 1 < groups.len()
                     && let Some(ungrouped) = groups.get(&None)
                 {
-                    for &(r, span) in ungrouped {
+                    for &(_src_node, r, span) in ungrouped {
                         self.diagnostics.push(Diagnostic::spanned(
                             span,
                             Level::Error,
@@ -952,13 +930,15 @@ impl FlatGraphBuilder {
                 }
                 // Rule 2. Every `#mut` must be in its own group.
                 for (group_idx, group) in groups {
-                    if 1 < group.len() && group.iter().any(|(r, _)| r.is_mut) {
+                    if 1 < group.len() && group.iter().any(|(_, r, _)| r.is_mut) {
                         let group_str = if let Some(n) = group_idx {
                             format!("`#{{{}}}`", n)
                         } else {
                             "<default>".to_owned()
                         };
-                        for (_mut, span) in group.into_iter().filter(|(r, _)| r.is_mut) {
+                        for (_src_node, _mut_r, span) in
+                            group.into_iter().filter(|(_, r, _)| r.is_mut)
+                        {
                             self.diagnostics.push(Diagnostic::spanned(
                                 span,
                                 Level::Error,

--- a/dfir_lang/src/graph/flat_graph_builder.rs
+++ b/dfir_lang/src/graph/flat_graph_builder.rs
@@ -906,34 +906,29 @@ impl FlatGraphBuilder {
             }
 
             for refs in refs_by_target.values() {
-                // Check ungrouped mutable refs.
-                let ungrouped_mut: Vec<_> = refs
-                    .iter()
-                    .filter(|(is_mut, group, _)| *is_mut && group.is_none())
-                    .collect();
-                if ungrouped_mut.len() > 1 {
-                    for &&(_, _, span) in &ungrouped_mut {
-                        self.diagnostics.push(Diagnostic::spanned(
-                            span,
-                            Level::Error,
-                            "Multiple ungrouped `#mut` references to the same singleton. \
-                             Use access groups `#{N} mut var` to specify ordering."
-                                .to_owned(),
-                        ));
+                // Group refs by access group: Option<u32> -> (shared_spans, mut_spans)
+                let mut by_group: BTreeMap<Option<u32>, (Vec<Span>, Vec<Span>)> =
+                    BTreeMap::new();
+                for &(is_mut, access_group, span) in refs {
+                    let entry = by_group.entry(access_group).or_default();
+                    if is_mut {
+                        entry.1.push(span);
+                    } else {
+                        entry.0.push(span);
                     }
                 }
 
-                // Check ungrouped shared refs cannot coexist with any mutable refs.
-                let ungrouped_shared: Vec<_> = refs
-                    .iter()
-                    .filter(|(is_mut, group, _)| !*is_mut && group.is_none())
+                let ungrouped_shared = by_group
+                    .get(&None)
+                    .map_or(&[][..], |(s, _)| s.as_slice());
+                let all_mut_spans: Vec<Span> = by_group
+                    .values()
+                    .flat_map(|(_, m)| m.iter().copied())
                     .collect();
-                let any_mut: Vec<_> = refs
-                    .iter()
-                    .filter(|(is_mut, _, _)| *is_mut)
-                    .collect();
-                if !any_mut.is_empty() && !ungrouped_shared.is_empty() {
-                    for &&(_, _, span) in any_mut.iter().chain(ungrouped_shared.iter()) {
+
+                // Ungrouped shared refs cannot coexist with any mutable refs.
+                if !ungrouped_shared.is_empty() && !all_mut_spans.is_empty() {
+                    for &span in ungrouped_shared.iter().chain(all_mut_spans.iter()) {
                         self.diagnostics.push(Diagnostic::spanned(
                             span,
                             Level::Error,
@@ -943,41 +938,41 @@ impl FlatGraphBuilder {
                                 .to_owned(),
                         ));
                     }
+                    continue;
                 }
 
-                // Check mixed shared + mutable in the same access group.
-                let mut grouped: BTreeMap<u32, (Vec<Span>, Vec<Span>)> = BTreeMap::new();
-                for &(is_mut, access_group, span) in refs {
-                    if let Some(group) = access_group {
-                        let entry = grouped.entry(group).or_default();
-                        if is_mut {
-                            entry.1.push(span);
-                        } else {
-                            entry.0.push(span);
-                        }
-                    }
-                }
-                for (shared_spans, mut_spans) in grouped.values() {
+                // Per-group checks (including ungrouped mutable-only).
+                for (&group, (shared_spans, mut_spans)) in &by_group {
                     if !shared_spans.is_empty() && !mut_spans.is_empty() {
+                        let msg = if group.is_none() {
+                            "Cannot mix ungrouped shared (`#var`) and mutable (`#mut var`) \
+                             references to the same singleton. Use access groups `#{N}` to \
+                             specify ordering."
+                        } else {
+                            "Cannot mix shared (`#`) and mutable (`#mut`) references \
+                             in the same access group."
+                        };
                         for &span in shared_spans.iter().chain(mut_spans.iter()) {
                             self.diagnostics.push(Diagnostic::spanned(
                                 span,
                                 Level::Error,
-                                "Cannot mix shared (`#`) and mutable (`#mut`) references \
-                                 in the same access group."
-                                    .to_owned(),
+                                msg.to_owned(),
                             ));
                         }
                     }
-                    // Multiple mutable refs in the same group is also an error.
                     if mut_spans.len() > 1 {
+                        let msg = if group.is_none() {
+                            "Multiple ungrouped `#mut` references to the same singleton. \
+                             Use access groups `#{N} mut var` to specify ordering."
+                        } else {
+                            "Multiple `#mut` references in the same access group. \
+                             Each mutable reference must be in its own access group."
+                        };
                         for &span in mut_spans {
                             self.diagnostics.push(Diagnostic::spanned(
                                 span,
                                 Level::Error,
-                                "Multiple `#mut` references in the same access group. \
-                                 Each mutable reference must be in its own access group."
-                                    .to_owned(),
+                                msg.to_owned(),
                             ));
                         }
                     }

--- a/dfir_lang/src/graph/flat_graph_builder.rs
+++ b/dfir_lang/src/graph/flat_graph_builder.rs
@@ -412,7 +412,9 @@ impl FlatGraphBuilder {
                             .map(|varname_info| &varname_info.ends)
                             .and_then(|ends| ends.out.as_ref())
                             .cloned();
-                        let resolved_node_id = if let Some((_port, node_id)) = self.helper_resolve_name(port_det, false) {
+                        let resolved_node_id = if let Some((_port, node_id)) =
+                            self.helper_resolve_name(port_det, false)
+                        {
                             Some(node_id)
                         } else {
                             self.diagnostics.push(Diagnostic::spanned(
@@ -883,12 +885,9 @@ impl FlatGraphBuilder {
         // - Multiple ungrouped `#mut var` to the same singleton is an error.
         // - `#var` and `#mut var` in the same access group is an error.
         {
-            use std::collections::HashMap;
-            // Collect all refs: target_node_id -> Vec<(consumer_node_id, is_mut, access_group, span)>
-            let mut refs_by_target: HashMap<
-                GraphNodeId,
-                Vec<(GraphNodeId, bool, Option<u32>, Span)>,
-            > = HashMap::new();
+            // Collect all refs: target_node_id -> Vec<(is_mut, access_group, span)>
+            let mut refs_by_target: BTreeMap<GraphNodeId, Vec<(bool, Option<u32>, Span)>> =
+                BTreeMap::new();
             for node_id in self.flat_graph.node_ids() {
                 if let GraphNode::Operator(operator) = self.flat_graph.node(node_id) {
                     let resolved = self.flat_graph.node_singleton_references(node_id);
@@ -897,7 +896,6 @@ impl FlatGraphBuilder {
                     {
                         if let Some(target_id) = resolved_ref.node_id {
                             refs_by_target.entry(target_id).or_default().push((
-                                node_id,
                                 ref_token.is_mut,
                                 ref_token.access_group,
                                 ref_token.ident.span(),
@@ -907,14 +905,14 @@ impl FlatGraphBuilder {
                 }
             }
 
-            for (_target_id, refs) in &refs_by_target {
+            for refs in refs_by_target.values() {
                 // Check ungrouped mutable refs.
                 let ungrouped_mut: Vec<_> = refs
                     .iter()
-                    .filter(|(_, is_mut, group, _)| *is_mut && group.is_none())
+                    .filter(|(is_mut, group, _)| *is_mut && group.is_none())
                     .collect();
                 if ungrouped_mut.len() > 1 {
-                    for &&(_, _, _, span) in &ungrouped_mut {
+                    for &&(_, _, span) in &ungrouped_mut {
                         self.diagnostics.push(Diagnostic::spanned(
                             span,
                             Level::Error,
@@ -926,8 +924,8 @@ impl FlatGraphBuilder {
                 }
 
                 // Check mixed shared + mutable in the same access group.
-                let mut grouped: HashMap<u32, (Vec<Span>, Vec<Span>)> = HashMap::new();
-                for &(_, is_mut, access_group, span) in refs {
+                let mut grouped: BTreeMap<u32, (Vec<Span>, Vec<Span>)> = BTreeMap::new();
+                for &(is_mut, access_group, span) in refs {
                     if let Some(group) = access_group {
                         let entry = grouped.entry(group).or_default();
                         if is_mut {
@@ -937,7 +935,7 @@ impl FlatGraphBuilder {
                         }
                     }
                 }
-                for (_group, (shared_spans, mut_spans)) in &grouped {
+                for (shared_spans, mut_spans) in grouped.values() {
                     if !shared_spans.is_empty() && !mut_spans.is_empty() {
                         for &span in shared_spans.iter().chain(mut_spans.iter()) {
                             self.diagnostics.push(Diagnostic::spanned(

--- a/dfir_lang/src/graph/flat_graph_builder.rs
+++ b/dfir_lang/src/graph/flat_graph_builder.rs
@@ -923,13 +923,17 @@ impl FlatGraphBuilder {
                     }
                 }
 
-                // Check ungrouped mutable + ungrouped shared coexistence.
+                // Check ungrouped shared refs cannot coexist with any mutable refs.
                 let ungrouped_shared: Vec<_> = refs
                     .iter()
                     .filter(|(is_mut, group, _)| !*is_mut && group.is_none())
                     .collect();
-                if !ungrouped_mut.is_empty() && !ungrouped_shared.is_empty() {
-                    for &&(_, _, span) in ungrouped_mut.iter().chain(ungrouped_shared.iter()) {
+                let any_mut: Vec<_> = refs
+                    .iter()
+                    .filter(|(is_mut, _, _)| *is_mut)
+                    .collect();
+                if !any_mut.is_empty() && !ungrouped_shared.is_empty() {
+                    for &&(_, _, span) in any_mut.iter().chain(ungrouped_shared.iter()) {
                         self.diagnostics.push(Diagnostic::spanned(
                             span,
                             Level::Error,

--- a/dfir_lang/src/graph/flat_graph_builder.rs
+++ b/dfir_lang/src/graph/flat_graph_builder.rs
@@ -11,6 +11,7 @@ use syn::spanned::Spanned;
 use syn::{Error, Ident, ItemUse};
 
 use crate::diagnostic::{Diagnostic, Diagnostics, Level};
+use crate::graph::meta_graph::ResolvedSingletonRef;
 use crate::graph::ops::next_iteration::NEXT_ITERATION;
 use crate::graph::ops::{FloType, Persistence, PortListSpec, RangeTrait};
 use crate::graph::{
@@ -389,8 +390,14 @@ impl FlatGraphBuilder {
     fn finalize_connect_operator_links(&mut self) {
         // `->` edges
         for Ends { out, inn } in std::mem::take(&mut self.links) {
-            let out_opt = self.helper_resolve_name(out, false);
-            let inn_opt = self.helper_resolve_name(inn, true);
+            let out_opt = Self::helper_resolve_name(
+                &mut self.varname_ends,
+                out,
+                false,
+                &mut self.diagnostics,
+            );
+            let inn_opt =
+                Self::helper_resolve_name(&mut self.varname_ends, inn, true, &mut self.diagnostics);
             // `None` already have errors in `self.diagnostics`.
             if let (Some((out_port, out_node)), Some((inn_port, inn_node))) = (out_opt, inn_opt) {
                 let _ = self.finalize_connect_operators(out_port, out_node, inn_port, inn_node);
@@ -402,8 +409,7 @@ impl FlatGraphBuilder {
             if let GraphNode::Operator(operator) = self.flat_graph.node(node_id) {
                 let singletons_referenced = operator
                     .singletons_referenced
-                    .clone()
-                    .into_iter()
+                    .iter()
                     .map(|singleton_ref| {
                         let port_det = self
                             .varname_ends
@@ -413,8 +419,12 @@ impl FlatGraphBuilder {
                             .and_then(|ends| ends.out.as_ref())
                             .cloned();
                         let resolved_node_id = if let Some((_port, node_id)) =
-                            self.helper_resolve_name(port_det, false)
-                        {
+                            Self::helper_resolve_name(
+                                &mut self.varname_ends,
+                                port_det,
+                                false,
+                                &mut self.diagnostics,
+                            ) {
                             Some(node_id)
                         } else {
                             self.diagnostics.push(Diagnostic::spanned(
@@ -427,10 +437,22 @@ impl FlatGraphBuilder {
                             ));
                             None
                         };
-                        crate::graph::meta_graph::ResolvedSingletonRef {
+                        ResolvedSingletonRef {
                             node_id: resolved_node_id,
                             is_mut: singleton_ref.token_mut.is_some(),
-                            access_group: singleton_ref.access_group.as_ref().map(|(_, n)| *n),
+                            access_group: singleton_ref.access_group.as_ref().and_then(
+                                |(_, lit_int)| match lit_int.base10_parse::<u32>() {
+                                    Ok(n) => Some(n),
+                                    Err(e) => {
+                                        self.diagnostics.push(Diagnostic::spanned(
+                                            lit_int.span(),
+                                            Level::Error,
+                                            format!("Access group is not a valid `u32`: {}", e),
+                                        ));
+                                        None
+                                    }
+                                },
+                            ),
                         }
                     })
                     .collect();
@@ -448,9 +470,10 @@ impl FlatGraphBuilder {
     ///
     /// `is_in` set to `true` means the _input_ side will be returned. `false` means the _output_ side will be returned.
     fn helper_resolve_name(
-        &mut self,
+        varname_ends: &mut BTreeMap<Ident, VarnameInfo>,
         mut port_det: Option<(PortIndexValue, GraphDet)>,
         is_in: bool,
+        diagnostics: &mut Diagnostics,
     ) -> Option<(PortIndexValue, GraphNodeId)> {
         const BACKUP_RECURSION_LIMIT: usize = 1024;
 
@@ -461,8 +484,8 @@ impl FlatGraphBuilder {
                     return Some((port, node_id));
                 }
                 (port, GraphDet::Undetermined(ident)) => {
-                    let Some(varname_info) = self.varname_ends.get_mut(&ident) else {
-                        self.diagnostics.push(Diagnostic::spanned(
+                    let Some(varname_info) = varname_ends.get_mut(&ident) else {
+                        diagnostics.push(Diagnostic::spanned(
                             ident.span(),
                             Level::Error,
                             format!("Cannot find name `{}`; name was never assigned.", ident),
@@ -477,7 +500,7 @@ impl FlatGraphBuilder {
                     if cycle_found || varname_info.illegal_cycle {
                         let len = names.len();
                         for (i, name) in names.into_iter().enumerate() {
-                            self.diagnostics.push(Diagnostic::spanned(
+                            diagnostics.push(Diagnostic::spanned(
                                 name.span(),
                                 Level::Error,
                                 format!(
@@ -489,7 +512,7 @@ impl FlatGraphBuilder {
                             ));
                             // Set value as `Err(())` to trigger `name_ends_result.is_err()`
                             // diagnostics above if the name is referenced in the future.
-                            self.varname_ends.get_mut(&name).unwrap().illegal_cycle = true;
+                            varname_ends.get_mut(&name).unwrap().illegal_cycle = true;
                         }
                         return None;
                     }
@@ -503,7 +526,7 @@ impl FlatGraphBuilder {
                         &varname_info.ends.out
                     };
                     port_det = Self::helper_combine_end(
-                        &mut self.diagnostics,
+                        diagnostics,
                         prev.clone(),
                         port,
                         if is_in { "input" } else { "output" },
@@ -511,7 +534,7 @@ impl FlatGraphBuilder {
                 }
             }
         }
-        self.diagnostics.push(Diagnostic::spanned(
+        diagnostics.push(Diagnostic::spanned(
             Span::call_site(),
             Level::Error,
             format!(
@@ -881,13 +904,17 @@ impl FlatGraphBuilder {
             }
         }
 
-        // Validate mutable singleton references:
-        // - Multiple ungrouped `#mut var` to the same singleton is an error.
-        // - `#var` and `#mut var` in the same access group is an error.
+        // Validate singleton references.
+        // All singleton references must have unambiguous group orderings.
+        // Rules:
+        // 1. If any singleton reference has an explicit group number, they all must have one.
+        // 2. Every `#mut` must be in its own group.
         {
-            // Collect all refs: target_node_id -> Vec<(is_mut, access_group, span)>
-            let mut refs_by_target: BTreeMap<GraphNodeId, Vec<(bool, Option<u32>, Span)>> =
-                BTreeMap::new();
+            // Collect all refs, grouped by the singleton they're pointing at, then by the access group idx `Option<u32>`.
+            let mut refs_by_target = BTreeMap::<
+                GraphNodeId,
+                BTreeMap<Option<u32>, Vec<(&ResolvedSingletonRef, Span)>>,
+            >::new();
             for node_id in self.flat_graph.node_ids() {
                 if let GraphNode::Operator(operator) = self.flat_graph.node(node_id) {
                     let resolved = self.flat_graph.node_singleton_references(node_id);
@@ -895,90 +922,47 @@ impl FlatGraphBuilder {
                         resolved.iter().zip(operator.singletons_referenced.iter())
                     {
                         if let Some(target_id) = resolved_ref.node_id {
-                            refs_by_target.entry(target_id).or_default().push((
-                                ref_token.token_mut.is_some(),
-                                ref_token.access_group.as_ref().map(|(_, n)| *n),
-                                ref_token.ident.span(),
-                            ));
+                            refs_by_target
+                                .entry(target_id)
+                                .or_default()
+                                .entry(resolved_ref.access_group)
+                                .or_default()
+                                .push((resolved_ref, ref_token.span()));
                         }
                     }
                 }
             }
 
-            for refs in refs_by_target.values() {
-                // Group refs by access group: Option<u32> -> (shared_spans, mut_spans)
-                let mut by_group: BTreeMap<Option<u32>, (Vec<Span>, Vec<Span>)> = BTreeMap::new();
-                for &(is_mut, access_group, span) in refs {
-                    let entry = by_group.entry(access_group).or_default();
-                    if is_mut {
-                        entry.1.push(span);
-                    } else {
-                        entry.0.push(span);
-                    }
-                }
-
-                let (ungrouped_shared, ungrouped_mut) = by_group
-                    .get(&None)
-                    .map_or((&[][..], &[][..]), |(s, m)| (s.as_slice(), m.as_slice()));
-                let all_mut_spans: Vec<Span> = by_group
-                    .values()
-                    .flat_map(|(_, m)| m.iter().copied())
-                    .collect();
-
-                // Ungrouped shared refs cannot coexist with any mutable refs.
-                if !ungrouped_shared.is_empty() && !all_mut_spans.is_empty() {
-                    for &span in ungrouped_shared.iter().chain(all_mut_spans.iter()) {
+            // For each singleton, check the groups.
+            for (_singleton, groups) in refs_by_target {
+                // Rule 1. If any singleton reference has an explicit group number, they all must have one.
+                if 1 < groups.len()
+                    && let Some(ungrouped) = groups.get(&None)
+                {
+                    for &(r, span) in ungrouped {
                         self.diagnostics.push(Diagnostic::spanned(
                             span,
                             Level::Error,
-                            "Cannot mix ungrouped shared (`#var`) and mutable (`#mut var`) \
-                             references to the same singleton. Use access groups `#{N}` to \
-                             specify ordering."
-                                .to_owned(),
+                            format!(
+                                "Must use an explicit group `#{{N}}{}` to reference a singleton when other references use explicit groups.",
+                                if r.is_mut { " mut" } else { "" },
+                            ),
                         ));
                     }
-                    continue;
                 }
-
-                // Ungrouped mutable refs cannot coexist with any other mutable refs.
-                if !ungrouped_mut.is_empty() && all_mut_spans.len() > 1 {
-                    for &span in &all_mut_spans {
-                        self.diagnostics.push(Diagnostic::spanned(
-                            span,
-                            Level::Error,
-                            "Ungrouped `#mut` references cannot coexist with other mutable \
-                             references to the same singleton. Use access groups `#{N} mut var` \
-                             to specify ordering."
-                                .to_owned(),
-                        ));
-                    }
-                    continue;
-                }
-
-                // Per-group checks (ungrouped cases fully handled above).
-                for (group, (shared_spans, mut_spans)) in &by_group {
-                    if group.is_none() {
-                        continue;
-                    }
-                    if !shared_spans.is_empty() && !mut_spans.is_empty() {
-                        for &span in shared_spans.iter().chain(mut_spans.iter()) {
+                // Rule 2. Every `#mut` must be in its own group.
+                for (group_idx, group) in groups {
+                    if 1 < group.len() && group.iter().any(|(r, _)| r.is_mut) {
+                        let group_str = if let Some(n) = group_idx {
+                            format!("`#{{{}}}`", n)
+                        } else {
+                            "<default>".to_owned()
+                        };
+                        for (_mut, span) in group.into_iter().filter(|(r, _)| r.is_mut) {
                             self.diagnostics.push(Diagnostic::spanned(
                                 span,
                                 Level::Error,
-                                "Cannot mix shared (`#`) and mutable (`#mut`) references \
-                                 in the same access group."
-                                    .to_owned(),
-                            ));
-                        }
-                    }
-                    if mut_spans.len() > 1 {
-                        for &span in mut_spans {
-                            self.diagnostics.push(Diagnostic::spanned(
-                                span,
-                                Level::Error,
-                                "Multiple `#mut` references in the same access group. \
-                                 Each mutable reference must be in its own access group."
-                                    .to_owned(),
+                                format!("Mutable singleton references must be the only one in their access group, but group {} has multiple.", group_str),
                             ));
                         }
                     }

--- a/dfir_lang/src/graph/flat_graph_builder.rs
+++ b/dfir_lang/src/graph/flat_graph_builder.rs
@@ -407,23 +407,28 @@ impl FlatGraphBuilder {
                     .map(|singleton_ref| {
                         let port_det = self
                             .varname_ends
-                            .get(&singleton_ref)
+                            .get(&singleton_ref.ident)
                             .filter(|varname_info| !varname_info.illegal_cycle)
                             .map(|varname_info| &varname_info.ends)
                             .and_then(|ends| ends.out.as_ref())
                             .cloned();
-                        if let Some((_port, node_id)) = self.helper_resolve_name(port_det, false) {
+                        let resolved_node_id = if let Some((_port, node_id)) = self.helper_resolve_name(port_det, false) {
                             Some(node_id)
                         } else {
                             self.diagnostics.push(Diagnostic::spanned(
-                                singleton_ref.span(),
+                                singleton_ref.ident.span(),
                                 Level::Error,
                                 format!(
                                     "Cannot find referenced name `{}`; name was never assigned.",
-                                    singleton_ref
+                                    singleton_ref.ident
                                 ),
                             ));
                             None
+                        };
+                        crate::graph::meta_graph::ResolvedSingletonRef {
+                            node_id: resolved_node_id,
+                            is_mut: singleton_ref.is_mut,
+                            access_group: singleton_ref.access_group,
                         }
                     })
                     .collect();
@@ -799,11 +804,11 @@ impl FlatGraphBuilder {
                     {
                         let singletons_resolved =
                             self.flat_graph.node_singleton_references(node_id);
-                        for (singleton_node_id, singleton_ident) in singletons_resolved
+                        for (resolved_ref, singleton_ref_token) in singletons_resolved
                             .iter()
                             .zip_eq(&*operator.singletons_referenced)
                         {
-                            let &Some(singleton_node_id) = singleton_node_id else {
+                            let Some(singleton_node_id) = resolved_ref.node_id else {
                                 // Error already emitted by `connect_operator_links`, "Cannot find referenced name...".
                                 continue;
                             };
@@ -825,7 +830,7 @@ impl FlatGraphBuilder {
                             let ref_op_constraints = ref_op_inst.op_constraints;
                             if !ref_op_constraints.has_singleton_output {
                                 self.diagnostics.push(Diagnostic::spanned(
-                                    singleton_ident.span(),
+                                    singleton_ref_token.ident.span(),
                                     Level::Error,
                                     format!(
                                         "Cannot reference operator `{}`. Only operators with singleton state can be referenced.",

--- a/dfir_lang/src/graph/flat_to_partitioned.rs
+++ b/dfir_lang/src/graph/flat_to_partitioned.rs
@@ -69,8 +69,8 @@ fn find_barrier_crossers(partitioned_graph: &DfirGraph) -> BarrierCrossers {
             partitioned_graph
                 .node_singleton_references(dst)
                 .iter()
-                .flatten()
-                .map(move |&src_ref| (src_ref, dst))
+                .filter_map(|r| r.node_id)
+                .map(move |src_ref| (src_ref, dst))
         })
         .collect();
     BarrierCrossers {

--- a/dfir_lang/src/graph/flat_to_partitioned.rs
+++ b/dfir_lang/src/graph/flat_to_partitioned.rs
@@ -63,7 +63,9 @@ fn find_barrier_crossers(partitioned_graph: &DfirGraph) -> BarrierCrossers {
             Some((edge_id, input_barrier))
         })
         .collect();
-    let singleton_barrier_crossers = partitioned_graph
+
+    // Basic singleton barriers: producer → consumer.
+    let mut singleton_barrier_crossers: Vec<(GraphNodeId, GraphNodeId)> = partitioned_graph
         .node_ids()
         .flat_map(|dst| {
             partitioned_graph
@@ -73,6 +75,65 @@ fn find_barrier_crossers(partitioned_graph: &DfirGraph) -> BarrierCrossers {
                 .map(move |src_ref| (src_ref, dst))
         })
         .collect();
+
+    // Access group ordering barriers: for the same singleton target, operators in
+    // lower access groups must run before operators in higher access groups.
+    // Also: ungrouped mutable refs must run after ungrouped shared refs.
+    //
+    // Collect all (target_node_id, consumer_node_id, is_mut, access_group) tuples.
+    let mut refs_by_target: BTreeMap<GraphNodeId, Vec<(GraphNodeId, bool, Option<u32>)>> =
+        BTreeMap::new();
+    for consumer_id in partitioned_graph.node_ids() {
+        for resolved_ref in partitioned_graph.node_singleton_references(consumer_id) {
+            if let Some(target_id) = resolved_ref.node_id {
+                refs_by_target.entry(target_id).or_default().push((
+                    consumer_id,
+                    resolved_ref.is_mut,
+                    resolved_ref.access_group,
+                ));
+            }
+        }
+    }
+
+    // For each singleton target, add ordering barriers between access groups.
+    for (_target_id, refs) in &refs_by_target {
+        // Separate into grouped and ungrouped.
+        let mut grouped: BTreeMap<u32, Vec<(GraphNodeId, bool)>> = BTreeMap::new();
+        let mut ungrouped_shared: Vec<GraphNodeId> = Vec::new();
+        let mut ungrouped_mut: Vec<GraphNodeId> = Vec::new();
+
+        for &(consumer_id, is_mut, access_group) in refs {
+            if let Some(group) = access_group {
+                grouped.entry(group).or_default().push((consumer_id, is_mut));
+            } else if is_mut {
+                ungrouped_mut.push(consumer_id);
+            } else {
+                ungrouped_shared.push(consumer_id);
+            }
+        }
+
+        // Grouped: add barriers between consecutive groups.
+        let groups_sorted: Vec<_> = grouped.keys().copied().collect();
+        for window in groups_sorted.windows(2) {
+            let (lower_group, higher_group) = (window[0], window[1]);
+            let lower_nodes = &grouped[&lower_group];
+            let higher_nodes = &grouped[&higher_group];
+            // Every node in the lower group must run before every node in the higher group.
+            for &(lower_node, _) in lower_nodes {
+                for &(higher_node, _) in higher_nodes {
+                    singleton_barrier_crossers.push((lower_node, higher_node));
+                }
+            }
+        }
+
+        // Ungrouped: shared refs must run before mutable refs.
+        for &shared_node in &ungrouped_shared {
+            for &mut_node in &ungrouped_mut {
+                singleton_barrier_crossers.push((shared_node, mut_node));
+            }
+        }
+    }
+
     BarrierCrossers {
         edge_barrier_crossers,
         singleton_barrier_crossers,

--- a/dfir_lang/src/graph/flat_to_partitioned.rs
+++ b/dfir_lang/src/graph/flat_to_partitioned.rs
@@ -96,7 +96,7 @@ fn find_barrier_crossers(partitioned_graph: &DfirGraph) -> BarrierCrossers {
     }
 
     // For each singleton target, add ordering barriers between access groups.
-    for (_target_id, refs) in &refs_by_target {
+    for refs in refs_by_target.values() {
         // Separate into grouped and ungrouped.
         let mut grouped: BTreeMap<u32, Vec<(GraphNodeId, bool)>> = BTreeMap::new();
         let mut ungrouped_shared: Vec<GraphNodeId> = Vec::new();
@@ -104,7 +104,10 @@ fn find_barrier_crossers(partitioned_graph: &DfirGraph) -> BarrierCrossers {
 
         for &(consumer_id, is_mut, access_group) in refs {
             if let Some(group) = access_group {
-                grouped.entry(group).or_default().push((consumer_id, is_mut));
+                grouped
+                    .entry(group)
+                    .or_default()
+                    .push((consumer_id, is_mut));
             } else if is_mut {
                 ungrouped_mut.push(consumer_id);
             } else {

--- a/dfir_lang/src/graph/flat_to_partitioned.rs
+++ b/dfir_lang/src/graph/flat_to_partitioned.rs
@@ -2,6 +2,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
+use itertools::Itertools;
 use proc_macro2::Span;
 use slotmap::{SecondaryMap, SparseSecondaryMap};
 
@@ -79,60 +80,22 @@ fn find_barrier_crossers(partitioned_graph: &DfirGraph) -> BarrierCrossers {
     // Access group ordering barriers: for the same singleton target, operators in
     // lower access groups must run before operators in higher access groups.
     // Also: ungrouped mutable refs must run after ungrouped shared refs.
-    //
-    // Collect all (target_node_id, consumer_node_id, is_mut, access_group) tuples.
-    let mut refs_by_target: BTreeMap<GraphNodeId, Vec<(GraphNodeId, bool, Option<u32>)>> =
-        BTreeMap::new();
-    for consumer_id in partitioned_graph.node_ids() {
-        for resolved_ref in partitioned_graph.node_singleton_references(consumer_id) {
-            if let Some(target_id) = resolved_ref.node_id {
-                refs_by_target.entry(target_id).or_default().push((
-                    consumer_id,
-                    resolved_ref.is_mut,
-                    resolved_ref.access_group,
-                ));
-            }
-        }
-    }
-
-    // For each singleton target, add ordering barriers between access groups.
-    for refs in refs_by_target.values() {
-        // Separate into grouped and ungrouped.
-        let mut grouped: BTreeMap<u32, Vec<(GraphNodeId, bool)>> = BTreeMap::new();
-        let mut ungrouped_shared: Vec<GraphNodeId> = Vec::new();
-        let mut ungrouped_mut: Vec<GraphNodeId> = Vec::new();
-
-        for &(consumer_id, is_mut, access_group) in refs {
-            if let Some(group) = access_group {
-                grouped
-                    .entry(group)
-                    .or_default()
-                    .push((consumer_id, is_mut));
-            } else if is_mut {
-                ungrouped_mut.push(consumer_id);
-            } else {
-                ungrouped_shared.push(consumer_id);
-            }
-        }
-
-        // Grouped: add barriers between consecutive groups.
-        let groups_sorted: Vec<_> = grouped.keys().copied().collect();
-        for window in groups_sorted.windows(2) {
-            let (lower_group, higher_group) = (window[0], window[1]);
-            let lower_nodes = &grouped[&lower_group];
-            let higher_nodes = &grouped[&higher_group];
-            // Every node in the lower group must run before every node in the higher group.
-            for &(lower_node, _) in lower_nodes {
-                for &(higher_node, _) in higher_nodes {
-                    singleton_barrier_crossers.push((lower_node, higher_node));
+    let refs_by_target = partitioned_graph.node_singleton_reference_groups();
+    // For each singleton target...
+    for (_singleton, groups) in refs_by_target {
+        // For sequential access groups...
+        for (group_a, group_b) in groups.values().tuple_windows() {
+            // Add ordering barriers so every node in the lower group must run before every node in the higher group.
+            for &(node_a, _, _) in group_a {
+                for &(node_b, _, _) in group_b {
+                    // TODO(mingwei): handle with diagnostics.
+                    assert_ne!(
+                        node_a, node_b,
+                        "encounted conflicted or cyclical singleton references\n{:?}\n{:?}",
+                        group_a, group_b,
+                    );
+                    singleton_barrier_crossers.push((node_a, node_b));
                 }
-            }
-        }
-
-        // Ungrouped: shared refs must run before mutable refs.
-        for &shared_node in &ungrouped_shared {
-            for &mut_node in &ungrouped_mut {
-                singleton_barrier_crossers.push((shared_node, mut_node));
             }
         }
     }

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -30,7 +30,7 @@ use crate::process_singletons;
 /// A resolved singleton reference: the target node ID plus mutability and access group info.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ResolvedSingletonRef {
-    /// The resolved target node ID (None if unresolved/error).
+    /// The resolved target node ID (`None` if unresolved/error).
     pub node_id: Option<GraphNodeId>,
     /// Whether this is a mutable reference (`#mut var`).
     pub is_mut: bool,

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -27,6 +27,17 @@ use crate::diagnostic::{Diagnostic, Diagnostics, Level};
 use crate::pretty_span::{PrettyRowCol, PrettySpan};
 use crate::process_singletons;
 
+/// A resolved singleton reference: the target node ID plus mutability and access group info.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ResolvedSingletonRef {
+    /// The resolved target node ID (None if unresolved/error).
+    pub node_id: Option<GraphNodeId>,
+    /// Whether this is a mutable reference (`#mut var`).
+    pub is_mut: bool,
+    /// Optional access group for ordering (`#{N} var`).
+    pub access_group: Option<u32>,
+}
+
 /// An abstract "meta graph" representation of a DFIR graph.
 ///
 /// Can be with or without subgraph partitioning, stratification, and handoff insertion. This is
@@ -70,7 +81,7 @@ pub struct DfirGraph {
     subgraph_nodes: SlotMap<GraphSubgraphId, Vec<GraphNodeId>>,
 
     /// Resolved singletons varnames references, per node.
-    node_singleton_references: SparseSecondaryMap<GraphNodeId, Vec<Option<GraphNodeId>>>,
+    node_singleton_references: SparseSecondaryMap<GraphNodeId, Vec<ResolvedSingletonRef>>,
     /// What variable name each graph node belongs to (if any). For debugging (graph writing) purposes only.
     node_varnames: SparseSecondaryMap<GraphNodeId, Varname>,
 
@@ -531,15 +542,15 @@ impl DfirGraph {
     pub fn set_node_singleton_references(
         &mut self,
         node_id: GraphNodeId,
-        singletons_referenced: Vec<Option<GraphNodeId>>,
-    ) -> Option<Vec<Option<GraphNodeId>>> {
+        singletons_referenced: Vec<ResolvedSingletonRef>,
+    ) -> Option<Vec<ResolvedSingletonRef>> {
         self.node_singleton_references
             .insert(node_id, singletons_referenced)
     }
 
-    /// Gets the singletons referenced by a node. Returns an empty iterator for non-operators and
+    /// Gets the singletons referenced by a node. Returns an empty slice for non-operators and
     /// operators that do not reference singletons.
-    pub fn node_singleton_references(&self, node_id: GraphNodeId) -> &[Option<GraphNodeId>] {
+    pub fn node_singleton_references(&self, node_id: GraphNodeId) -> &[ResolvedSingletonRef] {
         self.node_singleton_references
             .get(node_id)
             .map(std::ops::Deref::deref)
@@ -814,16 +825,17 @@ impl DfirGraph {
 
     /// Resolve the singletons via [`Self::node_singleton_references`] for the given `node_id`.
     /// Returns token streams for each reference:
-    /// - For stateful operators: `&singleton_op_XXX` (borrow the operator's state)
-    /// - For HandoffKind::Option: `&(hoff_XXX_buf.as_ref().unwrap())` (intentionally produce `&&T`
-    ///   so the later `(*expr)` deref yields `&T`) - TODO(mingwei)
+    /// - For stateful operators: `&singleton_op_XXX` or `&mut singleton_op_XXX`
+    /// - For HandoffKind::Option: `&(hoff_XXX_buf.as_ref().unwrap())` (shared) or
+    ///   `&mut(hoff_XXX_buf.as_mut().unwrap())` (mutable)
     fn helper_resolve_singletons(&self, node_id: GraphNodeId, span: Span) -> Vec<TokenStream> {
         self.node_singleton_references(node_id)
             .iter()
-            .map(|singleton_node_id| {
+            .map(|resolved_ref| {
                 // TODO(mingwei): this `expect` should be caught in error checking
-                let ref_node_id = singleton_node_id
+                let ref_node_id = resolved_ref.node_id
                     .expect("Expected singleton to be resolved but was not, this is a bug.");
+                let is_mut = resolved_ref.is_mut;
                 if matches!(
                     self.node(ref_node_id),
                     GraphNode::Handoff {
@@ -832,13 +844,22 @@ impl DfirGraph {
                     }
                 ) {
                     let buf_ident = self.hoff_buf_ident(ref_node_id, span);
-                    // Wrapping in &(...) produces &&T so that postprocess_singletons'
-                    // (*expr) deref gives &T — matching `type O = &'a T`.
-                    // TODO(mingwei): Make postprocess_singletons not deref, remove old singletons (the `else` case below).
-                    quote_spanned! {span=> &(#buf_ident.as_ref().unwrap()) }
+                    if is_mut {
+                        // `&mut(buf.as_mut().unwrap())` produces `&mut &mut T` so that
+                        // postprocess_singletons' `(*expr)` deref gives `&mut T`.
+                        quote_spanned! {span=> &mut(#buf_ident.as_mut().unwrap()) }
+                    } else {
+                        // `&(buf.as_ref().unwrap())` produces `&&T` so that
+                        // postprocess_singletons' `(*expr)` deref gives `&T`.
+                        quote_spanned! {span=> &(#buf_ident.as_ref().unwrap()) }
+                    }
                 } else {
                     let singleton_ident = self.node_as_singleton_ident(ref_node_id, span);
-                    quote_spanned! {span=> &#singleton_ident }
+                    if is_mut {
+                        quote_spanned! {span=> &mut #singleton_ident }
+                    } else {
+                        quote_spanned! {span=> &#singleton_ident }
+                    }
                 }
             })
             .collect::<Vec<_>>()
@@ -1031,8 +1052,7 @@ impl DfirGraph {
                 for src_ref_id in self
                     .node_singleton_references(dst_id)
                     .iter()
-                    .copied()
-                    .flatten()
+                    .filter_map(|r| r.node_id)
                 {
                     // For handoff nodes (no subgraph), use the predecessor's subgraph.
                     let src_sg = if let Some(sg) = self.node_subgraph(src_ref_id) {
@@ -1934,8 +1954,7 @@ impl DfirGraph {
                 for src_ref_id in self
                     .node_singleton_references(dst_id)
                     .iter()
-                    .copied()
-                    .flatten()
+                    .filter_map(|r| r.node_id)
                 {
                     let delay_type = Some(DelayType::Stratum);
                     let label = None;

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -556,7 +556,37 @@ impl DfirGraph {
             .map(std::ops::Deref::deref)
             .unwrap_or_default()
     }
+
+    /// Collect all refs, grouped by the singleton they're pointing at, then by the access group idx `Option<u32>`.
+    pub fn node_singleton_reference_groups(&self) -> NodeSingletonReferenceGroups<'_> {
+        let mut singleton_references = NodeSingletonReferenceGroups::new();
+        for node_id in self.node_ids() {
+            if let GraphNode::Operator(operator) = self.node(node_id) {
+                let resolved = self.node_singleton_references(node_id);
+                for (resolved_ref, ref_token) in
+                    resolved.iter().zip(operator.singletons_referenced.iter())
+                {
+                    if let Some(target_nid) = resolved_ref.node_id {
+                        singleton_references
+                            .entry(target_nid)
+                            .or_default()
+                            .entry(resolved_ref.access_group)
+                            .or_default()
+                            .push((node_id, resolved_ref, ref_token.span()));
+                    }
+                }
+            }
+        }
+        singleton_references
+    }
 }
+
+/// Per-node singleton references, in turn grouped by access group.
+/// Map: singleton_node_id -> access_group -> (source `GraphNodeId`, `ResolvedSingletonRef`, `#ref` span)
+pub type NodeSingletonReferenceGroups<'a> = BTreeMap<
+    GraphNodeId,
+    BTreeMap<Option<u32>, Vec<(GraphNodeId, &'a ResolvedSingletonRef, Span)>>,
+>;
 
 /// Module methods.
 impl DfirGraph {

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -833,7 +833,8 @@ impl DfirGraph {
             .iter()
             .map(|resolved_ref| {
                 // TODO(mingwei): this `expect` should be caught in error checking
-                let ref_node_id = resolved_ref.node_id
+                let ref_node_id = resolved_ref
+                    .node_id
                     .expect("Expected singleton to be resolved but was not, this is a bug.");
                 let is_mut = resolved_ref.is_mut;
                 if matches!(

--- a/dfir_lang/src/graph/mod.rs
+++ b/dfir_lang/src/graph/mod.rs
@@ -12,7 +12,7 @@ use syn::{Expr, ExprPath, GenericArgument, Token, Type};
 
 use self::ops::{OperatorConstraints, Persistence};
 use crate::diagnostic::{Diagnostic, Diagnostics, Level};
-use crate::parse::{DfirCode, IndexInt, Operator, PortIndex, Ported};
+use crate::parse::{DfirCode, IndexInt, Operator, PortIndex, Ported, SingletonRef};
 use crate::pretty_span::PrettySpan;
 
 mod di_mul_graph;
@@ -201,7 +201,7 @@ pub struct OperatorInstance {
     /// Port values used as this operator's output.
     pub output_ports: Vec<PortIndexValue>,
     /// Singleton references within the operator arguments.
-    pub singletons_referenced: Vec<crate::process_singletons::SingletonRefToken>,
+    pub singletons_referenced: Vec<SingletonRef>,
 
     /// Generic arguments.
     pub generics: OpInstGenerics,

--- a/dfir_lang/src/graph/mod.rs
+++ b/dfir_lang/src/graph/mod.rs
@@ -201,7 +201,7 @@ pub struct OperatorInstance {
     /// Port values used as this operator's output.
     pub output_ports: Vec<PortIndexValue>,
     /// Singleton references within the operator arguments.
-    pub singletons_referenced: Vec<Ident>,
+    pub singletons_referenced: Vec<crate::process_singletons::SingletonRefToken>,
 
     /// Generic arguments.
     pub generics: OpInstGenerics,

--- a/dfir_lang/src/parse.rs
+++ b/dfir_lang/src/parse.rs
@@ -430,7 +430,7 @@ pub struct Operator {
     pub paren_token: Paren,
     pub args_raw: TokenStream,
     pub args: Punctuated<Expr, Token![,]>,
-    pub singletons_referenced: Vec<Ident>,
+    pub singletons_referenced: Vec<crate::process_singletons::SingletonRefToken>,
 }
 
 impl Operator {

--- a/dfir_lang/src/parse.rs
+++ b/dfir_lang/src/parse.rs
@@ -6,7 +6,8 @@ use std::hash::Hash;
 
 use proc_macro2::{Span, TokenStream};
 use quote::ToTokens;
-use syn::parse::{Parse, ParseStream};
+use syn::parse::discouraged::Speculative;
+use syn::parse::{Parse, ParseStream, Parser};
 use syn::punctuated::Punctuated;
 use syn::token::{Brace, Bracket, Paren};
 use syn::{
@@ -430,7 +431,7 @@ pub struct Operator {
     pub paren_token: Paren,
     pub args_raw: TokenStream,
     pub args: Punctuated<Expr, Token![,]>,
-    pub singletons_referenced: Vec<crate::process_singletons::SingletonRefToken>,
+    pub singletons_referenced: Vec<SingletonRef>,
 }
 
 impl Operator {
@@ -509,8 +510,8 @@ impl Parse for Operator {
         let content;
         let paren_token = parenthesized!(content in input);
         let args_raw: TokenStream = content.parse()?;
-        let mut singletons_referenced = Vec::new();
-        let args = parse_terminated(preprocess_singletons(
+        let mut singletons_referenced: Vec<SingletonRef> = Vec::new();
+        let args = Punctuated::parse_terminated.parse2(preprocess_singletons(
             args_raw.clone(),
             &mut singletons_referenced,
         ))?;
@@ -593,23 +594,65 @@ impl Ord for IndexInt {
     }
 }
 
-pub fn parse_terminated<T, P>(tokens: TokenStream) -> syn::Result<Punctuated<T, P>>
-where
-    T: Parse,
-    P: Parse,
-{
-    struct ParseTerminated<T, P>(pub Punctuated<T, P>);
-    impl<T, P> Parse for ParseTerminated<T, P>
-    where
-        T: Parse,
-        P: Parse,
-    {
-        fn parse(input: ParseStream) -> syn::Result<Self> {
-            Ok(Self(Punctuated::parse_terminated(input)?))
-        }
-    }
+/// A parsed singleton reference token with mutability and optional access group.
+///
+/// Syntax: `#var`, `#mut var`, `#{N} var`, `#{N} mut var`
+#[derive(Clone, Debug)]
+pub struct SingletonRef {
+    /// Hash `#` marking the start of the singleton.
+    pub hash: Token![#],
+    /// Optional access group for ordering (`#{N}` prefix). Stores the brace group and parsed integer.
+    pub access_group: Option<(Brace, u32)>,
+    /// Whether this is a mutable reference (`#mut var` or `#{N} mut var`).
+    pub token_mut: Option<Token![mut]>,
+    /// The variable name being referenced.
+    pub ident: Ident,
+}
 
-    Ok(syn::parse2::<ParseTerminated<T, P>>(tokens)?.0)
+impl SingletonRef {
+    /// Returns a parsed singleton reference token (if valid) and all remaining tokens.
+    pub fn try_parse(input: ParseStream) -> syn::Result<(Option<Self>, TokenStream)> {
+        let this = if input.peek(Token![#]) {
+            let fork = input.fork();
+            if let Ok(this) = fork.parse() {
+                input.advance_to(&fork);
+                Some(this)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        let tokens = input.parse().expect("infallible");
+        Ok((this, tokens))
+    }
+}
+
+impl Parse for SingletonRef {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let hash = input.parse::<Token![#]>()?;
+        let access_group = input
+            .peek(Brace)
+            .then(|| {
+                let inner;
+                let brace = braced!(inner in input);
+                let lit_int = inner.parse::<LitInt>()?;
+                let idx = lit_int.base10_parse::<u32>()?;
+                if !inner.is_empty() {
+                    return Err(inner.error("expected only an integer"));
+                }
+                Ok((brace, idx))
+            })
+            .transpose()?;
+        let token_mut = input.parse()?;
+        let ident = input.parse()?;
+        Ok(Self {
+            hash,
+            token_mut,
+            access_group,
+            ident,
+        })
+    }
 }
 
 #[cfg(test)]

--- a/dfir_lang/src/parse.rs
+++ b/dfir_lang/src/parse.rs
@@ -602,7 +602,7 @@ pub struct SingletonRef {
     /// Hash `#` marking the start of the singleton.
     pub hash: Token![#],
     /// Optional access group for ordering (`#{N}` prefix). Stores the brace group and parsed integer.
-    pub access_group: Option<(Brace, u32)>,
+    pub access_group: Option<(Brace, LitInt)>,
     /// Whether this is a mutable reference (`#mut var` or `#{N} mut var`).
     pub token_mut: Option<Token![mut]>,
     /// The variable name being referenced.
@@ -630,18 +630,17 @@ impl SingletonRef {
 
 impl Parse for SingletonRef {
     fn parse(input: ParseStream) -> syn::Result<Self> {
-        let hash = input.parse::<Token![#]>()?;
+        let hash = input.parse()?;
         let access_group = input
             .peek(Brace)
             .then(|| {
                 let inner;
                 let brace = braced!(inner in input);
-                let lit_int = inner.parse::<LitInt>()?;
-                let idx = lit_int.base10_parse::<u32>()?;
+                let lit_int = inner.parse()?;
                 if !inner.is_empty() {
                     return Err(inner.error("expected only an integer"));
                 }
-                Ok((brace, idx))
+                Ok((brace, lit_int))
             })
             .transpose()?;
         let token_mut = input.parse()?;
@@ -652,6 +651,19 @@ impl Parse for SingletonRef {
             access_group,
             ident,
         })
+    }
+}
+
+impl ToTokens for SingletonRef {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.hash.to_tokens(tokens);
+        if let Some((brace, lit_int)) = self.access_group.as_ref() {
+            brace.surround(tokens, |tokens| {
+                lit_int.to_tokens(tokens);
+            });
+        }
+        self.token_mut.to_tokens(tokens);
+        self.ident.to_tokens(tokens);
     }
 }
 

--- a/dfir_lang/src/process_singletons.rs
+++ b/dfir_lang/src/process_singletons.rs
@@ -28,7 +28,6 @@ pub fn preprocess_singletons(tokens: TokenStream, found: &mut Vec<SingletonRef>)
 /// * `tokens` - The tokens to update singleton references within.
 /// * `resolved_exprs` - Token streams that correspond 1:1 and in the same
 ///   order as the singleton references within `tokens` (found in-order via [`preprocess_singletons`]).
-/// * `singleton_ref_tokens` - The parsed singleton ref tokens (for mutability info).
 ///
 /// For shared refs: generates `(*expr)` — an immutable place expression.
 /// For mutable refs: generates `(*expr)` — a mutable place expression (expr itself is `&mut`).

--- a/dfir_lang/src/process_singletons.rs
+++ b/dfir_lang/src/process_singletons.rs
@@ -14,8 +14,8 @@ pub struct SingletonRefToken {
     pub ident: Ident,
     /// Whether this is a mutable reference (`#mut var` or `#{N} mut var`).
     pub is_mut: bool,
-    /// Optional access group for ordering (`#{N}` prefix).
-    pub access_group: Option<u32>,
+    /// Optional access group for ordering (`#{N}` prefix). Stores the brace group and parsed integer.
+    pub access_group: Option<(Group, u32)>,
 }
 
 /// Finds all the singleton references and appends them to `found`. Returns the
@@ -103,11 +103,11 @@ fn process_singletons(
                             let group_tokens: Vec<TokenTree> =
                                 group.stream().into_iter().collect();
                             if let [TokenTree::Literal(lit)] = group_tokens.as_slice() {
-                                // Parse the integer literal
                                 let lit_str = lit.to_string();
-                                Some(lit_str.parse::<u32>().unwrap_or_else(|_| {
+                                let n = lit_str.parse::<u32>().unwrap_or_else(|_| {
                                     panic!("Expected integer in singleton access group, got `{}`", lit_str)
-                                }))
+                                });
+                                Some((group, n))
                             } else {
                                 panic!("Expected single integer in singleton access group `{{N}}`")
                             }

--- a/dfir_lang/src/process_singletons.rs
+++ b/dfir_lang/src/process_singletons.rs
@@ -1,4 +1,4 @@
-//! Utility methods for processing singleton references: `#my_var`.
+//! Utility methods for processing singleton references: `#my_var`, `#mut my_var`, `#{N} my_var`, `#{N} mut my_var`.
 
 use itertools::Itertools;
 use proc_macro2::{Group, Ident, TokenStream, TokenTree};
@@ -7,35 +7,56 @@ use syn::{Expr, Token};
 
 use crate::parse::parse_terminated;
 
-/// Finds all the singleton references `#my_var` and appends them to `found_idents`. Returns the
-/// `TokenStream` but with the hashes removed from the varnames.
+/// A parsed singleton reference token with mutability and optional access group.
+#[derive(Clone, Debug)]
+pub struct SingletonRefToken {
+    /// The variable name being referenced.
+    pub ident: Ident,
+    /// Whether this is a mutable reference (`#mut var` or `#{N} mut var`).
+    pub is_mut: bool,
+    /// Optional access group for ordering (`#{N}` prefix).
+    pub access_group: Option<u32>,
+}
+
+/// Finds all the singleton references and appends them to `found`. Returns the
+/// `TokenStream` but with the `#`, `{N}`, and `mut` removed from the varnames.
+///
+/// Syntax: `#var`, `#mut var`, `#{N} var`, `#{N} mut var`
 ///
 /// The returned tokens are used for "preflight" parsing, to check that the rest of the syntax is
 /// OK. However the returned tokens are not used in the codegen as we need to use [`postprocess_singletons`]
 /// later to substitute-in the context referencing code for each singleton
-pub fn preprocess_singletons(tokens: TokenStream, found_idents: &mut Vec<Ident>) -> TokenStream {
-    process_singletons(tokens, &mut |singleton_ident| {
-        found_idents.push(singleton_ident.clone());
-        TokenTree::Ident(singleton_ident)
+pub fn preprocess_singletons(
+    tokens: TokenStream,
+    found: &mut Vec<SingletonRefToken>,
+) -> TokenStream {
+    process_singletons(tokens, &mut |ref_token| {
+        let ident = ref_token.ident.clone();
+        found.push(ref_token);
+        TokenTree::Ident(ident)
     })
 }
 
-/// Replaces singleton references `#my_var` with the code needed to actually get the value inside.
+/// Replaces singleton references with the code needed to actually get the value inside.
 ///
 /// * `tokens` - The tokens to update singleton references within.
 /// * `resolved_exprs` - Token streams that correspond 1:1 and in the same
 ///   order as the singleton references within `tokens` (found in-order via [`preprocess_singletons`]).
+/// * `singleton_ref_tokens` - The parsed singleton ref tokens (for mutability info).
 ///
-/// Generates `(*expr)` — an immutable place expression that prevents consumer mutation.
+/// For shared refs: generates `(*expr)` — an immutable place expression.
+/// For mutable refs: generates `(*expr)` — a mutable place expression (expr itself is `&mut`).
 pub fn postprocess_singletons(
     tokens: TokenStream,
     resolved_exprs: impl IntoIterator<Item = TokenStream>,
 ) -> Punctuated<Expr, Token![,]> {
     let mut resolved_exprs_iter = resolved_exprs.into_iter();
-    let processed = process_singletons(tokens, &mut |singleton_ident| {
-        let span = singleton_ident.span();
+    let processed = process_singletons(tokens, &mut |_ref_token| {
+        let span = _ref_token.ident.span();
         let expr_tokens = resolved_exprs_iter.next().unwrap();
-        // Emit `(*expr)` so consumers get an immutable place expression.
+        // Emit `(*expr)` so consumers get a place expression.
+        // For shared refs, expr is `&T` so `(*expr)` is immutable.
+        // For mutable refs, expr is `&mut T` so `(*expr)` is mutable.
         let deref_tokens: TokenStream = std::iter::once(TokenTree::Punct(proc_macro2::Punct::new(
             '*',
             proc_macro2::Spacing::Alone,
@@ -51,9 +72,11 @@ pub fn postprocess_singletons(
 
 /// Traverse the token stream, applying the `map_singleton_fn` whenever a singleton is found,
 /// returning the transformed token stream.
+///
+/// Parses: `#ident`, `#mut ident`, `#{N} ident`, `#{N} mut ident`
 fn process_singletons(
     tokens: TokenStream,
-    map_singleton_fn: &mut impl FnMut(Ident) -> TokenTree,
+    map_singleton_fn: &mut impl FnMut(SingletonRefToken) -> TokenTree,
 ) -> TokenStream {
     tokens
         .into_iter()
@@ -70,20 +93,60 @@ fn process_singletons(
                 }
                 TokenTree::Ident(ident) => TokenTree::Ident(ident),
                 TokenTree::Punct(punct) => {
-                    if '#' == punct.as_char() && matches!(iter.peek(), Some(TokenTree::Ident(_))) {
-                        // Found a singleton.
-                        let Some(TokenTree::Ident(mut singleton_ident)) = iter.next() else {
-                            unreachable!()
-                        };
+                    if '#' == punct.as_char() {
+                        // Parse optional access group: `{N}`
+                        let access_group = if matches!(iter.peek(), Some(TokenTree::Group(g)) if g.delimiter() == proc_macro2::Delimiter::Brace)
                         {
-                            // Include the `#` in the span.
-                            let span = singleton_ident
-                                .span()
-                                .join(punct.span())
-                                .unwrap_or(singleton_ident.span());
-                            singleton_ident.set_span(span.resolved_at(singleton_ident.span()));
+                            let Some(TokenTree::Group(group)) = iter.next() else {
+                                unreachable!()
+                            };
+                            let group_tokens: Vec<TokenTree> =
+                                group.stream().into_iter().collect();
+                            if let [TokenTree::Literal(lit)] = group_tokens.as_slice() {
+                                // Parse the integer literal
+                                let lit_str = lit.to_string();
+                                Some(lit_str.parse::<u32>().unwrap_or_else(|_| {
+                                    panic!("Expected integer in singleton access group, got `{}`", lit_str)
+                                }))
+                            } else {
+                                panic!("Expected single integer in singleton access group `{{N}}`")
+                            }
+                        } else {
+                            None
+                        };
+
+                        // Parse optional `mut`
+                        let is_mut = if matches!(iter.peek(), Some(TokenTree::Ident(id)) if id == "mut")
+                        {
+                            iter.next(); // consume `mut`
+                            true
+                        } else {
+                            false
+                        };
+
+                        // Parse the ident
+                        if matches!(iter.peek(), Some(TokenTree::Ident(_))) {
+                            let Some(TokenTree::Ident(mut singleton_ident)) = iter.next() else {
+                                unreachable!()
+                            };
+                            {
+                                // Include the `#` in the span.
+                                let span = singleton_ident
+                                    .span()
+                                    .join(punct.span())
+                                    .unwrap_or(singleton_ident.span());
+                                singleton_ident.set_span(span.resolved_at(singleton_ident.span()));
+                            }
+                            (map_singleton_fn)(SingletonRefToken {
+                                ident: singleton_ident,
+                                is_mut,
+                                access_group,
+                            })
+                        } else {
+                            // No ident after `#` (or `#{N}` / `#mut`) — emit the punct as-is.
+                            // This shouldn't normally happen in valid DFIR syntax.
+                            TokenTree::Punct(punct)
                         }
-                        (map_singleton_fn)(singleton_ident)
                     } else {
                         TokenTree::Punct(punct)
                     }

--- a/dfir_lang/src/process_singletons.rs
+++ b/dfir_lang/src/process_singletons.rs
@@ -1,22 +1,11 @@
 //! Utility methods for processing singleton references: `#my_var`, `#mut my_var`, `#{N} my_var`, `#{N} mut my_var`.
 
-use itertools::Itertools;
-use proc_macro2::{Group, Ident, TokenStream, TokenTree};
+use proc_macro2::{Group, TokenStream, TokenTree};
+use syn::parse::Parser;
 use syn::punctuated::Punctuated;
 use syn::{Expr, Token};
 
-use crate::parse::parse_terminated;
-
-/// A parsed singleton reference token with mutability and optional access group.
-#[derive(Clone, Debug)]
-pub struct SingletonRefToken {
-    /// The variable name being referenced.
-    pub ident: Ident,
-    /// Whether this is a mutable reference (`#mut var` or `#{N} mut var`).
-    pub is_mut: bool,
-    /// Optional access group for ordering (`#{N}` prefix). Stores the brace group and parsed integer.
-    pub access_group: Option<(Group, u32)>,
-}
+use crate::parse::SingletonRef;
 
 /// Finds all the singleton references and appends them to `found`. Returns the
 /// `TokenStream` but with the `#`, `{N}`, and `mut` removed from the varnames.
@@ -26,10 +15,7 @@ pub struct SingletonRefToken {
 /// The returned tokens are used for "preflight" parsing, to check that the rest of the syntax is
 /// OK. However the returned tokens are not used in the codegen as we need to use [`postprocess_singletons`]
 /// later to substitute-in the context referencing code for each singleton
-pub fn preprocess_singletons(
-    tokens: TokenStream,
-    found: &mut Vec<SingletonRefToken>,
-) -> TokenStream {
+pub fn preprocess_singletons(tokens: TokenStream, found: &mut Vec<SingletonRef>) -> TokenStream {
     process_singletons(tokens, &mut |ref_token| {
         let ident = ref_token.ident.clone();
         found.push(ref_token);
@@ -67,7 +53,7 @@ pub fn postprocess_singletons(
         group.set_span(span);
         TokenTree::Group(group)
     });
-    parse_terminated(processed).unwrap()
+    Punctuated::parse_terminated.parse2(processed).unwrap()
 }
 
 /// Traverse the token stream, applying the `map_singleton_fn` whenever a singleton is found,
@@ -76,84 +62,36 @@ pub fn postprocess_singletons(
 /// Parses: `#ident`, `#mut ident`, `#{N} ident`, `#{N} mut ident`
 fn process_singletons(
     tokens: TokenStream,
-    map_singleton_fn: &mut impl FnMut(SingletonRefToken) -> TokenTree,
+    map_singleton_fn: &mut impl FnMut(SingletonRef) -> TokenTree,
 ) -> TokenStream {
-    tokens
-        .into_iter()
-        .peekable()
-        .batching(|iter| {
-            let out = match iter.next()? {
-                TokenTree::Group(group) => {
-                    let mut new_group = Group::new(
-                        group.delimiter(),
-                        process_singletons(group.stream(), map_singleton_fn),
-                    );
-                    new_group.set_span(group.span());
-                    TokenTree::Group(new_group)
-                }
-                TokenTree::Ident(ident) => TokenTree::Ident(ident),
-                TokenTree::Punct(punct) => {
-                    if '#' == punct.as_char() {
-                        // Parse optional access group: `{N}`
-                        let access_group = if matches!(iter.peek(), Some(TokenTree::Group(g)) if g.delimiter() == proc_macro2::Delimiter::Brace)
-                        {
-                            let Some(TokenTree::Group(group)) = iter.next() else {
-                                unreachable!()
-                            };
-                            let group_tokens: Vec<TokenTree> =
-                                group.stream().into_iter().collect();
-                            if let [TokenTree::Literal(lit)] = group_tokens.as_slice() {
-                                let lit_str = lit.to_string();
-                                let n = lit_str.parse::<u32>().unwrap_or_else(|_| {
-                                    panic!("Expected integer in singleton access group, got `{}`", lit_str)
-                                });
-                                Some((group, n))
-                            } else {
-                                panic!("Expected single integer in singleton access group `{{N}}`")
-                            }
-                        } else {
-                            None
-                        };
+    let mut iter = tokens.into_iter().peekable();
+    std::iter::from_fn(|| {
+        let out = match iter.peek()? {
+            TokenTree::Group(group) => {
+                let mut new_group = Group::new(
+                    group.delimiter(),
+                    process_singletons(group.stream(), map_singleton_fn),
+                );
+                new_group.set_span(group.span());
 
-                        // Parse optional `mut`
-                        let is_mut = if matches!(iter.peek(), Some(TokenTree::Ident(id)) if id == "mut")
-                        {
-                            iter.next(); // consume `mut`
-                            true
-                        } else {
-                            false
-                        };
-
-                        // Parse the ident
-                        if matches!(iter.peek(), Some(TokenTree::Ident(_))) {
-                            let Some(TokenTree::Ident(mut singleton_ident)) = iter.next() else {
-                                unreachable!()
-                            };
-                            {
-                                // Include the `#` in the span.
-                                let span = singleton_ident
-                                    .span()
-                                    .join(punct.span())
-                                    .unwrap_or(singleton_ident.span());
-                                singleton_ident.set_span(span.resolved_at(singleton_ident.span()));
-                            }
-                            (map_singleton_fn)(SingletonRefToken {
-                                ident: singleton_ident,
-                                is_mut,
-                                access_group,
-                            })
-                        } else {
-                            // No ident after `#` (or `#{N}` / `#mut`) — emit the punct as-is.
-                            // This shouldn't normally happen in valid DFIR syntax.
-                            TokenTree::Punct(punct)
-                        }
-                    } else {
-                        TokenTree::Punct(punct)
-                    }
+                let _ = iter.next().unwrap(); // Advance past the `peek`ed group.
+                TokenTree::Group(new_group)
+            }
+            TokenTree::Punct(punct) if '#' == punct.as_char() => {
+                let tokens = iter.by_ref().collect::<TokenStream>();
+                let (opt_singleton, tokens_rest) = SingletonRef::try_parse
+                    .parse2(tokens)
+                    .expect("bug: should be infallible");
+                iter = tokens_rest.into_iter().peekable();
+                if let Some(singleton) = opt_singleton {
+                    (map_singleton_fn)(singleton)
+                } else {
+                    iter.next().unwrap()
                 }
-                TokenTree::Literal(lit) => TokenTree::Literal(lit),
-            };
-            Some(out)
-        })
-        .collect()
+            }
+            _ => iter.next().unwrap(),
+        };
+        Some(out)
+    })
+    .collect()
 }

--- a/dfir_rs/tests/compile-fail/nightly/surface_anti_join_badtypes.stderr
+++ b/dfir_rs/tests/compile-fail/nightly/surface_anti_join_badtypes.stderr
@@ -6,14 +6,5 @@ error[E0277]: the trait bound `&str: Borrow<{integer}>` is not satisfied
   |
 help: the trait `Borrow<str>` is implemented for `std::string::String`
  --> $RUST/alloc/src/str.rs
-  |
-  | impl Borrow<str> for String {
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `HashSet::<T, S, A>::contains`
  --> $RUST/std/src/collections/hash/set.rs
-  |
-  |     pub fn contains<Q: ?Sized>(&self, value: &Q) -> bool
-  |            -------- required by a bound in this associated function
-  |     where
-  |         T: Borrow<Q>,
-  |            ^^^^^^^^^ required by this bound in `HashSet::<T, S, A>::contains`

--- a/dfir_rs/tests/compile-fail/nightly/surface_fold_keyed_generics_bad.stderr
+++ b/dfir_rs/tests/compile-fail/nightly/surface_fold_keyed_generics_bad.stderr
@@ -53,6 +53,3 @@ error[E0271]: expected `new` to return `usize`, but it returns `String`
   |
 note: required by a bound in `std::collections::hash_map::Entry::<'a, K, V, A>::or_insert_with`
  --> $RUST/std/src/collections/hash/map.rs
-  |
-  |     pub fn or_insert_with<F: FnOnce() -> V>(self, default: F) -> &'a mut V {
-  |                                          ^ required by this bound in `Entry::<'a, K, V, A>::or_insert_with`

--- a/dfir_rs/tests/compile-fail/nightly/surface_singleton_conflicted_closure.stderr
+++ b/dfir_rs/tests/compile-fail/nightly/surface_singleton_conflicted_closure.stderr
@@ -1,0 +1,16 @@
+error: proc macro panicked
+ --> tests/compile-fail/nightly/surface_singleton_conflicted_closure.rs:3:18
+  |
+3 |       let mut df = dfir_rs::dfir_syntax! {
+  |  __________________^
+4 | |         my_val = source_iter([0_i32]) -> singleton();
+5 | |         my_val -> for_each(|_| {});
+6 | |         source_iter(0..10) -> map(|x| x + #{0} my_val + #{1} my_val) -> for_each(|_| {});
+7 | |     };
+  | |_____^
+  |
+  = help: message: assertion `left != right` failed: encounted conflicted or cyclical singleton references
+          [(GraphNodeId(5v1), ResolvedSingletonRef { node_id: Some(GraphNodeId(2v1)), is_mut: false, access_group: Some(0) }, #0 bytes(252..263))]
+          [(GraphNodeId(5v1), ResolvedSingletonRef { node_id: Some(GraphNodeId(2v1)), is_mut: false, access_group: Some(1) }, #0 bytes(266..277))]
+            left: GraphNodeId(5v1)
+           right: GraphNodeId(5v1)

--- a/dfir_rs/tests/compile-fail/nightly/surface_singleton_conflicted_operator.stderr
+++ b/dfir_rs/tests/compile-fail/nightly/surface_singleton_conflicted_operator.stderr
@@ -1,0 +1,16 @@
+error: proc macro panicked
+ --> tests/compile-fail/nightly/surface_singleton_conflicted_operator.rs:3:18
+  |
+3 |       let mut df = dfir_rs::dfir_syntax! {
+  |  __________________^
+4 | |         my_val = source_iter([0_i32]) -> singleton();
+5 | |         my_val -> for_each(|_| {});
+6 | |         source_iter(0..10) -> fold(|| #{0} my_val, |a, b| *a = b + #{1} my_val) -> for_each(|_| {});
+7 | |     };
+  | |_____^
+  |
+  = help: message: assertion `left != right` failed: encounted conflicted or cyclical singleton references
+          [(GraphNodeId(5v1), ResolvedSingletonRef { node_id: Some(GraphNodeId(2v1)), is_mut: false, access_group: Some(0) }, #0 bytes(249..260))]
+          [(GraphNodeId(5v1), ResolvedSingletonRef { node_id: Some(GraphNodeId(2v1)), is_mut: false, access_group: Some(1) }, #0 bytes(278..289))]
+            left: GraphNodeId(5v1)
+           right: GraphNodeId(5v1)

--- a/dfir_rs/tests/compile-fail/nightly/surface_singleton_mut_mixed_group.stderr
+++ b/dfir_rs/tests/compile-fail/nightly/surface_singleton_mut_mixed_group.stderr
@@ -1,11 +1,5 @@
-error: Cannot mix shared (`#`) and mutable (`#mut`) references in the same access group.
- --> tests/compile-fail/nightly/surface_singleton_mut_mixed_group.rs:6:50
-  |
-6 |         source_iter([1_i32]) -> map(|x| x + #{0} my_val) -> for_each(|_| {});
-  |                                                  ^^^^^^
-
-error: Cannot mix shared (`#`) and mutable (`#mut`) references in the same access group.
- --> tests/compile-fail/nightly/surface_singleton_mut_mixed_group.rs:7:53
+error: Mutable singleton references must be the only one in their access group, but group `#{0}` has multiple.
+ --> tests/compile-fail/nightly/surface_singleton_mut_mixed_group.rs:7:44
   |
 7 |         source_iter([2_i32]) -> map(|x| { *#{0} mut my_val += x; x }) -> for_each(|_| {});
-  |                                                     ^^^^^^
+  |                                            ^^^^^^^^^^^^^^^

--- a/dfir_rs/tests/compile-fail/nightly/surface_singleton_mut_mixed_group.stderr
+++ b/dfir_rs/tests/compile-fail/nightly/surface_singleton_mut_mixed_group.stderr
@@ -1,0 +1,11 @@
+error: Cannot mix shared (`#`) and mutable (`#mut`) references in the same access group.
+ --> tests/compile-fail/nightly/surface_singleton_mut_mixed_group.rs:6:50
+  |
+6 |         source_iter([1_i32]) -> map(|x| x + #{0} my_val) -> for_each(|_| {});
+  |                                                  ^^^^^^
+
+error: Cannot mix shared (`#`) and mutable (`#mut`) references in the same access group.
+ --> tests/compile-fail/nightly/surface_singleton_mut_mixed_group.rs:7:53
+  |
+7 |         source_iter([2_i32]) -> map(|x| { *#{0} mut my_val += x; x }) -> for_each(|_| {});
+  |                                                     ^^^^^^

--- a/dfir_rs/tests/compile-fail/nightly/surface_singleton_mut_same_group.stderr
+++ b/dfir_rs/tests/compile-fail/nightly/surface_singleton_mut_same_group.stderr
@@ -1,11 +1,11 @@
-error: Multiple `#mut` references in the same access group. Each mutable reference must be in its own access group.
- --> tests/compile-fail/nightly/surface_singleton_mut_same_group.rs:6:53
+error: Mutable singleton references must be the only one in their access group, but group `#{0}` has multiple.
+ --> tests/compile-fail/nightly/surface_singleton_mut_same_group.rs:6:44
   |
 6 |         source_iter([1_i32]) -> map(|x| { *#{0} mut my_val += x; x }) -> for_each(|_| {});
-  |                                                     ^^^^^^
+  |                                            ^^^^^^^^^^^^^^^
 
-error: Multiple `#mut` references in the same access group. Each mutable reference must be in its own access group.
- --> tests/compile-fail/nightly/surface_singleton_mut_same_group.rs:7:53
+error: Mutable singleton references must be the only one in their access group, but group `#{0}` has multiple.
+ --> tests/compile-fail/nightly/surface_singleton_mut_same_group.rs:7:44
   |
 7 |         source_iter([2_i32]) -> map(|x| { *#{0} mut my_val += x; x }) -> for_each(|_| {});
-  |                                                     ^^^^^^
+  |                                            ^^^^^^^^^^^^^^^

--- a/dfir_rs/tests/compile-fail/nightly/surface_singleton_mut_same_group.stderr
+++ b/dfir_rs/tests/compile-fail/nightly/surface_singleton_mut_same_group.stderr
@@ -1,0 +1,11 @@
+error: Multiple `#mut` references in the same access group. Each mutable reference must be in its own access group.
+ --> tests/compile-fail/nightly/surface_singleton_mut_same_group.rs:6:53
+  |
+6 |         source_iter([1_i32]) -> map(|x| { *#{0} mut my_val += x; x }) -> for_each(|_| {});
+  |                                                     ^^^^^^
+
+error: Multiple `#mut` references in the same access group. Each mutable reference must be in its own access group.
+ --> tests/compile-fail/nightly/surface_singleton_mut_same_group.rs:7:53
+  |
+7 |         source_iter([2_i32]) -> map(|x| { *#{0} mut my_val += x; x }) -> for_each(|_| {});
+  |                                                     ^^^^^^

--- a/dfir_rs/tests/compile-fail/nightly/surface_singleton_mut_ungrouped.stderr
+++ b/dfir_rs/tests/compile-fail/nightly/surface_singleton_mut_ungrouped.stderr
@@ -1,11 +1,11 @@
-error: Ungrouped `#mut` references cannot coexist with other mutable references to the same singleton. Use access groups `#{N} mut var` to specify ordering.
- --> tests/compile-fail/nightly/surface_singleton_mut_ungrouped.rs:6:49
+error: Mutable singleton references must be the only one in their access group, but group <default> has multiple.
+ --> tests/compile-fail/nightly/surface_singleton_mut_ungrouped.rs:6:44
   |
 6 |         source_iter([1_i32]) -> map(|x| { *#mut my_val += x; x }) -> for_each(|_| {});
-  |                                                 ^^^^^^
+  |                                            ^^^^^^^^^^^
 
-error: Ungrouped `#mut` references cannot coexist with other mutable references to the same singleton. Use access groups `#{N} mut var` to specify ordering.
- --> tests/compile-fail/nightly/surface_singleton_mut_ungrouped.rs:7:49
+error: Mutable singleton references must be the only one in their access group, but group <default> has multiple.
+ --> tests/compile-fail/nightly/surface_singleton_mut_ungrouped.rs:7:44
   |
 7 |         source_iter([2_i32]) -> map(|x| { *#mut my_val += x; x }) -> for_each(|_| {});
-  |                                                 ^^^^^^
+  |                                            ^^^^^^^^^^^

--- a/dfir_rs/tests/compile-fail/nightly/surface_singleton_mut_ungrouped.stderr
+++ b/dfir_rs/tests/compile-fail/nightly/surface_singleton_mut_ungrouped.stderr
@@ -1,0 +1,11 @@
+error: Multiple ungrouped `#mut` references to the same singleton. Use access groups `#{N} mut var` to specify ordering.
+ --> tests/compile-fail/nightly/surface_singleton_mut_ungrouped.rs:6:49
+  |
+6 |         source_iter([1_i32]) -> map(|x| { *#mut my_val += x; x }) -> for_each(|_| {});
+  |                                                 ^^^^^^
+
+error: Multiple ungrouped `#mut` references to the same singleton. Use access groups `#{N} mut var` to specify ordering.
+ --> tests/compile-fail/nightly/surface_singleton_mut_ungrouped.rs:7:49
+  |
+7 |         source_iter([2_i32]) -> map(|x| { *#mut my_val += x; x }) -> for_each(|_| {});
+  |                                                 ^^^^^^

--- a/dfir_rs/tests/compile-fail/nightly/surface_singleton_mut_ungrouped_grouped.stderr
+++ b/dfir_rs/tests/compile-fail/nightly/surface_singleton_mut_ungrouped_grouped.stderr
@@ -1,11 +1,11 @@
 error: Ungrouped `#mut` references cannot coexist with other mutable references to the same singleton. Use access groups `#{N} mut var` to specify ordering.
- --> tests/compile-fail/nightly/surface_singleton_mut_ungrouped.rs:6:49
+ --> tests/compile-fail/nightly/surface_singleton_mut_ungrouped_grouped.rs:6:49
   |
 6 |         source_iter([1_i32]) -> map(|x| { *#mut my_val += x; x }) -> for_each(|_| {});
   |                                                 ^^^^^^
 
 error: Ungrouped `#mut` references cannot coexist with other mutable references to the same singleton. Use access groups `#{N} mut var` to specify ordering.
- --> tests/compile-fail/nightly/surface_singleton_mut_ungrouped.rs:7:49
+ --> tests/compile-fail/nightly/surface_singleton_mut_ungrouped_grouped.rs:7:53
   |
-7 |         source_iter([2_i32]) -> map(|x| { *#mut my_val += x; x }) -> for_each(|_| {});
-  |                                                 ^^^^^^
+7 |         source_iter([2_i32]) -> map(|x| { *#{0} mut my_val += x; x }) -> for_each(|_| {});
+  |                                                     ^^^^^^

--- a/dfir_rs/tests/compile-fail/nightly/surface_singleton_mut_ungrouped_grouped.stderr
+++ b/dfir_rs/tests/compile-fail/nightly/surface_singleton_mut_ungrouped_grouped.stderr
@@ -1,11 +1,5 @@
-error: Ungrouped `#mut` references cannot coexist with other mutable references to the same singleton. Use access groups `#{N} mut var` to specify ordering.
- --> tests/compile-fail/nightly/surface_singleton_mut_ungrouped_grouped.rs:6:49
+error: Must use an explicit group `#{N} mut` to reference a singleton when other references use explicit groups.
+ --> tests/compile-fail/nightly/surface_singleton_mut_ungrouped_grouped.rs:6:44
   |
 6 |         source_iter([1_i32]) -> map(|x| { *#mut my_val += x; x }) -> for_each(|_| {});
-  |                                                 ^^^^^^
-
-error: Ungrouped `#mut` references cannot coexist with other mutable references to the same singleton. Use access groups `#{N} mut var` to specify ordering.
- --> tests/compile-fail/nightly/surface_singleton_mut_ungrouped_grouped.rs:7:53
-  |
-7 |         source_iter([2_i32]) -> map(|x| { *#{0} mut my_val += x; x }) -> for_each(|_| {});
-  |                                                     ^^^^^^
+  |                                            ^^^^^^^^^^^

--- a/dfir_rs/tests/compile-fail/nightly/surface_singleton_mut_ungrouped_shared.stderr
+++ b/dfir_rs/tests/compile-fail/nightly/surface_singleton_mut_ungrouped_shared.stderr
@@ -1,11 +1,5 @@
-error: Cannot mix ungrouped shared (`#var`) and mutable (`#mut var`) references to the same singleton. Use access groups `#{N}` to specify ordering.
- --> tests/compile-fail/nightly/surface_singleton_mut_ungrouped_shared.rs:6:46
+error: Must use an explicit group `#{N}` to reference a singleton when other references use explicit groups.
+ --> tests/compile-fail/nightly/surface_singleton_mut_ungrouped_shared.rs:6:45
   |
 6 |         source_iter([1_i32]) -> map(|x| x + #my_val) -> for_each(|_| {});
-  |                                              ^^^^^^
-
-error: Cannot mix ungrouped shared (`#var`) and mutable (`#mut var`) references to the same singleton. Use access groups `#{N}` to specify ordering.
- --> tests/compile-fail/nightly/surface_singleton_mut_ungrouped_shared.rs:7:53
-  |
-7 |         source_iter([2_i32]) -> map(|x| { *#{0} mut my_val += x; x }) -> for_each(|_| {});
-  |                                                     ^^^^^^
+  |                                             ^^^^^^^

--- a/dfir_rs/tests/compile-fail/nightly/surface_singleton_mut_ungrouped_shared.stderr
+++ b/dfir_rs/tests/compile-fail/nightly/surface_singleton_mut_ungrouped_shared.stderr
@@ -1,11 +1,11 @@
 error: Cannot mix ungrouped shared (`#var`) and mutable (`#mut var`) references to the same singleton. Use access groups `#{N}` to specify ordering.
- --> tests/compile-fail/nightly/surface_singleton_mut_ungrouped_shared.rs:7:53
-  |
-7 |         source_iter([2_i32]) -> map(|x| { *#{0} mut my_val += x; x }) -> for_each(|_| {});
-  |                                                     ^^^^^^
-
-error: Cannot mix ungrouped shared (`#var`) and mutable (`#mut var`) references to the same singleton. Use access groups `#{N}` to specify ordering.
  --> tests/compile-fail/nightly/surface_singleton_mut_ungrouped_shared.rs:6:46
   |
 6 |         source_iter([1_i32]) -> map(|x| x + #my_val) -> for_each(|_| {});
   |                                              ^^^^^^
+
+error: Cannot mix ungrouped shared (`#var`) and mutable (`#mut var`) references to the same singleton. Use access groups `#{N}` to specify ordering.
+ --> tests/compile-fail/nightly/surface_singleton_mut_ungrouped_shared.rs:7:53
+  |
+7 |         source_iter([2_i32]) -> map(|x| { *#{0} mut my_val += x; x }) -> for_each(|_| {});
+  |                                                     ^^^^^^

--- a/dfir_rs/tests/compile-fail/nightly/surface_singleton_mut_ungrouped_shared.stderr
+++ b/dfir_rs/tests/compile-fail/nightly/surface_singleton_mut_ungrouped_shared.stderr
@@ -1,0 +1,11 @@
+error: Cannot mix ungrouped shared (`#var`) and mutable (`#mut var`) references to the same singleton. Use access groups `#{N}` to specify ordering.
+ --> tests/compile-fail/nightly/surface_singleton_mut_ungrouped_shared.rs:7:53
+  |
+7 |         source_iter([2_i32]) -> map(|x| { *#{0} mut my_val += x; x }) -> for_each(|_| {});
+  |                                                     ^^^^^^
+
+error: Cannot mix ungrouped shared (`#var`) and mutable (`#mut var`) references to the same singleton. Use access groups `#{N}` to specify ordering.
+ --> tests/compile-fail/nightly/surface_singleton_mut_ungrouped_shared.rs:6:46
+  |
+6 |         source_iter([1_i32]) -> map(|x| x + #my_val) -> for_each(|_| {});
+  |                                              ^^^^^^

--- a/dfir_rs/tests/compile-fail/nightly/surface_singleton_mutation.stderr
+++ b/dfir_rs/tests/compile-fail/nightly/surface_singleton_mutation.stderr
@@ -1,5 +1,5 @@
 error[E0594]: cannot assign to data in a `&` reference
- --> tests/compile-fail/nightly/surface_singleton_mutation.rs:9:17
+ --> tests/compile-fail/nightly/surface_singleton_mutation.rs:9:18
   |
 9 |                 #max_of_stream2 = 999;
-  |                 ^^^^^^^^^^^^^^^^^^^^^ cannot assign
+  |                  ^^^^^^^^^^^^^^^^^^^^ cannot assign

--- a/dfir_rs/tests/compile-fail/stable/surface_singleton_conflicted_closure.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_singleton_conflicted_closure.stderr
@@ -1,0 +1,16 @@
+error: proc macro panicked
+ --> tests/compile-fail/stable/surface_singleton_conflicted_closure.rs:3:18
+  |
+3 |       let mut df = dfir_rs::dfir_syntax! {
+  |  __________________^
+4 | |         my_val = source_iter([0_i32]) -> singleton();
+5 | |         my_val -> for_each(|_| {});
+6 | |         source_iter(0..10) -> map(|x| x + #{0} my_val + #{1} my_val) -> for_each(|_| {});
+7 | |     };
+  | |_____^
+  |
+  = help: message: assertion `left != right` failed: encounted conflicted or cyclical singleton references
+          [(GraphNodeId(5v1), ResolvedSingletonRef { node_id: Some(GraphNodeId(2v1)), is_mut: false, access_group: Some(0) }, #0 bytes(252..253))]
+          [(GraphNodeId(5v1), ResolvedSingletonRef { node_id: Some(GraphNodeId(2v1)), is_mut: false, access_group: Some(1) }, #0 bytes(266..267))]
+            left: GraphNodeId(5v1)
+           right: GraphNodeId(5v1)

--- a/dfir_rs/tests/compile-fail/stable/surface_singleton_conflicted_operator.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_singleton_conflicted_operator.stderr
@@ -1,0 +1,16 @@
+error: proc macro panicked
+ --> tests/compile-fail/stable/surface_singleton_conflicted_operator.rs:3:18
+  |
+3 |       let mut df = dfir_rs::dfir_syntax! {
+  |  __________________^
+4 | |         my_val = source_iter([0_i32]) -> singleton();
+5 | |         my_val -> for_each(|_| {});
+6 | |         source_iter(0..10) -> fold(|| #{0} my_val, |a, b| *a = b + #{1} my_val) -> for_each(|_| {});
+7 | |     };
+  | |_____^
+  |
+  = help: message: assertion `left != right` failed: encounted conflicted or cyclical singleton references
+          [(GraphNodeId(5v1), ResolvedSingletonRef { node_id: Some(GraphNodeId(2v1)), is_mut: false, access_group: Some(0) }, #0 bytes(249..250))]
+          [(GraphNodeId(5v1), ResolvedSingletonRef { node_id: Some(GraphNodeId(2v1)), is_mut: false, access_group: Some(1) }, #0 bytes(278..279))]
+            left: GraphNodeId(5v1)
+           right: GraphNodeId(5v1)

--- a/dfir_rs/tests/compile-fail/stable/surface_singleton_mut_mixed_group.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_singleton_mut_mixed_group.stderr
@@ -1,11 +1,5 @@
-error: Cannot mix shared (`#`) and mutable (`#mut`) references in the same access group.
- --> tests/compile-fail/stable/surface_singleton_mut_mixed_group.rs:6:50
-  |
-6 |         source_iter([1_i32]) -> map(|x| x + #{0} my_val) -> for_each(|_| {});
-  |                                                  ^^^^^^
-
-error: Cannot mix shared (`#`) and mutable (`#mut`) references in the same access group.
- --> tests/compile-fail/stable/surface_singleton_mut_mixed_group.rs:7:53
+error: Mutable singleton references must be the only one in their access group, but group `#{0}` has multiple.
+ --> tests/compile-fail/stable/surface_singleton_mut_mixed_group.rs:7:44
   |
 7 |         source_iter([2_i32]) -> map(|x| { *#{0} mut my_val += x; x }) -> for_each(|_| {});
-  |                                                     ^^^^^^
+  |                                            ^

--- a/dfir_rs/tests/compile-fail/stable/surface_singleton_mut_mixed_group.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_singleton_mut_mixed_group.stderr
@@ -1,0 +1,11 @@
+error: Cannot mix shared (`#`) and mutable (`#mut`) references in the same access group.
+ --> tests/compile-fail/stable/surface_singleton_mut_mixed_group.rs:6:50
+  |
+6 |         source_iter([1_i32]) -> map(|x| x + #{0} my_val) -> for_each(|_| {});
+  |                                                  ^^^^^^
+
+error: Cannot mix shared (`#`) and mutable (`#mut`) references in the same access group.
+ --> tests/compile-fail/stable/surface_singleton_mut_mixed_group.rs:7:53
+  |
+7 |         source_iter([2_i32]) -> map(|x| { *#{0} mut my_val += x; x }) -> for_each(|_| {});
+  |                                                     ^^^^^^

--- a/dfir_rs/tests/compile-fail/stable/surface_singleton_mut_same_group.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_singleton_mut_same_group.stderr
@@ -1,11 +1,11 @@
-error: Multiple `#mut` references in the same access group. Each mutable reference must be in its own access group.
- --> tests/compile-fail/stable/surface_singleton_mut_same_group.rs:6:53
+error: Mutable singleton references must be the only one in their access group, but group `#{0}` has multiple.
+ --> tests/compile-fail/stable/surface_singleton_mut_same_group.rs:6:44
   |
 6 |         source_iter([1_i32]) -> map(|x| { *#{0} mut my_val += x; x }) -> for_each(|_| {});
-  |                                                     ^^^^^^
+  |                                            ^
 
-error: Multiple `#mut` references in the same access group. Each mutable reference must be in its own access group.
- --> tests/compile-fail/stable/surface_singleton_mut_same_group.rs:7:53
+error: Mutable singleton references must be the only one in their access group, but group `#{0}` has multiple.
+ --> tests/compile-fail/stable/surface_singleton_mut_same_group.rs:7:44
   |
 7 |         source_iter([2_i32]) -> map(|x| { *#{0} mut my_val += x; x }) -> for_each(|_| {});
-  |                                                     ^^^^^^
+  |                                            ^

--- a/dfir_rs/tests/compile-fail/stable/surface_singleton_mut_same_group.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_singleton_mut_same_group.stderr
@@ -1,0 +1,11 @@
+error: Multiple `#mut` references in the same access group. Each mutable reference must be in its own access group.
+ --> tests/compile-fail/stable/surface_singleton_mut_same_group.rs:6:53
+  |
+6 |         source_iter([1_i32]) -> map(|x| { *#{0} mut my_val += x; x }) -> for_each(|_| {});
+  |                                                     ^^^^^^
+
+error: Multiple `#mut` references in the same access group. Each mutable reference must be in its own access group.
+ --> tests/compile-fail/stable/surface_singleton_mut_same_group.rs:7:53
+  |
+7 |         source_iter([2_i32]) -> map(|x| { *#{0} mut my_val += x; x }) -> for_each(|_| {});
+  |                                                     ^^^^^^

--- a/dfir_rs/tests/compile-fail/stable/surface_singleton_mut_ungrouped.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_singleton_mut_ungrouped.stderr
@@ -1,11 +1,11 @@
-error: Ungrouped `#mut` references cannot coexist with other mutable references to the same singleton. Use access groups `#{N} mut var` to specify ordering.
- --> tests/compile-fail/stable/surface_singleton_mut_ungrouped.rs:6:49
+error: Mutable singleton references must be the only one in their access group, but group <default> has multiple.
+ --> tests/compile-fail/stable/surface_singleton_mut_ungrouped.rs:6:44
   |
 6 |         source_iter([1_i32]) -> map(|x| { *#mut my_val += x; x }) -> for_each(|_| {});
-  |                                                 ^^^^^^
+  |                                            ^
 
-error: Ungrouped `#mut` references cannot coexist with other mutable references to the same singleton. Use access groups `#{N} mut var` to specify ordering.
- --> tests/compile-fail/stable/surface_singleton_mut_ungrouped.rs:7:49
+error: Mutable singleton references must be the only one in their access group, but group <default> has multiple.
+ --> tests/compile-fail/stable/surface_singleton_mut_ungrouped.rs:7:44
   |
 7 |         source_iter([2_i32]) -> map(|x| { *#mut my_val += x; x }) -> for_each(|_| {});
-  |                                                 ^^^^^^
+  |                                            ^

--- a/dfir_rs/tests/compile-fail/stable/surface_singleton_mut_ungrouped.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_singleton_mut_ungrouped.stderr
@@ -1,0 +1,11 @@
+error: Multiple ungrouped `#mut` references to the same singleton. Use access groups `#{N} mut var` to specify ordering.
+ --> tests/compile-fail/stable/surface_singleton_mut_ungrouped.rs:6:49
+  |
+6 |         source_iter([1_i32]) -> map(|x| { *#mut my_val += x; x }) -> for_each(|_| {});
+  |                                                 ^^^^^^
+
+error: Multiple ungrouped `#mut` references to the same singleton. Use access groups `#{N} mut var` to specify ordering.
+ --> tests/compile-fail/stable/surface_singleton_mut_ungrouped.rs:7:49
+  |
+7 |         source_iter([2_i32]) -> map(|x| { *#mut my_val += x; x }) -> for_each(|_| {});
+  |                                                 ^^^^^^

--- a/dfir_rs/tests/compile-fail/stable/surface_singleton_mut_ungrouped.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_singleton_mut_ungrouped.stderr
@@ -1,10 +1,10 @@
-error: Multiple ungrouped `#mut` references to the same singleton. Use access groups `#{N} mut var` to specify ordering.
+error: Ungrouped `#mut` references cannot coexist with other mutable references to the same singleton. Use access groups `#{N} mut var` to specify ordering.
  --> tests/compile-fail/stable/surface_singleton_mut_ungrouped.rs:6:49
   |
 6 |         source_iter([1_i32]) -> map(|x| { *#mut my_val += x; x }) -> for_each(|_| {});
   |                                                 ^^^^^^
 
-error: Multiple ungrouped `#mut` references to the same singleton. Use access groups `#{N} mut var` to specify ordering.
+error: Ungrouped `#mut` references cannot coexist with other mutable references to the same singleton. Use access groups `#{N} mut var` to specify ordering.
  --> tests/compile-fail/stable/surface_singleton_mut_ungrouped.rs:7:49
   |
 7 |         source_iter([2_i32]) -> map(|x| { *#mut my_val += x; x }) -> for_each(|_| {});

--- a/dfir_rs/tests/compile-fail/stable/surface_singleton_mut_ungrouped_grouped.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_singleton_mut_ungrouped_grouped.stderr
@@ -1,11 +1,11 @@
 error: Ungrouped `#mut` references cannot coexist with other mutable references to the same singleton. Use access groups `#{N} mut var` to specify ordering.
- --> tests/compile-fail/nightly/surface_singleton_mut_ungrouped.rs:6:49
+ --> tests/compile-fail/stable/surface_singleton_mut_ungrouped_grouped.rs:6:49
   |
 6 |         source_iter([1_i32]) -> map(|x| { *#mut my_val += x; x }) -> for_each(|_| {});
   |                                                 ^^^^^^
 
 error: Ungrouped `#mut` references cannot coexist with other mutable references to the same singleton. Use access groups `#{N} mut var` to specify ordering.
- --> tests/compile-fail/nightly/surface_singleton_mut_ungrouped.rs:7:49
+ --> tests/compile-fail/stable/surface_singleton_mut_ungrouped_grouped.rs:7:53
   |
-7 |         source_iter([2_i32]) -> map(|x| { *#mut my_val += x; x }) -> for_each(|_| {});
-  |                                                 ^^^^^^
+7 |         source_iter([2_i32]) -> map(|x| { *#{0} mut my_val += x; x }) -> for_each(|_| {});
+  |                                                     ^^^^^^

--- a/dfir_rs/tests/compile-fail/stable/surface_singleton_mut_ungrouped_grouped.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_singleton_mut_ungrouped_grouped.stderr
@@ -1,11 +1,5 @@
-error: Ungrouped `#mut` references cannot coexist with other mutable references to the same singleton. Use access groups `#{N} mut var` to specify ordering.
- --> tests/compile-fail/stable/surface_singleton_mut_ungrouped_grouped.rs:6:49
+error: Must use an explicit group `#{N} mut` to reference a singleton when other references use explicit groups.
+ --> tests/compile-fail/stable/surface_singleton_mut_ungrouped_grouped.rs:6:44
   |
 6 |         source_iter([1_i32]) -> map(|x| { *#mut my_val += x; x }) -> for_each(|_| {});
-  |                                                 ^^^^^^
-
-error: Ungrouped `#mut` references cannot coexist with other mutable references to the same singleton. Use access groups `#{N} mut var` to specify ordering.
- --> tests/compile-fail/stable/surface_singleton_mut_ungrouped_grouped.rs:7:53
-  |
-7 |         source_iter([2_i32]) -> map(|x| { *#{0} mut my_val += x; x }) -> for_each(|_| {});
-  |                                                     ^^^^^^
+  |                                            ^

--- a/dfir_rs/tests/compile-fail/stable/surface_singleton_mut_ungrouped_shared.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_singleton_mut_ungrouped_shared.stderr
@@ -1,0 +1,11 @@
+error: Cannot mix ungrouped shared (`#var`) and mutable (`#mut var`) references to the same singleton. Use access groups `#{N}` to specify ordering.
+ --> tests/compile-fail/stable/surface_singleton_mut_ungrouped_shared.rs:7:53
+  |
+7 |         source_iter([2_i32]) -> map(|x| { *#{0} mut my_val += x; x }) -> for_each(|_| {});
+  |                                                     ^^^^^^
+
+error: Cannot mix ungrouped shared (`#var`) and mutable (`#mut var`) references to the same singleton. Use access groups `#{N}` to specify ordering.
+ --> tests/compile-fail/stable/surface_singleton_mut_ungrouped_shared.rs:6:46
+  |
+6 |         source_iter([1_i32]) -> map(|x| x + #my_val) -> for_each(|_| {});
+  |                                              ^^^^^^

--- a/dfir_rs/tests/compile-fail/stable/surface_singleton_mut_ungrouped_shared.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_singleton_mut_ungrouped_shared.stderr
@@ -1,11 +1,11 @@
 error: Cannot mix ungrouped shared (`#var`) and mutable (`#mut var`) references to the same singleton. Use access groups `#{N}` to specify ordering.
- --> tests/compile-fail/stable/surface_singleton_mut_ungrouped_shared.rs:7:53
-  |
-7 |         source_iter([2_i32]) -> map(|x| { *#{0} mut my_val += x; x }) -> for_each(|_| {});
-  |                                                     ^^^^^^
-
-error: Cannot mix ungrouped shared (`#var`) and mutable (`#mut var`) references to the same singleton. Use access groups `#{N}` to specify ordering.
  --> tests/compile-fail/stable/surface_singleton_mut_ungrouped_shared.rs:6:46
   |
 6 |         source_iter([1_i32]) -> map(|x| x + #my_val) -> for_each(|_| {});
   |                                              ^^^^^^
+
+error: Cannot mix ungrouped shared (`#var`) and mutable (`#mut var`) references to the same singleton. Use access groups `#{N}` to specify ordering.
+ --> tests/compile-fail/stable/surface_singleton_mut_ungrouped_shared.rs:7:53
+  |
+7 |         source_iter([2_i32]) -> map(|x| { *#{0} mut my_val += x; x }) -> for_each(|_| {});
+  |                                                     ^^^^^^

--- a/dfir_rs/tests/compile-fail/stable/surface_singleton_mut_ungrouped_shared.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_singleton_mut_ungrouped_shared.stderr
@@ -1,11 +1,5 @@
-error: Cannot mix ungrouped shared (`#var`) and mutable (`#mut var`) references to the same singleton. Use access groups `#{N}` to specify ordering.
- --> tests/compile-fail/stable/surface_singleton_mut_ungrouped_shared.rs:6:46
+error: Must use an explicit group `#{N}` to reference a singleton when other references use explicit groups.
+ --> tests/compile-fail/stable/surface_singleton_mut_ungrouped_shared.rs:6:45
   |
 6 |         source_iter([1_i32]) -> map(|x| x + #my_val) -> for_each(|_| {});
-  |                                              ^^^^^^
-
-error: Cannot mix ungrouped shared (`#var`) and mutable (`#mut var`) references to the same singleton. Use access groups `#{N}` to specify ordering.
- --> tests/compile-fail/stable/surface_singleton_mut_ungrouped_shared.rs:7:53
-  |
-7 |         source_iter([2_i32]) -> map(|x| { *#{0} mut my_val += x; x }) -> for_each(|_| {});
-  |                                                     ^^^^^^
+  |                                             ^

--- a/dfir_rs/tests/compile-fail/stable/surface_singleton_nostate.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_singleton_nostate.stderr
@@ -1,5 +1,5 @@
 error: Cannot reference operator `null`. Only operators with singleton state can be referenced.
- --> tests/compile-fail/stable/surface_singleton_nostate.rs:7:41
+ --> tests/compile-fail/stable/surface_singleton_nostate.rs:7:40
   |
 7 |             -> filter(|value| value <= #my_ref.as_reveal_ref())
-  |                                         ^^^^^^
+  |                                        ^

--- a/dfir_rs/tests/compile-fail/stable/surface_singleton_nostate_undefined.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_singleton_nostate_undefined.stderr
@@ -1,11 +1,11 @@
 error: Cannot find referenced name `unknown`; name was never assigned.
- --> tests/compile-fail/stable/surface_singleton_nostate_undefined.rs:6:77
+ --> tests/compile-fail/stable/surface_singleton_nostate_undefined.rs:6:76
   |
 6 |             -> filter(|value| value <= #my_ref.as_reveal_ref() && value <= #unknown.as_reveal_ref())
-  |                                                                             ^^^^^^^
+  |                                                                            ^
 
 error: Cannot reference operator `null`. Only operators with singleton state can be referenced.
- --> tests/compile-fail/stable/surface_singleton_nostate_undefined.rs:6:41
+ --> tests/compile-fail/stable/surface_singleton_nostate_undefined.rs:6:40
   |
 6 |             -> filter(|value| value <= #my_ref.as_reveal_ref() && value <= #unknown.as_reveal_ref())
-  |                                         ^^^^^^
+  |                                        ^

--- a/dfir_rs/tests/compile-fail/stable/surface_singleton_undefined.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_singleton_undefined.stderr
@@ -1,5 +1,5 @@
 error: Cannot find referenced name `unknown`; name was never assigned.
- --> tests/compile-fail/stable/surface_singleton_undefined.rs:5:41
+ --> tests/compile-fail/stable/surface_singleton_undefined.rs:5:40
   |
 5 |             -> filter(|value| value <= #unknown.as_reveal_ref())
-  |                                         ^^^^^^^
+  |                                        ^

--- a/dfir_rs/tests/compile-fail/stable/surface_singleton_undefined_nostate.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_singleton_undefined_nostate.stderr
@@ -1,11 +1,11 @@
 error: Cannot find referenced name `unknown`; name was never assigned.
- --> tests/compile-fail/stable/surface_singleton_undefined_nostate.rs:6:41
+ --> tests/compile-fail/stable/surface_singleton_undefined_nostate.rs:6:40
   |
 6 |             -> filter(|value| value <= #unknown.as_reveal_ref() && value <= #my_ref.as_reveal_ref())
-  |                                         ^^^^^^^
+  |                                        ^
 
 error: Cannot reference operator `null`. Only operators with singleton state can be referenced.
- --> tests/compile-fail/stable/surface_singleton_undefined_nostate.rs:6:78
+ --> tests/compile-fail/stable/surface_singleton_undefined_nostate.rs:6:77
   |
 6 |             -> filter(|value| value <= #unknown.as_reveal_ref() && value <= #my_ref.as_reveal_ref())
-  |                                                                              ^^^^^^
+  |                                                                             ^

--- a/dfir_rs/tests/compile-fail/surface_singleton_conflicted_closure.rs
+++ b/dfir_rs/tests/compile-fail/surface_singleton_conflicted_closure.rs
@@ -1,0 +1,9 @@
+/// Multiple access groups in the same closure should be an error.
+fn main() {
+    let mut df = dfir_rs::dfir_syntax! {
+        my_val = source_iter([0_i32]) -> singleton();
+        my_val -> for_each(|_| {});
+        source_iter(0..10) -> map(|x| x + #{0} my_val + #{1} my_val) -> for_each(|_| {});
+    };
+    df.run_available_sync();
+}

--- a/dfir_rs/tests/compile-fail/surface_singleton_conflicted_operator.rs
+++ b/dfir_rs/tests/compile-fail/surface_singleton_conflicted_operator.rs
@@ -1,0 +1,9 @@
+/// Multiple access groups in the same operator should be an error.
+fn main() {
+    let mut df = dfir_rs::dfir_syntax! {
+        my_val = source_iter([0_i32]) -> singleton();
+        my_val -> for_each(|_| {});
+        source_iter(0..10) -> fold(|| #{0} my_val, |a, b| *a = b + #{1} my_val) -> for_each(|_| {});
+    };
+    df.run_available_sync();
+}

--- a/dfir_rs/tests/compile-fail/surface_singleton_mut_mixed_group.rs
+++ b/dfir_rs/tests/compile-fail/surface_singleton_mut_mixed_group.rs
@@ -1,0 +1,10 @@
+/// Mixed shared and mutable references in the same access group should be an error.
+fn main() {
+    let mut df = dfir_rs::dfir_syntax! {
+        my_val = source_iter([0_i32]) -> singleton();
+        my_val -> for_each(|_| {});
+        source_iter([1_i32]) -> map(|x| x + #{0} my_val) -> for_each(|_| {});
+        source_iter([2_i32]) -> map(|x| { *#{0} mut my_val += x; x }) -> for_each(|_| {});
+    };
+    df.run_available_sync();
+}

--- a/dfir_rs/tests/compile-fail/surface_singleton_mut_same_group.rs
+++ b/dfir_rs/tests/compile-fail/surface_singleton_mut_same_group.rs
@@ -1,0 +1,10 @@
+/// Multiple `#mut` references in the same access group should be an error.
+fn main() {
+    let mut df = dfir_rs::dfir_syntax! {
+        my_val = source_iter([0_i32]) -> singleton();
+        my_val -> for_each(|_| {});
+        source_iter([1_i32]) -> map(|x| { *#{0} mut my_val += x; x }) -> for_each(|_| {});
+        source_iter([2_i32]) -> map(|x| { *#{0} mut my_val += x; x }) -> for_each(|_| {});
+    };
+    df.run_available_sync();
+}

--- a/dfir_rs/tests/compile-fail/surface_singleton_mut_ungrouped.rs
+++ b/dfir_rs/tests/compile-fail/surface_singleton_mut_ungrouped.rs
@@ -1,0 +1,10 @@
+/// Multiple ungrouped `#mut` references to the same singleton should be an error.
+fn main() {
+    let mut df = dfir_rs::dfir_syntax! {
+        my_val = source_iter([0_i32]) -> singleton();
+        my_val -> for_each(|_| {});
+        source_iter([1_i32]) -> map(|x| { *#mut my_val += x; x }) -> for_each(|_| {});
+        source_iter([2_i32]) -> map(|x| { *#mut my_val += x; x }) -> for_each(|_| {});
+    };
+    df.run_available_sync();
+}

--- a/dfir_rs/tests/compile-fail/surface_singleton_mut_ungrouped_grouped.rs
+++ b/dfir_rs/tests/compile-fail/surface_singleton_mut_ungrouped_grouped.rs
@@ -1,0 +1,10 @@
+/// Ungrouped `#mut` cannot coexist with grouped `#{N} mut` to the same singleton.
+fn main() {
+    let mut df = dfir_rs::dfir_syntax! {
+        my_val = source_iter([0_i32]) -> singleton();
+        my_val -> for_each(|_| {});
+        source_iter([1_i32]) -> map(|x| { *#mut my_val += x; x }) -> for_each(|_| {});
+        source_iter([2_i32]) -> map(|x| { *#{0} mut my_val += x; x }) -> for_each(|_| {});
+    };
+    df.run_available_sync();
+}

--- a/dfir_rs/tests/compile-fail/surface_singleton_mut_ungrouped_shared.rs
+++ b/dfir_rs/tests/compile-fail/surface_singleton_mut_ungrouped_shared.rs
@@ -1,0 +1,10 @@
+/// Ungrouped shared refs cannot coexist with grouped mutable refs to the same singleton.
+fn main() {
+    let mut df = dfir_rs::dfir_syntax! {
+        my_val = source_iter([0_i32]) -> singleton();
+        my_val -> for_each(|_| {});
+        source_iter([1_i32]) -> map(|x| x + #my_val) -> for_each(|_| {});
+        source_iter([2_i32]) -> map(|x| { *#{0} mut my_val += x; x }) -> for_each(|_| {});
+    };
+    df.run_available_sync();
+}

--- a/dfir_rs/tests/surface_handoff.rs
+++ b/dfir_rs/tests/surface_handoff.rs
@@ -169,3 +169,36 @@ pub async fn test_singleton_reference_only_multi_tick() {
     flow.run_tick().await;
     assert_eq!(vec![43, 45, 142], *output.borrow());
 }
+
+/// Test: `singleton()` can be mutably referenced via `#mut var`.
+#[dfir_rs::test]
+pub async fn test_singleton_mut_reference() {
+    let mut output = Vec::<i32>::new();
+    let out = &mut output;
+    let mut flow = dfir_rs::dfir_syntax! {
+        my_val = source_iter([42_i32]) -> singleton();
+        my_val -> for_each(|_| {});
+        source_iter(1..=3_i32) -> map(|x| { *#mut my_val += x; x }) -> for_each(|v: i32| out.push(v));
+    };
+    flow.run_tick().await;
+    drop(flow);
+    assert_eq!(vec![1, 2, 3], output);
+}
+
+/// Test: `#{N}` access groups enforce ordering between mutable references.
+#[dfir_rs::test]
+pub async fn test_singleton_access_group_ordering() {
+    let mut output = Vec::<i32>::new();
+    let out = &mut output;
+    let mut flow = dfir_rs::dfir_syntax! {
+        my_val = source_iter([0_i32]) -> singleton();
+        my_val -> for_each(|_| {});
+        // Group 0 runs first: adds 10
+        source_iter([10_i32]) -> map(|x| { *#{0} mut my_val += x; x }) -> for_each(|_| {});
+        // Group 1 runs second: reads the value (should be 10)
+        source_iter([1_i32]) -> map(|x| x + #{1} my_val) -> for_each(|v: i32| out.push(v));
+    };
+    flow.run_tick().await;
+    drop(flow);
+    assert_eq!(vec![11], output);
+}

--- a/dfir_rs/tests/surface_parser.rs
+++ b/dfir_rs/tests/surface_parser.rs
@@ -249,3 +249,19 @@ pub fn test_flo_syntax() {
         };
     }
 }
+
+/// Tests that the singleton gets parsed as a singleton, and the attribute gets parsed as an attribute.
+#[multiplatform_test]
+pub fn test_singleton() {
+    dfir_parser! {
+        x = source_stream([0]) -> singleton();
+        source_stream(0..100)
+            -> map(|_| {
+                #[cfg(nightly)]
+                {}
+
+                #{0}x
+            })
+            -> null();
+    }
+}


### PR DESCRIPTION
Adds mutable singleton references and explicit access group ordering to DFIR's `#var` reference system.

## New Syntax

```rust
#var              // shared reference (&T) — unchanged
#mut var          // mutable reference (&mut T) — single owner only
#{0} var          // shared reference, access group 0
#{1} mut var      // mutable reference, access group 1
```

Access groups execute in ascending order, enforced by subgraph partitioning barriers.

## Validation Rules

- Multiple ungrouped `#mut var` to the same singleton → **error** (ambiguous ordering)
- Mixed `#var` and `#mut var` in the same access group → **error**
- Multiple `#mut var` in the same access group → **error**

## Changes

| File | Change |
|------|--------|
| `process_singletons.rs` | New `SingletonRefToken` struct; parser handles `#{N}` and `mut` |
| `parse.rs` | `Operator::singletons_referenced` → `Vec<SingletonRefToken>` |
| `graph/mod.rs` | `OperatorInstance::singletons_referenced` → `Vec<SingletonRefToken>` |
| `graph/meta_graph.rs` | New `ResolvedSingletonRef`; codegen emits `&mut` for mutable refs |
| `graph/flat_graph_builder.rs` | Constructs `ResolvedSingletonRef`; validation for mut conflicts |
| `graph/flat_to_partitioned.rs` | Pairwise barriers between access groups |

## Tests

- `test_singleton_mut_reference` — basic `#mut var` usage
- `test_singleton_access_group_ordering` — `#{0} mut` then `#{1}` ordering
- `surface_singleton_mut_ungrouped.rs` — compile-fail for ambiguous mut refs
- `surface_singleton_mut_mixed_group.rs` — compile-fail for mixed group

## Related

Part of #2713 (mutable singletons with single/multiple owners).