### PR TITLE
fix(hydro_lang/sim): unify atomic ticks through Chain/MergeOrdered nodes

### DIFF
--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -1837,16 +1837,44 @@ pub fn unify_atomic_ticks(ir: &mut [HydroRoot]) {
     transform_bottom_up(
         ir,
         &mut |_| {},
-        &mut |node: &mut HydroNode| {
-            if let HydroNode::Batch { inner, metadata } | HydroNode::YieldConcat { inner, metadata } =
-                node
-                && let (Some(a), Some(b)) = (
+        &mut |node: &mut HydroNode| match node {
+            HydroNode::Batch { inner, metadata } | HydroNode::YieldConcat { inner, metadata } => {
+                if let (Some(a), Some(b)) = (
                     tick_of(&inner.metadata().location_id),
                     tick_of(&metadata.location_id),
-                )
-            {
-                uf_union(&mut uf, a, b);
+                ) {
+                    uf_union(&mut uf, a, b);
+                }
             }
+            HydroNode::Chain {
+                first,
+                second,
+                metadata,
+            }
+            | HydroNode::ChainFirst {
+                first,
+                second,
+                metadata,
+            }
+            | HydroNode::MergeOrdered {
+                first,
+                second,
+                metadata,
+            } => {
+                if let (Some(a), Some(b)) = (
+                    tick_of(&first.metadata().location_id),
+                    tick_of(&metadata.location_id),
+                ) {
+                    uf_union(&mut uf, a, b);
+                }
+                if let (Some(a), Some(b)) = (
+                    tick_of(&second.metadata().location_id),
+                    tick_of(&metadata.location_id),
+                ) {
+                    uf_union(&mut uf, a, b);
+                }
+            }
+            _ => {}
         },
         false,
     );

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -4563,4 +4563,27 @@ mod tests {
                 .await;
         });
     }
+
+    #[cfg(feature = "sim")]
+    #[test]
+    fn sim_merge_unordered_independent_atomics() {
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<()>();
+
+        let (in1_send, input1) = node.sim_input::<_, TotalOrder, _>();
+        let (in2_send, input2) = node.sim_input::<_, TotalOrder, _>();
+
+        let out = input1
+            .atomic()
+            .merge_unordered(input2.atomic())
+            .end_atomic()
+            .sim_output();
+
+        flow.sim().exhaustive(async || {
+            in1_send.send(1);
+            in2_send.send(2);
+
+            out.assert_yields_only_unordered(vec![1, 2]).await;
+        });
+    }
 }


### PR DESCRIPTION
The unify_atomic_ticks pass only unified tick IDs connected through Batch and
YieldConcat nodes. When two streams were independently made .atomic() and then
merged via merge_unordered (Chain), their tick IDs were never unified, causing
codegen to reference missing identifiers across separate tick graphs.

Extended the unification pass to also unify tick IDs through Chain, ChainFirst,
and MergeOrdered nodes. Added a reproducing sim test.

Co-authored-by: Infinity 🤖 <infinity@hydro.run>