### PR TITLE
experiment: try blink-alloc for dfir handoff buffers [ci-bench]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "allocator-api2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c880a97d28a3681c0267bd29cff89621202715b065127cd445fa0f0fe0aa2880"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -847,6 +853,15 @@ dependencies = [
  "cfg-if",
  "constant_time_eq",
  "cpufeatures",
+]
+
+[[package]]
+name = "blink-alloc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce4c15bad517bc0fb4a44523adf470e2c3eb3a365769327acdba849948ea3705"
+dependencies = [
+ "allocator-api2 0.4.0",
 ]
 
 [[package]]
@@ -1798,8 +1813,9 @@ dependencies = [
 name = "dfir_rs"
 version = "0.16.0"
 dependencies = [
+ "allocator-api2 0.4.0",
  "bincode",
- "bumpalo",
+ "blink-alloc",
  "bytes",
  "chrono",
  "clap",
@@ -2467,7 +2483,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
- "allocator-api2",
+ "allocator-api2 0.2.21",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1799,6 +1799,7 @@ name = "dfir_rs"
 version = "0.16.0"
 dependencies = [
  "bincode",
+ "bumpalo",
  "bytes",
  "chrono",
  "clap",

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1690,12 +1690,16 @@ impl DfirGraph {
                             },
                         }
                     });
