### PR TITLE
fix(hydro_lang/sim): resolve infinite hang when cross_singleton uses top-level bounded singleton

### DIFF
--- a/dfir_lang/src/graph/ops/cross_singleton.rs
+++ b/dfir_lang/src/graph/ops/cross_singleton.rs
@@ -2,8 +2,8 @@ use quote::{ToTokens, quote_spanned};
 use syn::parse_quote;
 
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints, OperatorWriteOutput, RANGE_0, RANGE_1,
-    WriteContextArgs,
+    DelayType, OpInstGenerics, OperatorCategory, OperatorConstraints, OperatorInstance,
+    OperatorWriteOutput, Persistence, RANGE_0, RANGE_1, WriteContextArgs,
 };
 use crate::graph::PortIndexValue;
 
@@ -30,7 +30,7 @@ use crate::graph::PortIndexValue;
 pub const CROSS_SINGLETON: OperatorConstraints = OperatorConstraints {
     name: "cross_singleton",
     categories: &[OperatorCategory::MultiIn],
-    persistence_args: RANGE_0,
+    persistence_args: &(0..=1),
     type_args: RANGE_0,
     hard_range_inn: &(2..=2),
     soft_range_inn: &(2..=2),
@@ -54,10 +54,21 @@ pub const CROSS_SINGLETON: OperatorConstraints = OperatorConstraints {
                    op_span,
                    inputs,
                    is_pull,
+                   op_inst:
+                       OperatorInstance {
+                           generics: OpInstGenerics { persistence_args, .. },
+                           ..
+                       },
                    ..
                },
                _diagnostics| {
         assert!(is_pull);
+
+        let persistence = match persistence_args[..] {
+            [] => Persistence::Tick,
+            [p] => p,
+            _ => panic!(),
+        };
 
         let item_stream = &inputs[0];
         let singleton_stream = &inputs[1];
@@ -67,8 +78,11 @@ pub const CROSS_SINGLETON: OperatorConstraints = OperatorConstraints {
             let mut #singleton_state_ident: ::std::option::Option<_> = ::std::option::Option::None;
         };
 
-        let write_tick_end = quote_spanned! {op_span=>
-            #singleton_state_ident = ::std::option::Option::None;
+        let write_tick_end = match persistence {
+            Persistence::Static => Default::default(),
+            _ => quote_spanned! {op_span=>
+                #singleton_state_ident = ::std::option::Option::None;
+            },
         };
 
         let write_iterator = quote_spanned! {op_span=>

--- a/dfir_rs/tests/surface_cross_singleton.rs
+++ b/dfir_rs/tests/surface_cross_singleton.rs
@@ -69,3 +69,63 @@ pub fn test_union_defer_tick() {
     let out: Vec<_> = collect_ready(&mut egress_rx);
     assert_eq!(out, vec![(1, 0), (2, 0), (3, 0)]);
 }
+
+#[multiplatform_test(test, wasm, env_tracing)]
+pub fn test_static_persistence() {
+    let (input_tx, input_rx) = dfir_rs::util::unbounded_channel::<i32>();
+    let (egress_tx, mut egress_rx) = dfir_rs::util::unbounded_channel();
+
+    let mut df = dfir_syntax! {
+        join = cross_singleton::<'static>();
+        source_stream(input_rx) -> [input]join;
+        source_iter([42]) -> [single]join;
+
+        join -> for_each(|x| egress_tx.send(x).unwrap());
+    };
+
+    // First tick: singleton value is consumed, but no input yet.
+    df.run_available_sync();
+    let out: Vec<_> = collect_ready(&mut egress_rx);
+    assert_eq!(out, []);
+
+    // Second tick: input arrives, singleton state persists from first tick.
+    input_tx.send(1).unwrap();
+    df.run_available_sync();
+    let out: Vec<_> = collect_ready(&mut egress_rx);
+    assert_eq!(out, vec![(1, 42)]);
+
+    // Third tick: more input, singleton still available.
+    input_tx.send(2).unwrap();
+    input_tx.send(3).unwrap();
+    df.run_available_sync();
+    let out: Vec<_> = collect_ready(&mut egress_rx);
+    assert_eq!(out, vec![(2, 42), (3, 42)]);
+}
+
+#[multiplatform_test(test, wasm, env_tracing)]
+pub fn test_tick_persistence_resets() {
+    let (input_tx, input_rx) = dfir_rs::util::unbounded_channel::<i32>();
+    let (single_tx, single_rx) = dfir_rs::util::unbounded_channel::<i32>();
+    let (egress_tx, mut egress_rx) = dfir_rs::util::unbounded_channel();
+
+    let mut df = dfir_syntax! {
+        join = cross_singleton();
+        source_stream(input_rx) -> [input]join;
+        source_stream(single_rx) -> [single]join;
+
+        join -> for_each(|x| egress_tx.send(x).unwrap());
+    };
+
+    // Send singleton and input together.
+    single_tx.send(10).unwrap();
+    input_tx.send(1).unwrap();
+    df.run_available_sync();
+    let out: Vec<_> = collect_ready(&mut egress_rx);
+    assert_eq!(out, vec![(1, 10)]);
+
+    // Next tick: input but no singleton (default 'tick resets state).
+    input_tx.send(2).unwrap();
+    df.run_available_sync();
+    let out: Vec<_> = collect_ready(&mut egress_rx);
+    assert_eq!(out, []);
+}

--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -3693,9 +3693,9 @@ impl HydroNode {
                                 {
                                     builder.add_dfir(
                                         parse_quote! {
-                                            #cross_ident = cross_singleton();
+                                            #cross_ident = cross_singleton::<'static>();
                                             #left_ident -> [input]#cross_ident;
-                                            #right_ident -> persist::<'static>() -> [single]#cross_ident;
+                                            #right_ident -> [single]#cross_ident;
                                         },
                                         None,
                                         Some(&next_stmt_id.to_string()),

--- a/hydro_lang/src/live_collections/singleton.rs
+++ b/hydro_lang/src/live_collections/singleton.rs
@@ -1869,4 +1869,33 @@ mod tests {
 
         assert_eq!(count, 4);
     }
+
+    /// Reproducer for simulator hang when using cross_singleton on a top-level
+    /// unbounded stream (not inside sliced!). The exhaustive simulator hangs
+    /// after the first iteration.
+    #[cfg(feature = "sim")]
+    #[test]
+    fn sim_cross_singleton_top_level_unbounded_hang() {
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<()>();
+
+        let (cmd_port, input) = node.sim_input::<String, _, _>();
+
+        let top_level_singleton = node.singleton(q!(123));
+
+        // cross_singleton on a top-level stream - bug trigger
+        let crossed = input.cross_singleton(top_level_singleton);
+
+        // Output directly
+        let resp_port = crossed.sim_output();
+
+        let count = flow.sim().exhaustive(async || {
+            cmd_port.send("abc".to_owned());
+
+            let responses: Vec<_> = resp_port.collect().await;
+            assert!(!responses.is_empty());
+        });
+
+        assert_eq!(count, 1);
+    }
 }


### PR DESCRIPTION
The exhaustive simulator hung indefinitely because `persist::<'static>()` before
the `[single]` port of `cross_singleton` replayed data into a handoff buffer
every tick, causing the DFIR runtime to always report progress and preventing
quiescence.

- Add `'static` persistence arg support to `cross_singleton` operator in dfir_lang
- Emit `cross_singleton::<'static>()` instead of `persist::<'static>() -> [single]cross_singleton()` for top-level bounded singletons in hydro_lang codegen
- Add regression test in hydro_lang and surface tests in dfir_rs

Co-authored-by: Infinity 🤖 <infinity@hydro.run>