### PR TITLE
experiment: custom TickSlab for DFIR handoffs, replacing Vec for non-defer handoffs [ci-bench]

### DIFF
--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -937,19 +937,60 @@ impl DfirGraph {
             })
             .collect();
 
+        // Identify defer_tick handoffs (must remain as captured Vecs).
+        let defer_hoff_ids: BTreeSet<GraphNodeId> = handoff_nodes
+            .iter()
+            .filter(|(node_id, _, _)| self.handoff_delay_type(*node_id).is_some())
+            .map(|&(node_id, _, _)| node_id)
+            .collect();
+
+        // Assign stable slab slot indices to non-defer Vec handoffs.
+        let slab_slot_map: BTreeMap<GraphNodeId, usize> = handoff_nodes
+            .iter()
+            .filter(|&&(node_id, kind, _)| {
+                matches!(kind, HandoffKind::Vec) && !defer_hoff_ids.contains(&node_id)
+            })
+            .enumerate()
+            .map(|(idx, &(node_id, _, _))| (node_id, idx))
+            .collect();
+        let num_slab_slots = slab_slot_map.len();
+
+        // Buffer declarations: only defer_tick Vecs and Option singletons are captured.
         let buffer_code: Vec<TokenStream> = handoff_nodes
             .iter()
-            .map(|&(node_id, kind, (src_span, dst_span))| {
+            .filter_map(|&(node_id, kind, (src_span, dst_span))| {
                 let span = src_span.join(dst_span).unwrap_or(src_span);
                 let buf_ident = self.hoff_buf_ident(node_id, span);
                 match kind {
-                    HandoffKind::Vec => quote_spanned! {span=>
-                        let mut #buf_ident = ::std::vec::Vec::new();
-                    },
-                    HandoffKind::Option => quote_spanned! {span=>
+                    HandoffKind::Vec if defer_hoff_ids.contains(&node_id) => {
+                        Some(quote_spanned! {span=>
+                            let mut #buf_ident = ::std::vec::Vec::new();
+                        })
+                    }
+                    HandoffKind::Vec => None, // handled by slab
+                    HandoffKind::Option => Some(quote_spanned! {span=>
                         let mut #buf_ident = ::std::option::Option::None;
-                    },
+                    }),
                 }
+            })
+            .collect();
+
+        // Slab ident with call_site span for hygiene.
+        let slab_ident = Ident::new("__dfir_slab", Span::call_site());
+
+        // Tick-local SlabVec declarations (inside the tick closure).
+        let slab_vec_code: Vec<TokenStream> = handoff_nodes
+            .iter()
+            .filter_map(|&(node_id, kind, (src_span, dst_span))| {
+                if !matches!(kind, HandoffKind::Vec) || defer_hoff_ids.contains(&node_id) {
+                    return None;
+                }
+                let span = src_span.join(dst_span).unwrap_or(src_span);
+                let buf_ident = self.hoff_buf_ident(node_id, span);
+                let slot_idx = slab_slot_map[&node_id];
+                Some(quote_spanned! {span=>
+                    let mut #buf_ident = unsafe { #slab_ident.vec(#slot_idx, 0) };
+                })
             })
             .collect();
 
@@ -1109,6 +1150,9 @@ impl DfirGraph {
                 let buf_ident = self.hoff_buf_ident(node_id, span);
                 match kind {
                     HandoffKind::Option => quote_spanned! {span=> #buf_ident.take(); },
+                    HandoffKind::Vec if slab_slot_map.contains_key(&node_id) => {
+                        quote_spanned! {span=> drop(#buf_ident); }
+                    }
                     HandoffKind::Vec => quote_spanned! {span=> #buf_ident.clear(); },
                 }
             })
@@ -1218,8 +1262,18 @@ impl DfirGraph {
                                 }
                             }
                             HandoffKind::Vec => {
-                                quote_spanned! {port_ident.span()=>
-                                    let #port_ident = #root::dfir_pipes::push::vec_push(&mut #buf_ident);
+                                if slab_slot_map.contains_key(&hoff_id) {
+                                    // Slab-allocated: use for_each (SlabVec)
+                                    quote_spanned! {port_ident.span()=>
+                                        let #port_ident = #root::dfir_pipes::push::for_each(|__item| {
+                                            #buf_ident.push(__item);
+                                        });
+                                    }
+                                } else {
+                                    // defer_tick: regular Vec, use vec_push
+                                    quote_spanned! {port_ident.span()=>
+                                        let #port_ident = #root::dfir_pipes::push::vec_push(&mut #buf_ident);
+                                    }
                                 }
                             }
                         }
@@ -1720,6 +1774,7 @@ impl DfirGraph {
 
                 #( #buffer_code )*
                 #( #back_buffer_code )*
+                let #slab_ident = #root::slab_alloc::TickSlab::<#num_slab_slots>::new();
                 #( #op_prologue_code )*
 
                 // Pre-set to true so the first tick always returns true
@@ -1730,6 +1785,10 @@ impl DfirGraph {
                 #[allow(unused_qualifications, unused_mut, unused_variables, clippy::await_holding_refcell_ref, clippy::deref_addrof)]
                 let __dfir_inline_tick = async move |#df: &mut #root::scheduled::context::Context| {
                     let __dfir_metrics = #df.metrics();
+                    // Reset the slab allocator — retains capacity from previous tick.
+                    #slab_ident.reset();
+                    // Create tick-local SlabVec handoff buffers.
+                    #( #slab_vec_code )*
                     // Double-buffer swap for defer_tick handoffs: move last tick's
                     // producer output into the back buffer for the consumer to drain.
                     #( #back_edge_swap_code )*

--- a/dfir_rs/src/lib.rs
+++ b/dfir_rs/src/lib.rs
@@ -29,6 +29,7 @@ pub use ::{
 pub use dfir_lang as lang;
 pub use dfir_lang;
 pub use dfir_pipes::itertools;
+pub mod slab_alloc;
 pub use slotmap;
 pub use variadics::{self, var_args, var_expr, var_type};
 

--- a/dfir_rs/src/slab_alloc.rs
+++ b/dfir_rs/src/slab_alloc.rs
@@ -5,47 +5,116 @@
 //! compact/defragment since no live pointers exist.
 
 use std::alloc::{Layout, alloc, dealloc, realloc};
+use std::cell::RefCell;
+use std::marker::PhantomData;
 use std::ptr;
 
-/// A slab allocator with N stable slots, backed by a single contiguous buffer.
-///
-/// Slots are packed contiguously. Each slot's available capacity is implicitly
-/// the distance to the next slot (or buffer end for the last slot).
-pub struct TickSlab<const N: usize> {
+/// Inner mutable state of the slab.
+struct TickSlabInner<const N: usize> {
     buf: *mut u8,
     buf_cap: usize,
     /// `slot_order[position]` = handoff ID at that position in the buffer.
     slot_order: [usize; N],
-    /// `slot_pos[handoff_id]` = position in the buffer (index into slot_order/offsets).
+    /// `slot_pos[handoff_id]` = position in the buffer.
     slot_pos: [usize; N],
     /// `offsets[position]` = byte offset where that position's region starts.
     offsets: [usize; N],
-    /// `requested_cap[handoff_id]` = bytes actually needed (high-water from last tick).
+    /// `requested_cap[handoff_id]` = bytes actually needed (high-water).
     requested_cap: [usize; N],
-    /// Number of slots that have been initialized (first use).
+    /// Number of slots that have been initialized.
     initialized: usize,
 }
 
+/// A slab allocator with N stable slots, backed by a single contiguous buffer.
+///
+/// Uses `RefCell` for interior mutability so multiple `SlabVec`s can coexist
+/// while still allowing growth via `reserve`.
+pub struct TickSlab<const N: usize> {
+    inner: RefCell<TickSlabInner<N>>,
+}
+
 impl<const N: usize> TickSlab<N> {
-    /// Create a new slab with no backing memory. Allocates on first use.
     pub fn new() -> Self {
         Self {
-            buf: ptr::null_mut(),
-            buf_cap: 0,
-            slot_order: [0; N],
-            slot_pos: [0; N],
-            offsets: [0; N],
-            requested_cap: [0; N],
-            initialized: 0,
+            inner: RefCell::new(TickSlabInner {
+                buf: ptr::null_mut(),
+                buf_cap: 0,
+                slot_order: [0; N],
+                slot_pos: [0; N],
+                offsets: [0; N],
+                requested_cap: [0; N],
+                initialized: 0,
+            }),
         }
     }
 
-    /// Get the raw pointer and available capacity (in bytes) for a slot.
-    /// Allocates/grows the buffer if needed.
+    /// Get a [`SlabVec`] for the given slot, ensuring at least `min_cap` elements fit.
     ///
     /// # Safety
-    /// The returned pointer is valid until the next `grow_slot` or `reset` call.
-    pub fn slot_ptr_and_cap(&mut self, id: usize) -> (*mut u8, usize) {
+    /// - Must not create two `SlabVec`s for the same slot ID simultaneously.
+    /// - `T` must be consistent for a given slot ID across calls.
+    pub unsafe fn vec<T>(&self, id: usize, min_cap: usize) -> SlabVec<'_, T, N> {
+        let align = std::mem::align_of::<T>();
+        let elem_size = std::mem::size_of::<T>().max(1);
+        let min_bytes = min_cap * elem_size;
+
+        {
+            let mut inner = self.inner.borrow_mut();
+            inner.ensure_capacity(id, min_bytes, align);
+        }
+
+        let inner = self.inner.borrow();
+        let (ptr, cap_bytes) = inner.slot_ptr_and_cap(id);
+        debug_assert!(
+            ptr as usize % align == 0,
+            "slot pointer not aligned for T"
+        );
+        let cap_elems = cap_bytes / elem_size;
+
+        SlabVec {
+            ptr: ptr as *mut T,
+            len: 0,
+            cap: cap_elems,
+            slot_id: id,
+            slab: self,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Reset for a new tick. Compacts slots based on requested_cap.
+    ///
+    /// Must not be called while any `SlabVec` is live.
+    pub fn reset(&self) {
+        let mut inner = self.inner.borrow_mut();
+        if inner.initialized == 0 {
+            return;
+        }
+        let mut offset = 0;
+        for pos in 0..inner.initialized {
+            inner.offsets[pos] = offset;
+            let id = inner.slot_order[pos];
+            offset += inner.requested_cap[id];
+        }
+        if offset > inner.buf_cap {
+            inner.grow_buf(offset);
+        }
+    }
+}
+
+impl<const N: usize> Drop for TickSlab<N> {
+    fn drop(&mut self) {
+        let inner = self.inner.get_mut();
+        if !inner.buf.is_null() && inner.buf_cap > 0 {
+            unsafe {
+                let layout = Layout::from_size_align(inner.buf_cap, 16).unwrap();
+                dealloc(inner.buf, layout);
+            }
+        }
+    }
+}
+
+impl<const N: usize> TickSlabInner<N> {
+    fn slot_ptr_and_cap(&self, id: usize) -> (*mut u8, usize) {
         debug_assert!(id < N);
         let pos = self.slot_pos[id];
         let offset = self.offsets[pos];
@@ -57,12 +126,23 @@ impl<const N: usize> TickSlab<N> {
         (unsafe { self.buf.add(offset) }, cap)
     }
 
-    /// Ensure slot `id` has at least `min_bytes` of capacity.
-    /// If it doesn't, move it to the end of the buffer (growing the buffer if needed).
-    pub fn ensure_capacity(&mut self, id: usize, min_bytes: usize) {
-        if id >= self.initialized || self.slot_pos[id] >= self.initialized {
-            // First time initialization for this slot
-            self.init_slot(id, min_bytes);
+    fn ensure_capacity(&mut self, id: usize, min_bytes: usize, align: usize) {
+        if id >= N {
+            panic!("slot id {} exceeds slab capacity {}", id, N);
+        }
+
+        // Check if this slot has been initialized
+        let is_new = if self.initialized == 0 {
+            true
+        } else {
+            // A slot is "new" if its position hasn't been set yet.
+            // We detect this by checking if the slot_order at slot_pos[id] == id.
+            let pos = self.slot_pos[id];
+            pos >= self.initialized || self.slot_order[pos] != id
+        };
+
+        if is_new {
+            self.init_slot(id, min_bytes, align);
             return;
         }
 
@@ -75,58 +155,62 @@ impl<const N: usize> TickSlab<N> {
         };
 
         if current_cap >= min_bytes {
-            return; // Already big enough
+            return;
         }
 
-        // Update requested cap
         self.requested_cap[id] = min_bytes;
 
-        // Need more space. If we're the last slot, just grow the buffer.
+        // Last slot: just grow the buffer
         if pos + 1 == self.initialized {
             self.grow_buf(offset + min_bytes);
             return;
         }
 
-        // Not last: move to end. Shift subsequent slots left to fill gap.
+        // Not last: move to end
         let old_offset = offset;
         let old_cap = current_cap;
 
-        // Actually move the memory for shifted slots
-        unsafe {
-            let src = self.buf.add(old_offset + old_cap);
-            let dst = self.buf.add(old_offset);
-            let end = self.end_offset();
-            let move_len = end - (old_offset + old_cap);
-            if move_len > 0 {
+        // Move memory for shifted slots
+        let end = self.end_offset();
+        let move_len = end - (old_offset + old_cap);
+        if move_len > 0 {
+            unsafe {
+                let src = self.buf.add(old_offset + old_cap);
+                let dst = self.buf.add(old_offset);
                 ptr::copy(src, dst, move_len);
             }
         }
 
-        // Shift positions after `pos` one to the left
+        // Shift positions left
         for i in pos..self.initialized - 1 {
             self.slot_order[i] = self.slot_order[i + 1];
             self.offsets[i] = self.offsets[i + 1] - old_cap;
             self.slot_pos[self.slot_order[i]] = i;
         }
 
-        // Place this slot at the end
+        // Place at end, aligned
         let new_pos = self.initialized - 1;
-        let new_offset = self.end_offset() - old_cap;
+        let raw_offset = if new_pos > 0 {
+            let prev_id = self.slot_order[new_pos - 1];
+            self.offsets[new_pos - 1] + self.requested_cap[prev_id]
+        } else {
+            0
+        };
+        let new_offset = (raw_offset + align - 1) & !(align - 1);
         self.slot_order[new_pos] = id;
         self.slot_pos[id] = new_pos;
         self.offsets[new_pos] = new_offset;
 
-        // Now grow the buffer to accommodate min_bytes
         let needed = new_offset + min_bytes;
         if needed > self.buf_cap {
             self.grow_buf(needed);
         }
     }
 
-    /// Initialize a slot for first use.
-    fn init_slot(&mut self, id: usize, min_bytes: usize) {
+    fn init_slot(&mut self, id: usize, min_bytes: usize, align: usize) {
         let pos = self.initialized;
-        let offset = self.end_offset();
+        let raw_offset = self.end_offset();
+        let offset = (raw_offset + align - 1) & !(align - 1);
 
         self.slot_order[pos] = id;
         self.slot_pos[id] = pos;
@@ -134,26 +218,22 @@ impl<const N: usize> TickSlab<N> {
         self.requested_cap[id] = min_bytes;
         self.initialized += 1;
 
-        // Ensure buffer is large enough
         let needed = offset + min_bytes;
         if needed > self.buf_cap {
             self.grow_buf(needed);
         }
     }
 
-    /// Current end of used space.
     fn end_offset(&self) -> usize {
         if self.initialized == 0 {
             0
         } else {
-            // End is the last slot's offset + its allocated size
             let last_pos = self.initialized - 1;
             let last_id = self.slot_order[last_pos];
             self.offsets[last_pos] + self.requested_cap[last_id]
         }
     }
 
-    /// Grow the backing buffer to at least `min_cap` bytes.
     fn grow_buf(&mut self, min_cap: usize) {
         if min_cap <= self.buf_cap {
             return;
@@ -161,85 +241,46 @@ impl<const N: usize> TickSlab<N> {
         let new_cap = min_cap.next_power_of_two().max(64);
         unsafe {
             if self.buf.is_null() {
-                let layout = Layout::from_size_align_unchecked(new_cap, 16);
+                let layout = Layout::from_size_align(new_cap, 16).unwrap();
                 self.buf = alloc(layout);
             } else {
-                let old_layout = Layout::from_size_align_unchecked(self.buf_cap, 16);
+                let old_layout = Layout::from_size_align(self.buf_cap, 16).unwrap();
                 self.buf = realloc(self.buf, old_layout, new_cap);
             }
         }
         self.buf_cap = new_cap;
     }
-
-    /// Update the requested capacity for a slot (called at end of tick).
-    pub fn set_requested_cap(&mut self, id: usize, cap_bytes: usize) {
-        self.requested_cap[id] = cap_bytes;
-    }
-
-    /// Reset for a new tick. Compacts if beneficial.
-    pub fn reset(&mut self) {
-        // For now, just update offsets based on requested_caps (simple compaction).
-        // This packs slots tightly at their requested sizes.
-        if self.initialized == 0 {
-            return;
-        }
-        let mut offset = 0;
-        for pos in 0..self.initialized {
-            self.offsets[pos] = offset;
-            let id = self.slot_order[pos];
-            offset += self.requested_cap[id];
-        }
-        // Grow buffer if compacted layout exceeds current capacity
-        if offset > self.buf_cap {
-            self.grow_buf(offset);
-        }
-    }
-}
-
-impl<const N: usize> Drop for TickSlab<N> {
-    fn drop(&mut self) {
-        if !self.buf.is_null() && self.buf_cap > 0 {
-            unsafe {
-                let layout = Layout::from_size_align_unchecked(self.buf_cap, 16);
-                dealloc(self.buf, layout);
-            }
-        }
-    }
 }
 
 /// A Vec-like handle into a [`TickSlab`] slot.
 ///
-/// Tick-local: created each tick from a slot, can hold any `T` including references.
-/// Does NOT hold a reference to the slab — capacity is fixed at creation time.
-/// Use `reserve` on the slab before creating, or accept that push may panic on overflow.
-pub struct SlabVec<'a, T> {
-    ptr: *mut T,
+/// Tick-local: can hold any `T` including references.
+/// Holds a shared reference to the slab for `reserve`/growth.
+pub struct SlabVec<'a, T, const N: usize> {
+    pub(crate) ptr: *mut T,
     len: usize,
-    cap: usize, // in elements
-    _marker: std::marker::PhantomData<&'a mut [T]>,
+    cap: usize,
+    slot_id: usize,
+    slab: &'a TickSlab<N>,
+    _marker: PhantomData<&'a mut [T]>,
 }
 
-impl<'a, T> SlabVec<'a, T> {
-    /// Create a SlabVec from a raw pointer and capacity.
-    ///
-    /// # Safety
-    /// `ptr` must be valid for `cap` elements of `T`, properly aligned, and
-    /// not aliased for the lifetime `'a`.
-    pub unsafe fn from_raw(ptr: *mut T, cap: usize) -> Self {
-        Self {
-            ptr,
-            len: 0,
-            cap,
-            _marker: std::marker::PhantomData,
-        }
-    }
-
+impl<'a, T, const N: usize> SlabVec<'a, T, N> {
     pub fn push(&mut self, item: T) {
-        assert!(self.len < self.cap, "SlabVec overflow: len={}, cap={}", self.len, self.cap);
+        if self.len == self.cap {
+            self.grow(1);
+        }
         unsafe {
             ptr::write(self.ptr.add(self.len), item);
         }
         self.len += 1;
+    }
+
+    pub fn reserve(&mut self, additional: usize) {
+        let needed = self.len + additional;
+        if needed > self.cap {
+            self.grow(additional);
+        }
     }
 
     pub fn len(&self) -> usize {
@@ -261,7 +302,7 @@ impl<'a, T> SlabVec<'a, T> {
             ptr: self.ptr,
             idx: 0,
             len,
-            _marker: std::marker::PhantomData,
+            _marker: PhantomData,
         }
     }
 
@@ -271,11 +312,34 @@ impl<'a, T> SlabVec<'a, T> {
         }
         self.len = 0;
     }
+
+    fn grow(&mut self, additional: usize) {
+        let needed = self.len + additional;
+        let new_cap = needed.max(self.cap * 2).max(4);
+        let elem_size = std::mem::size_of::<T>().max(1);
+        let align = std::mem::align_of::<T>();
+        let new_bytes = new_cap * elem_size;
+
+        {
+            let mut inner = self.slab.inner.borrow_mut();
+            inner.ensure_capacity(self.slot_id, new_bytes, align);
+            let (ptr, cap_bytes) = inner.slot_ptr_and_cap(self.slot_id);
+            self.ptr = ptr as *mut T;
+            self.cap = cap_bytes / elem_size;
+        }
+    }
 }
 
-impl<'a, T> Drop for SlabVec<'a, T> {
+impl<'a, T, const N: usize> Drop for SlabVec<'a, T, N> {
     fn drop(&mut self) {
-        self.clear();
+        // Drop remaining elements
+        for i in 0..self.len {
+            unsafe { ptr::drop_in_place(self.ptr.add(i)); }
+        }
+        // Update requested_cap for next tick
+        let elem_size = std::mem::size_of::<T>().max(1);
+        let used_bytes = self.cap * elem_size;
+        self.slab.inner.borrow_mut().requested_cap[self.slot_id] = used_bytes;
     }
 }
 
@@ -284,7 +348,7 @@ pub struct SlabVecDrain<'a, T> {
     ptr: *mut T,
     idx: usize,
     len: usize,
-    _marker: std::marker::PhantomData<&'a mut T>,
+    _marker: PhantomData<&'a mut [T]>,
 }
 
 impl<'a, T> Iterator for SlabVecDrain<'a, T> {
@@ -308,7 +372,6 @@ impl<'a, T> Iterator for SlabVecDrain<'a, T> {
 
 impl<'a, T> Drop for SlabVecDrain<'a, T> {
     fn drop(&mut self) {
-        // Drop remaining undrained elements
         for i in self.idx..self.len {
             unsafe { ptr::drop_in_place(self.ptr.add(i)); }
         }
@@ -321,33 +384,24 @@ mod tests {
 
     #[test]
     fn basic_usage() {
-        let mut slab = TickSlab::<4>::new();
-        slab.ensure_capacity(0, 64);
-
+        let slab = TickSlab::<4>::new();
         unsafe {
-            let (ptr, cap) = slab.slot_ptr_and_cap(0);
-            let mut v0: SlabVec<i32> = SlabVec::from_raw(ptr as *mut i32, cap / 4);
-            v0.push(1);
-            v0.push(2);
-            v0.push(3);
-            assert_eq!(v0.len(), 3);
-            let items: Vec<i32> = v0.drain().collect();
+            let mut v: SlabVec<i32, 4> = slab.vec(0, 16);
+            v.push(1);
+            v.push(2);
+            v.push(3);
+            assert_eq!(v.len(), 3);
+            let items: Vec<i32> = v.drain().collect();
             assert_eq!(items, vec![1, 2, 3]);
         }
     }
 
     #[test]
-    fn multiple_slots() {
-        let mut slab = TickSlab::<4>::new();
-        slab.ensure_capacity(0, 32);
-        slab.ensure_capacity(1, 64);
-
+    fn multiple_slots_coexist() {
+        let slab = TickSlab::<4>::new();
         unsafe {
-            let (ptr0, cap0) = slab.slot_ptr_and_cap(0);
-            let (ptr1, cap1) = slab.slot_ptr_and_cap(1);
-
-            let mut v0: SlabVec<i32> = SlabVec::from_raw(ptr0 as *mut i32, cap0 / 4);
-            let mut v1: SlabVec<i32> = SlabVec::from_raw(ptr1 as *mut i32, cap1 / 4);
+            let mut v0: SlabVec<i32, 4> = slab.vec(0, 8);
+            let mut v1: SlabVec<i32, 4> = slab.vec(1, 8);
 
             v0.push(10);
             v0.push(20);
@@ -363,25 +417,48 @@ mod tests {
     }
 
     #[test]
-    fn across_ticks() {
-        let mut slab = TickSlab::<2>::new();
+    fn grow_via_push() {
+        let slab = TickSlab::<2>::new();
+        unsafe {
+            let mut v: SlabVec<i32, 2> = slab.vec(0, 2); // start small
+            for i in 0..100 {
+                v.push(i);
+            }
+            assert_eq!(v.len(), 100);
+            let items: Vec<i32> = v.drain().collect();
+            assert_eq!(items, (0..100).collect::<Vec<_>>());
+        }
+    }
 
-        // Tick 1: grow slot 0
-        slab.ensure_capacity(0, 400); // 100 i32s
-        slab.set_requested_cap(0, 400);
+    #[test]
+    fn across_ticks() {
+        let slab = TickSlab::<2>::new();
+
+        // Tick 1
+        unsafe {
+            let mut v: SlabVec<i32, 2> = slab.vec(0, 4);
+            for i in 0..100 {
+                v.push(i);
+            }
+            // Drop updates requested_cap
+        }
 
         slab.reset();
 
-        // Tick 2: slot 0 should have capacity from tick 1
-        let (ptr, cap) = slab.slot_ptr_and_cap(0);
-        assert!(cap >= 400);
-
+        // Tick 2: capacity retained
         unsafe {
-            let mut v0: SlabVec<i32> = SlabVec::from_raw(ptr as *mut i32, cap / 4);
-            for i in 0..100 {
-                v0.push(i);
-            }
-            assert_eq!(v0.len(), 100);
+            let v: SlabVec<i32, 2> = slab.vec(0, 0);
+            assert!(v.capacity() >= 100);
+        }
+    }
+
+    #[test]
+    fn alignment() {
+        let slab = TickSlab::<3>::new();
+        unsafe {
+            let _v0: SlabVec<u8, 3> = slab.vec(0, 3);
+            let v1: SlabVec<u64, 3> = slab.vec(1, 4);
+            assert_eq!(v1.ptr as usize % 8, 0, "u64 slot must be 8-byte aligned");
         }
     }
 }

--- a/dfir_rs/src/slab_alloc.rs
+++ b/dfir_rs/src/slab_alloc.rs
@@ -1,0 +1,387 @@
+//! Tick-scoped slab allocator with stable slots for DFIR handoff buffers.
+//!
+//! Each handoff has a stable ID (0..N). The slab remembers each slot's region
+//! across ticks — no re-allocation after warmup. Between ticks, `reset()` can
+//! compact/defragment since no live pointers exist.
+
+use std::alloc::{Layout, alloc, dealloc, realloc};
+use std::ptr;
+
+/// A slab allocator with N stable slots, backed by a single contiguous buffer.
+///
+/// Slots are packed contiguously. Each slot's available capacity is implicitly
+/// the distance to the next slot (or buffer end for the last slot).
+pub struct TickSlab<const N: usize> {
+    buf: *mut u8,
+    buf_cap: usize,
+    /// `slot_order[position]` = handoff ID at that position in the buffer.
+    slot_order: [usize; N],
+    /// `slot_pos[handoff_id]` = position in the buffer (index into slot_order/offsets).
+    slot_pos: [usize; N],
+    /// `offsets[position]` = byte offset where that position's region starts.
+    offsets: [usize; N],
+    /// `requested_cap[handoff_id]` = bytes actually needed (high-water from last tick).
+    requested_cap: [usize; N],
+    /// Number of slots that have been initialized (first use).
+    initialized: usize,
+}
+
+impl<const N: usize> TickSlab<N> {
+    /// Create a new slab with no backing memory. Allocates on first use.
+    pub fn new() -> Self {
+        Self {
+            buf: ptr::null_mut(),
+            buf_cap: 0,
+            slot_order: [0; N],
+            slot_pos: [0; N],
+            offsets: [0; N],
+            requested_cap: [0; N],
+            initialized: 0,
+        }
+    }
+
+    /// Get the raw pointer and available capacity (in bytes) for a slot.
+    /// Allocates/grows the buffer if needed.
+    ///
+    /// # Safety
+    /// The returned pointer is valid until the next `grow_slot` or `reset` call.
+    pub fn slot_ptr_and_cap(&mut self, id: usize) -> (*mut u8, usize) {
+        debug_assert!(id < N);
+        let pos = self.slot_pos[id];
+        let offset = self.offsets[pos];
+        let cap = if pos + 1 < self.initialized {
+            self.offsets[pos + 1] - offset
+        } else {
+            self.buf_cap - offset
+        };
+        (unsafe { self.buf.add(offset) }, cap)
+    }
+
+    /// Ensure slot `id` has at least `min_bytes` of capacity.
+    /// If it doesn't, move it to the end of the buffer (growing the buffer if needed).
+    pub fn ensure_capacity(&mut self, id: usize, min_bytes: usize) {
+        if id >= self.initialized || self.slot_pos[id] >= self.initialized {
+            // First time initialization for this slot
+            self.init_slot(id, min_bytes);
+            return;
+        }
+
+        let pos = self.slot_pos[id];
+        let offset = self.offsets[pos];
+        let current_cap = if pos + 1 < self.initialized {
+            self.offsets[pos + 1] - offset
+        } else {
+            self.buf_cap - offset
+        };
+
+        if current_cap >= min_bytes {
+            return; // Already big enough
+        }
+
+        // Update requested cap
+        self.requested_cap[id] = min_bytes;
+
+        // Need more space. If we're the last slot, just grow the buffer.
+        if pos + 1 == self.initialized {
+            self.grow_buf(offset + min_bytes);
+            return;
+        }
+
+        // Not last: move to end. Shift subsequent slots left to fill gap.
+        let old_offset = offset;
+        let old_cap = current_cap;
+
+        // Actually move the memory for shifted slots
+        unsafe {
+            let src = self.buf.add(old_offset + old_cap);
+            let dst = self.buf.add(old_offset);
+            let end = self.end_offset();
+            let move_len = end - (old_offset + old_cap);
+            if move_len > 0 {
+                ptr::copy(src, dst, move_len);
+            }
+        }
+
+        // Shift positions after `pos` one to the left
+        for i in pos..self.initialized - 1 {
+            self.slot_order[i] = self.slot_order[i + 1];
+            self.offsets[i] = self.offsets[i + 1] - old_cap;
+            self.slot_pos[self.slot_order[i]] = i;
+        }
+
+        // Place this slot at the end
+        let new_pos = self.initialized - 1;
+        let new_offset = self.end_offset() - old_cap;
+        self.slot_order[new_pos] = id;
+        self.slot_pos[id] = new_pos;
+        self.offsets[new_pos] = new_offset;
+
+        // Now grow the buffer to accommodate min_bytes
+        let needed = new_offset + min_bytes;
+        if needed > self.buf_cap {
+            self.grow_buf(needed);
+        }
+    }
+
+    /// Initialize a slot for first use.
+    fn init_slot(&mut self, id: usize, min_bytes: usize) {
+        let pos = self.initialized;
+        let offset = self.end_offset();
+
+        self.slot_order[pos] = id;
+        self.slot_pos[id] = pos;
+        self.offsets[pos] = offset;
+        self.requested_cap[id] = min_bytes;
+        self.initialized += 1;
+
+        // Ensure buffer is large enough
+        let needed = offset + min_bytes;
+        if needed > self.buf_cap {
+            self.grow_buf(needed);
+        }
+    }
+
+    /// Current end of used space.
+    fn end_offset(&self) -> usize {
+        if self.initialized == 0 {
+            0
+        } else {
+            // End is the last slot's offset + its allocated size
+            let last_pos = self.initialized - 1;
+            let last_id = self.slot_order[last_pos];
+            self.offsets[last_pos] + self.requested_cap[last_id]
+        }
+    }
+
+    /// Grow the backing buffer to at least `min_cap` bytes.
+    fn grow_buf(&mut self, min_cap: usize) {
+        if min_cap <= self.buf_cap {
+            return;
+        }
+        let new_cap = min_cap.next_power_of_two().max(64);
+        unsafe {
+            if self.buf.is_null() {
+                let layout = Layout::from_size_align_unchecked(new_cap, 16);
+                self.buf = alloc(layout);
+            } else {
+                let old_layout = Layout::from_size_align_unchecked(self.buf_cap, 16);
+                self.buf = realloc(self.buf, old_layout, new_cap);
+            }
+        }
+        self.buf_cap = new_cap;
+    }
+
+    /// Update the requested capacity for a slot (called at end of tick).
+    pub fn set_requested_cap(&mut self, id: usize, cap_bytes: usize) {
+        self.requested_cap[id] = cap_bytes;
+    }
+
+    /// Reset for a new tick. Compacts if beneficial.
+    pub fn reset(&mut self) {
+        // For now, just update offsets based on requested_caps (simple compaction).
+        // This packs slots tightly at their requested sizes.
+        if self.initialized == 0 {
+            return;
+        }
+        let mut offset = 0;
+        for pos in 0..self.initialized {
+            self.offsets[pos] = offset;
+            let id = self.slot_order[pos];
+            offset += self.requested_cap[id];
+        }
+        // Grow buffer if compacted layout exceeds current capacity
+        if offset > self.buf_cap {
+            self.grow_buf(offset);
+        }
+    }
+}
+
+impl<const N: usize> Drop for TickSlab<N> {
+    fn drop(&mut self) {
+        if !self.buf.is_null() && self.buf_cap > 0 {
+            unsafe {
+                let layout = Layout::from_size_align_unchecked(self.buf_cap, 16);
+                dealloc(self.buf, layout);
+            }
+        }
+    }
+}
+
+/// A Vec-like handle into a [`TickSlab`] slot.
+///
+/// Tick-local: created each tick from a slot, can hold any `T` including references.
+/// Does NOT hold a reference to the slab — capacity is fixed at creation time.
+/// Use `reserve` on the slab before creating, or accept that push may panic on overflow.
+pub struct SlabVec<'a, T> {
+    ptr: *mut T,
+    len: usize,
+    cap: usize, // in elements
+    _marker: std::marker::PhantomData<&'a mut [T]>,
+}
+
+impl<'a, T> SlabVec<'a, T> {
+    /// Create a SlabVec from a raw pointer and capacity.
+    ///
+    /// # Safety
+    /// `ptr` must be valid for `cap` elements of `T`, properly aligned, and
+    /// not aliased for the lifetime `'a`.
+    pub unsafe fn from_raw(ptr: *mut T, cap: usize) -> Self {
+        Self {
+            ptr,
+            len: 0,
+            cap,
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    pub fn push(&mut self, item: T) {
+        assert!(self.len < self.cap, "SlabVec overflow: len={}, cap={}", self.len, self.cap);
+        unsafe {
+            ptr::write(self.ptr.add(self.len), item);
+        }
+        self.len += 1;
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.cap
+    }
+
+    pub fn drain(&mut self) -> SlabVecDrain<'_, T> {
+        let len = self.len;
+        self.len = 0;
+        SlabVecDrain {
+            ptr: self.ptr,
+            idx: 0,
+            len,
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    pub fn clear(&mut self) {
+        for i in 0..self.len {
+            unsafe { ptr::drop_in_place(self.ptr.add(i)); }
+        }
+        self.len = 0;
+    }
+}
+
+impl<'a, T> Drop for SlabVec<'a, T> {
+    fn drop(&mut self) {
+        self.clear();
+    }
+}
+
+/// Drain iterator for [`SlabVec`].
+pub struct SlabVecDrain<'a, T> {
+    ptr: *mut T,
+    idx: usize,
+    len: usize,
+    _marker: std::marker::PhantomData<&'a mut T>,
+}
+
+impl<'a, T> Iterator for SlabVecDrain<'a, T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        if self.idx < self.len {
+            let item = unsafe { ptr::read(self.ptr.add(self.idx)) };
+            self.idx += 1;
+            Some(item)
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.len - self.idx;
+        (remaining, Some(remaining))
+    }
+}
+
+impl<'a, T> Drop for SlabVecDrain<'a, T> {
+    fn drop(&mut self) {
+        // Drop remaining undrained elements
+        for i in self.idx..self.len {
+            unsafe { ptr::drop_in_place(self.ptr.add(i)); }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_usage() {
+        let mut slab = TickSlab::<4>::new();
+        slab.ensure_capacity(0, 64);
+
+        unsafe {
+            let (ptr, cap) = slab.slot_ptr_and_cap(0);
+            let mut v0: SlabVec<i32> = SlabVec::from_raw(ptr as *mut i32, cap / 4);
+            v0.push(1);
+            v0.push(2);
+            v0.push(3);
+            assert_eq!(v0.len(), 3);
+            let items: Vec<i32> = v0.drain().collect();
+            assert_eq!(items, vec![1, 2, 3]);
+        }
+    }
+
+    #[test]
+    fn multiple_slots() {
+        let mut slab = TickSlab::<4>::new();
+        slab.ensure_capacity(0, 32);
+        slab.ensure_capacity(1, 64);
+
+        unsafe {
+            let (ptr0, cap0) = slab.slot_ptr_and_cap(0);
+            let (ptr1, cap1) = slab.slot_ptr_and_cap(1);
+
+            let mut v0: SlabVec<i32> = SlabVec::from_raw(ptr0 as *mut i32, cap0 / 4);
+            let mut v1: SlabVec<i32> = SlabVec::from_raw(ptr1 as *mut i32, cap1 / 4);
+
+            v0.push(10);
+            v0.push(20);
+            v1.push(30);
+            v1.push(40);
+            v1.push(50);
+
+            let items0: Vec<i32> = v0.drain().collect();
+            let items1: Vec<i32> = v1.drain().collect();
+            assert_eq!(items0, vec![10, 20]);
+            assert_eq!(items1, vec![30, 40, 50]);
+        }
+    }
+
+    #[test]
+    fn across_ticks() {
+        let mut slab = TickSlab::<2>::new();
+
+        // Tick 1: grow slot 0
+        slab.ensure_capacity(0, 400); // 100 i32s
+        slab.set_requested_cap(0, 400);
+
+        slab.reset();
+
+        // Tick 2: slot 0 should have capacity from tick 1
+        let (ptr, cap) = slab.slot_ptr_and_cap(0);
+        assert!(cap >= 400);
+
+        unsafe {
+            let mut v0: SlabVec<i32> = SlabVec::from_raw(ptr as *mut i32, cap / 4);
+            for i in 0..100 {
+                v0.push(i);
+            }
+            assert_eq!(v0.len(), 100);
+        }
+    }
+}

--- a/dfir_rs/src/slab_alloc.rs
+++ b/dfir_rs/src/slab_alloc.rs
@@ -135,8 +135,6 @@ impl<const N: usize> TickSlabInner<N> {
         let is_new = if self.initialized == 0 {
             true
         } else {
-            // A slot is "new" if its position hasn't been set yet.
-            // We detect this by checking if the slot_order at slot_pos[id] == id.
             let pos = self.slot_pos[id];
             pos >= self.initialized || self.slot_order[pos] != id
         };
@@ -166,45 +164,42 @@ impl<const N: usize> TickSlabInner<N> {
             return;
         }
 
-        // Not last: move to end
-        let old_offset = offset;
-        let old_cap = current_cap;
-
-        // Move memory for shifted slots
+        // Not last: allocate a new region at the end (don't move existing slots).
+        // The old region becomes dead space until reset() compacts.
         let end = self.end_offset();
-        let move_len = end - (old_offset + old_cap);
-        if move_len > 0 {
-            unsafe {
-                let src = self.buf.add(old_offset + old_cap);
-                let dst = self.buf.add(old_offset);
-                ptr::copy(src, dst, move_len);
-            }
-        }
+        let new_offset = (end + align - 1) & !(align - 1);
 
-        // Shift positions left
-        for i in pos..self.initialized - 1 {
-            self.slot_order[i] = self.slot_order[i + 1];
-            self.offsets[i] = self.offsets[i + 1] - old_cap;
-            self.slot_pos[self.slot_order[i]] = i;
-        }
-
-        // Place at end, aligned
-        let new_pos = self.initialized - 1;
-        let raw_offset = if new_pos > 0 {
-            let prev_id = self.slot_order[new_pos - 1];
-            self.offsets[new_pos - 1] + self.requested_cap[prev_id]
-        } else {
-            0
-        };
-        let new_offset = (raw_offset + align - 1) & !(align - 1);
-        self.slot_order[new_pos] = id;
-        self.slot_pos[id] = new_pos;
-        self.offsets[new_pos] = new_offset;
-
+        // Grow buffer if needed
         let needed = new_offset + min_bytes;
         if needed > self.buf_cap {
             self.grow_buf(needed);
         }
+
+        // Copy existing data to new location
+        let copy_len = current_cap.min(min_bytes);
+        if copy_len > 0 {
+            unsafe {
+                ptr::copy_nonoverlapping(
+                    self.buf.add(offset),
+                    self.buf.add(new_offset),
+                    copy_len,
+                );
+            }
+        }
+
+        // Update this slot's position to the end
+        // Remove from old position, shift others
+        for i in pos..self.initialized - 1 {
+            self.slot_order[i] = self.slot_order[i + 1];
+            self.slot_pos[self.slot_order[i]] = i;
+            // Note: offsets of other slots don't change (no memory movement)
+            self.offsets[i] = self.offsets[i + 1];
+        }
+
+        let new_pos = self.initialized - 1;
+        self.slot_order[new_pos] = id;
+        self.slot_pos[id] = new_pos;
+        self.offsets[new_pos] = new_offset;
     }
 
     fn init_slot(&mut self, id: usize, min_bytes: usize, align: usize) {
@@ -228,9 +223,16 @@ impl<const N: usize> TickSlabInner<N> {
         if self.initialized == 0 {
             0
         } else {
-            let last_pos = self.initialized - 1;
-            let last_id = self.slot_order[last_pos];
-            self.offsets[last_pos] + self.requested_cap[last_id]
+            // Find the highest end point across all slots
+            let mut max_end = 0;
+            for pos in 0..self.initialized {
+                let id = self.slot_order[pos];
+                let end = self.offsets[pos] + self.requested_cap[id];
+                if end > max_end {
+                    max_end = end;
+                }
+            }
+            max_end
         }
     }
 
@@ -295,7 +297,8 @@ impl<'a, T, const N: usize> SlabVec<'a, T, N> {
         self.cap
     }
 
-    pub fn drain(&mut self) -> SlabVecDrain<'_, T> {
+    pub fn drain<R: std::ops::RangeBounds<usize>>(&mut self, _range: R) -> SlabVecDrain<'_, T> {
+        // For now, always drains everything (ignores range).
         let len = self.len;
         self.len = 0;
         SlabVecDrain {
@@ -391,7 +394,7 @@ mod tests {
             v.push(2);
             v.push(3);
             assert_eq!(v.len(), 3);
-            let items: Vec<i32> = v.drain().collect();
+            let items: Vec<i32> = v.drain(..).collect();
             assert_eq!(items, vec![1, 2, 3]);
         }
     }
@@ -409,8 +412,8 @@ mod tests {
             v1.push(40);
             v1.push(50);
 
-            let items0: Vec<i32> = v0.drain().collect();
-            let items1: Vec<i32> = v1.drain().collect();
+            let items0: Vec<i32> = v0.drain(..).collect();
+            let items1: Vec<i32> = v1.drain(..).collect();
             assert_eq!(items0, vec![10, 20]);
             assert_eq!(items1, vec![30, 40, 50]);
         }
@@ -425,7 +428,7 @@ mod tests {
                 v.push(i);
             }
             assert_eq!(v.len(), 100);
-            let items: Vec<i32> = v.drain().collect();
+            let items: Vec<i32> = v.drain(..).collect();
             assert_eq!(items, (0..100).collect::<Vec<_>>());
         }
     }

--- a/dfir_rs/tests/compile-fail/stable/surface_fold_keyed_badtype_int.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_fold_keyed_badtype_int.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, {integer}>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<SlabVecDrain<'_, {integer}>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_fold_keyed_badtype_int.rs:3:9
   |
 3 |         source_iter(0..1)
@@ -14,7 +14,7 @@ note: required by a bound in `check_input`
 4 |             -> reduce_keyed(|old: &mut u32, val: u32| { *old += val; })
   |                ^^^^^^^^^^^^ required by this bound in `check_input`
 
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, {integer}>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<SlabVecDrain<'_, {integer}>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_fold_keyed_badtype_int.rs:4:16
   |
 4 |             -> reduce_keyed(|old: &mut u32, val: u32| { *old += val; })

--- a/dfir_rs/tests/compile-fail/stable/surface_fold_keyed_badtype_option.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_fold_keyed_badtype_option.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, Option<{integer}>>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<SlabVecDrain<'_, Option<{integer}>>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_fold_keyed_badtype_option.rs:3:9
   |
 3 |         source_iter([ Some(5), None, Some(12) ])
@@ -14,7 +14,7 @@ note: required by a bound in `check_input`
 4 |             -> reduce_keyed(|old: &mut u32, val: u32| { *old += val; })
   |                ^^^^^^^^^^^^ required by this bound in `check_input`
 
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, Option<{integer}>>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<SlabVecDrain<'_, Option<{integer}>>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_fold_keyed_badtype_option.rs:4:16
   |
 4 |             -> reduce_keyed(|old: &mut u32, val: u32| { *old += val; })

--- a/dfir_rs/tests/compile-fail/stable/surface_fold_keyed_generics_bad.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_fold_keyed_generics_bad.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, &str>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<SlabVecDrain<'_, &str>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_fold_keyed_generics_bad.rs:3:9
   |
 3 |         source_iter(["hello", "world"])
@@ -14,7 +14,7 @@ note: required by a bound in `check_input`
 4 |             -> fold_keyed::<'tick, &str, usize>(String::new, |old: &mut _, val| {
   |                ^^^^^^^^^^ required by this bound in `check_input`
 
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, &str>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<SlabVecDrain<'_, &str>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_fold_keyed_generics_bad.rs:4:16
   |
 4 |             -> fold_keyed::<'tick, &str, usize>(String::new, |old: &mut _, val| {

--- a/dfir_rs/tests/compile-fail/stable/surface_reduce_keyed_badtype_int.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_reduce_keyed_badtype_int.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, {integer}>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<SlabVecDrain<'_, {integer}>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_reduce_keyed_badtype_int.rs:3:9
   |
 3 |         source_iter(0..1)
@@ -14,7 +14,7 @@ note: required by a bound in `check_input`
 4 |             -> fold_keyed(|| 0, |old: &mut u32, val: u32| { *old += val; })
   |                ^^^^^^^^^^ required by this bound in `check_input`
 
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, {integer}>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<SlabVecDrain<'_, {integer}>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_reduce_keyed_badtype_int.rs:4:16
   |
 4 |             -> fold_keyed(|| 0, |old: &mut u32, val: u32| { *old += val; })

--- a/dfir_rs/tests/compile-fail/stable/surface_reduce_keyed_badtype_option.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_reduce_keyed_badtype_option.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, Option<{integer}>>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<SlabVecDrain<'_, Option<{integer}>>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_reduce_keyed_badtype_option.rs:3:9
   |
 3 |         source_iter([ Some(5), None, Some(12) ])
@@ -14,7 +14,7 @@ note: required by a bound in `check_input`
 4 |             -> fold_keyed(|| 0, |old: &mut u32, val: u32| { *old += val; })
   |                ^^^^^^^^^^ required by this bound in `check_input`
 
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, Option<{integer}>>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<SlabVecDrain<'_, Option<{integer}>>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_reduce_keyed_badtype_option.rs:4:16
   |
 4 |             -> fold_keyed(|| 0, |old: &mut u32, val: u32| { *old += val; })

--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -2555,10 +2555,10 @@ impl HydroNode {
             }
 
             HydroNode::Partition { inner, f, .. } => {
-                f.transform_children(&mut transform, seen_tees);
                 if let Some(transformed) = seen_tees.get(&inner.as_ptr()) {
                     *inner = SharedNode(transformed.clone());
                 } else {
+                    f.transform_children(&mut transform, seen_tees);
                     let transformed_cell = Rc::new(RefCell::new(HydroNode::Placeholder));
                     seen_tees.insert(inner.as_ptr(), transformed_cell.clone());
                     let mut orig = inner.0.replace(HydroNode::Placeholder);
@@ -3459,21 +3459,6 @@ impl HydroNode {
                         let is_true = *is_true; // need to copy early to avoid borrow checking issues with node
                         let ptr = inner.0.as_ref() as *const RefCell<HydroNode>;
                         let ret_ident = if let Some(built_idents) = built_tees.get(&ptr) {
-                            // Pop singleton ref idents (if any) that were pushed by transform_children
-                            // but won't be used since the partition was already built.
-                            //
-                            // When the second Partition branch is processed, transform_children
-                            // recurses into f.singleton_refs, causing each Singleton node's
-                            // transform_bottom_up to push an ident onto ident_stack. Since the
-                            // partition was already built by the first branch, these idents are
-                            // unused and must be popped to maintain stack invariants.
-                            //
-                            // Removing this pop triggers the ident_stack emptiness assertion at
-                            // the end of emit_core (verified by test_singleton_ref_partition_*).
-                            for _ in 0..f.singleton_refs.len() {
-                                ident_stack.pop().unwrap();
-                            }
-
                             match builders_or_callback {
                                 BuildersOrCallback::Builders(_) => {}
                                 BuildersOrCallback::Callback(_, node_callback) => {

--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -69,7 +69,9 @@ impl Clone for ClosureExpr {
 impl Hash for ClosureExpr {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.expr.hash(state);
-        // singleton_refs are not hashed (same as HydroIrMetadata)
+        // singleton_refs are structural children (like HydroIrMetadata), not
+        // identity-defining. Two closures with the same expr but different
+        // captured refs are the same closure text — the refs only affect codegen.
     }
 }
 
@@ -108,12 +110,6 @@ impl Debug for ClosureExpr {
 impl Display for ClosureExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         Display::fmt(&self.expr, f)
-    }
-}
-
-impl ToTokens for ClosureExpr {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        self.expr.to_tokens(tokens);
     }
 }
 
@@ -941,7 +937,7 @@ where
 #[derive(Debug, Hash, serde::Serialize)]
 pub enum HydroRoot {
     ForEach {
-        f: ClosureExpr,
+        f: DebugExpr,
         input: Box<HydroNode>,
         op_metadata: HydroIrOpMetadata,
     },
@@ -1395,7 +1391,7 @@ impl HydroRoot {
                 input,
                 op_metadata,
             } => HydroRoot::ForEach {
-                f: f.deep_clone(seen_tees),
+                f: f.clone(),
                 input: Box::new(input.deep_clone(seen_tees)),
                 op_metadata: op_metadata.clone(),
             },
@@ -1748,11 +1744,8 @@ impl HydroRoot {
 
     pub fn visit_debug_expr(&mut self, mut transform: impl FnMut(&mut DebugExpr)) {
         match self {
-            HydroRoot::ForEach { f, .. } => {
-                transform(&mut f.expr);
-            }
-            HydroRoot::DestSink { sink, .. } => {
-                transform(sink);
+            HydroRoot::ForEach { f, .. } | HydroRoot::DestSink { sink: f, .. } => {
+                transform(f);
             }
             HydroRoot::SendExternal { .. }
             | HydroRoot::CycleSink { .. }
@@ -2548,9 +2541,21 @@ impl HydroNode {
             | HydroNode::CycleSource { .. }
             | HydroNode::ExternalInput { .. } => {}
 
-            HydroNode::Tee { inner, .. }
-            | HydroNode::Singleton { inner, .. }
-            | HydroNode::Partition { inner, .. } => {
+            HydroNode::Tee { inner, .. } | HydroNode::Singleton { inner, .. } => {
+                if let Some(transformed) = seen_tees.get(&inner.as_ptr()) {
+                    *inner = SharedNode(transformed.clone());
+                } else {
+                    let transformed_cell = Rc::new(RefCell::new(HydroNode::Placeholder));
+                    seen_tees.insert(inner.as_ptr(), transformed_cell.clone());
+                    let mut orig = inner.0.replace(HydroNode::Placeholder);
+                    transform(&mut orig, seen_tees);
+                    *transformed_cell.borrow_mut() = orig;
+                    *inner = SharedNode(transformed_cell);
+                }
+            }
+
+            HydroNode::Partition { inner, f, .. } => {
+                f.transform_children(&mut transform, seen_tees);
                 if let Some(transformed) = seen_tees.get(&inner.as_ptr()) {
                     *inner = SharedNode(transformed.clone());
                 } else {
@@ -2718,7 +2723,7 @@ impl HydroNode {
                 if let Some(transformed) = seen_tees.get(&inner.as_ptr()) {
                     HydroNode::Partition {
                         inner: SharedNode(transformed.clone()),
-                        f: f.clone(),
+                        f: f.deep_clone(seen_tees),
                         is_true: *is_true,
                         metadata: metadata.clone(),
                     }
@@ -2729,7 +2734,7 @@ impl HydroNode {
                     *new_rc.borrow_mut() = cloned;
                     HydroNode::Partition {
                         inner: SharedNode(new_rc),
-                        f: f.clone(),
+                        f: f.deep_clone(seen_tees),
                         is_true: *is_true,
                         metadata: metadata.clone(),
                     }
@@ -3454,6 +3459,12 @@ impl HydroNode {
                         let is_true = *is_true; // need to copy early to avoid borrow checking issues with node
                         let ptr = inner.0.as_ref() as *const RefCell<HydroNode>;
                         let ret_ident = if let Some(built_idents) = built_tees.get(&ptr) {
+                            // Pop singleton ref idents (if any) that were pushed by transform_children
+                            // but won't be used since the partition was already built.
+                            for _ in 0..f.singleton_refs.len() {
+                                ident_stack.pop().unwrap();
+                            }
+
                             match builders_or_callback {
                                 BuildersOrCallback::Builders(_) => {}
                                 BuildersOrCallback::Callback(_, node_callback) => {
@@ -3467,6 +3478,7 @@ impl HydroNode {
                             // The inner node was already processed by transform_bottom_up,
                             // so its ident is on the stack
                             let inner_ident = ident_stack.pop().unwrap();
+                            let f_tokens = f.emit_tokens(&mut ident_stack);
 
                             let partition_ident = syn::Ident::new(
                                 &format!("stream_{}_partition", *next_stmt_id),
@@ -3491,7 +3503,7 @@ impl HydroNode {
                                     let builder = graph_builders.get_dfir_mut(&out_location);
                                     builder.add_dfir(
                                         parse_quote! {
-                                            #partition_ident = #inner_ident -> partition(|__item, __num_outputs| if (#f)(__item) { 0_usize } else { 1_usize });
+                                            #partition_ident = #inner_ident -> partition(|__item, __num_outputs| if (#f_tokens)(__item) { 0_usize } else { 1_usize });
                                             #true_ident = #partition_ident[0];
                                             #false_ident = #partition_ident[1];
                                         },
@@ -4225,6 +4237,9 @@ impl HydroNode {
                             unreachable!()
                         };
 
+                        let acc_tokens = acc.emit_tokens(&mut ident_stack);
+                        let init_tokens = init.emit_tokens(&mut ident_stack);
+
                         let fold_ident =
                             syn::Ident::new(&format!("stream_{}", *next_stmt_id), Span::call_site());
 
@@ -4244,9 +4259,9 @@ impl HydroNode {
                                         &node.metadata().op,
                                     );
 
-                                    let (effective_input, acc) = if let Some(ref hooked) = hooked_input_ident {
+                                    let (effective_input, _acc) = if let Some(ref hooked) = hooked_input_ident {
                                         let acc: syn::Expr = parse_quote!({
-                                            let mut __inner = #acc;
+                                            let mut __inner = #acc_tokens;
                                             move |__state, __batch: Vec<_>| {
                                                 if __batch.is_empty() {
                                                     return None;
@@ -4260,7 +4275,7 @@ impl HydroNode {
                                         (hooked, acc)
                                     } else {
                                         let acc: syn::Expr = parse_quote!({
-                                            let mut __inner = #acc;
+                                            let mut __inner = #acc_tokens;
                                             move |__state, __value| {
                                                 __inner(__state, __value);
                                                 Some(__state.clone())
@@ -4272,8 +4287,8 @@ impl HydroNode {
                                     let builder = graph_builders.get_dfir_mut(&out_location);
                                     builder.add_dfir(
                                         parse_quote! {
-                                            source_iter([(#init)()]) -> [0]#fold_ident;
-                                            #effective_input -> scan::<#lifetime>(#init, #acc) -> [1]#fold_ident;
+                                            source_iter([(#init_tokens)()]) -> [0]#fold_ident;
+                                            #effective_input -> scan::<#lifetime>(#init_tokens, #acc_tokens) -> [1]#fold_ident;
                                             #fold_ident = chain();
                                         },
                                         None,
@@ -4298,9 +4313,9 @@ impl HydroNode {
                                     );
                                     let builder = graph_builders.get_dfir_mut(&out_location);
 
-                                    let acc: syn::Expr = parse_quote!({
-                                        let mut __init = #init;
-                                        let mut __inner = #acc;
+                                    let _acc: syn::Expr = parse_quote!({
+                                        let mut __init = #init_tokens;
+                                        let mut __inner = #acc_tokens;
                                         move |__state, __kv: (_, _)| {
                                             // TODO(shadaj): we can avoid the clone when the entry exists
                                             let __state = __state
@@ -4314,7 +4329,7 @@ impl HydroNode {
                                     if let Some(hooked_input_ident) = hooked_input_ident {
                                         builder.add_dfir(
                                             parse_quote! {
-                                                #fold_ident = #hooked_input_ident -> flatten() -> scan::<#lifetime>(|| ::std::collections::HashMap::new(), #acc);
+                                                #fold_ident = #hooked_input_ident -> flatten() -> scan::<#lifetime>(|| ::std::collections::HashMap::new(), #acc_tokens);
                                             },
                                             None,
                                             Some(&next_stmt_id.to_string()),
@@ -4324,7 +4339,7 @@ impl HydroNode {
                                     } else {
                                         builder.add_dfir(
                                             parse_quote! {
-                                                #fold_ident = #input_ident -> scan::<#lifetime>(|| ::std::collections::HashMap::new(), #acc);
+                                                #fold_ident = #input_ident -> scan::<#lifetime>(|| ::std::collections::HashMap::new(), #acc_tokens);
                                             },
                                             None,
                                             Some(&next_stmt_id.to_string()),
@@ -4351,7 +4366,7 @@ impl HydroNode {
                                     let builder = graph_builders.get_dfir_mut(&out_location);
                                     builder.add_dfir(
                                         parse_quote! {
-                                            #fold_ident = #actual_input -> #operator::<#lifetime>(#init, #acc);
+                                            #fold_ident = #actual_input -> #operator::<#lifetime>(#init_tokens, #acc_tokens);
                                         },
                                         None,
                                         Some(&next_stmt_id.to_string()),
@@ -4360,7 +4375,7 @@ impl HydroNode {
                                     let builder = graph_builders.get_dfir_mut(&out_location);
                                     builder.add_dfir(
                                         parse_quote! {
-                                            #fold_ident = #input_ident -> #operator::<#lifetime>(#init, #acc);
+                                            #fold_ident = #input_ident -> #operator::<#lifetime>(#init_tokens, #acc_tokens);
                                         },
                                         None,
                                         Some(&next_stmt_id.to_string()),
@@ -4418,6 +4433,8 @@ impl HydroNode {
                             unreachable!()
                         };
 
+                        let f_tokens = f.emit_tokens(&mut ident_stack);
+
                         let reduce_ident =
                             syn::Ident::new(&format!("stream_{}", *next_stmt_id), Span::call_site());
 
@@ -4445,7 +4462,7 @@ impl HydroNode {
                                     let builder = graph_builders.get_dfir_mut(&out_location);
                                     builder.add_dfir(
                                         parse_quote! {
-                                            #reduce_ident = #input_ident -> #operator::<#lifetime>(#f);
+                                            #reduce_ident = #input_ident -> #operator::<#lifetime>(#f_tokens);
                                         },
                                         None,
                                         Some(&next_stmt_id.to_string()),
@@ -4477,6 +4494,7 @@ impl HydroNode {
                         // watermark is processed second, so it's on top
                         let watermark_ident = ident_stack.pop().unwrap();
                         let input_ident = ident_stack.pop().unwrap();
+                        let f_tokens = f.emit_tokens(&mut ident_stack);
 
                         let chain_ident = syn::Ident::new(
                             &format!("reduce_keyed_watermark_chain_{}", *next_stmt_id),
@@ -4518,7 +4536,7 @@ impl HydroNode {
 
                                             #fold_ident = #chain_ident
                                                 -> #agg_operator::<#lifetime>(|| (::std::collections::HashMap::new(), None), {
-                                                    let __reduce_keyed_fn = #f;
+                                                    let __reduce_keyed_fn = #f_tokens;
                                                     move |(map, opt_curr_watermark), (opt_payload, opt_watermark)| {
                                                         if let Some((k, v)) = opt_payload {
                                                             if let Some(curr_watermark) = *opt_curr_watermark {

--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -34,6 +34,167 @@ use crate::location::{LocationKey, NetworkHint};
 pub mod backtrace;
 use backtrace::Backtrace;
 
+/// A closure expression bundled with any singleton references it captures.
+///
+/// When a `q!()` closure captures a `SingletonRef`, the reference is recorded here
+/// alongside the closure's expression. This allows per-closure tracking of singleton
+/// captures, which is important for nodes with multiple closures (e.g. Fold has `init` and `acc`).
+pub struct ClosureExpr {
+    pub expr: DebugExpr,
+    pub singleton_refs: Vec<(syn::Ident, HydroNode)>,
+}
+
+impl Clone for ClosureExpr {
+    fn clone(&self) -> Self {
+        Self {
+            expr: self.expr.clone(),
+            singleton_refs: self
+                .singleton_refs
+                .iter()
+                .map(|(ident, node)| {
+                    let cloned_node = match node {
+                        HydroNode::Singleton { inner, metadata } => HydroNode::Singleton {
+                            inner: SharedNode(inner.0.clone()),
+                            metadata: metadata.clone(),
+                        },
+                        _ => panic!("singleton_refs should only contain HydroNode::Singleton"),
+                    };
+                    (ident.clone(), cloned_node)
+                })
+                .collect(),
+        }
+    }
+}
+
+impl Hash for ClosureExpr {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.expr.hash(state);
+        // singleton_refs are not hashed (same as HydroIrMetadata)
+    }
+}
+
+impl serde::Serialize for ClosureExpr {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+        let mut s = serializer.serialize_struct("ClosureExpr", 2)?;
+        s.serialize_field("expr", &self.expr)?;
+        s.serialize_field(
+            "singleton_refs",
+            &SerializableSingletonRefs(&self.singleton_refs),
+        )?;
+        s.end()
+    }
+}
+
+struct SerializableSingletonRefs<'a>(&'a [(syn::Ident, HydroNode)]);
+
+impl serde::Serialize for SerializableSingletonRefs<'_> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeSeq;
+        let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
+        for (ident, node) in self.0 {
+            seq.serialize_element(&(ident.to_string(), node))?;
+        }
+        seq.end()
+    }
+}
+
+impl Debug for ClosureExpr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(&self.expr, f)
+    }
+}
+
+impl Display for ClosureExpr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.expr, f)
+    }
+}
+
+impl ToTokens for ClosureExpr {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.expr.to_tokens(tokens);
+    }
+}
+
+impl From<syn::Expr> for ClosureExpr {
+    fn from(expr: syn::Expr) -> Self {
+        Self {
+            expr: DebugExpr(Box::new(expr)),
+            singleton_refs: Vec::new(),
+        }
+    }
+}
+
+impl From<DebugExpr> for ClosureExpr {
+    fn from(expr: DebugExpr) -> Self {
+        Self {
+            expr,
+            singleton_refs: Vec::new(),
+        }
+    }
+}
+
+impl ClosureExpr {
+    pub fn new(expr: DebugExpr, singleton_refs: Vec<(syn::Ident, HydroNode)>) -> Self {
+        Self {
+            expr,
+            singleton_refs,
+        }
+    }
+
+    pub fn deep_clone(&self, seen_tees: &mut SeenSharedNodes) -> Self {
+        Self {
+            expr: self.expr.clone(),
+            singleton_refs: self
+                .singleton_refs
+                .iter()
+                .map(|(ident, node)| (ident.clone(), node.deep_clone(seen_tees)))
+                .collect(),
+        }
+    }
+
+    pub fn transform_children(
+        &mut self,
+        transform: &mut impl FnMut(&mut HydroNode, &mut SeenSharedNodes),
+        seen_tees: &mut SeenSharedNodes,
+    ) {
+        for (_ident, ref_node) in self.singleton_refs.iter_mut() {
+            transform(ref_node, seen_tees);
+        }
+    }
+
+    /// Pop singleton ref idents from the stack and rewrite the closure's token stream,
+    /// replacing local singleton ref idents with `#dfir_ident` references.
+    #[cfg(feature = "build")]
+    pub fn emit_tokens(&self, ident_stack: &mut Vec<syn::Ident>) -> TokenStream {
+        if self.singleton_refs.is_empty() {
+            self.expr.0.to_token_stream()
+        } else {
+            let ref_idents = (0..self.singleton_refs.len())
+                .map(|_| ident_stack.pop().unwrap())
+                .collect::<Vec<_>>()
+                .into_iter()
+                .rev()
+                .collect::<Vec<_>>();
+            let local_idents = self
+                .singleton_refs
+                .iter()
+                .map(|(local_ident, _)| local_ident);
+            let hash = proc_macro2::Punct::new('#', proc_macro2::Spacing::Alone);
+            let expr = &self.expr.0;
+            quote! {
+                {
+                    #(
+                        let #local_idents = #hash #ref_idents;
+                    )*
+                    #expr
+                }
+            }
+        }
+    }
+}
+
 /// Wrapper that displays only the tokens of a parsed expr.
 ///
 /// Boxes `syn::Type` which is ~240 bytes.
@@ -282,18 +443,6 @@ fn serialize_ident<S: serde::Serializer>(
     serializer: S,
 ) -> Result<S::Ok, S::Error> {
     serializer.serialize_str(&ident.to_string())
-}
-
-fn serialize_singleton_refs<S: serde::Serializer>(
-    refs: &[(syn::Ident, HydroNode)],
-    serializer: S,
-) -> Result<S::Ok, S::Error> {
-    use serde::ser::SerializeSeq;
-    let mut seq = serializer.serialize_seq(Some(refs.len()))?;
-    for (ident, node) in refs {
-        seq.serialize_element(&(ident.to_string(), node))?;
-    }
-    seq.end()
 }
 
 pub enum DebugInstantiate {
@@ -792,7 +941,7 @@ where
 #[derive(Debug, Hash, serde::Serialize)]
 pub enum HydroRoot {
     ForEach {
-        f: DebugExpr,
+        f: ClosureExpr,
         input: Box<HydroNode>,
         op_metadata: HydroIrOpMetadata,
     },
@@ -1246,7 +1395,7 @@ impl HydroRoot {
                 input,
                 op_metadata,
             } => HydroRoot::ForEach {
-                f: f.clone(),
+                f: f.deep_clone(seen_tees),
                 input: Box::new(input.deep_clone(seen_tees)),
                 op_metadata: op_metadata.clone(),
             },
@@ -1599,8 +1748,11 @@ impl HydroRoot {
 
     pub fn visit_debug_expr(&mut self, mut transform: impl FnMut(&mut DebugExpr)) {
         match self {
-            HydroRoot::ForEach { f, .. } | HydroRoot::DestSink { sink: f, .. } => {
-                transform(f);
+            HydroRoot::ForEach { f, .. } => {
+                transform(&mut f.expr);
+            }
+            HydroRoot::DestSink { sink, .. } => {
+                transform(sink);
             }
             HydroRoot::SendExternal { .. }
             | HydroRoot::CycleSink { .. }
@@ -2123,7 +2275,7 @@ pub enum HydroNode {
 
     Partition {
         inner: SharedNode,
-        f: DebugExpr,
+        f: ClosureExpr,
         is_true: bool,
         metadata: HydroIrMetadata,
     },
@@ -2219,37 +2371,27 @@ pub enum HydroNode {
     },
 
     Map {
-        f: DebugExpr,
-        /// Singleton references captured by the closure `f` via `SingletonRef`.
-        /// Each entry maps a local ident (used in the closure body) to the IR node
-        /// of the referenced singleton.
-        ///
-        /// TODO: Currently only `Map` has this field. Other closure-bearing variants
-        /// (Filter, FlatMap, Fold, etc.) should be extended similarly. For nodes with
-        /// multiple closures (e.g. Fold has `init` and `acc`), we may need per-closure
-        /// tracking rather than per-node.
-        #[serde(serialize_with = "serialize_singleton_refs")]
-        singleton_refs: Vec<(syn::Ident, HydroNode)>,
+        f: ClosureExpr,
         input: Box<HydroNode>,
         metadata: HydroIrMetadata,
     },
     FlatMap {
-        f: DebugExpr,
+        f: ClosureExpr,
         input: Box<HydroNode>,
         metadata: HydroIrMetadata,
     },
     FlatMapStreamBlocking {
-        f: DebugExpr,
+        f: ClosureExpr,
         input: Box<HydroNode>,
         metadata: HydroIrMetadata,
     },
     Filter {
-        f: DebugExpr,
+        f: ClosureExpr,
         input: Box<HydroNode>,
         metadata: HydroIrMetadata,
     },
     FilterMap {
-        f: DebugExpr,
+        f: ClosureExpr,
         input: Box<HydroNode>,
         metadata: HydroIrMetadata,
     },
@@ -2263,7 +2405,7 @@ pub enum HydroNode {
         metadata: HydroIrMetadata,
     },
     Inspect {
-        f: DebugExpr,
+        f: ClosureExpr,
         input: Box<HydroNode>,
         metadata: HydroIrMetadata,
     },
@@ -2278,43 +2420,43 @@ pub enum HydroNode {
         metadata: HydroIrMetadata,
     },
     Fold {
-        init: DebugExpr,
-        acc: DebugExpr,
+        init: ClosureExpr,
+        acc: ClosureExpr,
         input: Box<HydroNode>,
         metadata: HydroIrMetadata,
     },
 
     Scan {
-        init: DebugExpr,
-        acc: DebugExpr,
+        init: ClosureExpr,
+        acc: ClosureExpr,
         input: Box<HydroNode>,
         metadata: HydroIrMetadata,
     },
     ScanAsyncBlocking {
-        init: DebugExpr,
-        acc: DebugExpr,
+        init: ClosureExpr,
+        acc: ClosureExpr,
         input: Box<HydroNode>,
         metadata: HydroIrMetadata,
     },
     FoldKeyed {
-        init: DebugExpr,
-        acc: DebugExpr,
+        init: ClosureExpr,
+        acc: ClosureExpr,
         input: Box<HydroNode>,
         metadata: HydroIrMetadata,
     },
 
     Reduce {
-        f: DebugExpr,
+        f: ClosureExpr,
         input: Box<HydroNode>,
         metadata: HydroIrMetadata,
     },
     ReduceKeyed {
-        f: DebugExpr,
+        f: ClosureExpr,
         input: Box<HydroNode>,
         metadata: HydroIrMetadata,
     },
     ReduceKeyedWatermark {
-        f: DebugExpr,
+        f: ClosureExpr,
         input: Box<HydroNode>,
         watermark: Box<HydroNode>,
         metadata: HydroIrMetadata,
@@ -2458,43 +2600,54 @@ impl HydroNode {
                 transform(neg.as_mut(), seen_tees);
             }
 
+            HydroNode::Map { f, input, .. } => {
+                f.transform_children(&mut transform, seen_tees);
+                transform(input.as_mut(), seen_tees);
+            }
+            HydroNode::FlatMap { f, input, .. }
+            | HydroNode::FlatMapStreamBlocking { f, input, .. }
+            | HydroNode::Filter { f, input, .. }
+            | HydroNode::FilterMap { f, input, .. }
+            | HydroNode::Inspect { f, input, .. }
+            | HydroNode::Reduce { f, input, .. }
+            | HydroNode::ReduceKeyed { f, input, .. } => {
+                f.transform_children(&mut transform, seen_tees);
+                transform(input.as_mut(), seen_tees);
+            }
             HydroNode::ReduceKeyedWatermark {
-                input, watermark, ..
+                f,
+                input,
+                watermark,
+                ..
             } => {
+                f.transform_children(&mut transform, seen_tees);
                 transform(input.as_mut(), seen_tees);
                 transform(watermark.as_mut(), seen_tees);
             }
-
-            HydroNode::Map {
-                input,
-                singleton_refs,
-                ..
+            HydroNode::Fold {
+                init, acc, input, ..
+            }
+            | HydroNode::Scan {
+                init, acc, input, ..
+            }
+            | HydroNode::ScanAsyncBlocking {
+                init, acc, input, ..
+            }
+            | HydroNode::FoldKeyed {
+                init, acc, input, ..
             } => {
-                // Transform each singleton ref node (these are HydroNode::Singleton wrappers).
-                for (_ident, ref_node) in singleton_refs.iter_mut() {
-                    transform(ref_node, seen_tees);
-                }
+                init.transform_children(&mut transform, seen_tees);
+                acc.transform_children(&mut transform, seen_tees);
                 transform(input.as_mut(), seen_tees);
             }
             HydroNode::ResolveFutures { input, .. }
             | HydroNode::ResolveFuturesBlocking { input, .. }
             | HydroNode::ResolveFuturesOrdered { input, .. }
-            | HydroNode::FlatMap { input, .. }
-            | HydroNode::FlatMapStreamBlocking { input, .. }
-            | HydroNode::Filter { input, .. }
-            | HydroNode::FilterMap { input, .. }
             | HydroNode::Sort { input, .. }
             | HydroNode::DeferTick { input, .. }
             | HydroNode::Enumerate { input, .. }
-            | HydroNode::Inspect { input, .. }
             | HydroNode::Unique { input, .. }
             | HydroNode::Network { input, .. }
-            | HydroNode::Fold { input, .. }
-            | HydroNode::Scan { input, .. }
-            | HydroNode::ScanAsyncBlocking { input, .. }
-            | HydroNode::FoldKeyed { input, .. }
-            | HydroNode::Reduce { input, .. }
-            | HydroNode::ReduceKeyed { input, .. }
             | HydroNode::Counter { input, .. } => {
                 transform(input.as_mut(), seen_tees);
             }
@@ -2687,39 +2840,30 @@ impl HydroNode {
                     metadata: metadata.clone(),
                 }
             }
-            HydroNode::Map {
-                f,
-                singleton_refs,
-                input,
-                metadata,
-            } => HydroNode::Map {
-                f: f.clone(),
-                singleton_refs: singleton_refs
-                    .iter()
-                    .map(|(ident, node)| (ident.clone(), node.deep_clone(seen_tees)))
-                    .collect(),
+            HydroNode::Map { f, input, metadata } => HydroNode::Map {
+                f: f.deep_clone(seen_tees),
                 input: Box::new(input.deep_clone(seen_tees)),
                 metadata: metadata.clone(),
             },
             HydroNode::FlatMap { f, input, metadata } => HydroNode::FlatMap {
-                f: f.clone(),
+                f: f.deep_clone(seen_tees),
                 input: Box::new(input.deep_clone(seen_tees)),
                 metadata: metadata.clone(),
             },
             HydroNode::FlatMapStreamBlocking { f, input, metadata } => {
                 HydroNode::FlatMapStreamBlocking {
-                    f: f.clone(),
+                    f: f.deep_clone(seen_tees),
                     input: Box::new(input.deep_clone(seen_tees)),
                     metadata: metadata.clone(),
                 }
             }
             HydroNode::Filter { f, input, metadata } => HydroNode::Filter {
-                f: f.clone(),
+                f: f.deep_clone(seen_tees),
                 input: Box::new(input.deep_clone(seen_tees)),
                 metadata: metadata.clone(),
             },
             HydroNode::FilterMap { f, input, metadata } => HydroNode::FilterMap {
-                f: f.clone(),
+                f: f.deep_clone(seen_tees),
                 input: Box::new(input.deep_clone(seen_tees)),
                 metadata: metadata.clone(),
             },
@@ -2732,7 +2876,7 @@ impl HydroNode {
                 metadata: metadata.clone(),
             },
             HydroNode::Inspect { f, input, metadata } => HydroNode::Inspect {
-                f: f.clone(),
+                f: f.deep_clone(seen_tees),
                 input: Box::new(input.deep_clone(seen_tees)),
                 metadata: metadata.clone(),
             },
@@ -2750,8 +2894,8 @@ impl HydroNode {
                 input,
                 metadata,
             } => HydroNode::Fold {
-                init: init.clone(),
-                acc: acc.clone(),
+                init: init.deep_clone(seen_tees),
+                acc: acc.deep_clone(seen_tees),
                 input: Box::new(input.deep_clone(seen_tees)),
                 metadata: metadata.clone(),
             },
@@ -2761,8 +2905,8 @@ impl HydroNode {
                 input,
                 metadata,
             } => HydroNode::Scan {
-                init: init.clone(),
-                acc: acc.clone(),
+                init: init.deep_clone(seen_tees),
+                acc: acc.deep_clone(seen_tees),
                 input: Box::new(input.deep_clone(seen_tees)),
                 metadata: metadata.clone(),
             },
@@ -2772,8 +2916,8 @@ impl HydroNode {
                 input,
                 metadata,
             } => HydroNode::ScanAsyncBlocking {
-                init: init.clone(),
-                acc: acc.clone(),
+                init: init.deep_clone(seen_tees),
+                acc: acc.deep_clone(seen_tees),
                 input: Box::new(input.deep_clone(seen_tees)),
                 metadata: metadata.clone(),
             },
@@ -2783,8 +2927,8 @@ impl HydroNode {
                 input,
                 metadata,
             } => HydroNode::FoldKeyed {
-                init: init.clone(),
-                acc: acc.clone(),
+                init: init.deep_clone(seen_tees),
+                acc: acc.deep_clone(seen_tees),
                 input: Box::new(input.deep_clone(seen_tees)),
                 metadata: metadata.clone(),
             },
@@ -2794,18 +2938,18 @@ impl HydroNode {
                 watermark,
                 metadata,
             } => HydroNode::ReduceKeyedWatermark {
-                f: f.clone(),
+                f: f.deep_clone(seen_tees),
                 input: Box::new(input.deep_clone(seen_tees)),
                 watermark: Box::new(watermark.deep_clone(seen_tees)),
                 metadata: metadata.clone(),
             },
             HydroNode::Reduce { f, input, metadata } => HydroNode::Reduce {
-                f: f.clone(),
+                f: f.deep_clone(seen_tees),
                 input: Box::new(input.deep_clone(seen_tees)),
                 metadata: metadata.clone(),
             },
             HydroNode::ReduceKeyed { f, input, metadata } => HydroNode::ReduceKeyed {
-                f: f.clone(),
+                f: f.deep_clone(seen_tees),
                 input: Box::new(input.deep_clone(seen_tees)),
                 metadata: metadata.clone(),
             },
@@ -3744,42 +3888,16 @@ impl HydroNode {
                         ident_stack.push(futures_ident);
                     }
 
-                    HydroNode::Map { f, singleton_refs, .. } => {
+                    HydroNode::Map { f, .. } => {
                         // Pop input ident (pushed last by transform_children).
                         let input_ident = ident_stack.pop().unwrap();
-                        // Pop singleton ref idents in reverse order (pushed before input).
-                        let ref_idents = (0..singleton_refs.len())
-                            .map(|_| ident_stack.pop().unwrap())
-                            .collect::<Vec<_>>()
-                            .into_iter()
-                            .rev()
-                            .collect::<Vec<_>>();
+                        let f_tokens = f.emit_tokens(&mut ident_stack);
 
                         let map_ident =
                             syn::Ident::new(&format!("stream_{}", *next_stmt_id), Span::call_site());
 
                         match builders_or_callback {
                             BuildersOrCallback::Builders(graph_builders) => {
-                                // Wrap the closure: assign local singleton ref idents to
-                                // `#ref_ident` (the `singleton()` node's DFIR variable name).
-                                let f_tokens = if singleton_refs.is_empty() {
-                                    f.0.to_token_stream()
-                                } else {
-                                    let local_idents = singleton_refs
-                                        .iter()
-                                        .map(|(local_ident, _)| local_ident);
-                                    let hash = proc_macro2::Punct::new('#', proc_macro2::Spacing::Alone);
-                                    let expr = &f.0;
-                                    quote! {
-                                        {
-                                            #(
-                                                let #local_idents = #hash #ref_idents;
-                                            )*
-                                            #expr
-                                        }
-                                    }
-                                };
-
                                 let builder = graph_builders.get_dfir_mut(&out_location);
                                 builder.add_dfir(
                                     parse_quote! {
@@ -3801,6 +3919,7 @@ impl HydroNode {
 
                     HydroNode::FlatMap { f, .. } => {
                         let input_ident = ident_stack.pop().unwrap();
+                        let f_tokens = f.emit_tokens(&mut ident_stack);
 
                         let flat_map_ident =
                             syn::Ident::new(&format!("stream_{}", *next_stmt_id), Span::call_site());
@@ -3810,7 +3929,7 @@ impl HydroNode {
                                 let builder = graph_builders.get_dfir_mut(&out_location);
                                 builder.add_dfir(
                                     parse_quote! {
-                                        #flat_map_ident = #input_ident -> flat_map(#f);
+                                        #flat_map_ident = #input_ident -> flat_map(#f_tokens);
                                     },
                                     None,
                                     Some(&next_stmt_id.to_string()),
@@ -3828,6 +3947,7 @@ impl HydroNode {
 
                     HydroNode::FlatMapStreamBlocking { f, .. } => {
                         let input_ident = ident_stack.pop().unwrap();
+                        let f_tokens = f.emit_tokens(&mut ident_stack);
 
                         let flat_map_stream_blocking_ident =
                             syn::Ident::new(&format!("stream_{}", *next_stmt_id), Span::call_site());
@@ -3837,7 +3957,7 @@ impl HydroNode {
                                 let builder = graph_builders.get_dfir_mut(&out_location);
                                 builder.add_dfir(
                                     parse_quote! {
-                                        #flat_map_stream_blocking_ident = #input_ident -> flat_map_stream_blocking(#f);
+                                        #flat_map_stream_blocking_ident = #input_ident -> flat_map_stream_blocking(#f_tokens);
                                     },
                                     None,
                                     Some(&next_stmt_id.to_string()),
@@ -3855,6 +3975,7 @@ impl HydroNode {
 
                     HydroNode::Filter { f, .. } => {
                         let input_ident = ident_stack.pop().unwrap();
+                        let f_tokens = f.emit_tokens(&mut ident_stack);
 
                         let filter_ident =
                             syn::Ident::new(&format!("stream_{}", *next_stmt_id), Span::call_site());
@@ -3864,7 +3985,7 @@ impl HydroNode {
                                 let builder = graph_builders.get_dfir_mut(&out_location);
                                 builder.add_dfir(
                                     parse_quote! {
-                                        #filter_ident = #input_ident -> filter(#f);
+                                        #filter_ident = #input_ident -> filter(#f_tokens);
                                     },
                                     None,
                                     Some(&next_stmt_id.to_string()),
@@ -3882,6 +4003,7 @@ impl HydroNode {
 
                     HydroNode::FilterMap { f, .. } => {
                         let input_ident = ident_stack.pop().unwrap();
+                        let f_tokens = f.emit_tokens(&mut ident_stack);
 
                         let filter_map_ident =
                             syn::Ident::new(&format!("stream_{}", *next_stmt_id), Span::call_site());
@@ -3891,7 +4013,7 @@ impl HydroNode {
                                 let builder = graph_builders.get_dfir_mut(&out_location);
                                 builder.add_dfir(
                                     parse_quote! {
-                                        #filter_map_ident = #input_ident -> filter_map(#f);
+                                        #filter_map_ident = #input_ident -> filter_map(#f_tokens);
                                     },
                                     None,
                                     Some(&next_stmt_id.to_string()),
@@ -3995,6 +4117,7 @@ impl HydroNode {
 
                     HydroNode::Inspect { f, .. } => {
                         let input_ident = ident_stack.pop().unwrap();
+                        let f_tokens = f.emit_tokens(&mut ident_stack);
 
                         let inspect_ident =
                             syn::Ident::new(&format!("stream_{}", *next_stmt_id), Span::call_site());
@@ -4004,7 +4127,7 @@ impl HydroNode {
                                 let builder = graph_builders.get_dfir_mut(&out_location);
                                 builder.add_dfir(
                                     parse_quote! {
-                                        #inspect_ident = #input_ident -> inspect(#f);
+                                        #inspect_ident = #input_ident -> inspect(#f_tokens);
                                     },
                                     None,
                                     Some(&next_stmt_id.to_string()),
@@ -4621,14 +4744,14 @@ impl HydroNode {
             | HydroNode::Reduce { f, .. }
             | HydroNode::ReduceKeyed { f, .. }
             | HydroNode::ReduceKeyedWatermark { f, .. } => {
-                transform(f);
+                transform(&mut f.expr);
             }
             HydroNode::Fold { init, acc, .. }
             | HydroNode::Scan { init, acc, .. }
             | HydroNode::ScanAsyncBlocking { init, acc, .. }
             | HydroNode::FoldKeyed { init, acc, .. } => {
-                transform(init);
-                transform(acc);
+                transform(&mut init.expr);
+                transform(&mut acc.expr);
             }
             HydroNode::Network {
                 serialize_fn,
@@ -5122,7 +5245,7 @@ mod test {
         ignore = "expects inclusion of feature-gated fields"
     )]
     fn hydro_node_size() {
-        assert_eq!(size_of::<HydroNode>(), 248);
+        assert_eq!(size_of::<HydroNode>(), 256);
     }
 
     #[test]

--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -3461,6 +3461,15 @@ impl HydroNode {
                         let ret_ident = if let Some(built_idents) = built_tees.get(&ptr) {
                             // Pop singleton ref idents (if any) that were pushed by transform_children
                             // but won't be used since the partition was already built.
+                            //
+                            // When the second Partition branch is processed, transform_children
+                            // recurses into f.singleton_refs, causing each Singleton node's
+                            // transform_bottom_up to push an ident onto ident_stack. Since the
+                            // partition was already built by the first branch, these idents are
+                            // unused and must be popped to maintain stack invariants.
+                            //
+                            // Removing this pop triggers the ident_stack emptiness assertion at
+                            // the end of emit_core (verified by test_singleton_ref_partition_*).
                             for _ in 0..f.singleton_refs.len() {
                                 ident_stack.pop().unwrap();
                             }
@@ -4707,9 +4716,16 @@ impl HydroNode {
             false,
         );
 
-        ident_stack
+        let ret = ident_stack
             .pop()
-            .expect("ident_stack should have exactly one element after traversal")
+            .expect("ident_stack should have exactly one element after traversal");
+        assert!(
+            ident_stack.is_empty(),
+            "ident_stack should be empty after popping the final ident, but has {} remaining element(s). \
+             This indicates a bug in the code gen: some node pushed idents that were never consumed.",
+            ident_stack.len()
+        );
+        ret
     }
 
     pub fn visit_debug_expr(&mut self, mut transform: impl FnMut(&mut DebugExpr)) {

--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -4259,7 +4259,7 @@ impl HydroNode {
                                         &node.metadata().op,
                                     );
 
-                                    let (effective_input, _acc) = if let Some(ref hooked) = hooked_input_ident {
+                                    let (effective_input, wrapped_acc) = if let Some(ref hooked) = hooked_input_ident {
                                         let acc: syn::Expr = parse_quote!({
                                             let mut __inner = #acc_tokens;
                                             move |__state, __batch: Vec<_>| {
@@ -4288,7 +4288,7 @@ impl HydroNode {
                                     builder.add_dfir(
                                         parse_quote! {
                                             source_iter([(#init_tokens)()]) -> [0]#fold_ident;
-                                            #effective_input -> scan::<#lifetime>(#init_tokens, #acc_tokens) -> [1]#fold_ident;
+                                            #effective_input -> scan::<#lifetime>(#init_tokens, #wrapped_acc) -> [1]#fold_ident;
                                             #fold_ident = chain();
                                         },
                                         None,
@@ -4313,7 +4313,7 @@ impl HydroNode {
                                     );
                                     let builder = graph_builders.get_dfir_mut(&out_location);
 
-                                    let _acc: syn::Expr = parse_quote!({
+                                    let wrapped_acc: syn::Expr = parse_quote!({
                                         let mut __init = #init_tokens;
                                         let mut __inner = #acc_tokens;
                                         move |__state, __kv: (_, _)| {
@@ -4329,7 +4329,7 @@ impl HydroNode {
                                     if let Some(hooked_input_ident) = hooked_input_ident {
                                         builder.add_dfir(
                                             parse_quote! {
-                                                #fold_ident = #hooked_input_ident -> flatten() -> scan::<#lifetime>(|| ::std::collections::HashMap::new(), #acc_tokens);
+                                                #fold_ident = #hooked_input_ident -> flatten() -> scan::<#lifetime>(|| ::std::collections::HashMap::new(), #wrapped_acc);
                                             },
                                             None,
                                             Some(&next_stmt_id.to_string()),
@@ -4339,7 +4339,7 @@ impl HydroNode {
                                     } else {
                                         builder.add_dfir(
                                             parse_quote! {
-                                                #fold_ident = #input_ident -> scan::<#lifetime>(|| ::std::collections::HashMap::new(), #acc_tokens);
+                                                #fold_ident = #input_ident -> scan::<#lifetime>(|| ::std::collections::HashMap::new(), #wrapped_acc);
                                             },
                                             None,
                                             Some(&next_stmt_id.to_string()),

--- a/hydro_lang/src/compile/ir/snapshots/hydro_lang__compile__ir__serde_test__tests__ir_json_snapshot.snap
+++ b/hydro_lang/src/compile/ir/snapshots/hydro_lang__compile__ir__serde_test__tests__ir_json_snapshot.snap
@@ -5,15 +5,20 @@ expression: json
 [
   {
     "ForEach": {
-      "f": "q!(| v | println ! (\"{}\" , v))",
+      "f": {
+        "expr": "q!(| v | println ! (\"{}\" , v))",
+        "singleton_refs": []
+      },
       "input": {
         "Tee": {
           "inner": {
             "$shared": 0,
             "node": {
               "Map": {
-                "f": "q!(| x | x * 2)",
-                "singleton_refs": [],
+                "f": {
+                  "expr": "q!(| x | x * 2)",
+                  "singleton_refs": []
+                },
                 "input": {
                   "Source": {
                     "source": {
@@ -108,7 +113,10 @@ expression: json
   },
   {
     "ForEach": {
-      "f": "q!(| v | eprintln ! (\"{}\" , v))",
+      "f": {
+        "expr": "q!(| v | eprintln ! (\"{}\" , v))",
+        "singleton_refs": []
+      },
       "input": {
         "Tee": {
           "inner": {

--- a/hydro_lang/src/compile/ir/snapshots/hydro_lang__compile__ir__serde_test__tests__ir_json_snapshot.snap
+++ b/hydro_lang/src/compile/ir/snapshots/hydro_lang__compile__ir__serde_test__tests__ir_json_snapshot.snap
@@ -5,10 +5,7 @@ expression: json
 [
   {
     "ForEach": {
-      "f": {
-        "expr": "q!(| v | println ! (\"{}\" , v))",
-        "singleton_refs": []
-      },
+      "f": "q!(| v | println ! (\"{}\" , v))",
       "input": {
         "Tee": {
           "inner": {
@@ -113,10 +110,7 @@ expression: json
   },
   {
     "ForEach": {
-      "f": {
-        "expr": "q!(| v | eprintln ! (\"{}\" , v))",
-        "singleton_refs": []
-      },
+      "f": "q!(| v | eprintln ! (\"{}\" , v))",
       "input": {
         "Tee": {
           "inner": {

--- a/hydro_lang/src/live_collections/keyed_singleton.rs
+++ b/hydro_lang/src/live_collections/keyed_singleton.rs
@@ -378,7 +378,6 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound> KeyedSingleton<K, V, L, 
             self.location.clone(),
             HydroNode::Map {
                 f: map_f,
-                singleton_refs: Vec::new(),
                 input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.new_node_metadata(KeyedSingleton::<
                     K,
@@ -443,7 +442,6 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound> KeyedSingleton<K, V, L, 
             self.location.clone(),
             HydroNode::Map {
                 f: map_f,
-                singleton_refs: Vec::new(),
                 input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.new_node_metadata(KeyedSingleton::<
                     K,
@@ -942,7 +940,6 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound<ValueBound = Bounded>>
             self.location.clone(),
             HydroNode::Map {
                 f: map_f,
-                singleton_refs: Vec::new(),
                 input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self.location.new_node_metadata(Stream::<
                     V,

--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -688,7 +688,6 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
             self.location.clone(),
             HydroNode::Map {
                 f: map_f,
-                singleton_refs: Vec::new(),
                 input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
@@ -748,7 +747,6 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
             self.location.clone(),
             HydroNode::Map {
                 f: map_f,
-                singleton_refs: Vec::new(),
                 input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
@@ -805,7 +803,6 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
             self.location.clone(),
             HydroNode::Map {
                 f: map_f,
-                singleton_refs: Vec::new(),
                 input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location

--- a/hydro_lang/src/live_collections/optional.rs
+++ b/hydro_lang/src/live_collections/optional.rs
@@ -357,7 +357,6 @@ where
             self.location.clone(),
             HydroNode::Map {
                 f,
-                singleton_refs: Vec::new(),
                 input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location

--- a/hydro_lang/src/live_collections/singleton.rs
+++ b/hydro_lang/src/live_collections/singleton.rs
@@ -438,7 +438,6 @@ where
             self.location.clone(),
             HydroNode::Map {
                 f,
-                singleton_refs: Vec::new(),
                 input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -1135,9 +1135,7 @@ where
         O: IsOrdered,
         R: IsExactlyOnce,
     {
-        let f = crate::singleton_ref::with_singleton_capture(|| {
-            f.splice_fn1_ctx(&self.location).into()
-        });
+        let f = f.splice_fn1_ctx(&self.location).into();
         self.location
             .flow_state()
             .borrow_mut()

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -456,14 +456,13 @@ where
     where
         F: Fn(T) -> U + 'a,
     {
-        let (f, singleton_refs) = crate::singleton_ref::with_singleton_capture(|| {
+        let f = crate::singleton_ref::with_singleton_capture(|| {
             f.splice_fn1_ctx(&self.location).into()
         });
         Stream::new(
             self.location.clone(),
             HydroNode::Map {
                 f,
-                singleton_refs,
                 input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
@@ -501,7 +500,9 @@ where
         I: IntoIterator<Item = U>,
         F: Fn(T) -> I + 'a,
     {
-        let f = f.splice_fn1_ctx(&self.location).into();
+        let f = crate::singleton_ref::with_singleton_capture(|| {
+            f.splice_fn1_ctx(&self.location).into()
+        });
         Stream::new(
             self.location.clone(),
             HydroNode::FlatMap {
@@ -548,7 +549,9 @@ where
         I: IntoIterator<Item = U>,
         F: Fn(T) -> I + 'a,
     {
-        let f = f.splice_fn1_ctx(&self.location).into();
+        let f = crate::singleton_ref::with_singleton_capture(|| {
+            f.splice_fn1_ctx(&self.location).into()
+        });
         Stream::new(
             self.location.clone(),
             HydroNode::FlatMap {
@@ -685,7 +688,9 @@ where
     where
         F: Fn(&T) -> bool + 'a,
     {
-        let f = f.splice_fn1_borrow_ctx(&self.location).into();
+        let f = crate::singleton_ref::with_singleton_capture(|| {
+            f.splice_fn1_borrow_ctx(&self.location).into()
+        });
         Stream::new(
             self.location.clone(),
             HydroNode::Filter {
@@ -741,7 +746,9 @@ where
     where
         F: Fn(&T) -> bool + 'a,
     {
-        let f: crate::compile::ir::DebugExpr = f.splice_fn1_borrow_ctx(&self.location).into();
+        let f = crate::singleton_ref::with_singleton_capture(|| {
+            f.splice_fn1_borrow_ctx(&self.location).into()
+        });
         let shared = SharedNode(Rc::new(RefCell::new(
             self.ir_node.replace(HydroNode::Placeholder),
         )));
@@ -1103,7 +1110,9 @@ where
     where
         F: Fn(&T) + 'a,
     {
-        let f = f.splice_fn1_borrow_ctx(&self.location).into();
+        let f = crate::singleton_ref::with_singleton_capture(|| {
+            f.splice_fn1_borrow_ctx(&self.location).into()
+        });
 
         Stream::new(
             self.location.clone(),
@@ -1126,7 +1135,9 @@ where
         O: IsOrdered,
         R: IsExactlyOnce,
     {
-        let f = f.splice_fn1_ctx(&self.location).into();
+        let f = crate::singleton_ref::with_singleton_capture(|| {
+            f.splice_fn1_ctx(&self.location).into()
+        });
         self.location
             .flow_state()
             .borrow_mut()

--- a/hydro_lang/src/singleton_ref.rs
+++ b/hydro_lang/src/singleton_ref.rs
@@ -168,4 +168,82 @@ mod tests {
 
         let _built = flow.finalize();
     }
+
+    /// Compile-only: singleton ref inside filter closure.
+    #[test]
+    fn singleton_by_ref_filter() {
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<P1>();
+
+        let threshold = node
+            .source_iter(q!(0..5i32))
+            .fold(q!(|| 0i32), q!(|acc: &mut i32, x| *acc += x));
+        let threshold_ref = threshold.by_ref();
+
+        node.source_iter(q!(1..=10i32))
+            .filter(q!(|x| *x > *threshold_ref))
+            .for_each(q!(|_| {}));
+
+        threshold.into_stream().for_each(q!(|_| {}));
+        let _built = flow.finalize();
+    }
+
+    /// Compile-only: singleton ref inside flat_map closure.
+    #[test]
+    fn singleton_by_ref_flat_map() {
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<P1>();
+
+        let count = node
+            .source_iter(q!(0..3i32))
+            .fold(q!(|| 0i32), q!(|acc: &mut i32, _| *acc += 1));
+        let count_ref = count.by_ref();
+
+        node.source_iter(q!(1..=2i32))
+            .flat_map_ordered(q!(|x| (0..*count_ref).map(move |i| x + i)))
+            .for_each(q!(|_| {}));
+
+        count.into_stream().for_each(q!(|_| {}));
+        let _built = flow.finalize();
+    }
+
+    /// Compile-only: singleton ref inside inspect closure.
+    #[test]
+    fn singleton_by_ref_inspect() {
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<P1>();
+
+        let count = node
+            .source_iter(q!(0..5i32))
+            .fold(q!(|| 0i32), q!(|acc: &mut i32, _| *acc += 1));
+        let count_ref = count.by_ref();
+
+        node.source_iter(q!(1..=3i32))
+            .inspect(q!(|x| println!("count={}, x={}", *count_ref, x)))
+            .for_each(q!(|_| {}));
+
+        count.into_stream().for_each(q!(|_| {}));
+        let _built = flow.finalize();
+    }
+
+    /// Compile-only: singleton ref inside partition predicate.
+    #[test]
+    fn singleton_by_ref_partition() {
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<P1>();
+
+        let threshold = node
+            .source_iter(q!(0..5i32))
+            .fold(q!(|| 0i32), q!(|acc: &mut i32, x| *acc += x));
+        let threshold_ref = threshold.by_ref();
+
+        let (above, below) = node
+            .source_iter(q!(1..=10i32))
+            .partition(q!(|x| *x > *threshold_ref));
+
+        above.for_each(q!(|_| {}));
+        below.for_each(q!(|_| {}));
+        threshold.into_stream().for_each(q!(|_| {}));
+        let _built = flow.finalize();
+    }
 }

--- a/hydro_lang/src/singleton_ref.rs
+++ b/hydro_lang/src/singleton_ref.rs
@@ -246,4 +246,30 @@ mod tests {
         threshold.into_stream().for_each(q!(|_| {}));
         let _built = flow.finalize();
     }
+
+    /// Compile-only: singleton ref inside partition with downstream operators on both branches.
+    ///
+    /// This exercises the ident_stack pop logic in the "already built" path of Partition
+    /// code generation. When the second branch is processed, singleton ref idents pushed by
+    /// transform_children must be popped to keep the stack consistent for downstream ops.
+    #[test]
+    fn singleton_by_ref_partition_with_downstream_ops() {
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<P1>();
+
+        let threshold = node
+            .source_iter(q!(0..5i32))
+            .fold(q!(|| 0i32), q!(|acc: &mut i32, x| *acc += x));
+        let threshold_ref = threshold.by_ref();
+
+        let (above, below) = node
+            .source_iter(q!(1..=10i32))
+            .partition(q!(|x| *x > *threshold_ref));
+
+        // Downstream operators on both branches — if the pop is missing, these will fail
+        above.map(q!(|x| x * 2)).for_each(q!(|_| {}));
+        below.map(q!(|x| x + 100)).for_each(q!(|_| {}));
+        threshold.into_stream().for_each(q!(|_| {}));
+        let _built = flow.finalize();
+    }
 }

--- a/hydro_lang/src/singleton_ref.rs
+++ b/hydro_lang/src/singleton_ref.rs
@@ -51,8 +51,11 @@ thread_local! {
 }
 
 /// Activate the singleton reference capture context. Must be called before `q!()` expansion
-/// that may capture singletons. Returns the captured references when the scope ends.
-pub fn with_singleton_capture<R>(f: impl FnOnce() -> R) -> (R, Vec<(syn::Ident, HydroNode)>) {
+/// that may capture singletons. Returns a `ClosureExpr` bundling the expression with any
+/// captured singleton references.
+pub fn with_singleton_capture(
+    f: impl FnOnce() -> crate::compile::ir::DebugExpr,
+) -> crate::compile::ir::ClosureExpr {
     SINGLETON_REFS.with(|cell| {
         let prev = cell.borrow_mut().replace(Vec::new());
         assert!(
@@ -60,9 +63,9 @@ pub fn with_singleton_capture<R>(f: impl FnOnce() -> R) -> (R, Vec<(syn::Ident, 
             "nested singleton capture scopes are not supported"
         );
     });
-    let result = f();
-    let captured = SINGLETON_REFS.with(|cell| cell.borrow_mut().take().unwrap());
-    (result, captured)
+    let expr = f();
+    let singleton_refs = SINGLETON_REFS.with(|cell| cell.borrow_mut().take().unwrap());
+    crate::compile::ir::ClosureExpr::new(expr, singleton_refs)
 }
 
 static SINGLETON_REF_COUNTER: std::sync::atomic::AtomicUsize =

--- a/hydro_lang/src/viz/render.rs
+++ b/hydro_lang/src/viz/render.rs
@@ -876,7 +876,7 @@ impl HydroRoot {
                 config,
                 input,
                 None,
-                NodeLabel::with_exprs("for_each".to_owned(), vec![f.expr.clone()]),
+                NodeLabel::with_exprs("for_each".to_owned(), vec![f.clone()]),
             ),
 
             HydroRoot::SendExternal {

--- a/hydro_lang/src/viz/render.rs
+++ b/hydro_lang/src/viz/render.rs
@@ -876,7 +876,7 @@ impl HydroRoot {
                 config,
                 input,
                 None,
-                NodeLabel::with_exprs("for_each".to_owned(), vec![f.clone()]),
+                NodeLabel::with_exprs("for_each".to_owned(), vec![f.expr.clone()]),
             ),
 
             HydroRoot::SendExternal {
@@ -1274,7 +1274,7 @@ impl HydroNode {
                     op_name: extract_op_name(self.print_root()),
                     node_type: HydroNodeType::Transform,
                 },
-                f,
+                &f.expr,
             ),
 
             // Single-expression Aggregation operations - grouped by node type
@@ -1289,7 +1289,7 @@ impl HydroNode {
                     op_name: extract_op_name(self.print_root()),
                     node_type: HydroNodeType::Aggregation,
                 },
-                f,
+                &f.expr,
             ),
 
             // Join-like operations with left/right edge labels - grouped by edge labeling
@@ -1429,8 +1429,8 @@ impl HydroNode {
                         op_name: extract_op_name(self.print_root()),
                         node_type,
                     },
-                    init,
-                    acc,
+                    &init.expr,
+                    &acc.expr,
                 )
             }
 
@@ -1474,7 +1474,7 @@ impl HydroNode {
                 );
 
                 let node_id = structure.add_node_with_backtrace(
-                    NodeLabel::with_exprs(extract_op_name(self.print_root()), vec![f.clone()]),
+                    NodeLabel::with_exprs(extract_op_name(self.print_root()), vec![f.expr.clone()]),
                     HydroNodeType::Aggregation,
                     location_key,
                     Some(metadata.op.backtrace.clone()),

--- a/hydro_test/src/cluster/snapshots/compute_pi_ir.snap
+++ b/hydro_test/src/cluster/snapshots/compute_pi_ir.snap
@@ -213,7 +213,7 @@ expression: built.ir()
                                                 first: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                                     input: Map {
-                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                         input: Reduce {
                                                             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
                                                             input: FlatMap {

--- a/hydro_test/src/cluster/snapshots/compute_pi_ir.snap
+++ b/hydro_test/src/cluster/snapshots/compute_pi_ir.snap
@@ -11,7 +11,6 @@ expression: built.ir()
                     inner: Cast {
                         inner: Map {
                             f: stageleft :: runtime_support :: fn1_type_hint :: < ((u64 , u64) , bool) , (u64 , u64) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | (d , _) | d }),
-                            singleton_refs: [],
                             input: CrossSingleton {
                                 left: Batch {
                                     inner: Reduce {
@@ -19,7 +18,6 @@ expression: built.ir()
                                         input: ObserveNonDet {
                                             inner: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: compute_pi :: Worker > , (u64 , u64)) , (u64 , u64) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                                singleton_refs: [],
                                                 input: Cast {
                                                     inner: Cast {
                                                         inner: Network {
@@ -41,14 +39,11 @@ expression: built.ir()
                                                                         acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (u64 , u64) , bool , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: compute_pi :: * ; | (inside , total) , sample_inside | { if sample_inside { * inside += 1 ; } * total += 1 ; } }),
                                                                         input: Map {
                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (f64 , f64) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: compute_pi :: * ; | (x , y) | x * x + y * y < 1.0 }),
-                                                                            singleton_refs: [],
                                                                             input: Map {
                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , (f64 , f64) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: compute_pi :: * ; | _ | rand :: random :: < (f64 , f64) > () }),
-                                                                                singleton_refs: [],
                                                                                 input: Batch {
                                                                                     inner: Map {
                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: tick :: * ; | _ | () }),
-                                                                                        singleton_refs: [],
                                                                                         input: FlatMap {
                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < () , std :: ops :: Range < usize > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: tick :: * ; let batch_size__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: compute_pi :: * ; let batch_size__free = 8192usize ; batch_size__free } ; move | _ | 0 .. batch_size__free }),
                                                                                             input: Source {
@@ -213,15 +208,12 @@ expression: built.ir()
                                     f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | b | * b }),
                                     input: Map {
                                         f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_some () }),
-                                        singleton_refs: [],
                                         input: Cast {
                                             inner: ChainFirst {
                                                 first: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                    singleton_refs: [],
                                                     input: Map {
-                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                        singleton_refs: [],
+                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                         input: Reduce {
                                                             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
                                                             input: FlatMap {

--- a/hydro_test/src/cluster/snapshots/many_to_many_ir.snap
+++ b/hydro_test/src/cluster/snapshots/many_to_many_ir.snap
@@ -27,7 +27,6 @@ expression: built.ir()
                                 left: ObserveNonDet {
                                     inner: Map {
                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                        singleton_refs: [],
                                         input: Cast {
                                             inner: Cast {
                                                 inner: Filter {
@@ -39,7 +38,6 @@ expression: built.ir()
                                                             input: Cast {
                                                                 inner: Map {
                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | (k , v) | (MemberId :: from_tagless (k) , v) }),
-                                                                    singleton_refs: [],
                                                                     input: Source {
                                                                         source: ClusterMembers(
                                                                             Cluster(loc1v1),

--- a/hydro_test/src/cluster/snapshots/map_reduce_ir.snap
+++ b/hydro_test/src/cluster/snapshots/map_reduce_ir.snap
@@ -16,7 +16,6 @@ expression: built.ir()
                                     inner: Cast {
                                         inner: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: map_reduce :: Worker > , (std :: string :: String , i32)) , (std :: string :: String , i32) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                            singleton_refs: [],
                                             input: Cast {
                                                 inner: Cast {
                                                     inner: Network {
@@ -43,7 +42,6 @@ expression: built.ir()
                                                                                 inner: Cast {
                                                                                     inner: Map {
                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < std :: string :: String , (std :: string :: String , ()) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: map_reduce :: * ; | string | (string , ()) }),
-                                                                                        singleton_refs: [],
                                                                                         input: Network {
                                                                                             name: None,
                                                                                             networking_info: Tcp {
@@ -65,7 +63,6 @@ expression: built.ir()
                                                                                                                 inner: Enumerate {
                                                                                                                     input: Map {
                                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < & str , std :: string :: String > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: map_reduce :: * ; | s | s . to_owned () }),
-                                                                                                                        singleton_refs: [],
                                                                                                                         input: Source {
                                                                                                                             source: Iter(
                                                                                                                                 stageleft :: runtime_support :: type_hint :: < std :: vec :: Vec < & str > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: map_reduce :: * ; vec ! ["abc" , "abc" , "xyz" , "abc"] }),
@@ -117,7 +114,6 @@ expression: built.ir()
                                                                                                                     input: ObserveNonDet {
                                                                                                                         inner: Map {
                                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: map_reduce :: Worker > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: map_reduce :: Worker > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                                                                                            singleton_refs: [],
                                                                                                                             input: Cast {
                                                                                                                                 inner: Cast {
                                                                                                                                     inner: Filter {
@@ -129,7 +125,6 @@ expression: built.ir()
                                                                                                                                                 input: Cast {
                                                                                                                                                     inner: Map {
                                                                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: map_reduce :: Worker > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | (k , v) | (MemberId :: from_tagless (k) , v) }),
-                                                                                                                                                        singleton_refs: [],
                                                                                                                                                         input: Source {
                                                                                                                                                             source: ClusterMembers(
                                                                                                                                                                 Cluster(loc2v1),

--- a/hydro_test/src/cluster/snapshots/paxos_ir.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir.snap
@@ -35,7 +35,6 @@ expression: built.ir()
                         },
                         second: Map {
                             f: stageleft :: runtime_support :: fn1_type_hint :: < ((u32 , core :: option :: Option < i32 >) , bool) , (u32 , core :: option :: Option < i32 >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | (d , _) | d }),
-                            singleton_refs: [],
                             input: CrossSingleton {
                                 left: Cast {
                                     inner: SingletonSource {
@@ -61,15 +60,12 @@ expression: built.ir()
                                     f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | b | * b }),
                                     input: Map {
                                         f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_some () }),
-                                        singleton_refs: [],
                                         input: Cast {
                                             inner: ChainFirst {
                                                 first: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                    singleton_refs: [],
                                                     input: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                        singleton_refs: [],
                                                         input: SingletonSource {
                                                             value: { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; () },
                                                             first_tick_only: true,
@@ -271,7 +267,6 @@ expression: built.ir()
         input: Tee {
             inner: <shared 1>: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , u32) , u32 > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless ((__hydro_lang_cluster_self_id_loc1v1) . clone ()) ; move | (received_max_ballot , ballot_num) | { if received_max_ballot > (Ballot { num : ballot_num , proposer_id : CLUSTER_SELF_ID__free . clone () , }) { received_max_ballot . num + 1 } else { ballot_num } } }),
-                singleton_refs: [],
                 input: Cast {
                     inner: CrossSingleton {
                         left: Tee {
@@ -591,7 +586,6 @@ expression: built.ir()
         input: Tee {
             inner: <shared 3>: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                singleton_refs: [],
                 input: Cast {
                     inner: Network {
                         name: None,
@@ -612,7 +606,6 @@ expression: built.ir()
                                         inner: Cast {
                                             inner: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                singleton_refs: [],
                                                 input: Cast {
                                                     inner: Cast {
                                                         inner: Filter {
@@ -624,7 +617,6 @@ expression: built.ir()
                                                                     input: Cast {
                                                                         inner: Map {
                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | (k , v) | (MemberId :: from_tagless (k) , v) }),
-                                                                            singleton_refs: [],
                                                                             input: Source {
                                                                                 source: ClusterMembers(
                                                                                     Cluster(loc1v1),
@@ -746,13 +738,11 @@ expression: built.ir()
                                                 inner: Cast {
                                                     inner: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , bool) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | (d , _) | d }),
-                                                        singleton_refs: [],
                                                         input: CrossSingleton {
                                                             left: Batch {
                                                                 inner: YieldConcat {
                                                                     inner: Map {
                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , bool) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                                                                        singleton_refs: [],
                                                                         input: CrossSingleton {
                                                                             left: Tee {
                                                                                 inner: <shared 4>: Batch {
@@ -760,7 +750,6 @@ expression: built.ir()
                                                                                         inner: Tee {
                                                                                             inner: <shared 5>: Map {
                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < u32 , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless ((__hydro_lang_cluster_self_id_loc1v1) . clone ()) ; move | num | Ballot { num , proposer_id : CLUSTER_SELF_ID__free . clone () } }),
-                                                                                                singleton_refs: [],
                                                                                                 input: Tee {
                                                                                                     inner: <shared 1>,
                                                                                                     metadata: HydroIrMetadata {
@@ -878,15 +867,12 @@ expression: built.ir()
                                                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | b | * b }),
                                                                 input: Map {
                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_some () }),
-                                                                    singleton_refs: [],
                                                                     input: Cast {
                                                                         inner: ChainFirst {
                                                                             first: Map {
                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                                                singleton_refs: [],
                                                                                 input: Map {
-                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                                                    singleton_refs: [],
+                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                                                     input: Reduce {
                                                                                         f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
                                                                                         input: FlatMap {
@@ -1184,7 +1170,6 @@ expression: built.ir()
                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | p1b | println ! ("Proposer received P1b: {:?}" , p1b) }),
                                 input: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                    singleton_refs: [],
                                     input: Cast {
                                         inner: Network {
                                             name: None,
@@ -1202,14 +1187,12 @@ expression: built.ir()
                                                 inner: YieldConcat {
                                                     inner: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < ((hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | ((ballot , max_ballot) , log) | (ballot . proposer_id . clone () , (ballot . clone () , if ballot == max_ballot { Ok (log) } else { Err (max_ballot) })) }),
-                                                        singleton_refs: [],
                                                         input: CrossSingleton {
                                                             left: CrossSingleton {
                                                                 left: Tee {
                                                                     inner: <shared 9>: Batch {
                                                                         inner: Map {
                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                                                            singleton_refs: [],
                                                                             input: Cast {
                                                                                 inner: Network {
                                                                                     name: None,
@@ -1229,7 +1212,6 @@ expression: built.ir()
                                                                                                 left: ObserveNonDet {
                                                                                                     inner: Map {
                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                                                                        singleton_refs: [],
                                                                                                         input: Cast {
                                                                                                             inner: Cast {
                                                                                                                 inner: Filter {
@@ -1241,7 +1223,6 @@ expression: built.ir()
                                                                                                                             input: Cast {
                                                                                                                                 inner: Map {
                                                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | (k , v) | (MemberId :: from_tagless (k) , v) }),
-                                                                                                                                    singleton_refs: [],
                                                                                                                                     input: Source {
                                                                                                                                         source: ClusterMembers(
                                                                                                                                             Cluster(loc2v1),
@@ -1354,7 +1335,6 @@ expression: built.ir()
                                                                                                             inner: Cast {
                                                                                                                 inner: Map {
                                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , bool) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                                                                                                                    singleton_refs: [],
                                                                                                                     input: CrossSingleton {
                                                                                                                         left: Tee {
                                                                                                                             inner: <shared 4>,
@@ -1370,23 +1350,18 @@ expression: built.ir()
                                                                                                                             f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
                                                                                                                             input: Map {
                                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (bool , bool) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (a , b) | a && b }),
-                                                                                                                                singleton_refs: [],
                                                                                                                                 input: Cast {
                                                                                                                                     inner: CrossSingleton {
                                                                                                                                         left: Map {
                                                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_some () }),
-                                                                                                                                            singleton_refs: [],
                                                                                                                                             input: Cast {
                                                                                                                                                 inner: ChainFirst {
                                                                                                                                                     first: Map {
                                                                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                                                                                                                        singleton_refs: [],
                                                                                                                                                         input: Map {
                                                                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                                                                                                                            singleton_refs: [],
                                                                                                                                                             input: Map {
                                                                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (() , bool) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | (d , _) | d }),
-                                                                                                                                                                singleton_refs: [],
                                                                                                                                                                 input: CrossSingleton {
                                                                                                                                                                     left: Batch {
                                                                                                                                                                         inner: YieldConcat {
@@ -1464,7 +1439,6 @@ expression: built.ir()
                                                                                                                                                                         f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | b | * b }),
                                                                                                                                                                         input: Map {
                                                                                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | ! b }),
-                                                                                                                                                                            singleton_refs: [],
                                                                                                                                                                             input: Tee {
                                                                                                                                                                                 inner: <shared 6>,
                                                                                                                                                                                 metadata: HydroIrMetadata {
@@ -1569,15 +1543,12 @@ expression: built.ir()
                                                                                                                                         },
                                                                                                                                         right: Map {
                                                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_some () }),
-                                                                                                                                            singleton_refs: [],
                                                                                                                                             input: Cast {
                                                                                                                                                 inner: ChainFirst {
                                                                                                                                                     first: Map {
                                                                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                                                                                                                        singleton_refs: [],
                                                                                                                                                         input: Map {
-                                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                                                                                                                            singleton_refs: [],
+                                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                                                                                                                             input: Reduce {
                                                                                                                                                                 f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
                                                                                                                                                                 input: FlatMap {
@@ -2147,7 +2118,6 @@ expression: built.ir()
             neg: Tee {
                 inner: <shared 11>: Map {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                    singleton_refs: [],
                     input: Cast {
                         inner: Cast {
                             inner: Filter {
@@ -2267,7 +2237,6 @@ expression: built.ir()
         input: Difference {
             pos: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                singleton_refs: [],
                 input: Cast {
                     inner: Cast {
                         inner: Filter {
@@ -2354,20 +2323,16 @@ expression: built.ir()
         input: Tee {
             inner: <shared 13>: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (bool , bool) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (a , b) | a && b }),
-                singleton_refs: [],
                 input: Cast {
                     inner: CrossSingleton {
                         left: Map {
                             f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_some () }),
-                            singleton_refs: [],
                             input: Cast {
                                 inner: ChainFirst {
                                     first: Map {
                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                        singleton_refs: [],
                                         input: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                            singleton_refs: [],
                                             input: Tee {
                                                 inner: <shared 14>: FilterMap {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < ((hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; move | ((quorum_ballot , quorum_accepted) , my_ballot) | if quorum_ballot == my_ballot { Some (quorum_accepted) } else { None } }),
@@ -2405,7 +2370,6 @@ expression: built.ir()
                                                                                                                 },
                                                                                                                 neg: Map {
                                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                                                                                    singleton_refs: [],
                                                                                                                     input: Cast {
                                                                                                                         inner: Cast {
                                                                                                                             inner: Filter {
@@ -2734,7 +2698,6 @@ expression: built.ir()
                             inner: YieldConcat {
                                 inner: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (received_max_ballot , cur_ballot) | received_max_ballot <= cur_ballot }),
-                                    singleton_refs: [],
                                     input: Cast {
                                         inner: CrossSingleton {
                                             left: Tee {
@@ -2837,7 +2800,6 @@ expression: built.ir()
         ),
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (_ , ballot) | ballot }),
-            singleton_refs: [],
             input: FilterMap {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | (key , res) | match res { Ok (_) => None , Err (e) => Some ((key , e)) , } }),
                 input: Tee {
@@ -2880,7 +2842,6 @@ expression: built.ir()
         ),
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , bool) , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | (d , _) | d }),
-            singleton_refs: [],
             input: CrossSingleton {
                 left: Tee {
                     inner: <shared 15>: Chain {
@@ -2913,12 +2874,10 @@ expression: built.ir()
                             inner: ObserveNonDet {
                                 inner: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , i32) , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos_bench :: Client > :: from_tagless ((__hydro_lang_cluster_self_id_loc3v1) . clone ()) ; move | (virtual_id , payload) | { (virtual_id , (CLUSTER_SELF_ID__free . clone () , payload)) } }),
-                                    singleton_refs: [],
                                     input: Cast {
                                         inner: Tee {
                                             inner: <shared 16>: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , core :: option :: Option < i32 >) , (u32 , i32) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < i32 > , i32 > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; move | payload | { if let Some (counter) = payload { counter + 1 } else { 0 } } }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
-                                                singleton_refs: [],
                                                 input: Chain {
                                                     first: YieldConcat {
                                                         inner: Cast {
@@ -2967,7 +2926,6 @@ expression: built.ir()
                                                     },
                                                     second: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , i32) , (u32 , core :: option :: Option < i32 >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < i32 , core :: option :: Option < i32 > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | payload | Some (payload) }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
-                                                        singleton_refs: [],
                                                         input: CycleSource {
                                                             cycle_id: CycleId(
                                                                 1,
@@ -3092,20 +3050,16 @@ expression: built.ir()
                     f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | b | * b }),
                     input: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_none () }),
-                        singleton_refs: [],
                         input: Cast {
                             inner: ChainFirst {
                                 first: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                    singleton_refs: [],
                                     input: Map {
                                         f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                        singleton_refs: [],
                                         input: Tee {
                                             inner: <shared 17>: Batch {
                                                 inner: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | ballot | ballot . proposer_id }),
-                                                    singleton_refs: [],
                                                     input: Reduce {
                                                         f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | curr , new | { if new > * curr { * curr = new ; } } }),
                                                         input: ObserveNonDet {
@@ -3113,7 +3067,6 @@ expression: built.ir()
                                                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_with_client :: * ; | ballot | println ! ("Client notified that leader was elected: {:?}" , ballot) }),
                                                                 input: Map {
                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                                                    singleton_refs: [],
                                                                     input: Cast {
                                                                         inner: Network {
                                                                             name: None,
@@ -3133,7 +3086,6 @@ expression: built.ir()
                                                                                         left: ObserveNonDet {
                                                                                             inner: Map {
                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                                                                singleton_refs: [],
                                                                                                 input: Cast {
                                                                                                     inner: Cast {
                                                                                                         inner: Filter {
@@ -3145,7 +3097,6 @@ expression: built.ir()
                                                                                                                     input: Cast {
                                                                                                                         inner: Map {
                                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | (k , v) | (MemberId :: from_tagless (k) , v) }),
-                                                                                                                            singleton_refs: [],
                                                                                                                             input: Source {
                                                                                                                                 source: ClusterMembers(
                                                                                                                                     Cluster(loc3v1),
@@ -3256,7 +3207,6 @@ expression: built.ir()
                                                                                                 inner: Cast {
                                                                                                     inner: Map {
                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , bool) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                                                                                                        singleton_refs: [],
                                                                                                         input: CrossSingleton {
                                                                                                             left: Tee {
                                                                                                                 inner: <shared 4>,
@@ -3273,7 +3223,6 @@ expression: built.ir()
                                                                                                                 input: Tee {
                                                                                                                     inner: <shared 18>: Map {
                                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (bool , bool) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (a , b) | a && b }),
-                                                                                                                        singleton_refs: [],
                                                                                                                         input: Cast {
                                                                                                                             inner: CrossSingleton {
                                                                                                                                 left: Tee {
@@ -3288,21 +3237,17 @@ expression: built.ir()
                                                                                                                                 },
                                                                                                                                 right: Map {
                                                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_none () }),
-                                                                                                                                    singleton_refs: [],
                                                                                                                                     input: Cast {
                                                                                                                                         inner: ChainFirst {
                                                                                                                                             first: Map {
                                                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                                                                                                                singleton_refs: [],
                                                                                                                                                 input: Map {
                                                                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                                                                                                                    singleton_refs: [],
                                                                                                                                                     input: DeferTick {
                                                                                                                                                         input: FilterMap {
                                                                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | v | v }),
                                                                                                                                                             input: Map {
                                                                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < bool , core :: option :: Option < () > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | is_leader | is_leader . then_some (()) }),
-                                                                                                                                                                singleton_refs: [],
                                                                                                                                                                 input: Tee {
                                                                                                                                                                     inner: <shared 13>,
                                                                                                                                                                     metadata: HydroIrMetadata {
@@ -3695,7 +3640,6 @@ expression: built.ir()
         ),
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , usize) , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (num_payloads , base_slot) | base_slot + num_payloads }),
-            singleton_refs: [],
             input: Cast {
                 inner: CrossSingleton {
                     left: Fold {
@@ -3704,20 +3648,17 @@ expression: built.ir()
                         input: Tee {
                             inner: <shared 19>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , usize) , (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | ((index , payload) , base_slot) | (base_slot + index , payload) }),
-                                singleton_refs: [],
                                 input: CrossSingleton {
                                     left: Enumerate {
                                         input: Batch {
                                             inner: YieldConcat {
                                                 inner: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , bool) , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | (d , _) | d }),
-                                                    singleton_refs: [],
                                                     input: CrossSingleton {
                                                         left: Batch {
                                                             inner: ObserveNonDet {
                                                                 inner: Map {
                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                                                    singleton_refs: [],
                                                                     input: Cast {
                                                                         inner: Network {
                                                                             name: None,
@@ -3734,7 +3675,6 @@ expression: built.ir()
                                                                             input: Cast {
                                                                                 inner: Map {
                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_with_client :: * ; move | (payload , leader_id) | (leader_id , payload) }),
-                                                                                    singleton_refs: [],
                                                                                     input: YieldConcat {
                                                                                         inner: CrossSingleton {
                                                                                             left: Tee {
@@ -3928,7 +3868,6 @@ expression: built.ir()
                                                 inner: ChainFirst {
                                                     first: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < usize , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | s | s + 1 }),
-                                                        singleton_refs: [],
                                                         input: Batch {
                                                             inner: YieldConcat {
                                                                 inner: Tee {
@@ -3937,13 +3876,11 @@ expression: built.ir()
                                                                         input: ObserveNonDet {
                                                                             inner: Map {
                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                                                singleton_refs: [],
                                                                                 input: Cast {
                                                                                     inner: Cast {
                                                                                         inner: Tee {
                                                                                             inner: <shared 22>: Map {
                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)) , (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (count , entry) | (count , entry . unwrap ()) }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
-                                                                                                singleton_refs: [],
                                                                                                 input: FoldKeyed {
                                                                                                     init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | | (0 , None) }),
                                                                                                     acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | curr_entry , new_entry | { if let Some (curr_entry_payload) = & mut curr_entry . 1 { let same_values = new_entry . value == curr_entry_payload . value ; let higher_ballot = new_entry . ballot > curr_entry_payload . ballot ; if same_values { curr_entry . 0 += 1 ; } if higher_ballot { curr_entry_payload . ballot = new_entry . ballot ; if ! same_values { curr_entry . 0 = 1 ; curr_entry_payload . value = new_entry . value ; } } } else { * curr_entry = (1 , Some (new_entry)) ; } } }),
@@ -3952,7 +3889,6 @@ expression: built.ir()
                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | d | d }),
                                                                                                             input: Map {
                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (_checkpoint , log) | log }),
-                                                                                                                singleton_refs: [],
                                                                                                                 input: Tee {
                                                                                                                     inner: <shared 23>: FlatMap {
                                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | v }),
@@ -4347,7 +4283,6 @@ expression: built.ir()
                         inner: Tee {
                             inner: <shared 25>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                singleton_refs: [],
                                 input: Cast {
                                     inner: Network {
                                         name: None,
@@ -4365,13 +4300,11 @@ expression: built.ir()
                                             inner: YieldConcat {
                                                 inner: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (p2a , max_ballot) | (p2a . sender , ((p2a . slot , p2a . ballot . clone ()) , if p2a . ballot == max_ballot { Ok (()) } else { Err (max_ballot) })) }),
-                                                    singleton_refs: [],
                                                     input: CrossSingleton {
                                                         left: Tee {
                                                             inner: <shared 26>: Batch {
                                                                 inner: Map {
                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >) , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                                                    singleton_refs: [],
                                                                     input: Cast {
                                                                         inner: Network {
                                                                             name: None,
@@ -4391,7 +4324,6 @@ expression: built.ir()
                                                                                         left: ObserveNonDet {
                                                                                             inner: Map {
                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                                                                singleton_refs: [],
                                                                                                 input: Cast {
                                                                                                     inner: Cast {
                                                                                                         inner: Filter {
@@ -4403,7 +4335,6 @@ expression: built.ir()
                                                                                                                     input: Cast {
                                                                                                                         inner: Map {
                                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | (k , v) | (MemberId :: from_tagless (k) , v) }),
-                                                                                                                            singleton_refs: [],
                                                                                                                             input: Source {
                                                                                                                                 source: ClusterMembers(
                                                                                                                                     Cluster(loc2v1),
@@ -4512,18 +4443,15 @@ expression: built.ir()
                                                                                         right: Batch {
                                                                                             inner: Map {
                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless ((__hydro_lang_cluster_self_id_loc1v1) . clone ()) ; move | ((slot , ballot) , value) | P2a { sender : CLUSTER_SELF_ID__free . clone () , ballot , slot , value } }),
-                                                                                                singleton_refs: [],
                                                                                                 input: EndAtomic {
                                                                                                     inner: Tee {
                                                                                                         inner: <shared 27>: YieldConcat {
                                                                                                             inner: Map {
                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , bool) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | (d , _) | d }),
-                                                                                                                singleton_refs: [],
                                                                                                                 input: CrossSingleton {
                                                                                                                     left: Chain {
                                                                                                                         first: Map {
                                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | ((slot , payload) , ballot) | ((slot , ballot) , Some (payload)) }),
-                                                                                                                            singleton_refs: [],
                                                                                                                             input: CrossSingleton {
                                                                                                                                 left: Batch {
                                                                                                                                     inner: YieldConcat {
@@ -4672,7 +4600,6 @@ expression: built.ir()
                                                                                                                                                 inner: ChainFirst {
                                                                                                                                                     first: Map {
                                                                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < usize , core :: option :: Option < usize > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                                                                                                                        singleton_refs: [],
                                                                                                                                                         input: Reduce {
                                                                                                                                                             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | curr , new | { if new > * curr { * curr = new ; } } }),
                                                                                                                                                             input: ObserveNonDet {
@@ -4801,7 +4728,6 @@ expression: built.ir()
                                                                                                                             },
                                                                                                                             second: Map {
                                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; move | (slot , ballot) | ((slot , ballot) , None) }),
-                                                                                                                                singleton_refs: [],
                                                                                                                                 input: CrossSingleton {
                                                                                                                                     left: Difference {
                                                                                                                                         pos: FlatMap {
@@ -4867,7 +4793,6 @@ expression: built.ir()
                                                                                                                                         },
                                                                                                                                         neg: Map {
                                                                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                                                                                                            singleton_refs: [],
                                                                                                                                             input: Cast {
                                                                                                                                                 inner: Cast {
                                                                                                                                                     inner: Tee {
@@ -5288,7 +5213,6 @@ expression: built.ir()
             neg: Tee {
                 inner: <shared 29>: Map {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (usize , usize)) , (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                    singleton_refs: [],
                     input: Cast {
                         inner: Cast {
                             inner: Filter {
@@ -5586,12 +5510,10 @@ expression: built.ir()
             },
             neg: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ()) , (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: request_response :: * ; | (key , _) | key }),
-                singleton_refs: [],
                 input: Tee {
                     inner: <shared 33>: Batch {
                         inner: Map {
                             f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ()) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | k | (k , ()) }),
-                            singleton_refs: [],
                             input: YieldConcat {
                                 inner: Difference {
                                     pos: Tee {
@@ -5715,7 +5637,6 @@ expression: built.ir()
                             inner: ChainFirst {
                                 first: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < usize , core :: option :: Option < usize > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                    singleton_refs: [],
                                     input: Tee {
                                         inner: <shared 34>: Batch {
                                             inner: CycleSource {
@@ -5985,7 +5906,6 @@ expression: built.ir()
         ),
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (_ , ballot) | ballot }),
-            singleton_refs: [],
             input: FilterMap {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , core :: option :: Option < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | (key , res) | match res { Ok (_) => None , Err (e) => Some ((key , e)) , } }),
                 input: Tee {
@@ -6027,7 +5947,6 @@ expression: built.ir()
             inner: Cast {
                 inner: Map {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , bool) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                    singleton_refs: [],
                     input: CrossSingleton {
                         left: Tee {
                             inner: <shared 4>,
@@ -6103,7 +6022,6 @@ expression: built.ir()
         ),
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; | (sorted_payload , _) | { sorted_payload } }),
-            singleton_refs: [],
             input: Filter {
                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; | (sorted_payload , highest_seq) | sorted_payload . seq > * highest_seq }),
                 input: CrossSingleton {
@@ -6113,13 +6031,10 @@ expression: built.ir()
                                 first: Batch {
                                     inner: Map {
                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > >) , hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; | (slot , kv) | SequencedKv { seq : slot , kv } }),
-                                        singleton_refs: [],
                                         input: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; | (index , payload) | (index , payload . map (| (key , value) | KvPayload { key , value })) }),
-                                            singleton_refs: [],
                                             input: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (usize , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , (usize , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                                singleton_refs: [],
                                                 input: Cast {
                                                     inner: Network {
                                                         name: None,
@@ -6139,7 +6054,6 @@ expression: built.ir()
                                                                     left: ObserveNonDet {
                                                                         inner: Map {
                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                                            singleton_refs: [],
                                                                             input: Cast {
                                                                                 inner: Cast {
                                                                                     inner: Filter {
@@ -6151,7 +6065,6 @@ expression: built.ir()
                                                                                                 input: Cast {
                                                                                                     inner: Map {
                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | (k , v) | (MemberId :: from_tagless (k) , v) }),
-                                                                                                        singleton_refs: [],
                                                                                                         input: Source {
                                                                                                             source: ClusterMembers(
                                                                                                                 Cluster(loc5v1),
@@ -6260,11 +6173,9 @@ expression: built.ir()
                                                                     right: Batch {
                                                                         inner: Map {
                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , ())) , (usize , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | ((slot , _ballot) , (value , _)) | (slot , value) }),
-                                                                            singleton_refs: [],
                                                                             input: YieldConcat {
                                                                                 inner: Map {
                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , ())) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , ())) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: request_response :: * ; | (key , (meta , resp)) | (key , (meta , resp)) }),
-                                                                                    singleton_refs: [],
                                                                                     input: JoinHalf {
                                                                                         left: Tee {
                                                                                             inner: <shared 32>,
@@ -6647,7 +6558,6 @@ expression: built.ir()
         input: Tee {
             inner: <shared 37>: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: collections :: hash_map :: HashMap < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; | (_kv_store , next_slot) | next_slot }),
-                singleton_refs: [],
                 input: Batch {
                     inner: Fold {
                         init: stageleft :: runtime_support :: fn0_type_hint :: < (std :: collections :: hash_map :: HashMap < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; | | (HashMap :: new () , 0) }),
@@ -6656,7 +6566,6 @@ expression: built.ir()
                             inner: Tee {
                                 inner: <shared 38>: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; | (sorted_payload , _) | { sorted_payload } }),
-                                    singleton_refs: [],
                                     input: Filter {
                                         f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; | (sorted_payload , highest_seq) | sorted_payload . seq < * highest_seq }),
                                         input: CrossSingleton {
@@ -6788,7 +6697,6 @@ expression: built.ir()
                             inner: ChainFirst {
                                 first: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < usize , core :: option :: Option < usize > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                    singleton_refs: [],
                                     input: Batch {
                                         inner: Reduce {
                                             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | curr , new | { if new > * curr { * curr = new ; } } }),
@@ -7005,10 +6913,8 @@ expression: built.ir()
                 input: ObserveNonDet {
                     inner: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica > , usize) , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; | (_sender , seq) | seq }),
-                        singleton_refs: [],
                         input: Map {
                             f: stageleft :: runtime_support :: fn1_type_hint :: < ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica > , usize) , bool) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica > , usize) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | (d , _) | d }),
-                            singleton_refs: [],
                             input: CrossSingleton {
                                 left: Cast {
                                     inner: Cast {
@@ -7034,7 +6940,6 @@ expression: built.ir()
                                                                     left: ObserveNonDet {
                                                                         inner: Map {
                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                                            singleton_refs: [],
                                                                             input: Cast {
                                                                                 inner: Cast {
                                                                                     inner: Filter {
@@ -7046,7 +6951,6 @@ expression: built.ir()
                                                                                                 input: Cast {
                                                                                                     inner: Map {
                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | (k , v) | (MemberId :: from_tagless (k) , v) }),
-                                                                                                        singleton_refs: [],
                                                                                                         input: Source {
                                                                                                             source: ClusterMembers(
                                                                                                                 Cluster(loc2v1),
@@ -7290,7 +7194,6 @@ expression: built.ir()
                                     f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | b | * b }),
                                     input: Map {
                                         f: stageleft :: runtime_support :: fn1_type_hint :: < usize , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; let f__free = 1usize ; move | num_received | num_received == f__free + 1 }),
-                                        singleton_refs: [],
                                         input: Fold {
                                             init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | | 0usize }),
                                             acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica > , usize) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | count , _ | * count += 1 }),
@@ -7459,7 +7362,6 @@ expression: built.ir()
                         inner: Tee {
                             inner: <shared 42>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica > , ((u32 , i32) , core :: result :: Result < () , () >)) , ((u32 , i32) , core :: result :: Result < () , () >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                singleton_refs: [],
                                 input: Cast {
                                     inner: Network {
                                         name: None,
@@ -7476,7 +7378,6 @@ expression: built.ir()
                                         input: Cast {
                                             inner: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , ((u32 , i32) , core :: result :: Result < () , () >)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; | payload | (payload . value . 0 , ((payload . key , payload . value . 1) , Ok (()))) }),
-                                                singleton_refs: [],
                                                 input: YieldConcat {
                                                     inner: FilterMap {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; | payload | payload . kv }),
@@ -7827,7 +7728,6 @@ expression: built.ir()
             inner: ChainFirst {
                 first: Map {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (new , old) | { old . borrow_mut () . add (new) . expect ("Error adding value to histogram") ; old } }),
-                    singleton_refs: [],
                     input: CrossSingleton {
                         left: Tee {
                             inner: <shared 46>: Fold {
@@ -7837,14 +7737,12 @@ expression: built.ir()
                                     inner: <shared 47>: Batch {
                                         inner: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , (i32 , core :: time :: Duration)) , core :: time :: Duration > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; | (_virtual_client_id , (_output , latency)) | latency }),
-                                            singleton_refs: [],
                                             input: Cast {
                                                 inner: YieldConcat {
                                                     inner: Cast {
                                                         inner: Cast {
                                                             inner: Map {
                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , (std :: time :: Instant , (std :: time :: Instant , i32))) , (u32 , (i32 , core :: time :: Duration)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < (std :: time :: Instant , (std :: time :: Instant , i32)) , (i32 , core :: time :: Duration) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (start_time , (end_time , output)) | (output , end_time . duration_since (start_time)) }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
-                                                                singleton_refs: [],
                                                                 input: Cast {
                                                                     inner: Cast {
                                                                         inner: JoinHalf {
@@ -7920,7 +7818,6 @@ expression: built.ir()
                                                                                 inner: Cast {
                                                                                     inner: Map {
                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , i32) , (u32 , (std :: time :: Instant , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < i32 , (std :: time :: Instant , i32) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | output | (Instant :: now () , output) }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
-                                                                                        singleton_refs: [],
                                                                                         input: ReduceKeyed {
                                                                                             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < i32 , i32 , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | curr , new | { * curr = new ; } }),
                                                                                             input: ObserveNonDet {
@@ -8131,7 +8028,6 @@ expression: built.ir()
                         right: Tee {
                             inner: <shared 48>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                                singleton_refs: [],
                                 input: CrossSingleton {
                                     left: Tee {
                                         inner: <shared 49>: Cast {
@@ -8205,15 +8101,12 @@ expression: built.ir()
                                         f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
                                         input: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_none () }),
-                                            singleton_refs: [],
                                             input: Cast {
                                                 inner: ChainFirst {
                                                     first: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                        singleton_refs: [],
                                                         input: Map {
-                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                            singleton_refs: [],
+                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                             input: Tee {
                                                                 inner: <shared 50>: Reduce {
                                                                     f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
@@ -8394,7 +8287,6 @@ expression: built.ir()
                 second: Cast {
                     inner: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | histogram | Rc :: new (RefCell :: new (histogram)) }),
-                        singleton_refs: [],
                         input: Tee {
                             inner: <shared 46>,
                             metadata: HydroIrMetadata {
@@ -8447,7 +8339,6 @@ expression: built.ir()
             inner: ChainFirst {
                 first: Map {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , usize) , usize > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (new , old) | new + old }),
-                    singleton_refs: [],
                     input: CrossSingleton {
                         left: Tee {
                             inner: <shared 51>: Fold {
@@ -8496,7 +8387,6 @@ expression: built.ir()
                         right: Tee {
                             inner: <shared 52>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                                singleton_refs: [],
                                 input: CrossSingleton {
                                     left: Tee {
                                         inner: <shared 53>: Cast {
@@ -8570,15 +8460,12 @@ expression: built.ir()
                                         f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
                                         input: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_none () }),
-                                            singleton_refs: [],
                                             input: Cast {
                                                 inner: ChainFirst {
                                                     first: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                        singleton_refs: [],
                                                         input: Map {
-                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                            singleton_refs: [],
+                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                             input: Tee {
                                                                 inner: <shared 50>,
                                                                 metadata: HydroIrMetadata {
@@ -8739,8 +8626,7 @@ expression: built.ir()
             23,
         ),
         input: Map {
-            f: stageleft :: runtime_support :: fn1_type_hint :: < ((std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > >) , core :: option :: Option < () >) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | ((old , new) , reset) | { if reset . is_some () { old . replace (Histogram :: < u64 > :: new (3) . unwrap ()) ; } if let Some (new) = new { old . borrow_mut () . add (& * new . borrow_mut ()) . expect ("Error adding value to histogram") ; } old } }),
-            singleton_refs: [],
+            f: stageleft :: runtime_support :: fn1_type_hint :: < ((std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > >) , core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant >) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | ((old , new) , reset) | { if reset . is_some () { old . replace (Histogram :: < u64 > :: new (3) . unwrap ()) ; } if let Some (new) = new { old . borrow_mut () . add (& * new . borrow_mut ()) . expect ("Error adding value to histogram") ; } old } }),
             input: Cast {
                 inner: CrossSingleton {
                     left: Cast {
@@ -8817,17 +8703,14 @@ expression: built.ir()
                                 inner: ChainFirst {
                                     first: Map {
                                         f: stageleft :: runtime_support :: fn1_type_hint :: < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                        singleton_refs: [],
                                         input: Reduce {
                                             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | curr , new | { curr . borrow_mut () . add (& * new . borrow_mut ()) . expect ("Error adding value to histogram") ; } }),
                                             input: ObserveNonDet {
                                                 inner: Batch {
                                                     inner: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | wrapper | wrapper . histogram }),
-                                                        singleton_refs: [],
                                                         input: Map {
                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper) , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                                            singleton_refs: [],
                                                             input: Cast {
                                                                 inner: Cast {
                                                                     inner: Network {
@@ -8844,12 +8727,10 @@ expression: built.ir()
                                                                         ),
                                                                         input: Map {
                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | latencies | { SerializableHistogramWrapper { histogram : latencies , } } }),
-                                                                            singleton_refs: [],
                                                                             input: YieldConcat {
                                                                                 inner: Cast {
                                                                                     inner: Map {
                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                                                                                        singleton_refs: [],
                                                                                         input: CrossSingleton {
                                                                                             left: Tee {
                                                                                                 inner: <shared 49>,
@@ -8865,15 +8746,12 @@ expression: built.ir()
                                                                                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
                                                                                                 input: Map {
                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_some () }),
-                                                                                                    singleton_refs: [],
                                                                                                     input: Cast {
                                                                                                         inner: ChainFirst {
                                                                                                             first: Map {
                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                                                                                singleton_refs: [],
                                                                                                                 input: Map {
-                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                                                                                    singleton_refs: [],
+                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                                                                                     input: Tee {
                                                                                                                         inner: <shared 50>,
                                                                                                                         metadata: HydroIrMetadata {
@@ -9141,8 +9019,7 @@ expression: built.ir()
                     right: Cast {
                         inner: ChainFirst {
                             first: Map {
-                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                singleton_refs: [],
+                                f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                 input: DeferTick {
                                     input: Tee {
                                         inner: <shared 55>: Reduce {
@@ -9302,7 +9179,6 @@ expression: built.ir()
                 first: Batch {
                     inner: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , usize) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                        singleton_refs: [],
                         input: Cast {
                             inner: Cast {
                                 inner: Network {
@@ -9321,7 +9197,6 @@ expression: built.ir()
                                         inner: Cast {
                                             inner: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                                                singleton_refs: [],
                                                 input: CrossSingleton {
                                                     left: Tee {
                                                         inner: <shared 53>,
@@ -9337,15 +9212,12 @@ expression: built.ir()
                                                         f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
                                                         input: Map {
                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_some () }),
-                                                            singleton_refs: [],
                                                             input: Cast {
                                                                 inner: ChainFirst {
                                                                     first: Map {
                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                                        singleton_refs: [],
                                                                         input: Map {
-                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                                            singleton_refs: [],
+                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                                             input: Tee {
                                                                                 inner: <shared 50>,
                                                                                 metadata: HydroIrMetadata {
@@ -9514,7 +9386,6 @@ expression: built.ir()
                 second: Cast {
                     inner: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                        singleton_refs: [],
                         input: CrossSingleton {
                             left: Tee {
                                 inner: <shared 56>: Cast {
@@ -9588,15 +9459,12 @@ expression: built.ir()
                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
                                 input: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_none () }),
-                                    singleton_refs: [],
                                     input: Cast {
                                         inner: ChainFirst {
                                             first: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                singleton_refs: [],
                                                 input: Map {
-                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                    singleton_refs: [],
+                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                     input: Tee {
                                                         inner: <shared 55>,
                                                         metadata: HydroIrMetadata {
@@ -9727,7 +9595,6 @@ expression: built.ir()
             inner: Cast {
                 inner: Map {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                    singleton_refs: [],
                     input: CrossSingleton {
                         left: Tee {
                             inner: <shared 56>,
@@ -9743,15 +9610,12 @@ expression: built.ir()
                             f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
                             input: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_some () }),
-                                singleton_refs: [],
                                 input: Cast {
                                     inner: ChainFirst {
                                         first: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                            singleton_refs: [],
                                             input: Map {
-                                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                singleton_refs: [],
+                                                f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                 input: Tee {
                                                     inner: <shared 55>,
                                                     metadata: HydroIrMetadata {
@@ -9872,12 +9736,10 @@ expression: built.ir()
         f: stageleft :: runtime_support :: fn1_type_hint :: < (f64 , f64 , f64 , u64) , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; move | (p50 , p99 , p999 , num_samples) | { println ! ("Latency p50: {:.3} | p99 {:.3} | p999 {:.3} ms ({:} samples)" , p50 , p99 , p999 , num_samples) ; } }),
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , (f64 , f64 , f64 , u64) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; move | latencies | (Duration :: from_nanos (latencies . borrow () . value_at_quantile (0.5)) . as_micros () as f64 / 1000.0 , Duration :: from_nanos (latencies . borrow () . value_at_quantile (0.99)) . as_micros () as f64 / 1000.0 , Duration :: from_nanos (latencies . borrow () . value_at_quantile (0.999)) . as_micros () as f64 / 1000.0 , latencies . borrow () . len () ,) }),
-            singleton_refs: [],
             input: YieldConcat {
                 inner: Cast {
                     inner: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                        singleton_refs: [],
                         input: CrossSingleton {
                             left: Tee {
                                 inner: <shared 54>,
@@ -9893,15 +9755,12 @@ expression: built.ir()
                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
                                 input: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_some () }),
-                                    singleton_refs: [],
                                     input: Cast {
                                         inner: ChainFirst {
                                             first: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                singleton_refs: [],
                                                 input: Map {
-                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                    singleton_refs: [],
+                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                     input: Tee {
                                                         inner: <shared 55>,
                                                         metadata: HydroIrMetadata {

--- a/hydro_test/src/cluster/snapshots/paxos_ir.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir.snap
@@ -872,7 +872,7 @@ expression: built.ir()
                                                                             first: Map {
                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                                                                 input: Map {
-                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                                                     input: Reduce {
                                                                                         f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
                                                                                         input: FlatMap {
@@ -1548,7 +1548,7 @@ expression: built.ir()
                                                                                                                                                     first: Map {
                                                                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                                                                                                                                         input: Map {
-                                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                                                                                                                             input: Reduce {
                                                                                                                                                                 f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
                                                                                                                                                                 input: FlatMap {
@@ -8106,7 +8106,7 @@ expression: built.ir()
                                                     first: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                                         input: Map {
-                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                             input: Tee {
                                                                 inner: <shared 50>: Reduce {
                                                                     f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
@@ -8465,7 +8465,7 @@ expression: built.ir()
                                                     first: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                                         input: Map {
-                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                             input: Tee {
                                                                 inner: <shared 50>,
                                                                 metadata: HydroIrMetadata {
@@ -8626,7 +8626,7 @@ expression: built.ir()
             23,
         ),
         input: Map {
-            f: stageleft :: runtime_support :: fn1_type_hint :: < ((std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > >) , core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant >) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | ((old , new) , reset) | { if reset . is_some () { old . replace (Histogram :: < u64 > :: new (3) . unwrap ()) ; } if let Some (new) = new { old . borrow_mut () . add (& * new . borrow_mut ()) . expect ("Error adding value to histogram") ; } old } }),
+            f: stageleft :: runtime_support :: fn1_type_hint :: < ((std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > >) , core :: option :: Option < () >) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | ((old , new) , reset) | { if reset . is_some () { old . replace (Histogram :: < u64 > :: new (3) . unwrap ()) ; } if let Some (new) = new { old . borrow_mut () . add (& * new . borrow_mut ()) . expect ("Error adding value to histogram") ; } old } }),
             input: Cast {
                 inner: CrossSingleton {
                     left: Cast {
@@ -8751,7 +8751,7 @@ expression: built.ir()
                                                                                                             first: Map {
                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                                                                                                 input: Map {
-                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                                                                                     input: Tee {
                                                                                                                         inner: <shared 50>,
                                                                                                                         metadata: HydroIrMetadata {
@@ -9019,7 +9019,7 @@ expression: built.ir()
                     right: Cast {
                         inner: ChainFirst {
                             first: Map {
-                                f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
+                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                 input: DeferTick {
                                     input: Tee {
                                         inner: <shared 55>: Reduce {
@@ -9217,7 +9217,7 @@ expression: built.ir()
                                                                     first: Map {
                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                                                         input: Map {
-                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                                             input: Tee {
                                                                                 inner: <shared 50>,
                                                                                 metadata: HydroIrMetadata {
@@ -9464,7 +9464,7 @@ expression: built.ir()
                                             first: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                                 input: Map {
-                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                     input: Tee {
                                                         inner: <shared 55>,
                                                         metadata: HydroIrMetadata {
@@ -9615,7 +9615,7 @@ expression: built.ir()
                                         first: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                             input: Map {
-                                                f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                 input: Tee {
                                                     inner: <shared 55>,
                                                     metadata: HydroIrMetadata {
@@ -9760,7 +9760,7 @@ expression: built.ir()
                                             first: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                                 input: Map {
-                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                     input: Tee {
                                                         inner: <shared 55>,
                                                         metadata: HydroIrMetadata {

--- a/hydro_test/src/cluster/snapshots/simple_cluster_ir.snap
+++ b/hydro_test/src/cluster/snapshots/simple_cluster_ir.snap
@@ -37,21 +37,17 @@ expression: built.ir()
                                 input: Cast {
                                     inner: Map {
                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: simple_cluster :: * ; | (id , n) | (id . clone () , (id , n)) }),
-                                        singleton_refs: [],
                                         input: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (() , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32)) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , i32) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | (() , (v1 , v2)) | (v1 , v2) }),
-                                            singleton_refs: [],
                                             input: JoinHalf {
                                                 left: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , (() , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | v | (() , v) }),
-                                                    singleton_refs: [],
                                                     input: FilterMap {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , core :: option :: Option < hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: simple_cluster :: * ; | (i , e) | match e { MembershipEvent :: Joined => Some (i) , MembershipEvent :: Left => None , } }),
                                                         input: Cast {
                                                             inner: Cast {
                                                                 inner: Map {
                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | (k , v) | (MemberId :: from_tagless (k) , v) }),
-                                                                    singleton_refs: [],
                                                                     input: Source {
                                                                         source: ClusterMembers(
                                                                             Cluster(loc2v1),
@@ -120,7 +116,6 @@ expression: built.ir()
                                                 },
                                                 right: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < i32 , (() , i32) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | v | (() , v) }),
-                                                    singleton_refs: [],
                                                     input: Source {
                                                         source: Iter(
                                                             stageleft :: runtime_support :: type_hint :: < std :: ops :: Range < i32 > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: simple_cluster :: * ; 0 .. 5 }),

--- a/hydro_test/src/cluster/snapshots/two_pc_ir.snap
+++ b/hydro_test/src/cluster/snapshots/two_pc_ir.snap
@@ -35,7 +35,6 @@ expression: built.ir()
                         },
                         second: Map {
                             f: stageleft :: runtime_support :: fn1_type_hint :: < ((u32 , core :: option :: Option < i32 >) , bool) , (u32 , core :: option :: Option < i32 >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | (d , _) | d }),
-                            singleton_refs: [],
                             input: CrossSingleton {
                                 left: Cast {
                                     inner: SingletonSource {
@@ -61,15 +60,12 @@ expression: built.ir()
                                     f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | b | * b }),
                                     input: Map {
                                         f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_some () }),
-                                        singleton_refs: [],
                                         input: Cast {
                                             inner: ChainFirst {
                                                 first: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                    singleton_refs: [],
                                                     input: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                        singleton_refs: [],
                                                         input: SingletonSource {
                                                             value: { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; () },
                                                             first_tick_only: true,
@@ -264,10 +260,8 @@ expression: built.ir()
                         inner: Tee {
                             inner: <shared 2>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) , ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) , core :: result :: Result < () , () >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: two_pc :: * ; | kv | (kv , Ok :: < () , () > (())) }),
-                                singleton_refs: [],
                                 input: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32))) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                    singleton_refs: [],
                                     input: Cast {
                                         inner: Cast {
                                             inner: Network {
@@ -300,7 +294,6 @@ expression: built.ir()
                                                                 left: ObserveNonDet {
                                                                     inner: Map {
                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                                        singleton_refs: [],
                                                                         input: Cast {
                                                                             inner: Cast {
                                                                                 inner: Filter {
@@ -312,7 +305,6 @@ expression: built.ir()
                                                                                             input: Cast {
                                                                                                 inner: Map {
                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | (k , v) | (MemberId :: from_tagless (k) , v) }),
-                                                                                                    singleton_refs: [],
                                                                                                     input: Source {
                                                                                                         source: ClusterMembers(
                                                                                                             Cluster(loc2v1),
@@ -437,7 +429,6 @@ expression: built.ir()
                                                                                     inner: Tee {
                                                                                         inner: <shared 3>: Map {
                                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , core :: option :: Option < i32 >) , (u32 , i32) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < i32 > , i32 > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; move | payload | { if let Some (counter) = payload { counter + 1 } else { 0 } } }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
-                                                                                            singleton_refs: [],
                                                                                             input: Chain {
                                                                                                 first: YieldConcat {
                                                                                                     inner: Cast {
@@ -486,7 +477,6 @@ expression: built.ir()
                                                                                                 },
                                                                                                 second: Map {
                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , i32) , (u32 , core :: option :: Option < i32 >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < i32 , core :: option :: Option < i32 > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | payload | Some (payload) }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
-                                                                                                    singleton_refs: [],
                                                                                                     input: CycleSource {
                                                                                                         cycle_id: CycleId(
                                                                                                             1,
@@ -928,10 +918,8 @@ expression: built.ir()
                         inner: Tee {
                             inner: <shared 7>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) , ((hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) , core :: result :: Result < () , () >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: two_pc :: * ; | kv | (kv , Ok :: < () , () > (())) }),
-                                singleton_refs: [],
                                 input: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32))) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                    singleton_refs: [],
                                     input: Cast {
                                         inner: Cast {
                                             inner: Network {
@@ -964,7 +952,6 @@ expression: built.ir()
                                                                 left: ObserveNonDet {
                                                                     inner: Map {
                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                                        singleton_refs: [],
                                                                         input: Cast {
                                                                             inner: Cast {
                                                                                 inner: Filter {
@@ -976,7 +963,6 @@ expression: built.ir()
                                                                                             input: Cast {
                                                                                                 inner: Map {
                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | (k , v) | (MemberId :: from_tagless (k) , v) }),
-                                                                                                    singleton_refs: [],
                                                                                                     input: Source {
                                                                                                         source: ClusterMembers(
                                                                                                             Cluster(loc2v1),
@@ -1506,7 +1492,6 @@ expression: built.ir()
             inner: ChainFirst {
                 first: Map {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (new , old) | { old . borrow_mut () . add (new) . expect ("Error adding value to histogram") ; old } }),
-                    singleton_refs: [],
                     input: CrossSingleton {
                         left: Tee {
                             inner: <shared 11>: Fold {
@@ -1516,14 +1501,12 @@ expression: built.ir()
                                     inner: <shared 12>: Batch {
                                         inner: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , (i32 , core :: time :: Duration)) , core :: time :: Duration > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: two_pc_bench :: * ; | (_virtual_client_id , (_output , latency)) | latency }),
-                                            singleton_refs: [],
                                             input: Cast {
                                                 inner: YieldConcat {
                                                     inner: Cast {
                                                         inner: Cast {
                                                             inner: Map {
                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , (std :: time :: Instant , (std :: time :: Instant , i32))) , (u32 , (i32 , core :: time :: Duration)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < (std :: time :: Instant , (std :: time :: Instant , i32)) , (i32 , core :: time :: Duration) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (start_time , (end_time , output)) | (output , end_time . duration_since (start_time)) }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
-                                                                singleton_refs: [],
                                                                 input: Cast {
                                                                     inner: Cast {
                                                                         inner: JoinHalf {
@@ -1599,7 +1582,6 @@ expression: built.ir()
                                                                                 inner: Cast {
                                                                                     inner: Map {
                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , i32) , (u32 , (std :: time :: Instant , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < i32 , (std :: time :: Instant , i32) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | output | (Instant :: now () , output) }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
-                                                                                        singleton_refs: [],
                                                                                         input: ReduceKeyed {
                                                                                             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < i32 , i32 , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | curr , new | { * curr = new ; } }),
                                                                                             input: ObserveNonDet {
@@ -1810,7 +1792,6 @@ expression: built.ir()
                         right: Tee {
                             inner: <shared 13>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                                singleton_refs: [],
                                 input: CrossSingleton {
                                     left: Tee {
                                         inner: <shared 14>: Cast {
@@ -1884,15 +1865,12 @@ expression: built.ir()
                                         f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
                                         input: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_none () }),
-                                            singleton_refs: [],
                                             input: Cast {
                                                 inner: ChainFirst {
                                                     first: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                        singleton_refs: [],
                                                         input: Map {
-                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                            singleton_refs: [],
+                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                             input: Tee {
                                                                 inner: <shared 15>: Reduce {
                                                                     f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
@@ -2073,7 +2051,6 @@ expression: built.ir()
                 second: Cast {
                     inner: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | histogram | Rc :: new (RefCell :: new (histogram)) }),
-                        singleton_refs: [],
                         input: Tee {
                             inner: <shared 11>,
                             metadata: HydroIrMetadata {
@@ -2126,7 +2103,6 @@ expression: built.ir()
             inner: ChainFirst {
                 first: Map {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , usize) , usize > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (new , old) | new + old }),
-                    singleton_refs: [],
                     input: CrossSingleton {
                         left: Tee {
                             inner: <shared 16>: Fold {
@@ -2175,7 +2151,6 @@ expression: built.ir()
                         right: Tee {
                             inner: <shared 17>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                                singleton_refs: [],
                                 input: CrossSingleton {
                                     left: Tee {
                                         inner: <shared 18>: Cast {
@@ -2249,15 +2224,12 @@ expression: built.ir()
                                         f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
                                         input: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_none () }),
-                                            singleton_refs: [],
                                             input: Cast {
                                                 inner: ChainFirst {
                                                     first: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                        singleton_refs: [],
                                                         input: Map {
-                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                            singleton_refs: [],
+                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                             input: Tee {
                                                                 inner: <shared 15>,
                                                                 metadata: HydroIrMetadata {
@@ -2418,8 +2390,7 @@ expression: built.ir()
             8,
         ),
         input: Map {
-            f: stageleft :: runtime_support :: fn1_type_hint :: < ((std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > >) , core :: option :: Option < () >) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | ((old , new) , reset) | { if reset . is_some () { old . replace (Histogram :: < u64 > :: new (3) . unwrap ()) ; } if let Some (new) = new { old . borrow_mut () . add (& * new . borrow_mut ()) . expect ("Error adding value to histogram") ; } old } }),
-            singleton_refs: [],
+            f: stageleft :: runtime_support :: fn1_type_hint :: < ((std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > >) , core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant >) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | ((old , new) , reset) | { if reset . is_some () { old . replace (Histogram :: < u64 > :: new (3) . unwrap ()) ; } if let Some (new) = new { old . borrow_mut () . add (& * new . borrow_mut ()) . expect ("Error adding value to histogram") ; } old } }),
             input: Cast {
                 inner: CrossSingleton {
                     left: Cast {
@@ -2496,17 +2467,14 @@ expression: built.ir()
                                 inner: ChainFirst {
                                     first: Map {
                                         f: stageleft :: runtime_support :: fn1_type_hint :: < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                        singleton_refs: [],
                                         input: Reduce {
                                             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | curr , new | { curr . borrow_mut () . add (& * new . borrow_mut ()) . expect ("Error adding value to histogram") ; } }),
                                             input: ObserveNonDet {
                                                 inner: Batch {
                                                     inner: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | wrapper | wrapper . histogram }),
-                                                        singleton_refs: [],
                                                         input: Map {
                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper) , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                                            singleton_refs: [],
                                                             input: Cast {
                                                                 inner: Cast {
                                                                     inner: Network {
@@ -2523,12 +2491,10 @@ expression: built.ir()
                                                                         ),
                                                                         input: Map {
                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , hydro_test :: __staged :: __deps :: hydro_std :: bench_client :: SerializableHistogramWrapper > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | latencies | { SerializableHistogramWrapper { histogram : latencies , } } }),
-                                                                            singleton_refs: [],
                                                                             input: YieldConcat {
                                                                                 inner: Cast {
                                                                                     inner: Map {
                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                                                                                        singleton_refs: [],
                                                                                         input: CrossSingleton {
                                                                                             left: Tee {
                                                                                                 inner: <shared 14>,
@@ -2544,15 +2510,12 @@ expression: built.ir()
                                                                                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
                                                                                                 input: Map {
                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_some () }),
-                                                                                                    singleton_refs: [],
                                                                                                     input: Cast {
                                                                                                         inner: ChainFirst {
                                                                                                             first: Map {
                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                                                                                singleton_refs: [],
                                                                                                                 input: Map {
-                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                                                                                    singleton_refs: [],
+                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                                                                                     input: Tee {
                                                                                                                         inner: <shared 15>,
                                                                                                                         metadata: HydroIrMetadata {
@@ -2820,8 +2783,7 @@ expression: built.ir()
                     right: Cast {
                         inner: ChainFirst {
                             first: Map {
-                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                singleton_refs: [],
+                                f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                 input: DeferTick {
                                     input: Tee {
                                         inner: <shared 20>: Reduce {
@@ -2981,7 +2943,6 @@ expression: built.ir()
                 first: Batch {
                     inner: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , usize) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                        singleton_refs: [],
                         input: Cast {
                             inner: Cast {
                                 inner: Network {
@@ -3000,7 +2961,6 @@ expression: built.ir()
                                         inner: Cast {
                                             inner: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                                                singleton_refs: [],
                                                 input: CrossSingleton {
                                                     left: Tee {
                                                         inner: <shared 18>,
@@ -3016,15 +2976,12 @@ expression: built.ir()
                                                         f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
                                                         input: Map {
                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_some () }),
-                                                            singleton_refs: [],
                                                             input: Cast {
                                                                 inner: ChainFirst {
                                                                     first: Map {
                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                                        singleton_refs: [],
                                                                         input: Map {
-                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                                            singleton_refs: [],
+                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                                             input: Tee {
                                                                                 inner: <shared 15>,
                                                                                 metadata: HydroIrMetadata {
@@ -3193,7 +3150,6 @@ expression: built.ir()
                 second: Cast {
                     inner: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                        singleton_refs: [],
                         input: CrossSingleton {
                             left: Tee {
                                 inner: <shared 21>: Cast {
@@ -3267,15 +3223,12 @@ expression: built.ir()
                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
                                 input: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_none () }),
-                                    singleton_refs: [],
                                     input: Cast {
                                         inner: ChainFirst {
                                             first: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                singleton_refs: [],
                                                 input: Map {
-                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                    singleton_refs: [],
+                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                     input: Tee {
                                                         inner: <shared 20>,
                                                         metadata: HydroIrMetadata {
@@ -3406,7 +3359,6 @@ expression: built.ir()
             inner: Cast {
                 inner: Map {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                    singleton_refs: [],
                     input: CrossSingleton {
                         left: Tee {
                             inner: <shared 21>,
@@ -3422,15 +3374,12 @@ expression: built.ir()
                             f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
                             input: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_some () }),
-                                singleton_refs: [],
                                 input: Cast {
                                     inner: ChainFirst {
                                         first: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                            singleton_refs: [],
                                             input: Map {
-                                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                singleton_refs: [],
+                                                f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                 input: Tee {
                                                     inner: <shared 20>,
                                                     metadata: HydroIrMetadata {
@@ -3551,12 +3500,10 @@ expression: built.ir()
         f: stageleft :: runtime_support :: fn1_type_hint :: < (f64 , f64 , f64 , u64) , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; move | (p50 , p99 , p999 , num_samples) | { println ! ("Latency p50: {:.3} | p99 {:.3} | p999 {:.3} ms ({:} samples)" , p50 , p99 , p999 , num_samples) ; } }),
         input: Map {
             f: stageleft :: runtime_support :: fn1_type_hint :: < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , (f64 , f64 , f64 , u64) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; move | latencies | (Duration :: from_nanos (latencies . borrow () . value_at_quantile (0.5)) . as_micros () as f64 / 1000.0 , Duration :: from_nanos (latencies . borrow () . value_at_quantile (0.99)) . as_micros () as f64 / 1000.0 , Duration :: from_nanos (latencies . borrow () . value_at_quantile (0.999)) . as_micros () as f64 / 1000.0 , latencies . borrow () . len () ,) }),
-            singleton_refs: [],
             input: YieldConcat {
                 inner: Cast {
                     inner: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
-                        singleton_refs: [],
                         input: CrossSingleton {
                             left: Tee {
                                 inner: <shared 19>,
@@ -3572,15 +3519,12 @@ expression: built.ir()
                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | b | * b }),
                                 input: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | o | o . is_some () }),
-                                    singleton_refs: [],
                                     input: Cast {
                                         inner: ChainFirst {
                                             first: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                singleton_refs: [],
                                                 input: Map {
-                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
-                                                    singleton_refs: [],
+                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                     input: Tee {
                                                         inner: <shared 20>,
                                                         metadata: HydroIrMetadata {

--- a/hydro_test/src/cluster/snapshots/two_pc_ir.snap
+++ b/hydro_test/src/cluster/snapshots/two_pc_ir.snap
@@ -1870,7 +1870,7 @@ expression: built.ir()
                                                     first: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                                         input: Map {
-                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                             input: Tee {
                                                                 inner: <shared 15>: Reduce {
                                                                     f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
@@ -2229,7 +2229,7 @@ expression: built.ir()
                                                     first: Map {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                                         input: Map {
-                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                             input: Tee {
                                                                 inner: <shared 15>,
                                                                 metadata: HydroIrMetadata {
@@ -2390,7 +2390,7 @@ expression: built.ir()
             8,
         ),
         input: Map {
-            f: stageleft :: runtime_support :: fn1_type_hint :: < ((std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > >) , core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant >) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | ((old , new) , reset) | { if reset . is_some () { old . replace (Histogram :: < u64 > :: new (3) . unwrap ()) ; } if let Some (new) = new { old . borrow_mut () . add (& * new . borrow_mut ()) . expect ("Error adding value to histogram") ; } old } }),
+            f: stageleft :: runtime_support :: fn1_type_hint :: < ((std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > >) , core :: option :: Option < () >) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | ((old , new) , reset) | { if reset . is_some () { old . replace (Histogram :: < u64 > :: new (3) . unwrap ()) ; } if let Some (new) = new { old . borrow_mut () . add (& * new . borrow_mut ()) . expect ("Error adding value to histogram") ; } old } }),
             input: Cast {
                 inner: CrossSingleton {
                     left: Cast {
@@ -2515,7 +2515,7 @@ expression: built.ir()
                                                                                                             first: Map {
                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                                                                                                 input: Map {
-                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                                                                                     input: Tee {
                                                                                                                         inner: <shared 15>,
                                                                                                                         metadata: HydroIrMetadata {
@@ -2783,7 +2783,7 @@ expression: built.ir()
                     right: Cast {
                         inner: ChainFirst {
                             first: Map {
-                                f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
+                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                 input: DeferTick {
                                     input: Tee {
                                         inner: <shared 20>: Reduce {
@@ -2981,7 +2981,7 @@ expression: built.ir()
                                                                     first: Map {
                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                                                         input: Map {
-                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                                             input: Tee {
                                                                                 inner: <shared 15>,
                                                                                 metadata: HydroIrMetadata {
@@ -3228,7 +3228,7 @@ expression: built.ir()
                                             first: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                                 input: Map {
-                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                     input: Tee {
                                                         inner: <shared 20>,
                                                         metadata: HydroIrMetadata {
@@ -3379,7 +3379,7 @@ expression: built.ir()
                                         first: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                             input: Map {
-                                                f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                 input: Tee {
                                                     inner: <shared 20>,
                                                     metadata: HydroIrMetadata {
@@ -3524,7 +3524,7 @@ expression: built.ir()
                                             first: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                                 input: Map {
-                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: tokio :: time :: Instant , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
+                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                     input: Tee {
                                                         inner: <shared 20>,
                                                         metadata: HydroIrMetadata {

--- a/hydro_test/src/distributed/snapshots/first_ten_distributed_ir.snap
+++ b/hydro_test/src/distributed/snapshots/first_ten_distributed_ir.snap
@@ -107,7 +107,6 @@ expression: builder.finalize().ir()
             ),
             input: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < u32 , hydro_test :: __staged :: distributed :: first_ten :: SendOverNetwork > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: distributed :: first_ten :: * ; | n | SendOverNetwork { n } }),
-                singleton_refs: [],
                 input: Source {
                     source: Iter(
                         stageleft :: runtime_support :: type_hint :: < std :: ops :: Range < u32 > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: distributed :: first_ten :: * ; 0 .. 10 }),

--- a/hydro_test/src/local/singleton_ref.rs
+++ b/hydro_test/src/local/singleton_ref.rs
@@ -290,6 +290,196 @@ mod tests {
         assert_eq!(results, vec![11, 15]);
     }
 
+    /// Test: singleton ref inside a partition closure.
+    /// partition is unique because it has a closure but produces two consumer streams,
+    /// so the singleton ref must be correctly shared across both output branches.
+    #[tokio::test]
+    async fn test_singleton_ref_partition() {
+        let mut deployment = Deployment::new();
+
+        let mut builder = FlowBuilder::new();
+        let external = builder.external::<()>();
+        let p1 = builder.process::<()>();
+
+        // Singleton: fold 0..5 => 10 (threshold)
+        let threshold = p1
+            .source_iter(q!(0..5i32))
+            .fold(q!(|| 0i32), q!(|acc: &mut i32, x| *acc += x));
+        let threshold_ref = threshold.by_ref();
+
+        // Partition: elements > threshold go to true branch, others to false branch
+        let (above, below) = p1
+            .source_iter(q!(vec![5i32, 8, 10, 11, 15, 3]))
+            .partition(q!(|x| *x > *threshold_ref));
+
+        let out_above = above.send_bincode_external(&external);
+        let out_below = below.send_bincode_external(&external);
+
+        threshold.into_stream().for_each(q!(|_| {}));
+
+        let nodes = builder
+            .with_default_optimize()
+            .with_process(&p1, deployment.Localhost())
+            .with_external(&external, deployment.Localhost())
+            .deploy(&mut deployment);
+
+        deployment.deploy().await.unwrap();
+
+        let mut recv_above = nodes.connect(out_above).await;
+        let mut recv_below = nodes.connect(out_below).await;
+
+        deployment.start().await.unwrap();
+
+        let mut results_above = Vec::new();
+        for _ in 0..2 {
+            results_above.push(recv_above.next().await.unwrap());
+        }
+        results_above.sort();
+        // threshold = 10, elements strictly > 10 are 11 and 15
+        assert_eq!(results_above, vec![11, 15]);
+
+        let mut results_below = Vec::new();
+        for _ in 0..4 {
+            results_below.push(recv_below.next().await.unwrap());
+        }
+        results_below.sort();
+        // elements <= 10 are 3, 5, 8, 10
+        assert_eq!(results_below, vec![3, 5, 8, 10]);
+    }
+
+    /// Test: singleton ref in partition with downstream map operators on both branches.
+    ///
+    /// This specifically exercises the ident_stack pop logic in the "already built" path
+    /// of Partition code generation (lines 3462-3466 in ir/mod.rs). When the second branch
+    /// of a partition is processed, transform_children pushes singleton ref idents onto the
+    /// stack, but since the partition was already built by the first branch, those idents
+    /// must be popped to keep the stack consistent for downstream operators.
+    ///
+    /// Without the pop, the ident_stack would be corrupted and downstream operators (the
+    /// maps on each branch) would read wrong idents, causing a compile/runtime failure.
+    #[tokio::test]
+    async fn test_singleton_ref_partition_with_downstream_ops() {
+        let mut deployment = Deployment::new();
+
+        let mut builder = FlowBuilder::new();
+        let external = builder.external::<()>();
+        let p1 = builder.process::<()>();
+
+        // Singleton: fold 0..5 => 10
+        let threshold = p1
+            .source_iter(q!(0..5i32))
+            .fold(q!(|| 0i32), q!(|acc: &mut i32, x| *acc += x));
+        let threshold_ref = threshold.by_ref();
+
+        // Partition using the singleton ref
+        let (above, below) = p1
+            .source_iter(q!(vec![5i32, 8, 11, 15]))
+            .partition(q!(|x| *x > *threshold_ref));
+
+        // Apply downstream operators on BOTH branches — this is the key part.
+        // If the ident_stack pop is missing, these maps will get wrong idents.
+        let out_above = above
+            .map(q!(|x| x * 2))
+            .send_bincode_external(&external);
+        let out_below = below
+            .map(q!(|x| x + 100))
+            .send_bincode_external(&external);
+
+        threshold.into_stream().for_each(q!(|_| {}));
+
+        let nodes = builder
+            .with_default_optimize()
+            .with_process(&p1, deployment.Localhost())
+            .with_external(&external, deployment.Localhost())
+            .deploy(&mut deployment);
+
+        deployment.deploy().await.unwrap();
+
+        let mut recv_above = nodes.connect(out_above).await;
+        let mut recv_below = nodes.connect(out_below).await;
+
+        deployment.start().await.unwrap();
+
+        let mut results_above = Vec::new();
+        for _ in 0..2 {
+            results_above.push(recv_above.next().await.unwrap());
+        }
+        results_above.sort();
+        // threshold = 10, above = [11, 15], mapped: [22, 30]
+        assert_eq!(results_above, vec![22, 30]);
+
+        let mut results_below = Vec::new();
+        for _ in 0..2 {
+            results_below.push(recv_below.next().await.unwrap());
+        }
+        results_below.sort();
+        // below = [5, 8], mapped: [105, 108]
+        assert_eq!(results_below, vec![105, 108]);
+    }
+
+    /// Test: singleton ref in partition where the false branch is chained with another stream.
+    ///
+    /// This creates a scenario where the stale singleton ref ident left on the ident_stack
+    /// (if the pop is missing) would be incorrectly consumed by the chain operator,
+    /// causing a compilation or runtime failure.
+    #[tokio::test]
+    async fn test_singleton_ref_partition_chain_false_branch() {
+        let mut deployment = Deployment::new();
+
+        let mut builder = FlowBuilder::new();
+        let external = builder.external::<()>();
+        let p1 = builder.process::<()>();
+
+        // Singleton: fold 0..5 => 10
+        let threshold = p1
+            .source_iter(q!(0..5i32))
+            .fold(q!(|| 0i32), q!(|acc: &mut i32, x| *acc += x));
+        let threshold_ref = threshold.by_ref();
+
+        // Partition using the singleton ref
+        let (above, below) = p1
+            .source_iter(q!(vec![5i32, 8, 11, 15]))
+            .partition(q!(|x| *x > *threshold_ref));
+
+        // Chain the false branch with another stream — this forces the chain operator
+        // to pop two idents from the stack. If the singleton ref ident wasn't popped,
+        // the chain would get the wrong ident.
+        let extra_stream = p1.source_iter(q!(vec![99i32]));
+        let out_above = above.send_bincode_external(&external);
+        let out_below = below.chain(extra_stream).send_bincode_external(&external);
+
+        threshold.into_stream().for_each(q!(|_| {}));
+
+        let nodes = builder
+            .with_default_optimize()
+            .with_process(&p1, deployment.Localhost())
+            .with_external(&external, deployment.Localhost())
+            .deploy(&mut deployment);
+
+        deployment.deploy().await.unwrap();
+
+        let mut recv_above = nodes.connect(out_above).await;
+        let mut recv_below = nodes.connect(out_below).await;
+
+        deployment.start().await.unwrap();
+
+        let mut results_above = Vec::new();
+        for _ in 0..2 {
+            results_above.push(recv_above.next().await.unwrap());
+        }
+        results_above.sort();
+        // threshold = 10, above = [11, 15]
+        assert_eq!(results_above, vec![11, 15]);
+
+        let mut results_below = Vec::new();
+        for _ in 0..3 {
+            results_below.push(recv_below.next().await.unwrap());
+        }
+        results_below.sort();
+        // below = [5, 8] chained with [99]
+        assert_eq!(results_below, vec![5, 8, 99]);
+    }
+
     /// Test: singleton ref inside a flat_map closure.
     #[tokio::test]
     async fn test_singleton_ref_flat_map() {

--- a/hydro_test/src/local/singleton_ref.rs
+++ b/hydro_test/src/local/singleton_ref.rs
@@ -245,4 +245,99 @@ mod tests {
         // ref_a = 10, ref_b = 33, so results = 1+10+33=44, 2+10+33=45
         assert_eq!(results, vec![44, 45]);
     }
+
+    /// Test: singleton ref inside a filter closure.
+    #[tokio::test]
+    async fn test_singleton_ref_filter() {
+        let mut deployment = Deployment::new();
+
+        let mut builder = FlowBuilder::new();
+        let external = builder.external::<()>();
+        let p1 = builder.process::<()>();
+
+        // Singleton: fold 0..5 => 10 (threshold)
+        let threshold = p1
+            .source_iter(q!(0..5i32))
+            .fold(q!(|| 0i32), q!(|acc: &mut i32, x| *acc += x));
+        let threshold_ref = threshold.by_ref();
+
+        // Filter: keep only elements > threshold (10)
+        let out_port = p1
+            .source_iter(q!(vec![5i32, 8, 11, 15, 3]))
+            .filter(q!(|x| *x > *threshold_ref))
+            .send_bincode_external(&external);
+
+        threshold.into_stream().for_each(q!(|_| {}));
+
+        let nodes = builder
+            .with_default_optimize()
+            .with_process(&p1, deployment.Localhost())
+            .with_external(&external, deployment.Localhost())
+            .deploy(&mut deployment);
+
+        deployment.deploy().await.unwrap();
+
+        let mut out_recv = nodes.connect(out_port).await;
+
+        deployment.start().await.unwrap();
+
+        let mut results = Vec::new();
+        for _ in 0..2 {
+            results.push(out_recv.next().await.unwrap());
+        }
+        results.sort();
+        // threshold = 10, so only 11 and 15 pass
+        assert_eq!(results, vec![11, 15]);
+    }
+
+    /// Test: singleton ref inside a flat_map closure.
+    #[tokio::test]
+    async fn test_singleton_ref_flat_map() {
+        let mut deployment = Deployment::new();
+
+        let mut builder = FlowBuilder::new();
+        let external = builder.external::<()>();
+        let p1 = builder.process::<()>();
+
+        // Singleton: fold 0..3 => 3 (repeat count)
+        let count = p1
+            .source_iter(q!(0..3i32))
+            .fold(q!(|| 0i32), q!(|acc: &mut i32, _| *acc += 1));
+        let count_ref = count.by_ref();
+
+        // flat_map: for each element, produce a vec of `count` copies
+        let out_port = p1
+            .source_iter(q!(vec![10i32, 20]))
+            .flat_map_ordered(q!(|x| {
+                let n = *count_ref as usize;
+                let mut v = Vec::new();
+                for _ in 0..n {
+                    v.push(x);
+                }
+                v
+            }))
+            .send_bincode_external(&external);
+
+        count.into_stream().for_each(q!(|_| {}));
+
+        let nodes = builder
+            .with_default_optimize()
+            .with_process(&p1, deployment.Localhost())
+            .with_external(&external, deployment.Localhost())
+            .deploy(&mut deployment);
+
+        deployment.deploy().await.unwrap();
+
+        let mut out_recv = nodes.connect(out_port).await;
+
+        deployment.start().await.unwrap();
+
+        let mut results = Vec::new();
+        for _ in 0..6 {
+            results.push(out_recv.next().await.unwrap());
+        }
+        results.sort();
+        // count = 3, so [10, 10, 10, 20, 20, 20]
+        assert_eq!(results, vec![10, 10, 10, 20, 20, 20]);
+    }
 }

--- a/hydro_test/src/local/singleton_ref.rs
+++ b/hydro_test/src/local/singleton_ref.rs
@@ -378,12 +378,8 @@ mod tests {
 
         // Apply downstream operators on BOTH branches — this is the key part.
         // If the ident_stack pop is missing, these maps will get wrong idents.
-        let out_above = above
-            .map(q!(|x| x * 2))
-            .send_bincode_external(&external);
-        let out_below = below
-            .map(q!(|x| x + 100))
-            .send_bincode_external(&external);
+        let out_above = above.map(q!(|x| x * 2)).send_bincode_external(&external);
+        let out_below = below.map(q!(|x| x + 100)).send_bincode_external(&external);
 
         threshold.into_stream().for_each(q!(|_| {}));
 


### PR DESCRIPTION
[ci-bench]

- Non-defer Vec handoffs now use TickSlab with stable slot IDs
- Each handoff gets a dense index (0..N) assigned at codegen time
- Codegen emits: TickSlab::<N>::new() captured, slab.reset() + slab.vec()
  per tick, for_each push for slab vecs, vec_push for defer_tick vecs
- On grow, slot is moved to end of buffer (data copied, no shifting of
  other slots' memory — avoids pointer invalidation for live SlabVecs)
- reset() compacts slots based on requested_cap
- All dfir_rs tests pass (21 surface_inline, 34 others, 5 slab unit tests)

Co-authored-by: Infinity 🤖 <infinity@hydro.run>