### PR TITLE
feat(dfir_lang): add vec handoff reference support via `#var` and `#mut var` syntax

### DIFF
--- a/dfir_lang/src/graph/flat_graph_builder.rs
+++ b/dfir_lang/src/graph/flat_graph_builder.rs
@@ -837,13 +837,10 @@ impl FlatGraphBuilder {
                                 // Error already emitted by `connect_operator_links`, "Cannot find referenced name...".
                                 continue;
                             };
-                            // HandoffKind::Option nodes are valid singleton reference targets.
+                            // Handoff nodes (Option or Vec) are valid reference targets.
                             if matches!(
                                 self.flat_graph.node(singleton_node_id),
-                                GraphNode::Handoff {
-                                    kind: HandoffKind::Option,
-                                    ..
-                                }
+                                GraphNode::Handoff { .. }
                             ) {
                                 continue;
                             }
@@ -884,8 +881,8 @@ impl FlatGraphBuilder {
                     );
                     let out_degree = self.flat_graph.node_degree_out(node_id);
                     let out_degree_range = match kind {
-                        HandoffKind::Vec => 1..=1,
-                        // `singleton()` may be no-output, only by ref. In the future this will also apply to vec.
+                        // Both `handoff()` and `singleton()` may be no-output, only by ref.
+                        HandoffKind::Vec => 0..=1,
                         HandoffKind::Option => 0..=1,
                     };
                     emit_arity_error(

--- a/dfir_lang/src/graph/flat_graph_builder.rs
+++ b/dfir_lang/src/graph/flat_graph_builder.rs
@@ -880,18 +880,13 @@ impl FlatGraphBuilder {
                         &mut self.diagnostics,
                     );
                     let out_degree = self.flat_graph.node_degree_out(node_id);
-                    let out_degree_range = match kind {
-                        // Both `handoff()` and `singleton()` may be no-output, only by ref.
-                        HandoffKind::Vec => 0..=1,
-                        HandoffKind::Option => 0..=1,
-                    };
                     emit_arity_error(
                         *src_span,
                         op_name,
                         false,
                         true,
                         out_degree,
-                        &out_degree_range,
+                        &(0..=1), /* Both `handoff()` and `singleton()` may be no-output, for use by ref. */
                         &mut self.diagnostics,
                     );
                 }

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -858,6 +858,7 @@ impl DfirGraph {
     /// - For stateful operators: `&singleton_op_XXX` or `&mut singleton_op_XXX`
     /// - For HandoffKind::Option: `&(hoff_XXX_buf.as_ref().unwrap())` (shared) or
     ///   `&mut(hoff_XXX_buf.as_mut().unwrap())` (mutable)
+    /// - For HandoffKind::Vec: `&(&#buf)` (shared) or `&mut(&mut #buf)` (mutable)
     fn helper_resolve_singletons(&self, node_id: GraphNodeId, span: Span) -> Vec<TokenStream> {
         self.node_singleton_references(node_id)
             .iter()
@@ -883,6 +884,25 @@ impl DfirGraph {
                         // `&(buf.as_ref().unwrap())` produces `&&T` so that
                         // postprocess_singletons' `(*expr)` deref gives `&T`.
                         quote_spanned! {span=> &(#buf_ident.as_ref().unwrap()) }
+                    }
+                } else if matches!(
+                    self.node(ref_node_id),
+                    GraphNode::Handoff {
+                        kind: HandoffKind::Vec,
+                        ..
+                    }
+                ) {
+                    let buf_ident = self.hoff_buf_ident(ref_node_id, span);
+                    if is_mut {
+                        // `&mut(#buf_ident)` produces `&mut Vec<T>` so that
+                        // postprocess_singletons' `(*expr)` deref gives `Vec<T>` as a place.
+                        // But we actually want `&mut Vec<T>`, so we need an extra indirection:
+                        // `&mut(&mut #buf_ident)` produces `&mut &mut Vec<T>`, deref gives `&mut Vec<T>`.
+                        quote_spanned! {span=> &mut(&mut #buf_ident) }
+                    } else {
+                        // `&(&#buf_ident)` produces `&&Vec<T>` so that
+                        // postprocess_singletons' `(*expr)` deref gives `&Vec<T>`.
+                        quote_spanned! {span=> &(&#buf_ident) }
                     }
                 } else {
                     let singleton_ident = self.node_as_singleton_ident(ref_node_id, span);

--- a/dfir_lang/src/graph/ops/iter_ref.rs
+++ b/dfir_lang/src/graph/ops/iter_ref.rs
@@ -1,0 +1,57 @@
+use quote::quote_spanned;
+
+use super::{
+    OperatorCategory, OperatorConstraints, OperatorWriteOutput, RANGE_0, RANGE_1, WriteContextArgs,
+};
+
+/// > 0 input streams, 1 output stream
+///
+/// > Arguments: A `#handoff_name` reference to a `handoff()` node.
+///
+/// Iterates over the referenced handoff buffer each tick, emitting `&T` for each element.
+/// This is a zero-copy alternative to `tee()` — multiple `iter_ref` operators can read
+/// the same handoff without cloning.
+///
+/// The referenced handoff must be filled by a producer in the same tick. Scheduling
+/// constraints are automatically created via the `#` reference mechanism.
+///
+/// ```dfir
+/// my_buf = source_iter(1..=5_i32) -> handoff();
+/// my_buf -> for_each(|v| println!("consumed: {v}"));
+///
+/// iter_ref(#my_buf) -> for_each(|v: &i32| println!("ref: {v}"));
+/// ```
+pub const ITER_REF: OperatorConstraints = OperatorConstraints {
+    name: "iter_ref",
+    categories: &[OperatorCategory::Source],
+    hard_range_inn: RANGE_0,
+    soft_range_inn: RANGE_0,
+    hard_range_out: RANGE_1,
+    soft_range_out: RANGE_1,
+    num_args: 1,
+    persistence_args: RANGE_0,
+    type_args: RANGE_0,
+    is_external_input: false,
+    has_singleton_output: false,
+    flo_type: None,
+    ports_inn: None,
+    ports_out: None,
+    input_delaytype_fn: |_| None,
+    write_fn: |&WriteContextArgs {
+                   root,
+                   op_span,
+                   ident,
+                   arguments,
+                   ..
+               },
+               _| {
+        let arg = &arguments[0];
+        let write_iterator = quote_spanned! {op_span=>
+            let #ident = #root::dfir_pipes::pull::iter((#arg).iter());
+        };
+        Ok(OperatorWriteOutput {
+            write_iterator,
+            ..Default::default()
+        })
+    },
+};

--- a/dfir_lang/src/graph/ops/iter_ref.rs
+++ b/dfir_lang/src/graph/ops/iter_ref.rs
@@ -42,9 +42,18 @@ pub const ITER_REF: OperatorConstraints = OperatorConstraints {
                    op_span,
                    ident,
                    arguments,
+                   op_inst,
                    ..
                },
-               _| {
+               diagnostics| {
+        if op_inst.singletons_referenced.is_empty() {
+            diagnostics.push(crate::diagnostic::Diagnostic::spanned(
+                op_span,
+                crate::diagnostic::Level::Error,
+                "iter_ref() requires a `#handoff_name` reference as its argument.".to_owned(),
+            ));
+        }
+
         let arg = &arguments[0];
         let write_iterator = quote_spanned! {op_span=>
             let #ident = #root::dfir_pipes::pull::iter((#arg).iter());

--- a/dfir_lang/src/graph/ops/mod.rs
+++ b/dfir_lang/src/graph/ops/mod.rs
@@ -305,6 +305,7 @@ declare_ops![
     identity::IDENTITY,
     initialize::INITIALIZE,
     inspect::INSPECT,
+    iter_ref::ITER_REF,
     join::JOIN,
     join_fused::JOIN_FUSED,
     join_fused_lhs::JOIN_FUSED_LHS,

--- a/dfir_rs/tests/compile-fail/stable/surface_handoff_multi_out.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_handoff_multi_out.stderr
@@ -1,4 +1,4 @@
-error: `handoff` must have exactly 1 output(s), actually has 2.
+error: `handoff` must have at least 0 and at most 1 output(s), actually has 2.
  --> tests/compile-fail/stable/surface_handoff_multi_out.rs:6:22
   |
 6 |         my_handoff = handoff();

--- a/dfir_rs/tests/compile-fail/stable/surface_handoff_sink.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_handoff_sink.stderr
@@ -1,5 +1,0 @@
-error: `handoff` must have exactly 1 output(s), actually has 0.
- --> tests/compile-fail/stable/surface_handoff_sink.rs:5:31
-  |
-5 |         source_iter(0..10) -> handoff();
-  |                               ^^^^^^^

--- a/dfir_rs/tests/compile-fail/stable/surface_iter_ref_no_hash.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_iter_ref_no_hash.stderr
@@ -1,0 +1,5 @@
+error: iter_ref() requires a `#handoff_name` reference as its argument.
+ --> tests/compile-fail/stable/surface_iter_ref_no_hash.rs:5:9
+  |
+5 |         iter_ref(my_vec) -> for_each(|v: &i32| println!("{v}"));
+  |         ^^^^^^^^

--- a/dfir_rs/tests/compile-fail/surface_handoff_sink.rs
+++ b/dfir_rs/tests/compile-fail/surface_handoff_sink.rs
@@ -1,8 +1,0 @@
-use dfir_rs::dfir_syntax;
-
-fn main() {
-    let mut df = dfir_syntax! {
-        source_iter(0..10) -> handoff();
-    };
-    df.run_available_sync();
-}

--- a/dfir_rs/tests/compile-fail/surface_iter_ref_no_hash.rs
+++ b/dfir_rs/tests/compile-fail/surface_iter_ref_no_hash.rs
@@ -1,0 +1,8 @@
+/// iter_ref() requires a `#handoff_name` reference as its argument.
+fn main() {
+    let my_vec = vec![1_i32, 2, 3];
+    let mut df = dfir_rs::dfir_syntax! {
+        iter_ref(my_vec) -> for_each(|v: &i32| println!("{v}"));
+    };
+    df.run_available_sync();
+}

--- a/dfir_rs/tests/surface_handoff.rs
+++ b/dfir_rs/tests/surface_handoff.rs
@@ -248,3 +248,32 @@ pub async fn test_handoff_mut_reference() {
     // The pipe consumer should only see items that survived the retain.
     assert_eq!(vec![4, 5], output);
 }
+
+/// Test: `iter_ref(#my_buf)` iterates the handoff buffer each tick, emitting `&T`.
+#[dfir_rs::test]
+pub async fn test_iter_ref_basic() {
+    let mut output = Vec::<i32>::new();
+    let out = &mut output;
+    let mut flow = dfir_rs::dfir_syntax! {
+        my_buf = source_iter(1..=3_i32) -> handoff();
+        my_buf -> for_each(|_| {});
+        iter_ref(#my_buf) -> for_each(|v: &i32| out.push(*v));
+    };
+    flow.run_tick().await;
+    drop(flow);
+    assert_eq!(vec![1, 2, 3], output);
+}
+
+/// Test: `iter_ref(#my_buf)` with no pipe consumer on the handoff.
+#[dfir_rs::test]
+pub async fn test_iter_ref_no_consumer() {
+    let mut output = Vec::<i32>::new();
+    let out = &mut output;
+    let mut flow = dfir_rs::dfir_syntax! {
+        my_buf = source_iter(1..=3_i32) -> handoff();
+        iter_ref(#my_buf) -> for_each(|v: &i32| out.push(*v));
+    };
+    flow.run_tick().await;
+    drop(flow);
+    assert_eq!(vec![1, 2, 3], output);
+}

--- a/dfir_rs/tests/surface_handoff.rs
+++ b/dfir_rs/tests/surface_handoff.rs
@@ -202,3 +202,49 @@ pub async fn test_singleton_access_group_ordering() {
     drop(flow);
     assert_eq!(vec![11], output);
 }
+
+/// Test: `handoff()` can be referenced via `#var`, resolving to `&Vec<T>`.
+#[dfir_rs::test]
+pub async fn test_handoff_reference() {
+    let mut output = Vec::<usize>::new();
+    let out = &mut output;
+    let mut flow = dfir_rs::dfir_syntax! {
+        my_buf = source_iter(1..=5_i32) -> handoff();
+        my_buf -> for_each(|_| {});
+        source_iter([()]) -> map(|_| #my_buf.len()) -> for_each(|v: usize| out.push(v));
+    };
+    flow.run_tick().await;
+    drop(flow);
+    assert_eq!(vec![5], output);
+}
+
+/// Test: `handoff()` referenced via `#var` with no direct consumer (0 successors).
+#[dfir_rs::test]
+pub async fn test_handoff_reference_only() {
+    let mut output = Vec::<usize>::new();
+    let out = &mut output;
+    let mut flow = dfir_rs::dfir_syntax! {
+        my_buf = source_iter(1..=5_i32) -> handoff();
+        source_iter([()]) -> map(|_| #my_buf.len()) -> for_each(|v: usize| out.push(v));
+    };
+    flow.run_tick().await;
+    drop(flow);
+    assert_eq!(vec![5], output);
+}
+
+/// Test: `handoff()` can be mutably referenced via `#mut var`.
+#[dfir_rs::test]
+pub async fn test_handoff_mut_reference() {
+    let mut output = Vec::<i32>::new();
+    let out = &mut output;
+    let mut flow = dfir_rs::dfir_syntax! {
+        my_buf = source_iter(1..=5_i32) -> handoff();
+        my_buf -> for_each(|v: i32| out.push(v));
+        // Mutably reference the buffer to retain only items > 3 before the pipe consumer drains.
+        source_iter([()]) -> map(|_| { #mut my_buf.retain(|x| *x > 3); }) -> for_each(|_| {});
+    };
+    flow.run_tick().await;
+    drop(flow);
+    // The pipe consumer should only see items that survived the retain.
+    assert_eq!(vec![4, 5], output);
+}

--- a/dfir_rs/tests/surface_handoff.rs
+++ b/dfir_rs/tests/surface_handoff.rs
@@ -277,3 +277,31 @@ pub async fn test_iter_ref_no_consumer() {
     drop(flow);
     assert_eq!(vec![1, 2, 3], output);
 }
+
+/// Test: `iter_ref(#my_buf)` across multiple ticks with a streaming source.
+#[dfir_rs::test]
+pub async fn test_iter_ref_multi_tick() {
+    let (send, recv) = dfir_rs::util::unbounded_channel::<i32>();
+    let output = std::rc::Rc::new(std::cell::RefCell::new(Vec::<i32>::new()));
+    let out = output.clone();
+    let mut flow = dfir_rs::dfir_syntax! {
+        my_buf = source_stream(recv) -> handoff();
+        my_buf -> for_each(|_| {});
+        iter_ref(#my_buf) -> for_each(|v: &i32| out.borrow_mut().push(*v));
+    };
+
+    send.send(10).unwrap();
+    send.send(20).unwrap();
+    flow.run_tick().await;
+    assert_eq!(vec![10, 20], *output.borrow());
+
+    output.borrow_mut().clear();
+    send.send(30).unwrap();
+    flow.run_tick().await;
+    assert_eq!(vec![30], *output.borrow());
+
+    // No input: handoff is empty, iter_ref emits nothing.
+    output.borrow_mut().clear();
+    flow.run_tick().await;
+    assert_eq!(Vec::<i32>::new(), *output.borrow());
+}


### PR DESCRIPTION
Extends the existing singleton reference mechanism to work with vec handoffs.
Previously only `singleton()` (Option<T>) could be referenced in closures;
now `handoff()` (Vec<T>) can also be referenced.

Changes:
- dfir_lang/src/graph/flat_graph_builder.rs:
  - Allow any Handoff node (Vec or Option) as a valid reference target
  - Relax Vec handoff out-degree from 1..=1 to 0..=1 (reference-only handoffs)

- dfir_lang/src/graph/meta_graph.rs:
  - Add HandoffKind::Vec case to helper_resolve_singletons codegen
  - Shared: `&(&#buf)` → deref gives `&Vec<T>`
  - Mutable: `&mut(&mut #buf)` → deref gives `&mut Vec<T>`

- dfir_rs/tests/surface_handoff.rs:
  - test_handoff_reference: `#my_buf.len()` works with &Vec<T>
  - test_handoff_reference_only: no pipe consumer, reference-only
  - test_handoff_mut_reference: `#mut my_buf.retain(...)` modifies buffer

Co-authored-by: Infinity 🤖 <infinity@hydro.run>