-                let recv_hoff_drop_code = recv_buf_idents.iter().map(|buf_ident| {
-                    let span = buf_ident.span();
-                    quote_spanned! {span=>
-                        let _ = #buf_ident;
-                    }
-                });
+                let recv_hoff_drop_code = recv_buf_idents
+                    .iter()
+                    .zip(recv_hoffs.iter())
+                    .filter(|&(_, &hoff_id)| !back_edge_hoffs_lazyness.contains_key(hoff_id))
+                    .map(|(buf_ident, _)| {
+                        let span = buf_ident.span();
+                        quote_spanned! {span=>
+                            let _ = #buf_ident;
+                        }
+                    });
 
                 subgraph_blocks.push(quote! {
                     // Create the send handoffs we will push to.
@@ -1779,10 +1783,21 @@ impl DfirGraph {
         let back_buffer_idents = back_buffer_idents_laziness
             .iter()
             .map(|(back_ident, _is_lazy)| back_ident);
-        // For if we should start the next tick (`schedule_subgraph`).
-        let back_buffer_idents_non_lazy = back_buffer_idents_laziness
+        // For checking if we should start the next tick (`schedule_subgraph`):
+        // check the regular (send) buffer for non-lazy defer_tick handoffs, since
+        // that's where the producer writes during this tick.
+        let non_lazy_buf_idents: Vec<_> = handoff_nodes
             .iter()
-            .filter_map(|(ident, is_lazy)| (!is_lazy).then_some(ident));
+            .filter_map(|&(hoff_id, _kind, _)| {
+                back_edge_hoffs_lazyness.get(hoff_id).and_then(|&is_lazy| {
+                    if !is_lazy {
+                        Some(self.hoff_buf_ident(hoff_id, self.nodes[hoff_id].span()))
+                    } else {
+                        None
+                    }
+                })
+            })
+            .collect();
 
         // Prologues and buffer declarations persist across ticks (outside the closure).
         // Subgraph blocks run each tick (inside the closure).
@@ -1835,7 +1850,7 @@ impl DfirGraph {
 
                     // For non-lazy defer_tick: if any deferred buffer has data,
                     // signal that another tick should run.
-                    if false #( || !#back_buffer_idents_non_lazy.is_empty() )* {
+                    if false #( || !#non_lazy_buf_idents.is_empty() )* {
                         #df.schedule_subgraph(true);
                     }
 

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1684,7 +1684,7 @@ impl DfirGraph {
                         let span = buf_ident.span();
                         match kind {
                             HandoffKind::Vec => quote_spanned! {span=>
-                                let mut #buf_ident = #root::bumpalo::collections::Vec::new_in(&#bump_ident);
+                                let mut #buf_ident = #root::allocator_api2::vec::Vec::new_in(&#bump_ident);
                             },
                             HandoffKind::Option => quote_spanned! {span=>
                                 let mut #buf_ident = ::std::option::Option::None;
@@ -1827,7 +1827,7 @@ impl DfirGraph {
                 #( let mut #back_buffer_idents = ::std::vec::Vec::new(); )*
 
                 // Bump allocator for handoffs (except for back-edge handoffs, above).
-                let mut #bump_ident = #root::bumpalo::Bump::new();
+                let mut #bump_ident = #root::blink_alloc::BlinkAlloc::new();
 
                 // Pre-set to true so the first tick always returns true
                 // (matching Dfir pre-scheduling behavior). Subsequent ticks

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -921,9 +921,28 @@ impl DfirGraph {
     ) -> Result<TokenStream, Diagnostics> {
         let df = Ident::new(GRAPH, Span::call_site());
         let context = Ident::new(CONTEXT, Span::call_site());
+        // Tick-local bump-allocated Vec handoff declarations (inside the tick closure).
+        let bump_ident = Ident::new("__dfir_bump", Span::call_site());
 
-        // 1. Generate local buffers for each handoff node (Vec for streams, Option for singletons).
-        let handoff_nodes: Vec<_> = self
+        // // Handoff buffers that live within the tick.
+        // let buffer_code = handoff_nodes
+        //     .iter()
+        //     .map(|&(node_id, kind, (src_span, dst_span))| {
+        //         let span = src_span.join(dst_span).unwrap_or(src_span);
+        //         let buf_ident = self.hoff_buf_ident(node_id, span);
+        //         match kind {
+        //             HandoffKind::Vec => quote_spanned! {span=>
+        //                 let mut #buf_ident = ::std::vec::Vec::new();
+        //             },
+        //             HandoffKind::Option => quote_spanned! {span=>
+        //                 let mut #buf_ident = ::std::option::Option::None;
+        //             },
+        //         }
+        //     })
+        //     .collect::<Vec<_>>();
+
+        // 1. Collect all handoff nodes.
+        let handoff_nodes = self
             .nodes
             .iter()
             .filter_map(|(node_id, node)| match node {
@@ -935,29 +954,13 @@ impl DfirGraph {
                 GraphNode::Operator(_) => None,
                 GraphNode::ModuleBoundary { .. } => panic!(),
             })
-            .collect();
+            .collect::<Vec<_>>();
 
-        let buffer_code: Vec<TokenStream> = handoff_nodes
-            .iter()
-            .map(|&(node_id, kind, (src_span, dst_span))| {
-                let span = src_span.join(dst_span).unwrap_or(src_span);
-                let buf_ident = self.hoff_buf_ident(node_id, span);
-                match kind {
-                    HandoffKind::Vec => quote_spanned! {span=>
-                        let mut #buf_ident = ::std::vec::Vec::new();
-                    },
-                    HandoffKind::Option => quote_spanned! {span=>
-                        let mut #buf_ident = ::std::option::Option::None;
-                    },
-                }
-            })
-            .collect();
-
-        // For tick-boundary handoffs (`defer_tick` / `defer_tick_lazy`), declare a
-        // second "back" buffer for double-buffering. At the start of each tick, the
-        // main buffer and back buffer are swapped so the consumer reads last tick's
-        // data while the producer writes to a fresh buffer.
-        let back_buffer_code: Vec<TokenStream> = handoff_nodes
+        // For tick-boundary handoffs (`defer_tick` / `defer_tick_lazy`), declare a second "back" buffer for double-
+        // buffering, which survives beyond the tick. At the start of each tick, the regular (inside-tick) buffer and
+        // this back buffer are swapped so the consumer reads last tick's data while the producer writes to a fresh
+        // buffer.
+        let back_buffer_code = handoff_nodes
             .iter()
             .filter(|(node_id, _kind, _)| self.handoff_delay_type(*node_id).is_some())
             .map(|&(node_id, kind, (src_span, dst_span))| {
@@ -968,12 +971,12 @@ impl DfirGraph {
                 let span = src_span.join(dst_span).unwrap_or(src_span);
                 let back_ident = self.hoff_back_ident(node_id, span);
                 quote_spanned! {span=>
-                    let mut #back_ident: Vec<_> = Vec::new();
+                    let mut #back_ident = #root::bumpalo::collections::Vec::new();
                 }
             })
-            .collect();
+            .collect::<Vec<_>>();
 
-        // 2. Collect subgraph handoffs (same as as_code).
+        // 2. Collect per-subgraph recv & send handoffs.
         let subgraph_handoffs = self.helper_collect_subgraph_handoffs();
 
         // 3. Sort subgraphs topologically and collect non-lazy defer_tick buffer idents.
@@ -986,8 +989,10 @@ impl DfirGraph {
         // While iterating handoffs, we also collect buffer idents for non-lazy tick-boundary
         // edges (defer_tick). When these buffers are non-empty at end of tick, we set
         // can_start_tick so that run_available continues ticking.
-        let mut defer_tick_buf_idents: Vec<Ident> = Vec::new();
-        let mut back_edge_hoff_ids: BTreeSet<GraphNodeId> = BTreeSet::new();
+        //
+        // TODO(mingwei): right now we topo sort more than once in the build process, we should keep a single order.
+        // let mut defer_tick_buf_idents: Vec<Ident> = Vec::new();
+        // let mut back_edge_hoff_ids: BTreeSet<GraphNodeId> = BTreeSet::new();
         let all_subgraphs = {
             // Build predecessor map for subgraphs.
             let mut sg_preds: SecondaryMap<GraphSubgraphId, Vec<GraphSubgraphId>> =
@@ -1014,12 +1019,13 @@ impl DfirGraph {
                     debug_assert!(matches!(delay_type, DelayType::Tick | DelayType::TickLazy));
                     // Tick/back-edge handoff: no ordering constraint. Double-buffering
                     // handles the tick deferral regardless of execution order.
-                    back_edge_hoff_ids.insert(hoff_id);
 
-                    // Non-lazy tick-boundary: defer_tick (not defer_tick_lazy).
-                    if !matches!(delay_type, DelayType::TickLazy) {
-                        defer_tick_buf_idents.push(self.hoff_buf_ident(hoff_id, hoff.span()));
-                    }
+                    // back_edge_hoff_ids.insert(hoff_id);
+
+                    // // Non-lazy tick-boundary: defer_tick (not defer_tick_lazy).
+                    // if !matches!(delay_type, DelayType::TickLazy) {
+                    //     defer_tick_buf_idents.push(self.hoff_buf_ident(hoff_id, hoff.span()));
+                    // }
                 } else {
                     sg_preds.entry(succ_sg).unwrap().or_default().push(pred_sg);
                 }
@@ -1084,20 +1090,20 @@ impl DfirGraph {
                 .collect::<Vec<_>>()
         };
 
-        // Generate swap code for tick-boundary (defer_tick / defer_tick_lazy) handoffs.
-        // At the start of each tick, swap the main buffer and back buffer so the
-        // consumer reads last tick's data from the back buffer.
-        let back_edge_swap_code: Vec<TokenStream> = back_edge_hoff_ids
-            .iter()
-            .map(|&hoff_id| {
-                let span = self.nodes[hoff_id].span();
-                let buf_ident = self.hoff_buf_ident(hoff_id, span);
-                let back_ident = self.hoff_back_ident(hoff_id, span);
-                quote_spanned! {span=>
-                    ::std::mem::swap(&mut #buf_ident, &mut #back_ident);
-                }
-            })
-            .collect();
+        // // Generate swap code for tick-boundary (defer_tick / defer_tick_lazy) handoffs.
+        // // At the start of each tick, swap the main buffer and back buffer so the
+        // // consumer reads last tick's data from the back buffer.
+        // let back_edge_swap_code = back_edge_hoff_ids
+        //     .iter()
+        //     .map(|&hoff_id| {
+        //         let span = self.nodes[hoff_id].span();
+        //         let buf_ident = self.hoff_buf_ident(hoff_id, span);
+        //         let back_ident = self.hoff_back_ident(hoff_id, span);
+        //         quote_spanned! {span=>
+        //             ::std::mem::swap(&mut #buf_ident, &mut #back_ident);
+        //         }
+        //     })
+        //     .collect::<Vec<_>>();
 
         // Generate drain code for handoffs with no pipe consumer (0 successors).
         // These are only accessed via #var references and must be cleared each tick.
@@ -1142,6 +1148,26 @@ impl DfirGraph {
                     .map(|&hoff_id| self.hoff_buf_ident(hoff_id, self.nodes[hoff_id].span()))
                     .collect();
 
+                // Handoff kinds
+                let recv_kinds = recv_hoffs
+                    .iter()
+                    .map(|&hoff_id| {
+                        let GraphNode::Handoff { kind, .. } = self.node(hoff_id) else {
+                            panic!()
+                        };
+                        *kind
+                    })
+                    .collect::<Vec<_>>();
+                let send_kinds = send_hoffs
+                    .iter()
+                    .map(|&hoff_id| {
+                        let GraphNode::Handoff { kind, .. } = self.node(hoff_id) else {
+                            panic!()
+                        };
+                        *kind
+                    })
+                    .collect::<Vec<_>>();
+
                 // Recv port code: drain from buffer into iterator, tracking if non-empty.
                 // For back-edge (defer_tick) handoffs, drain from the back buffer instead.
                 // Also update handoff metrics (measured at recv, not send — see graph.rs).
@@ -1149,17 +1175,14 @@ impl DfirGraph {
                     .iter()
                     .zip(recv_buf_idents.iter())
                     .zip(recv_hoffs.iter())
-                    .map(|((port_ident, buf_ident), &hoff_id)| {
+                    .zip(recv_kinds.iter())
+                    .map(|(((port_ident, buf_ident), &hoff_id), kind)| {
                         let hoff_ffi = hoff_id.data().as_ffi();
                         // Use call_site span for internal identifiers to avoid
                         // hygiene issues when invoked through declarative macros
                         // (e.g. dfir_expect_warnings!). TODO(#2781): define these once.
                         let work_done = Ident::new("__dfir_work_done", Span::call_site());
                         let metrics = Ident::new("__dfir_metrics", Span::call_site());
-
-                        let GraphNode::Handoff { kind, .. } = self.node(hoff_id) else {
-                            unreachable!()
-                        };
 
                         // Compute len and drain expressions based on handoff kind.
                         let (len_expr, drain_expr) = match kind {
@@ -1201,11 +1224,8 @@ impl DfirGraph {
                 let send_port_code: Vec<TokenStream> = send_port_idents
                     .iter()
                     .zip(send_buf_idents.iter())
-                    .zip(send_hoffs.iter())
-                    .map(|((port_ident, buf_ident), &hoff_id)| {
-                        let GraphNode::Handoff { kind, .. } = self.node(hoff_id) else {
-                            unreachable!()
-                        };
+                    .zip(send_kinds.iter())
+                    .map(|((port_ident, buf_ident), kind)| {
                         match kind {
                             HandoffKind::Option => {
                                 // Singleton slot: store exactly one item, panic on duplicate.
@@ -1600,7 +1620,7 @@ impl DfirGraph {
                 let sg_fut_ident = subgraph_id.as_ident(Span::call_site());
 
                 // Generate send-side curr_items_count updates (after subgraph runs).
-                let send_metrics_code: Vec<TokenStream> = send_hoffs
+                let send_metrics_code = send_hoffs
                     .iter()
                     .zip(send_buf_idents.iter())
                     .map(|(&hoff_id, buf_ident)| {
@@ -1622,9 +1642,36 @@ impl DfirGraph {
                             ].curr_items_count.set(#len_expr);
                         }
                     })
-                    .collect();
+                    .collect::<Vec<_>>();
+
+                let send_hoff_make_code = send_hoffs
+                    .iter()
+                    .zip(send_buf_idents.iter())
+                    .map(|(&hoff_id, buf_ident)| {
+                        let span = src_span.join(dst_span).unwrap_or(src_span);
+                        let buf_ident = self.hoff_buf_ident(node_id, span);
+                        match kind {
+                            HandoffKind::Vec => quote_spanned! {span=>
+                                let mut #buf_ident = ::std::vec::Vec::new();
+                            },
+                            HandoffKind::Option => quote_spanned! {span=>
+                                let mut #buf_ident = ::std::option::Option::None;
+                            },
+                        }
+                        let hoff_ffi = hoff_id.data().as_ffi();
+                        quote! {
+                            let mut #buf_ident = #root::scheduled::context::HandoffBuffer::new(
+                                #root::slotmap::KeyData::from_ffi(#hoff_ffi).into(),
+                                #df,
+                            );
+                        }
+                    })
+                    .collect::<Vec<_>>();
 
                 subgraph_blocks.push(quote! {
+                    // Create the send handoffs we will push to.
+                    #( #send_hoff_make_code )*
+
                     let #sg_fut_ident = async {
                         let #context = &#df;
                         #( #recv_port_code )*
@@ -1640,8 +1687,13 @@ impl DfirGraph {
                             #sg_fut_ident, sg_metrics
                         ).await;
                         sg_metrics.total_run_count.update(|x| x + 1);
+
+                        // Update send (output) handoff metrics.
+                        #( #send_metrics_code )*
+
+                        // Drop the recv handoffs we just drained.
+                        #( #recv_hoff_drop_code )*
                     }
-                    #( #send_metrics_code )*
                 });
 
                 // Collect per-subgraph prologues into the main prologue lists.

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -975,14 +975,15 @@ impl DfirGraph {
             })
             .collect::<SparseSecondaryMap<_, _>>();
 
-        // Back buffer idents, and if they are lazy.
+        // Back buffer idents, buf idents, and if they are lazy.
         let back_buffer_idents_laziness = handoff_nodes
             .iter()
             .filter_map(|&(hoff_id, _kind, (src_span, dst_span))| {
                 back_edge_hoffs_lazyness.get(hoff_id).map(|&is_lazy| {
                     let span = src_span.join(dst_span).unwrap_or(src_span);
                     let back_ident = self.hoff_back_ident(hoff_id, span);
-                    (back_ident, is_lazy)
+                    let buf_ident = self.hoff_buf_ident(hoff_id, span);
+                    (back_ident, buf_ident, is_lazy)
                 })
             })
             .collect::<Vec<_>>();
@@ -1782,22 +1783,13 @@ impl DfirGraph {
         // For creating back-buffer handoff vecs.
         let back_buffer_idents = back_buffer_idents_laziness
             .iter()
-            .map(|(back_ident, _is_lazy)| back_ident);
+            .map(|(back_ident, _, _)| back_ident);
         // For checking if we should start the next tick (`schedule_subgraph`):
         // check the regular (send) buffer for non-lazy defer_tick handoffs, since
         // that's where the producer writes during this tick.
-        let non_lazy_buf_idents: Vec<_> = handoff_nodes
+        let non_lazy_buf_idents = back_buffer_idents_laziness
             .iter()
-            .filter_map(|&(hoff_id, _kind, _)| {
-                back_edge_hoffs_lazyness.get(hoff_id).and_then(|&is_lazy| {
-                    if !is_lazy {
-                        Some(self.hoff_buf_ident(hoff_id, self.nodes[hoff_id].span()))
-                    } else {
-                        None
-                    }
-                })
-            })
-            .collect();
+            .filter_map(|(_, buf_ident, is_lazy)| (!is_lazy).then_some(buf_ident));
 
         // Prologues and buffer declarations persist across ticks (outside the closure).
         // Subgraph blocks run each tick (inside the closure).

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -988,25 +988,6 @@ impl DfirGraph {
             })
             .collect::<Vec<_>>();
 
-        // // For tick-boundary handoffs (`defer_tick` / `defer_tick_lazy`), declare a second "back" buffer for double-
-        // // buffering, which survives beyond the tick. At the start of each tick, the regular (inside-tick) buffer and
-        // // this back buffer are swapped so the consumer reads last tick's data while the producer writes to a fresh
-        // // buffer.
-        // let back_buffer_code = handoff_nodes
-        //     .iter()
-        //     .filter(|&&(node_id, _kind, _)| back_edge_hoffs_lazyness.contains_key(node_id))
-        //     .map(|&(node_id, kind, (src_span, dst_span))| {
-        //         assert!(
-        //             matches!(kind, HandoffKind::Vec),
-        //             "bug: only Vec handoffs should have delay types"
-        //         );
-        //         let span = src_span.join(dst_span).unwrap_or(src_span);
-        //         let back_ident = self.hoff_back_ident(node_id, span);
-        //         quote_spanned! {span=>
-        //             let mut #back_ident = #root::bumpalo::collections::Vec::new();
-        //         }
-        //     })
-        //     .collect::<Vec<_>>();
 
         // Generate swap code for tick-boundary (defer_tick / defer_tick_lazy) handoffs.
         // At the end of each tick, swap the regular buffer and back buffer so the
@@ -1019,14 +1000,7 @@ impl DfirGraph {
                 let buf_ident = self.hoff_buf_ident(hoff_id, span);
                 let back_ident = self.hoff_back_ident(hoff_id, span);
                 quote_spanned! {span=>
-                    // TODO(mingwei) - need to unify bumpalo and std::vec::vec.
-                    // TODO(mingwei) - this is terribly inefficient.
-                    {
-                        let x = #back_ident.len();
-                        #back_ident.extend(#buf_ident.drain(..));
-                        #buf_ident.extend(#back_ident.drain(..x));
-                    }
-                    // ::std::mem::swap(&mut #buf_ident, &mut #back_ident);
+                    ::std::mem::swap(&mut #buf_ident, &mut #back_ident);
                 }
             })
             .collect::<Vec<_>>();
@@ -1680,15 +1654,24 @@ impl DfirGraph {
 
                 let send_hoff_make_code = send_buf_idents.iter()
                     .zip(send_kinds.iter())
-                    .map(|(buf_ident, &kind)| {
+                    .zip(send_hoffs.iter())
+                    .map(|((buf_ident, &kind), &hoff_id)| {
                         let span = buf_ident.span();
-                        match kind {
-                            HandoffKind::Vec => quote_spanned! {span=>
-                                let mut #buf_ident = #root::allocator_api2::vec::Vec::new_in(&#bump_ident);
-                            },
-                            HandoffKind::Option => quote_spanned! {span=>
-                                let mut #buf_ident = ::std::option::Option::None;
-                            },
+                        if back_edge_hoffs_lazyness.contains_key(hoff_id) {
+                            // Defer_tick send buffers are declared outside the tick closure
+                            // as std::vec::Vec for O(1) swap. Just clear here.
+                            quote_spanned! {span=>
+                                #buf_ident.clear();
+                            }
+                        } else {
+                            match kind {
+                                HandoffKind::Vec => quote_spanned! {span=>
+                                    let mut #buf_ident = #root::allocator_api2::vec::Vec::new_in(&#bump_ident);
+                                },
+                                HandoffKind::Option => quote_spanned! {span=>
+                                    let mut #buf_ident = ::std::option::Option::None;
+                                },
+                            }
                         }
                     });
                 let recv_hoff_drop_code = recv_buf_idents
@@ -1784,6 +1767,10 @@ impl DfirGraph {
         let back_buffer_idents = back_buffer_idents_laziness
             .iter()
             .map(|(back_ident, _, _)| back_ident);
+        // For creating the send-side buffer for defer_tick handoffs (also outside the closure).
+        let defer_tick_buf_idents = back_buffer_idents_laziness
+            .iter()
+            .map(|(_, buf_ident, _)| buf_ident);
         // For checking if we should start the next tick (`schedule_subgraph`):
         // check the regular (send) buffer for non-lazy defer_tick handoffs, since
         // that's where the producer writes during this tick.
@@ -1820,11 +1807,11 @@ impl DfirGraph {
                 // #( #buffer_code )*
 
 
-                // For tick-boundary handoffs (`defer_tick` / `defer_tick_lazy`), declare a second "back" buffer for double-
-                // buffering, which survives beyond the tick. At the start of each tick, the regular (inside-tick) buffer and
-                // this back buffer are swapped so the consumer reads last tick's data while the producer writes to a fresh
-                // buffer.
+                // For tick-boundary handoffs (`defer_tick` / `defer_tick_lazy`), declare both the
+                // send buffer and the "back" buffer as std::vec::Vec outside the tick closure.
+                // This enables O(1) mem::swap at end of tick for double-buffering.
                 #( let mut #back_buffer_idents = ::std::vec::Vec::new(); )*
+                #( let mut #defer_tick_buf_idents = ::std::vec::Vec::new(); )*
 
                 // Bump allocator for handoffs (except for back-edge handoffs, above).
                 let mut #bump_ident = #root::blink_alloc::BlinkAlloc::with_chunk_size(4096);

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1827,7 +1827,7 @@ impl DfirGraph {
                 #( let mut #back_buffer_idents = ::std::vec::Vec::new(); )*
 
                 // Bump allocator for handoffs (except for back-edge handoffs, above).
-                let mut #bump_ident = #root::blink_alloc::BlinkAlloc::new();
+                let mut #bump_ident = #root::blink_alloc::BlinkAlloc::with_chunk_size(4096);
 
                 // Pre-set to true so the first tick always returns true
                 // (matching Dfir pre-scheduling behavior). Subsequent ticks

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1836,24 +1836,29 @@ impl DfirGraph {
                 let mut __dfir_work_done = true;
                 #[allow(unused_qualifications, unused_mut, unused_variables, clippy::await_holding_refcell_ref, clippy::deref_addrof)]
                 let __dfir_inline_tick = async move |#df: &mut #root::scheduled::context::Context| {
-                    let __dfir_metrics = #df.metrics();
+                    {
+                        let __dfir_metrics = #df.metrics();
 
-                    #( #subgraph_blocks )*
+                        #( #subgraph_blocks )*
 
-                    // For non-lazy defer_tick: if any deferred buffer has data,
-                    // signal that another tick should run.
-                    if false #( || !#non_lazy_buf_idents.is_empty() )* {
-                        #df.schedule_subgraph(true);
+                        // For non-lazy defer_tick: if any deferred buffer has data,
+                        // signal that another tick should run.
+                        if false #( || !#non_lazy_buf_idents.is_empty() )* {
+                            #df.schedule_subgraph(true);
+                        }
+
+                        // Double-buffer swap for defer_tick handoffs: move last tick's producer output (regular buffer)
+                        // into the back buffer for the consumer to drain.
+                        #( #back_edge_swap_code )*
                     }
 
-                    // End-of-tick state reset (e.g. 'tick persistence).
+                    // Reset arena for end-of-tick.
+                    #bump_ident.reset();
+
+                    // End-of-tick per-operator state handling (i.e. 'tick persistence).
                     #( #op_tick_end_code )*
 
                     #df.__end_tick();
-
-                    // Double-buffer swap for defer_tick handoffs: move last tick's producer output (regular buffer)
-                    // into the back buffer for the consumer to drain.
-                    #( #back_edge_swap_code )*
 
                     ::std::mem::take(&mut __dfir_work_done)
                 };

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1823,6 +1823,10 @@ impl DfirGraph {
                 let mut __dfir_work_done = true;
                 #[allow(unused_qualifications, unused_mut, unused_variables, clippy::await_holding_refcell_ref, clippy::deref_addrof)]
                 let __dfir_inline_tick = async move |#df: &mut #root::scheduled::context::Context| {
+
+                    // Reset arena between ticks (start-of-tick).
+                    #bump_ident.reset();
+
                     {
                         let __dfir_metrics = #df.metrics();
 
@@ -1838,9 +1842,6 @@ impl DfirGraph {
                         // into the back buffer for the consumer to drain.
                         #( #back_edge_swap_code )*
                     }
-
-                    // Reset arena for end-of-tick.
-                    #bump_ident.reset();
 
                     // End-of-tick per-operator state handling (i.e. 'tick persistence).
                     #( #op_tick_end_code )*

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -956,22 +956,76 @@ impl DfirGraph {
             })
             .collect::<Vec<_>>();
 
-        // For tick-boundary handoffs (`defer_tick` / `defer_tick_lazy`), declare a second "back" buffer for double-
-        // buffering, which survives beyond the tick. At the start of each tick, the regular (inside-tick) buffer and
-        // this back buffer are swapped so the consumer reads last tick's data while the producer writes to a fresh
-        // buffer.
-        let back_buffer_code = handoff_nodes
+        // Determine which handoff nodes are tick-boundary (defer_tick) back-edges.
+        // These must remain as captured Vec<T> since they persist across ticks.
+        // All other Vec handoffs will be bump-allocated (tick-local).
+        let back_edge_hoffs_lazyness = handoff_nodes
             .iter()
-            .filter(|(node_id, _kind, _)| self.handoff_delay_type(*node_id).is_some())
-            .map(|&(node_id, kind, (src_span, dst_span))| {
-                assert!(
-                    matches!(kind, HandoffKind::Vec),
-                    "bug: only Vec handoffs should have delay types"
-                );
-                let span = src_span.join(dst_span).unwrap_or(src_span);
-                let back_ident = self.hoff_back_ident(node_id, span);
+            .map(|&(node_id, _, _)| node_id)
+            .filter_map(|node_id| {
+                if let Some(delay_type) = self.handoff_delay_type(node_id) {
+                    assert!(
+                        matches!(delay_type, DelayType::Tick | DelayType::TickLazy),
+                        "Handoff `DelayType` must be either `Tick` or `TickLazy` (or unset)."
+                    );
+                    Some((node_id, matches!(delay_type, DelayType::TickLazy)))
+                } else {
+                    None
+                }
+            })
+            .collect::<SparseSecondaryMap<_, _>>();
+
+        // Back buffer idents, and if they are lazy.
+        let back_buffer_idents_laziness = handoff_nodes
+            .iter()
+            .filter_map(|&(hoff_id, _kind, (src_span, dst_span))| {
+                back_edge_hoffs_lazyness.get(hoff_id).map(|&is_lazy| {
+                    let span = src_span.join(dst_span).unwrap_or(src_span);
+                    let back_ident = self.hoff_back_ident(hoff_id, span);
+                    (back_ident, is_lazy)
+                })
+            })
+            .collect::<Vec<_>>();
+
+        // // For tick-boundary handoffs (`defer_tick` / `defer_tick_lazy`), declare a second "back" buffer for double-
+        // // buffering, which survives beyond the tick. At the start of each tick, the regular (inside-tick) buffer and
+        // // this back buffer are swapped so the consumer reads last tick's data while the producer writes to a fresh
+        // // buffer.
+        // let back_buffer_code = handoff_nodes
+        //     .iter()
+        //     .filter(|&&(node_id, _kind, _)| back_edge_hoffs_lazyness.contains_key(node_id))
+        //     .map(|&(node_id, kind, (src_span, dst_span))| {
+        //         assert!(
+        //             matches!(kind, HandoffKind::Vec),
+        //             "bug: only Vec handoffs should have delay types"
+        //         );
+        //         let span = src_span.join(dst_span).unwrap_or(src_span);
+        //         let back_ident = self.hoff_back_ident(node_id, span);
+        //         quote_spanned! {span=>
+        //             let mut #back_ident = #root::bumpalo::collections::Vec::new();
+        //         }
+        //     })
+        //     .collect::<Vec<_>>();
+
+        // Generate swap code for tick-boundary (defer_tick / defer_tick_lazy) handoffs.
+        // At the end of each tick, swap the regular buffer and back buffer so the
+        // consumer reads last tick's data from the back buffer.
+        let back_edge_swap_code = handoff_nodes
+            .iter()
+            .filter(|&&(node_id, _kind, _)| back_edge_hoffs_lazyness.contains_key(node_id))
+            .map(|&(hoff_id, _kind, _)| {
+                let span = self.nodes[hoff_id].span();
+                let buf_ident = self.hoff_buf_ident(hoff_id, span);
+                let back_ident = self.hoff_back_ident(hoff_id, span);
                 quote_spanned! {span=>
-                    let mut #back_ident = #root::bumpalo::collections::Vec::new();
+                    // TODO(mingwei) - need to unify bumpalo and std::vec::vec.
+                    // TODO(mingwei) - this is terribly inefficient.
+                    {
+                        let x = #back_ident.len();
+                        #back_ident.extend(#buf_ident.drain(..));
+                        #buf_ident.extend(#back_ident.drain(..x));
+                    }
+                    // ::std::mem::swap(&mut #buf_ident, &mut #back_ident);
                 }
             })
             .collect::<Vec<_>>();
@@ -992,7 +1046,7 @@ impl DfirGraph {
         //
         // TODO(mingwei): right now we topo sort more than once in the build process, we should keep a single order.
         // let mut defer_tick_buf_idents: Vec<Ident> = Vec::new();
-        // let mut back_edge_hoff_ids: BTreeSet<GraphNodeId> = BTreeSet::new();
+        // let mut back_edge_hoffs_lazyness: BTreeSet<GraphNodeId> = BTreeSet::new();
         let all_subgraphs = {
             // Build predecessor map for subgraphs.
             let mut sg_preds: SecondaryMap<GraphSubgraphId, Vec<GraphSubgraphId>> =
@@ -1015,18 +1069,8 @@ impl DfirGraph {
                 if pred_sg == succ_sg {
                     panic!("bug: unexpected subgraph self-handoff cycle");
                 }
-                if let Some(delay_type) = self.handoff_delay_type(hoff_id) {
-                    debug_assert!(matches!(delay_type, DelayType::Tick | DelayType::TickLazy));
-                    // Tick/back-edge handoff: no ordering constraint. Double-buffering
-                    // handles the tick deferral regardless of execution order.
-
-                    // back_edge_hoff_ids.insert(hoff_id);
-
-                    // // Non-lazy tick-boundary: defer_tick (not defer_tick_lazy).
-                    // if !matches!(delay_type, DelayType::TickLazy) {
-                    //     defer_tick_buf_idents.push(self.hoff_buf_ident(hoff_id, hoff.span()));
-                    // }
-                } else {
+                // Only consider non-back-edges.
+                if !back_edge_hoffs_lazyness.contains_key(hoff_id) {
                     sg_preds.entry(succ_sg).unwrap().or_default().push(pred_sg);
                 }
             }
@@ -1090,35 +1134,22 @@ impl DfirGraph {
                 .collect::<Vec<_>>()
         };
 
-        // // Generate swap code for tick-boundary (defer_tick / defer_tick_lazy) handoffs.
-        // // At the start of each tick, swap the main buffer and back buffer so the
-        // // consumer reads last tick's data from the back buffer.
-        // let back_edge_swap_code = back_edge_hoff_ids
+        // TODO(mingwei): If a handoff has no pipe consumers we should drop it as soon as possible, after all reference
+        // consumers. Right now we just let these handoffs die at the end of the tick.
+        // // Generate drain code for handoffs with no pipe consumer (0 successors).
+        // // These are only accessed via #var references and must be cleared each tick.
+        // let no_consumer_drain_code: Vec<TokenStream> = handoff_nodes
         //     .iter()
-        //     .map(|&hoff_id| {
-        //         let span = self.nodes[hoff_id].span();
-        //         let buf_ident = self.hoff_buf_ident(hoff_id, span);
-        //         let back_ident = self.hoff_back_ident(hoff_id, span);
-        //         quote_spanned! {span=>
-        //             ::std::mem::swap(&mut #buf_ident, &mut #back_ident);
+        //     .filter(|&&(node_id, _, _)| self.node_degree_out(node_id) == 0)
+        //     .map(|&(node_id, kind, (src_span, dst_span))| {
+        //         let span = src_span.join(dst_span).unwrap_or(src_span);
+        //         let buf_ident = self.hoff_buf_ident(node_id, span);
+        //         match kind {
+        //             HandoffKind::Option => quote_spanned! {span=> #buf_ident.take(); },
+        //             HandoffKind::Vec => quote_spanned! {span=> #buf_ident.clear(); },
         //         }
         //     })
-        //     .collect::<Vec<_>>();
-
-        // Generate drain code for handoffs with no pipe consumer (0 successors).
-        // These are only accessed via #var references and must be cleared each tick.
-        let no_consumer_drain_code: Vec<TokenStream> = handoff_nodes
-            .iter()
-            .filter(|&&(node_id, _, _)| self.node_degree_out(node_id) == 0)
-            .map(|&(node_id, kind, (src_span, dst_span))| {
-                let span = src_span.join(dst_span).unwrap_or(src_span);
-                let buf_ident = self.hoff_buf_ident(node_id, span);
-                match kind {
-                    HandoffKind::Option => quote_spanned! {span=> #buf_ident.take(); },
-                    HandoffKind::Vec => quote_spanned! {span=> #buf_ident.clear(); },
-                }
-            })
-            .collect();
+        //     .collect();
 
         let mut op_prologue_code = Vec::new();
         let mut op_tick_end_code = Vec::new();
@@ -1174,9 +1205,9 @@ impl DfirGraph {
                 let recv_port_code: Vec<TokenStream> = recv_port_idents
                     .iter()
                     .zip(recv_buf_idents.iter())
-                    .zip(recv_hoffs.iter())
                     .zip(recv_kinds.iter())
-                    .map(|(((port_ident, buf_ident), &hoff_id), kind)| {
+                    .zip(recv_hoffs.iter())
+                    .map(|(((port_ident, buf_ident), &kind), &hoff_id)| {
                         let hoff_ffi = hoff_id.data().as_ffi();
                         // Use call_site span for internal identifiers to avoid
                         // hygiene issues when invoked through declarative macros
@@ -1191,10 +1222,13 @@ impl DfirGraph {
                                 quote! { #root::dfir_pipes::pull::iter(#buf_ident.take().into_iter()) },
                             ),
                             HandoffKind::Vec => {
-                                let drain_ident = if back_edge_hoff_ids.contains(&hoff_id) {
-                                    self.hoff_back_ident(hoff_id, buf_ident.span())
+                                // Special asymmetric handling for defer tick handoffs, which are double-buffered. We
+                                // _send_ to the back buffer (here) and _recv_ from the regular buffer (regular case
+                                // below).
+                                let drain_ident = if back_edge_hoffs_lazyness.contains_key(hoff_id) {
+                                    &self.hoff_back_ident(hoff_id, buf_ident.span())
                                 } else {
-                                    buf_ident.clone()
+                                    buf_ident
                                 };
                                 (
                                     quote! { #drain_ident.len() },
@@ -1225,7 +1259,7 @@ impl DfirGraph {
                     .iter()
                     .zip(send_buf_idents.iter())
                     .zip(send_kinds.iter())
-                    .map(|((port_ident, buf_ident), kind)| {
+                    .map(|((port_ident, buf_ident), &kind)| {
                         match kind {
                             HandoffKind::Option => {
                                 // Singleton slot: store exactly one item, panic on duplicate.
@@ -1239,7 +1273,8 @@ impl DfirGraph {
                             }
                             HandoffKind::Vec => {
                                 quote_spanned! {port_ident.span()=>
-                                    let #port_ident = #root::dfir_pipes::push::vec_push(&mut #buf_ident);
+                                    let #port_ident = #root::dfir_pipes::push::for_each(|item| { #buf_ident.push(item); });
+                                    // let #port_ident = #root::dfir_pipes::push::vec_push(&mut #buf_ident);
                                 }
                             }
                         }
@@ -1623,11 +1658,9 @@ impl DfirGraph {
                 let send_metrics_code = send_hoffs
                     .iter()
                     .zip(send_buf_idents.iter())
-                    .map(|(&hoff_id, buf_ident)| {
+                    .zip(send_kinds.iter())
+                    .map(|((&hoff_id, buf_ident), &kind)| {
                         let hoff_ffi = hoff_id.data().as_ffi();
-                        let GraphNode::Handoff { kind, .. } = self.node(hoff_id) else {
-                            unreachable!()
-                        };
                         let len_expr = match kind {
                             HandoffKind::Option => {
                                 quote! { if #buf_ident.is_some() { 1 } else { 0 } }
@@ -1644,29 +1677,25 @@ impl DfirGraph {
                     })
                     .collect::<Vec<_>>();
 
-                let send_hoff_make_code = send_hoffs
-                    .iter()
-                    .zip(send_buf_idents.iter())
-                    .map(|(&hoff_id, buf_ident)| {
-                        let span = src_span.join(dst_span).unwrap_or(src_span);
-                        let buf_ident = self.hoff_buf_ident(node_id, span);
+                let send_hoff_make_code = send_buf_idents.iter()
+                    .zip(send_kinds.iter())
+                    .map(|(buf_ident, &kind)| {
+                        let span = buf_ident.span();
                         match kind {
                             HandoffKind::Vec => quote_spanned! {span=>
-                                let mut #buf_ident = ::std::vec::Vec::new();
+                                let mut #buf_ident = #root::bumpalo::collections::Vec::new_in(&#bump_ident);
                             },
                             HandoffKind::Option => quote_spanned! {span=>
                                 let mut #buf_ident = ::std::option::Option::None;
                             },
                         }
-                        let hoff_ffi = hoff_id.data().as_ffi();
-                        quote! {
-                            let mut #buf_ident = #root::scheduled::context::HandoffBuffer::new(
-                                #root::slotmap::KeyData::from_ffi(#hoff_ffi).into(),
-                                #df,
-                            );
-                        }
-                    })
-                    .collect::<Vec<_>>();
+                    });
+                let recv_hoff_drop_code = recv_buf_idents.iter().map(|buf_ident| {
+                    let span = buf_ident.span();
+                    quote_spanned! {span=>
+                        let _ = #buf_ident;
+                    }
+                });
 
                 subgraph_blocks.push(quote! {
                     // Create the send handoffs we will push to.
@@ -1680,6 +1709,7 @@ impl DfirGraph {
                         #( #subgraph_op_iter_after_code )*
                     };
                     {
+                        // Instrument w/ the subgraph metrics.
                         let sg_metrics = &__dfir_metrics.subgraphs[
                             #root::slotmap::KeyData::from_ffi(#sg_metrics_ffi).into()
                         ];
@@ -1745,6 +1775,15 @@ impl DfirGraph {
             handoff_inits.chain(subgraph_inits).collect::<Vec<_>>()
         };
 
+        // For creating back-buffer handoff vecs.
+        let back_buffer_idents = back_buffer_idents_laziness
+            .iter()
+            .map(|(back_ident, _is_lazy)| back_ident);
+        // For if we should start the next tick (`schedule_subgraph`).
+        let back_buffer_idents_non_lazy = back_buffer_idents_laziness
+            .iter()
+            .filter_map(|(ident, is_lazy)| (!is_lazy).then_some(ident));
+
         // Prologues and buffer declarations persist across ticks (outside the closure).
         // Subgraph blocks run each tick (inside the closure).
         Ok(quote! {
@@ -1769,9 +1808,19 @@ impl DfirGraph {
                     __dfir_metrics,
                 );
 
-                #( #buffer_code )*
-                #( #back_buffer_code )*
                 #( #op_prologue_code )*
+
+                // #( #buffer_code )*
+
+
+                // For tick-boundary handoffs (`defer_tick` / `defer_tick_lazy`), declare a second "back" buffer for double-
+                // buffering, which survives beyond the tick. At the start of each tick, the regular (inside-tick) buffer and
+                // this back buffer are swapped so the consumer reads last tick's data while the producer writes to a fresh
+                // buffer.
+                #( let mut #back_buffer_idents = ::std::vec::Vec::new(); )*
+
+                // Bump allocator for handoffs (except for back-edge handoffs, above).
+                let mut #bump_ident = #root::bumpalo::Bump::new();
 
                 // Pre-set to true so the first tick always returns true
                 // (matching Dfir pre-scheduling behavior). Subsequent ticks
@@ -1781,26 +1830,24 @@ impl DfirGraph {
                 #[allow(unused_qualifications, unused_mut, unused_variables, clippy::await_holding_refcell_ref, clippy::deref_addrof)]
                 let __dfir_inline_tick = async move |#df: &mut #root::scheduled::context::Context| {
                     let __dfir_metrics = #df.metrics();
-                    // Double-buffer swap for defer_tick handoffs: move last tick's
-                    // producer output into the back buffer for the consumer to drain.
-                    #( #back_edge_swap_code )*
+
                     #( #subgraph_blocks )*
 
                     // For non-lazy defer_tick: if any deferred buffer has data,
                     // signal that another tick should run.
-                    if false #( || !#defer_tick_buf_idents.is_empty() )* {
+                    if false #( || !#back_buffer_idents_non_lazy.is_empty() )* {
                         #df.schedule_subgraph(true);
                     }
 
                     // End-of-tick state reset (e.g. 'tick persistence).
                     #( #op_tick_end_code )*
 
-                    // Drain handoff buffers that have no pipe consumer (e.g. singleton
-                    // used only via #var reference). Without this, the value would
-                    // persist across ticks and cause panics on the next write.
-                    #( #no_consumer_drain_code )*
-
                     #df.__end_tick();
+
+                    // Double-buffer swap for defer_tick handoffs: move last tick's producer output (regular buffer)
+                    // into the back buffer for the consumer to drain.
+                    #( #back_edge_swap_code )*
+
                     ::std::mem::take(&mut __dfir_work_done)
                 };
                 #root::scheduled::context::Dfir::new(

--- a/dfir_rs/Cargo.toml
+++ b/dfir_rs/Cargo.toml
@@ -26,8 +26,9 @@ all-features = true
 name = "kvs_bench"
 
 [dependencies]
+allocator-api2 = "0.4.0"
 bincode = "1.3.1"
-bumpalo = { version = "3.0.0", features = ["collections"] }
+blink-alloc = "0.4.0"
 bytes = "1.1.0"
 dfir_lang = { path = "../dfir_lang", version = "^0.16.0", default-features = false }
 dfir_macro = { optional = true, path = "../dfir_macro", version = "^0.16.0" }

--- a/dfir_rs/Cargo.toml
+++ b/dfir_rs/Cargo.toml
@@ -27,6 +27,7 @@ name = "kvs_bench"
 
 [dependencies]
 bincode = "1.3.1"
+bumpalo = { version = "3.0.0", features = ["collections"] }
 bytes = "1.1.0"
 dfir_lang = { path = "../dfir_lang", version = "^0.16.0", default-features = false }
 dfir_macro = { optional = true, path = "../dfir_macro", version = "^0.16.0" }

--- a/dfir_rs/src/lib.rs
+++ b/dfir_rs/src/lib.rs
@@ -20,17 +20,18 @@ pub mod compiled;
 pub mod scheduled;
 pub mod util;
 
+#[doc(hidden)]
 pub use ::{
-    bincode, bytes, dfir_pipes, futures, lattices, pin_project_lite, rustc_hash, serde, serde_json,
-    sinktools, tokio, tokio_stream, tokio_util, tracing, web_time,
+    bincode, bumpalo, bytes, dfir_lang, dfir_lang as lang, dfir_pipes, futures, lattices,
+    pin_project_lite, rustc_hash, serde, serde_json, sinktools, slotmap, tokio, tokio_stream,
+    tokio_util, tracing, variadics, web_time,
 };
 #[cfg(feature = "meta")]
 #[cfg_attr(docsrs, doc(cfg(feature = "meta")))]
-pub use dfir_lang as lang;
-pub use dfir_lang;
+#[doc(hidden)]
 pub use dfir_pipes::itertools;
-pub use slotmap;
-pub use variadics::{self, var_args, var_expr, var_type};
+#[doc(hidden)]
+pub use variadics::{var_args, var_expr, var_type};
 
 /// `#[macro_use]` automagically brings the declarative macro export to the crate-level.
 mod declarative_macro;

--- a/dfir_rs/src/lib.rs
+++ b/dfir_rs/src/lib.rs
@@ -22,9 +22,9 @@ pub mod util;
 
 #[doc(hidden)]
 pub use ::{
-    bincode, bumpalo, bytes, dfir_lang, dfir_lang as lang, dfir_pipes, futures, lattices,
-    pin_project_lite, rustc_hash, serde, serde_json, sinktools, slotmap, tokio, tokio_stream,
-    tokio_util, tracing, variadics, web_time,
+    allocator_api2, bincode, blink_alloc, bytes, dfir_lang, dfir_lang as lang, dfir_pipes, futures,
+    lattices, pin_project_lite, rustc_hash, serde, serde_json, sinktools, slotmap, tokio,
+    tokio_stream, tokio_util, tracing, variadics, web_time,
 };
 #[cfg(feature = "meta")]
 #[cfg_attr(docsrs, doc(cfg(feature = "meta")))]

--- a/dfir_rs/tests/compile-fail/stable/surface_fold_keyed_badtype_int.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_fold_keyed_badtype_int.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, {integer}>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, '_, {integer}>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_fold_keyed_badtype_int.rs:3:9
   |
 3 |         source_iter(0..1)
@@ -14,7 +14,7 @@ note: required by a bound in `check_input`
 4 |             -> reduce_keyed(|old: &mut u32, val: u32| { *old += val; })
   |                ^^^^^^^^^^^^ required by this bound in `check_input`
 
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, {integer}>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, '_, {integer}>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_fold_keyed_badtype_int.rs:4:16
   |
 4 |             -> reduce_keyed(|old: &mut u32, val: u32| { *old += val; })

--- a/dfir_rs/tests/compile-fail/stable/surface_fold_keyed_badtype_int.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_fold_keyed_badtype_int.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, '_, {integer}>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, {integer}, &BlinkAlloc>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_fold_keyed_badtype_int.rs:3:9
   |
 3 |         source_iter(0..1)
@@ -14,7 +14,7 @@ note: required by a bound in `check_input`
 4 |             -> reduce_keyed(|old: &mut u32, val: u32| { *old += val; })
   |                ^^^^^^^^^^^^ required by this bound in `check_input`
 
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, '_, {integer}>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, {integer}, &BlinkAlloc>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_fold_keyed_badtype_int.rs:4:16
   |
 4 |             -> reduce_keyed(|old: &mut u32, val: u32| { *old += val; })

--- a/dfir_rs/tests/compile-fail/stable/surface_fold_keyed_badtype_option.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_fold_keyed_badtype_option.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, '_, Option<{integer}>>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, Option<{integer}>, &BlinkAlloc>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_fold_keyed_badtype_option.rs:3:9
   |
 3 |         source_iter([ Some(5), None, Some(12) ])
@@ -14,7 +14,7 @@ note: required by a bound in `check_input`
 4 |             -> reduce_keyed(|old: &mut u32, val: u32| { *old += val; })
   |                ^^^^^^^^^^^^ required by this bound in `check_input`
 
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, '_, Option<{integer}>>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, Option<{integer}>, &BlinkAlloc>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_fold_keyed_badtype_option.rs:4:16
   |
 4 |             -> reduce_keyed(|old: &mut u32, val: u32| { *old += val; })

--- a/dfir_rs/tests/compile-fail/stable/surface_fold_keyed_badtype_option.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_fold_keyed_badtype_option.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, Option<{integer}>>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, '_, Option<{integer}>>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_fold_keyed_badtype_option.rs:3:9
   |
 3 |         source_iter([ Some(5), None, Some(12) ])
@@ -14,7 +14,7 @@ note: required by a bound in `check_input`
 4 |             -> reduce_keyed(|old: &mut u32, val: u32| { *old += val; })
   |                ^^^^^^^^^^^^ required by this bound in `check_input`
 
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, Option<{integer}>>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, '_, Option<{integer}>>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_fold_keyed_badtype_option.rs:4:16
   |
 4 |             -> reduce_keyed(|old: &mut u32, val: u32| { *old += val; })

--- a/dfir_rs/tests/compile-fail/stable/surface_fold_keyed_generics_bad.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_fold_keyed_generics_bad.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, '_, &str>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, &str, &BlinkAlloc>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_fold_keyed_generics_bad.rs:3:9
   |
 3 |         source_iter(["hello", "world"])
@@ -14,7 +14,7 @@ note: required by a bound in `check_input`
 4 |             -> fold_keyed::<'tick, &str, usize>(String::new, |old: &mut _, val| {
   |                ^^^^^^^^^^ required by this bound in `check_input`
 
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, '_, &str>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, &str, &BlinkAlloc>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_fold_keyed_generics_bad.rs:4:16
   |
 4 |             -> fold_keyed::<'tick, &str, usize>(String::new, |old: &mut _, val| {

--- a/dfir_rs/tests/compile-fail/stable/surface_fold_keyed_generics_bad.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_fold_keyed_generics_bad.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, &str>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, '_, &str>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_fold_keyed_generics_bad.rs:3:9
   |
 3 |         source_iter(["hello", "world"])
@@ -14,7 +14,7 @@ note: required by a bound in `check_input`
 4 |             -> fold_keyed::<'tick, &str, usize>(String::new, |old: &mut _, val| {
   |                ^^^^^^^^^^ required by this bound in `check_input`
 
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, &str>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, '_, &str>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_fold_keyed_generics_bad.rs:4:16
   |
 4 |             -> fold_keyed::<'tick, &str, usize>(String::new, |old: &mut _, val| {

--- a/dfir_rs/tests/compile-fail/stable/surface_reduce_keyed_badtype_int.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_reduce_keyed_badtype_int.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, {integer}>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, '_, {integer}>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_reduce_keyed_badtype_int.rs:3:9
   |
 3 |         source_iter(0..1)
@@ -14,7 +14,7 @@ note: required by a bound in `check_input`
 4 |             -> fold_keyed(|| 0, |old: &mut u32, val: u32| { *old += val; })
   |                ^^^^^^^^^^ required by this bound in `check_input`
 
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, {integer}>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, '_, {integer}>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_reduce_keyed_badtype_int.rs:4:16
   |
 4 |             -> fold_keyed(|| 0, |old: &mut u32, val: u32| { *old += val; })

--- a/dfir_rs/tests/compile-fail/stable/surface_reduce_keyed_badtype_int.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_reduce_keyed_badtype_int.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, '_, {integer}>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, {integer}, &BlinkAlloc>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_reduce_keyed_badtype_int.rs:3:9
   |
 3 |         source_iter(0..1)
@@ -14,7 +14,7 @@ note: required by a bound in `check_input`
 4 |             -> fold_keyed(|| 0, |old: &mut u32, val: u32| { *old += val; })
   |                ^^^^^^^^^^ required by this bound in `check_input`
 
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, '_, {integer}>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, {integer}, &BlinkAlloc>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_reduce_keyed_badtype_int.rs:4:16
   |
 4 |             -> fold_keyed(|| 0, |old: &mut u32, val: u32| { *old += val; })

--- a/dfir_rs/tests/compile-fail/stable/surface_reduce_keyed_badtype_option.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_reduce_keyed_badtype_option.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, Option<{integer}>>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, '_, Option<{integer}>>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_reduce_keyed_badtype_option.rs:3:9
   |
 3 |         source_iter([ Some(5), None, Some(12) ])
@@ -14,7 +14,7 @@ note: required by a bound in `check_input`
 4 |             -> fold_keyed(|| 0, |old: &mut u32, val: u32| { *old += val; })
   |                ^^^^^^^^^^ required by this bound in `check_input`
 
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, Option<{integer}>>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, '_, Option<{integer}>>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_reduce_keyed_badtype_option.rs:4:16
   |
 4 |             -> fold_keyed(|| 0, |old: &mut u32, val: u32| { *old += val; })

--- a/dfir_rs/tests/compile-fail/stable/surface_reduce_keyed_badtype_option.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_reduce_keyed_badtype_option.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, '_, Option<{integer}>>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, Option<{integer}>, &BlinkAlloc>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_reduce_keyed_badtype_option.rs:3:9
   |
 3 |         source_iter([ Some(5), None, Some(12) ])
@@ -14,7 +14,7 @@ note: required by a bound in `check_input`
 4 |             -> fold_keyed(|| 0, |old: &mut u32, val: u32| { *old += val; })
   |                ^^^^^^^^^^ required by this bound in `check_input`
 
-error[E0271]: type mismatch resolving `<Iter<Drain<'_, '_, Option<{integer}>>> as Pull>::Item == (_, _)`
+error[E0271]: type mismatch resolving `<Iter<Drain<'_, Option<{integer}>, &BlinkAlloc>> as Pull>::Item == (_, _)`
  --> tests/compile-fail/stable/surface_reduce_keyed_badtype_option.rs:4:16
   |
 4 |             -> fold_keyed(|| 0, |old: &mut u32, val: u32| { *old += val; })


### PR DESCRIPTION
Swap the bump allocator from bumpalo to blink-alloc + allocator-api2.
blink-alloc provides proper drop support and uses the standard Allocator
trait (via allocator-api2 polyfill on stable Rust).

- dfir_rs/Cargo.toml: bumpalo → blink-alloc + allocator-api2
- dfir_rs/src/lib.rs: update re-exports
- dfir_lang/src/graph/meta_graph.rs: update generated code to use
  blink_alloc::BlinkAlloc::new() and allocator_api2::vec::Vec::new_in()

Co-authored-by: Infinity 🤖 <infinity@hydro.run>