### PR TITLE
feat(variadics)!: `#[no_std]` support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,12 +118,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2465,8 +2459,7 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash",
- "allocator-api2",
+ "rustc-std-workspace-alloc",
 ]
 
 [[package]]
@@ -4827,6 +4820,12 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc-std-workspace-alloc"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d441c3b2ebf55cebf796bfdc265d67fa09db17b7bb6bd4be75c509e1e8fec3"
 
 [[package]]
 name = "rustc_version"

--- a/dfir_rs/tests/surface_lattice_bimorphism.rs
+++ b/dfir_rs/tests/surface_lattice_bimorphism.rs
@@ -9,7 +9,7 @@ use lattices::map_union::{KeyedBimorphism, MapUnionHashMap, MapUnionSingletonMap
 use lattices::set_union::{CartesianProductBimorphism, SetUnionHashSet, SetUnionSingletonSet};
 use multiplatform_test::multiplatform_test;
 use variadics::CloneVariadic;
-use variadics::variadic_collections::VariadicHashSet;
+use variadics::variadic_collections::VariadicHashSetStd;
 
 #[multiplatform_test]
 pub fn test_cartesian_product() {
@@ -166,13 +166,13 @@ pub fn test_cartesian_product_tick_state() {
 
 #[multiplatform_test]
 fn test_ght_join_bimorphism() {
-    type MyGhtATrie = GhtType!(u32, u64, u16 => &'static str: VariadicHashSet);
-    type MyGhtBTrie = GhtType!(u32, u64, u16 => &'static str: VariadicHashSet);
+    type MyGhtATrie = GhtType!(u32, u64, u16 => &'static str: VariadicHashSetStd);
+    type MyGhtBTrie = GhtType!(u32, u64, u16 => &'static str: VariadicHashSetStd);
 
     type JoinSchema = variadics::var_type!(u32, u64, u16, &'static str, &'static str);
 
     type MyNodeBim = <(MyGhtATrie, MyGhtBTrie) as DeepJoinLatticeBimorphism<
-        VariadicHashSet<JoinSchema>,
+        VariadicHashSetStd<JoinSchema>,
     >>::DeepJoinLatticeBimorphism;
     type MyBim = GhtBimorphism<MyNodeBim>;
 

--- a/dfir_rs/tests/surface_lattice_generalized_hash_trie.rs
+++ b/dfir_rs/tests/surface_lattice_generalized_hash_trie.rs
@@ -4,11 +4,11 @@ use dfir_rs::lattices::ght::GeneralizedHashTrieNode;
 use dfir_rs::lattices::ght::lattice::{DeepJoinLatticeBimorphism, GhtBimorphism};
 use dfir_rs::util::collect_ready;
 use dfir_rs::variadics::{var_expr, var_type};
-use variadics::variadic_collections::VariadicHashSet; // Import the Insert trait
+use variadics::variadic_collections::VariadicHashSetStd; // Import the Insert trait
 
 #[test]
 fn test_basic() {
-    type MyGht = GhtType!(u16, u32 => u64: VariadicHashSet);
+    type MyGht = GhtType!(u16, u32 => u64: VariadicHashSetStd);
     type FlatTup = var_type!(u16, u32, u64);
     let input: Vec<FlatTup> = vec![
         var_expr!(42, 314, 43770),
@@ -34,8 +34,8 @@ fn test_basic() {
 
 #[test]
 fn test_join() {
-    type MyGht = GhtType!(u8 => u16: VariadicHashSet);
-    type ResultGht = GhtType!(u8 => u16, u16: VariadicHashSet);
+    type MyGht = GhtType!(u8 => u16: VariadicHashSetStd);
+    type ResultGht = GhtType!(u8 => u16, u16: VariadicHashSetStd);
     let (out_send, out_recv) = dfir_rs::util::unbounded_channel::<_>();
 
     let r = vec![
@@ -47,7 +47,7 @@ fn test_join() {
     let s = vec![var_expr!(1, 10), var_expr!(5, 50)];
 
     type MyNodeBim = <(MyGht, MyGht) as DeepJoinLatticeBimorphism<
-        VariadicHashSet<var_type!(u8, u16, u16)>,
+        VariadicHashSetStd<var_type!(u8, u16, u16)>,
     >>::DeepJoinLatticeBimorphism;
     type MyBim = GhtBimorphism<MyNodeBim>;
 

--- a/lattices/src/ght/macros.rs
+++ b/lattices/src/ght/macros.rs
@@ -41,14 +41,14 @@ macro_rules! GhtTypeWithSchema {
 /// # Example
 /// ```
 /// use lattices::GhtType;
-/// use variadics::variadic_collections::VariadicHashSet;
+/// use variadics::variadic_collections::VariadicHashSetStd;
 ///
-/// // This generates a Ght struct with (u16, u32) as key, (u64) as val, and VariadicHashSet as storage
-/// type MyHashGht = GhtType!(u16, u32 => u64: VariadicHashSet);
+/// // This generates a Ght struct with (u16, u32) as key, (u64) as val, and VariadicHashSetStd as storage
+/// type MyHashGht = GhtType!(u16, u32 => u64: VariadicHashSetStd);
 /// let my_ght = MyHashGht::default();
 ///
-/// /// // This generates a Ght struct with (u16, u32) as key, () as val, and VariadicCountedHashSet as storage
-/// type MyMultisetGht = GhtType!(u16, u32 => (): VariadicCountedHashSet);
+/// /// // This generates a Ght struct with (u16, u32) as key, () as val, and VariadicCountedHashSetStd as storage
+/// type MyMultisetGht = GhtType!(u16, u32 => (): VariadicCountedHashSetStd);
 /// let my_ght = MyMultisetGht::default();
 ///
 /// // This generates a Ght struct with (u16, u32) as key, () as val, and VariadicColumnSet as storage

--- a/lattices/src/ght/test.rs
+++ b/lattices/src/ght/test.rs
@@ -11,7 +11,7 @@ mod tests {
         use crate::ght::GeneralizedHashTrieNode;
 
         // Example usage
-        type MyTrie1 = GhtType!(u32, u32 => &'static str: VariadicCountedHashSet);
+        type MyTrie1 = GhtType!(u32, u32 => &'static str: VariadicCountedHashSetStd);
 
         fn ght_type<T: GeneralizedHashTrieNode>() {}
         ght_type::<MyTrie1>();
@@ -20,12 +20,12 @@ mod tests {
         assert!(htrie1.contains(var_expr!(&42, &314, &"hello")));
         assert_eq!(htrie1.recursive_iter().count(), 1);
 
-        type MyTrie2 = GhtType!(u32 => u32: VariadicCountedHashSet);
+        type MyTrie2 = GhtType!(u32 => u32: VariadicCountedHashSetStd);
         let htrie2 = MyTrie2::new_from(vec![var_expr!(42, 314)]);
         assert!(htrie2.contains(var_expr!(&42, &314)));
         assert_eq!(htrie1.recursive_iter().count(), 1);
 
-        type MyTrie3 = GhtType!(u32, u64, u16 => &'static str: VariadicCountedHashSet);
+        type MyTrie3 = GhtType!(u32, u64, u16 => &'static str: VariadicCountedHashSetStd);
         let htrie3 = MyTrie3::new_from(vec![
             var_expr!(123, 2, 5, "hello"),
             var_expr!(50, 1, 1, "hi"),
@@ -43,44 +43,47 @@ mod tests {
         use crate::ght::GeneralizedHashTrieNode;
 
         // 0 => 1
-        type LilTrie = GhtType!(() => u32: VariadicCountedHashSet);
+        type LilTrie = GhtType!(() => u32: VariadicCountedHashSetStd);
         let _j = LilTrie::default();
         let _l = LilTrie::new_from(vec![var_expr!(1)]);
 
         // 0 => >1
-        type LilTrie2 = GhtType!(() => u32, u64: VariadicCountedHashSet);
+        type LilTrie2 = GhtType!(() => u32, u64: VariadicCountedHashSetStd);
         let _l = LilTrie2::default();
         let _l = LilTrie2::new_from(vec![var_expr!(1, 1)]);
 
         // 1 => 0
-        type KeyNoValTrie = GhtType!(u32 => (): VariadicCountedHashSet);
+        type KeyNoValTrie = GhtType!(u32 => (): VariadicCountedHashSetStd);
         let l = KeyNoValTrie::new_from(vec![var_expr!(1)]);
         let _: KeyNoValTrie = l;
 
         // 1 => 1
-        type SmallTrie = GhtType!(u32 => &'static str: VariadicCountedHashSet);
-        type SmallKeyedTrie = GhtType!(u32 => &'static str: VariadicCountedHashSet);
+        type SmallTrie = GhtType!(u32 => &'static str: VariadicCountedHashSetStd);
+        type SmallKeyedTrie = GhtType!(u32 => &'static str: VariadicCountedHashSetStd);
         let l = SmallTrie::new_from(vec![var_expr!(1, "hello")]);
         let _: SmallKeyedTrie = l;
 
         // 1 => >1
-        type SmallKeyLongValTrie = GhtType!(u32 => u64, u16, &'static str: VariadicCountedHashSet);
+        type SmallKeyLongValTrie =
+            GhtType!(u32 => u64, u16, &'static str: VariadicCountedHashSetStd);
         let _x = SmallKeyLongValTrie::new_from(vec![var_expr!(1, 999, 222, "hello")]);
 
         // >1 => 0
-        type LongKeyNoValTrie = GhtType!(u32, u64 => (): VariadicCountedHashSet);
+        type LongKeyNoValTrie = GhtType!(u32, u64 => (): VariadicCountedHashSetStd);
         let l = LongKeyNoValTrie::new_from(vec![var_expr!(1, 999)]);
         let _: LongKeyNoValTrie = l;
 
         // >1 => 1
-        type LongKeySmallValTrie = GhtType!(u32, u16 => &'static str: VariadicCountedHashSet);
-        type LongKeySmallValKeyedTrie = GhtType!(u32, u16 => &'static str: VariadicCountedHashSet);
+        type LongKeySmallValTrie = GhtType!(u32, u16 => &'static str: VariadicCountedHashSetStd);
+        type LongKeySmallValKeyedTrie =
+            GhtType!(u32, u16 => &'static str: VariadicCountedHashSetStd);
         let x = LongKeySmallValTrie::new_from(vec![var_expr!(1, 314, "hello")]);
         let _: LongKeySmallValKeyedTrie = x;
         let _ = LongKeySmallValTrie::new_from(vec![var_expr!(1, 314, "hello")]);
 
         // >1 => >1
-        type LongKeyLongValTrie = GhtType!(u32, u64 => u16, &'static str: VariadicCountedHashSet);
+        type LongKeyLongValTrie =
+            GhtType!(u32, u64 => u16, &'static str: VariadicCountedHashSetStd);
         let _x = LongKeyLongValTrie::new_from(vec![var_expr!(1, 999, 222, "hello")]);
     }
 
@@ -91,7 +94,7 @@ mod tests {
         use crate::GhtType;
         use crate::ght::GeneralizedHashTrieNode;
 
-        type MyGht = GhtType!(u16, u32 => u64: VariadicCountedHashSet);
+        type MyGht = GhtType!(u16, u32 => u64: VariadicCountedHashSetStd);
         let mut htrie = MyGht::default();
         htrie.insert(var_expr!(42, 314, 43770));
         assert_eq!(htrie.recursive_iter().count(), 1);
@@ -106,7 +109,8 @@ mod tests {
         assert!(htrie.contains(var_expr!(&42, &315, &43770)));
         assert!(htrie.contains(var_expr!(&43, &10, &600)));
 
-        type LongKeyLongValTrie = GhtType!(u32, u64 => u16, &'static str: VariadicCountedHashSet);
+        type LongKeyLongValTrie =
+            GhtType!(u32, u64 => u16, &'static str: VariadicCountedHashSetStd);
         let mut htrie = LongKeyLongValTrie::new_from(vec![var_expr!(1, 999, 222, "hello")]);
         htrie.insert(var_expr!(1, 999, 111, "bye"));
         htrie.insert(var_expr!(1, 1000, 123, "cya"));
@@ -122,7 +126,7 @@ mod tests {
         use crate::GhtType;
         use crate::ght::GeneralizedHashTrieNode;
 
-        type MyGht = GhtType!(bool, usize, &'static str => i32: VariadicCountedHashSet);
+        type MyGht = GhtType!(bool, usize, &'static str => i32: VariadicCountedHashSetStd);
         let mut htrie = MyGht::new_from(vec![var_expr!(true, 1, "hello", -5)]);
         assert_eq!(htrie.recursive_iter().count(), 1);
         for i in 1..1000000 {
@@ -138,7 +142,7 @@ mod tests {
         use crate::GhtType;
         use crate::ght::GeneralizedHashTrieNode;
 
-        type MyGht = GhtType!(u16, u32 => u64: VariadicCountedHashSet);
+        type MyGht = GhtType!(u16, u32 => u64: VariadicCountedHashSetStd);
         let htrie = MyGht::new_from(vec![var_expr!(42_u16, 314_u32, 43770_u64)]);
         let x = var_expr!(&42, &314, &43770);
         assert!(htrie.contains(x));
@@ -156,7 +160,7 @@ mod tests {
         use crate::GhtType;
         use crate::ght::{GeneralizedHashTrieNode, GhtGet};
 
-        type MyGht = GhtType!(u32, u32 => u32: VariadicCountedHashSet);
+        type MyGht = GhtType!(u32, u32 => u32: VariadicCountedHashSetStd);
         let ht_root = MyGht::new_from(vec![var_expr!(42, 314, 43770)]);
 
         let inner = ht_root.get(&42).unwrap();
@@ -174,7 +178,7 @@ mod tests {
 
         use crate::GhtType;
         use crate::ght::{GeneralizedHashTrieNode, GhtGet};
-        type MyGht = GhtType!(u32, u32 => u32: VariadicCountedHashSet);
+        type MyGht = GhtType!(u32, u32 => u32: VariadicCountedHashSetStd);
         let ht_root = MyGht::new_from(vec![var_expr!(42, 314, 43770)]);
         let inner_key = ht_root.iter().next().unwrap();
         let inner = ht_root.get(&inner_key).unwrap();
@@ -195,7 +199,7 @@ mod tests {
         use crate::GhtType;
         use crate::ght::GeneralizedHashTrieNode;
 
-        type MyGht = GhtType!(u32, u32 => u32: VariadicCountedHashSet);
+        type MyGht = GhtType!(u32, u32 => u32: VariadicCountedHashSetStd);
         type InputType = var_type!(u32, u32, u32);
         type ResultType<'a> = var_type!(&'a u32, &'a u32, &'a u32);
         let input: HashSet<InputType> = HashSet::from_iter(
@@ -220,7 +224,7 @@ mod tests {
 
     #[test]
     fn test_prefix_iter_leaf() {
-        use variadics::variadic_collections::VariadicCountedHashSet;
+        use variadics::variadic_collections::VariadicCountedHashSetStd;
         use variadics::{var_expr, var_type};
 
         use crate::ght::{GeneralizedHashTrieNode, GhtLeaf, GhtPrefixIter};
@@ -239,7 +243,7 @@ mod tests {
             .map(|&(a, b, c)| var_expr!(a, b, c)),
         );
         let leaf =
-            GhtLeaf::<InputType, var_type!(u16, u32), VariadicCountedHashSet<InputType>>::new_from(
+            GhtLeaf::<InputType, var_type!(u16, u32), VariadicCountedHashSetStd<InputType>>::new_from(
                 input.clone(),
             );
         // let key = var_expr!(42u8).as_ref_var();
@@ -264,7 +268,7 @@ mod tests {
         use crate::GhtType;
         use crate::ght::{GeneralizedHashTrieNode, GhtPrefixIter};
 
-        type MyGht = GhtType!(u8, u16 => u32: VariadicCountedHashSet);
+        type MyGht = GhtType!(u8, u16 => u32: VariadicCountedHashSetStd);
         type InputType = var_type!(u8, u16, u32);
         type ResultType<'a> = var_type!(&'a u8, &'a u16, &'a u32);
         let input: HashSet<InputType> = HashSet::from_iter(
@@ -307,7 +311,7 @@ mod tests {
         use crate::GhtType;
         use crate::ght::{GeneralizedHashTrieNode, GhtPrefixIter};
 
-        type MyGht = GhtType!(bool, u32, &'static str => i32: VariadicCountedHashSet);
+        type MyGht = GhtType!(bool, u32, &'static str => i32: VariadicCountedHashSetStd);
         type InputType = var_type!(bool, u32, &'static str, i32);
         type ResultType<'a> = var_type!(&'a bool, &'a u32, &'a &'static str, &'a i32);
         let input: HashSet<InputType> = HashSet::from_iter(
@@ -361,7 +365,7 @@ mod tests {
         use crate::ght::GeneralizedHashTrieNode;
         use crate::{GhtType, Merge};
 
-        type MyGht = GhtType!(u32, u64 => u16, &'static str: VariadicHashSet);
+        type MyGht = GhtType!(u32, u64 => u16, &'static str: VariadicHashSetStd);
 
         let mut test_ght1 = MyGht::new_from(vec![var_expr!(42, 314, 10, "hello")]);
         let test_ght2 = MyGht::new_from(vec![var_expr!(42, 314, 10, "hello")]);
@@ -405,8 +409,8 @@ mod tests {
         use crate::ght::GeneralizedHashTrieNode;
         use crate::{GhtType, NaiveLatticeOrd};
 
-        type MyGht = GhtType!(u32, u64 => u16, &'static str: VariadicHashSet);
-        type MyGhtNode = GhtType!(u32, u64 => u16, &'static str: VariadicHashSet);
+        type MyGht = GhtType!(u32, u64 => u16, &'static str: VariadicHashSetStd);
+        type MyGhtNode = GhtType!(u32, u64 => u16, &'static str: VariadicHashSetStd);
 
         let mut test_vec: Vec<MyGhtNode> = Vec::new();
 
@@ -437,8 +441,8 @@ mod tests {
         use crate::ght::lattice::GhtCartesianProductBimorphism;
         use crate::{GhtType, LatticeBimorphism};
 
-        type MyGhtA = GhtType!(u32, u64 => u16, &'static str: VariadicHashSet);
-        type MyGhtB = GhtType!(u32, u64, u16 => &'static str: VariadicHashSet);
+        type MyGhtA = GhtType!(u32, u64 => u16, &'static str: VariadicHashSetStd);
+        type MyGhtB = GhtType!(u32, u64, u16 => &'static str: VariadicHashSetStd);
 
         let mut ght_a = MyGhtA::default();
         let mut ght_b = MyGhtB::default();
@@ -450,7 +454,7 @@ mod tests {
         ght_b.insert(var_expr!(10, 1, 2, "hi"));
         ght_b.insert(var_expr!(12, 10, 98, "bye"));
 
-        type MyGhtAb = GhtType!(u32, u64, u16, &'static str, u32, u64 => u16, &'static str: VariadicCountedHashSet);
+        type MyGhtAb = GhtType!(u32, u64, u16, &'static str, u32, u64 => u16, &'static str: VariadicCountedHashSetStd);
 
         let mut bim = GhtCartesianProductBimorphism::<MyGhtAb>::default();
         let ght_out = bim.call(&ght_a, &ght_b);
@@ -462,7 +466,7 @@ mod tests {
 
     #[test]
     fn test_join_bimorphism() {
-        use variadics::variadic_collections::{VariadicCountedHashSet, VariadicHashSet};
+        use variadics::variadic_collections::{VariadicCountedHashSetStd, VariadicHashSetStd};
         use variadics::{var_expr, var_type};
 
         use crate::ght::lattice::{
@@ -479,8 +483,8 @@ mod tests {
             &'a &'static str,
             &'a &'static str
         );
-        type MyGhtATrie = GhtType!(u32, u64, u16 => &'static str: VariadicHashSet);
-        type MyGhtBTrie = GhtType!(u32, u64, u16 => &'static str: VariadicHashSet);
+        type MyGhtATrie = GhtType!(u32, u64, u16 => &'static str: VariadicHashSetStd);
+        type MyGhtBTrie = GhtType!(u32, u64, u16 => &'static str: VariadicHashSetStd);
 
         let mut ght_a = MyGhtATrie::default();
         let mut ght_b = MyGhtBTrie::default();
@@ -508,7 +512,7 @@ mod tests {
                 GhtLeaf<
                     ResultSchemaType,
                     var_type!(&'static str),
-                    VariadicCountedHashSet<ResultSchemaType>,
+                    VariadicCountedHashSetStd<ResultSchemaType>,
                 >,
             >;
             // let mut bim = GhtNodeKeyedBimorphism::new(GhtNodeKeyedBimorphism::new(
@@ -525,7 +529,7 @@ mod tests {
             // Here we use DeepJoinLatticeBimorphism as a more compact representation of the
             // manual stack of bimorphisms above. This is the recommended approach.
             type MyNodeBim<'a> = <(MyGhtATrie, MyGhtBTrie) as DeepJoinLatticeBimorphism<
-                VariadicHashSet<ResultSchemaType>,
+                VariadicHashSetStd<ResultSchemaType>,
             >>::DeepJoinLatticeBimorphism;
             let mut bim = <MyNodeBim as Default>::default();
             let out = bim.call(&ght_a, &ght_b);
@@ -542,7 +546,7 @@ mod tests {
         use crate::GhtType;
         use crate::ght::GeneralizedHashTrieNode;
 
-        type MyRoot = GhtType!(u16, u32 => u64: VariadicCountedHashSet);
+        type MyRoot = GhtType!(u16, u32 => u64: VariadicCountedHashSetStd);
 
         let mut trie1 = MyRoot::default();
         assert_eq!(3, <<MyRoot as GeneralizedHashTrieNode>::Schema>::LEN);
@@ -562,7 +566,7 @@ mod tests {
         use crate::ght::{GeneralizedHashTrieNode, GhtPrefixIter};
 
         const MATCHES: u32 = 1000;
-        type MyGht = GhtType!(u32 => u32: VariadicCountedHashSet);
+        type MyGht = GhtType!(u32 => u32: VariadicCountedHashSetStd);
 
         let r_iter = (0..MATCHES)
             .map(|i| (0, i))
@@ -674,7 +678,7 @@ mod tests {
         const MATCHES: usize = 1000;
         let (r_iter, s_iter, t_iter) = clover_setup(MATCHES);
 
-        type MyGht = GhtType!(u32 => u32: VariadicCountedHashSet);
+        type MyGht = GhtType!(u32 => u32: VariadicCountedHashSetStd);
         let rx_ght = MyGht::new_from(r_iter.map(|(x, a)| var_expr!(x, a)));
         let sx_ght = MyGht::new_from(s_iter.map(|(x, b)| var_expr!(x, b)));
         let tx_ght = MyGht::new_from(t_iter.map(|(x, c)| var_expr!(x, c)));
@@ -705,8 +709,8 @@ mod tests {
         const MATCHES: usize = 1000;
         let (r_iter, s_iter, t_iter) = clover_setup(MATCHES);
 
-        type Ght1 = GhtType!(() => u32, u32: VariadicCountedHashSet);
-        type Ght2 = GhtType!(u32 => u32: VariadicCountedHashSet);
+        type Ght1 = GhtType!(() => u32, u32: VariadicCountedHashSetStd);
+        type Ght2 = GhtType!(u32 => u32: VariadicCountedHashSetStd);
         let rx_ght = Ght1::new_from(r_iter.map(|(x, a)| var_expr!(x, a)));
         let sx_ght = Ght2::new_from(s_iter.map(|(x, b)| var_expr!(x, b)));
         let tx_ght = Ght2::new_from(t_iter.map(|(x, c)| var_expr!(x, c)));
@@ -735,7 +739,7 @@ mod tests {
         use crate::ght::GeneralizedHashTrieNode;
         use crate::ght::colt::ColtForestNode;
 
-        type LeafType = GhtType!(() => u16, u32, u64: VariadicCountedHashSet);
+        type LeafType = GhtType!(() => u16, u32, u64: VariadicCountedHashSetStd);
         let n = LeafType::new_from(vec![
             var_expr!(1, 1, 1),
             var_expr!(1, 2, 2),

--- a/variadics/Cargo.toml
+++ b/variadics/Cargo.toml
@@ -16,11 +16,12 @@ all-features = true
 
 [features]
 default = ["std"]
-std = []
+std = ["alloc"]
+alloc = ["hashbrown/alloc"]
 
 [dependencies]
 sealed = "0.6.0"
-hashbrown = "0.14.0"
+hashbrown = { version = "0.14.0", default-features = false }
 
 # coax cargo-smart-release into publishing this crate.
 # https://github.com/hydro-project/hydro/blob/main/RELEASING.md#addendum-adding-new-crates

--- a/variadics/src/lib.rs
+++ b/variadics/src/lib.rs
@@ -1,4 +1,6 @@
+#![no_std]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
 //! &nbsp;
 //!
@@ -10,17 +12,16 @@
 #![doc = include_str!("../var_type.md")]
 //! ## [`var_args!`]
 #![doc = include_str!("../var_args.md")]
-#![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(not(any(test, feature = "std")), no_std)]
 
+#[cfg(any(test, feature = "alloc"))]
 extern crate alloc;
+#[cfg(any(test, feature = "std"))]
+extern crate std;
 
 use core::any::Any;
 
 use sealed::sealed;
-/// module of collection types for variadics
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-#[cfg(feature = "std")]
+/// Module of collection types for variadics
 pub mod variadic_collections;
 
 #[doc = include_str!("../var_expr.md")]
@@ -195,12 +196,12 @@ pub trait VariadicExt: Variadic {
     fn into_option(self) -> Self::IntoOption;
 
     /// type for all elements of the variadic being wrapped in `Vec`
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    #[cfg(feature = "alloc")]
     type IntoVec: VecVariadic<UnVec = Self> + Default;
     /// wrap all elements of the variadic in a `Vec`
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    #[cfg(feature = "alloc")]
     fn into_singleton_vec(self) -> Self::IntoVec;
 }
 
@@ -287,12 +288,12 @@ where
         var_expr!(Some(item), ...rest.into_option())
     }
 
-    #[cfg(feature = "std")]
-    type IntoVec = (Vec<Item>, Rest::IntoVec);
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
+    type IntoVec = (alloc::vec::Vec<Item>, Rest::IntoVec);
+    #[cfg(feature = "alloc")]
     fn into_singleton_vec(self) -> Self::IntoVec {
         let var_args!(item, ...rest) = self;
-        var_expr!(vec!(item), ...rest.into_singleton_vec())
+        var_expr!(alloc::vec!(item), ...rest.into_singleton_vec())
     }
 }
 
@@ -346,9 +347,9 @@ impl VariadicExt for () {
     type IntoOption = ();
     fn into_option(self) -> Self::IntoOption {}
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     type IntoVec = ();
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn into_singleton_vec(self) -> Self::IntoVec {}
 }
 
@@ -771,7 +772,7 @@ where
 }
 
 /// Trait for Variadic of vecs, as formed by `VariadicExt::into_vec()`.
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 #[sealed]
 pub trait VecVariadic: VariadicExt {
     /// Individual variadic items without the Vec wrapper
@@ -801,9 +802,9 @@ pub trait VecVariadic: VariadicExt {
         R: core::ops::RangeBounds<usize> + Clone;
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 #[sealed]
-impl<Item, Rest> VecVariadic for (Vec<Item>, Rest)
+impl<Item, Rest> VecVariadic for (alloc::vec::Vec<Item>, Rest)
 where
     Rest: VecVariadic,
 {
@@ -849,7 +850,7 @@ where
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 #[sealed]
 impl VecVariadic for () {
     type UnVec = ();
@@ -912,16 +913,24 @@ mod test {
     type _ListB = var_type!(..._ListA, bool, Option<()>);
     type _ListC = var_type!(..._ListA, bool, Option::<()>);
 
+    #[cfg(feature = "alloc")]
     #[test]
     fn test_as_ref_var() {
+        use alloc::borrow::ToOwned;
+        use alloc::boxed::Box;
+
         let my_owned = var_expr!("Hello".to_owned(), Box::new(5));
         let my_ref_a = my_owned.as_ref_var();
         let my_ref_b = my_owned.as_ref_var();
         assert_eq!(my_ref_a, my_ref_b);
     }
 
+    #[cfg(feature = "alloc")]
     #[test]
     fn test_as_mut_var() {
+        use alloc::borrow::ToOwned;
+        use alloc::boxed::Box;
+
         let mut my_owned = var_expr!("Hello".to_owned(), Box::new(5));
         let var_args!(mut_str, mut_box) = my_owned.as_mut_var();
         *mut_str += " World";
@@ -930,8 +939,12 @@ mod test {
         assert_eq!(var_expr!("Hello World".to_owned(), Box::new(6)), my_owned);
     }
 
+    #[cfg(feature = "alloc")]
     #[test]
     fn test_iter_any() {
+        use alloc::borrow::ToOwned;
+        use alloc::string::String;
+
         let mut var = var_expr!(1_i32, false, "Hello".to_owned());
 
         let mut mut_iter = var.iter_any_mut();
@@ -973,9 +986,12 @@ mod test {
         }
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     #[test]
     fn test_into_vec() {
+        use alloc::borrow::ToOwned;
+        use alloc::string::String;
+
         use crate::VecVariadic;
 
         type Item = var_type!(i32, String);
@@ -989,8 +1005,12 @@ mod test {
     }
 }
 
+#[cfg(feature = "alloc")]
 #[test]
 fn test_eq_ref_vec() {
+    use alloc::vec;
+    use alloc::vec::Vec;
+
     type MyVar = var_type!(i32, bool, &'static str);
     let vec: Vec<MyVar> = vec![
         var_expr!(0, true, "hello"),
@@ -1015,8 +1035,12 @@ fn test_eq_ref_vec() {
     );
 }
 
+#[cfg(feature = "alloc")]
 #[test]
 fn clone_var_test() {
+    use alloc::borrow::ToOwned;
+    use alloc::{format, vec};
+
     let ref_var = var_expr!(&1, &format!("hello {}", "world"), &vec![1, 2, 3]);
     let clone_var = CloneVariadic::clone_ref_var(ref_var);
     assert_eq!(

--- a/variadics/src/variadic_collections.rs
+++ b/variadics/src/variadic_collections.rs
@@ -1,9 +1,11 @@
-use std::fmt;
-use std::hash::{BuildHasher, Hash, RandomState};
+use core::fmt;
+use core::hash::{BuildHasher, Hash};
 
 use hashbrown::hash_table::{Entry, HashTable};
 
-use crate::{PartialEqVariadic, VariadicExt, VecVariadic};
+#[cfg(feature = "alloc")]
+use crate::VecVariadic;
+use crate::{PartialEqVariadic, VariadicExt};
 
 /// Trait for a set of Variadic Tuples
 pub trait VariadicCollection: Extend<Self::Schema> {
@@ -32,34 +34,44 @@ pub trait VariadicCollection: Extend<Self::Schema> {
 /// trait for sets or multisets of variadics
 pub trait VariadicSet: VariadicCollection {}
 
+/// Default implementation of a set.
+#[cfg(feature = "std")]
+pub type VariadicHashSetStd<T> = VariadicHashSet<T, std::hash::RandomState>;
+
 /// HashSet that stores Variadics of owned values but allows
 /// for lookups with RefVariadics as well
 #[derive(Clone)]
-pub struct VariadicHashSet<T, S = RandomState> {
+pub struct VariadicHashSet<T, S> {
     table: HashTable<T>,
     hasher: S,
 }
 
-impl<T> VariadicHashSet<T> {
+#[cfg(feature = "std")]
+impl<T> VariadicHashSet<T, std::hash::RandomState> {
     /// Creates a new `VariadicHashSet` with a default hasher.
     pub fn new() -> Self {
         Self {
             table: HashTable::new(),
-            hasher: RandomState::default(),
+            hasher: std::hash::RandomState::default(),
         }
     }
 }
 
-impl<T> Default for VariadicHashSet<T> {
+impl<T, S> Default for VariadicHashSet<T, S>
+where
+    S: Default,
+{
     fn default() -> Self {
-        Self::new()
+        Self::with_hasher(S::default())
     }
 }
 
-impl<T> fmt::Debug for VariadicHashSet<T>
+#[cfg(feature = "alloc")]
+impl<T, S> fmt::Debug for VariadicHashSet<T, S>
 where
     T: fmt::Debug + VariadicExt + PartialEqVariadic + Eq + Hash,
     for<'a> T::AsRefVar<'a>: Hash + fmt::Debug,
+    S: BuildHasher,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_set().entries(self.iter()).finish()
@@ -218,13 +230,17 @@ where
     }
 }
 
+/// Default implementation of a counted set.
+#[cfg(feature = "std")]
+pub type VariadicCountedHashSetStd<K> = VariadicCountedHashSet<K, std::hash::RandomState>;
+
 /// Trait for a multiset of Tuples
 pub trait VariadicMultiset: VariadicCollection {}
 
 /// HashMap keyed on Variadics of (owned value, count) pairs, allows
 /// for lookups with RefVariadics.
 #[derive(Clone)]
-pub struct VariadicCountedHashSet<K, S = RandomState>
+pub struct VariadicCountedHashSet<K, S>
 where
     K: VariadicExt,
 {
@@ -233,7 +249,8 @@ where
     len: usize,
 }
 
-impl<K> VariadicCountedHashSet<K>
+#[cfg(feature = "std")]
+impl<K> VariadicCountedHashSet<K, std::hash::RandomState>
 where
     K: VariadicExt,
 {
@@ -241,22 +258,24 @@ where
     pub fn new() -> Self {
         Self {
             table: HashTable::new(),
-            hasher: RandomState::default(),
+            hasher: std::hash::RandomState::default(),
             len: 0,
         }
     }
 }
 
-impl<K> Default for VariadicCountedHashSet<K>
+impl<K, S> Default for VariadicCountedHashSet<K, S>
 where
     K: VariadicExt,
+    S: Default,
 {
     fn default() -> Self {
-        Self::new()
+        Self::with_hasher(S::default())
     }
 }
 
-impl<K> fmt::Debug for VariadicCountedHashSet<K>
+#[cfg(feature = "alloc")]
+impl<K, S> fmt::Debug for VariadicCountedHashSet<K, S>
 where
     K: fmt::Debug + VariadicExt + PartialEqVariadic,
     for<'a> K::AsRefVar<'a>: Hash + fmt::Debug,
@@ -339,7 +358,7 @@ where
 {
 }
 
-impl<T> IntoIterator for VariadicCountedHashSet<T>
+impl<T, S> IntoIterator for VariadicCountedHashSet<T, S>
 where
     T: VariadicExt + PartialEqVariadic + Clone,
 {
@@ -475,6 +494,7 @@ where
 
 /// Column storage for Variadic tuples of type Schema
 /// An alternative to VariadicHashMultiset
+#[cfg(feature = "alloc")]
 #[derive(Clone)]
 pub struct VariadicColumnMultiset<Schema>
 where
@@ -484,6 +504,7 @@ where
     last_offset: usize,
 }
 
+#[cfg(feature = "alloc")]
 impl<T> VariadicColumnMultiset<T>
 where
     T: VariadicExt + Eq + Hash,
@@ -497,6 +518,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<T> Default for VariadicColumnMultiset<T>
 where
     T: VariadicExt + Eq + Hash,
@@ -506,6 +528,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<Schema> VariadicCollection for VariadicColumnMultiset<Schema>
 where
     Schema: PartialEqVariadic + Eq + Hash,
@@ -546,6 +569,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<Schema> VariadicMultiset for VariadicColumnMultiset<Schema>
 where
     Schema: PartialEqVariadic + Eq + Hash,
@@ -553,6 +577,7 @@ where
 {
 }
 
+#[cfg(feature = "alloc")]
 impl<T> fmt::Debug for VariadicColumnMultiset<T>
 where
     T: fmt::Debug + VariadicExt + PartialEqVariadic + Eq + Hash,
@@ -563,6 +588,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<Schema> IntoIterator for VariadicColumnMultiset<Schema>
 where
     Schema: PartialEqVariadic + Eq + Hash,
@@ -576,6 +602,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<K> Extend<K> for VariadicColumnMultiset<K>
 where
     K: Eq + Hash + PartialEqVariadic,
@@ -589,6 +616,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 #[cfg(test)]
 mod test {
     use super::*;
@@ -598,6 +626,9 @@ mod test {
 
     #[test]
     fn test_collections() {
+        use std::vec;
+        use std::vec::Vec;
+
         let test_data: Vec<TestSchema> = vec![
             var_expr!(1, 1, 1, "hello"),
             var_expr!(1, 1, 1, "hello"),
@@ -605,9 +636,9 @@ mod test {
             var_expr!(1, 1, 2, "world"),
         ];
 
-        let mut hash_set: VariadicHashSet<TestSchema> = Default::default();
+        let mut hash_set: VariadicHashSet<TestSchema, _> = VariadicHashSet::new();
         hash_set.extend(test_data.clone());
-        let mut multi_set: VariadicCountedHashSet<TestSchema> = Default::default();
+        let mut multi_set: VariadicCountedHashSet<TestSchema, _> = VariadicCountedHashSet::new();
         let hash = multi_set
             .hasher
             .hash_one(var_expr!(1, 1, 1, "world").as_ref_var());


### PR DESCRIPTION
Adds default `std` and `alloc` features

BREAKING CHANGE: `VariadicCountedHashSet` now must have both parameters supplied, use `VariadicCountedHashSetStd` for only one.
BREAKING CHANGE: `VariadicHashSet` now must have both parameters supplied, use `VariadicHashSetStd` for only one.