### PR TITLE
refactor(hydro_test): migrate paxos cross_singleton to by_ref() singleton mechanism [ci-bench]

### DIFF
--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -32,6 +32,8 @@ use crate::compile::builder::{CycleId, ExternalPortId};
 use crate::compile::deploy_provider::{Deploy, Node, RegisterPort};
 use crate::location::dynamic::{ClusterConsistency, LocationId};
 use crate::location::{LocationKey, NetworkHint};
+#[cfg(feature = "build")]
+use crate::singleton_ref::singleton_ref_ident;
 
 pub mod backtrace;
 use backtrace::Backtrace;
@@ -42,9 +44,10 @@ use backtrace::Backtrace;
 /// alongside the closure's expression. This allows per-closure tracking of singleton
 /// captures, which is important for nodes with multiple closures (e.g. Fold has `init` and `acc`).
 pub struct ClosureExpr {
-    pub expr: DebugExpr,
-    /// Each entry is `(local_ident, singleton_node, is_mut)`.
-    pub singleton_refs: Vec<(syn::Ident, HydroNode, bool)>,
+    pub(crate) expr: DebugExpr,
+    /// Each entry is `(singleton_node, is_mut)`.
+    /// The index in the Vec determines the ident name via [`singleton_ref_ident`].
+    pub(crate) singleton_refs: Vec<(HydroNode, bool)>,
 }
 
 impl Clone for ClosureExpr {
@@ -54,15 +57,17 @@ impl Clone for ClosureExpr {
             singleton_refs: self
                 .singleton_refs
                 .iter()
-                .map(|(ident, node, is_mut)| {
-                    let cloned_node = match node {
-                        HydroNode::Singleton { inner, metadata } => HydroNode::Singleton {
-                            inner: SharedNode(inner.0.clone()),
+                .map(|(node, is_mut)| {
+                    let HydroNode::Singleton { inner, metadata } = node else {
+                        panic!("singleton_refs should only contain HydroNode::Singleton");
+                    };
+                    (
+                        HydroNode::Singleton {
+                            inner: SharedNode(Rc::clone(&inner.0)),
                             metadata: metadata.clone(),
                         },
-                        _ => panic!("singleton_refs should only contain HydroNode::Singleton"),
-                    };
-                    (ident.clone(), cloned_node, *is_mut)
+                        *is_mut,
+                    )
                 })
                 .collect(),
         }
@@ -91,14 +96,14 @@ impl serde::Serialize for ClosureExpr {
     }
 }
 
-struct SerializableSingletonRefs<'a>(&'a [(syn::Ident, HydroNode, bool)]);
+struct SerializableSingletonRefs<'a>(&'a [(HydroNode, bool)]);
 
 impl serde::Serialize for SerializableSingletonRefs<'_> {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         use serde::ser::SerializeSeq;
         let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
-        for (ident, node, is_mut) in self.0 {
-            seq.serialize_element(&(ident.to_string(), node, is_mut))?;
+        for (node, is_mut) in self.0.iter() {
+            seq.serialize_element(&(node, is_mut))?;
         }
         seq.end()
     }
@@ -135,7 +140,7 @@ impl From<DebugExpr> for ClosureExpr {
 }
 
 impl ClosureExpr {
-    pub fn new(expr: DebugExpr, singleton_refs: Vec<(syn::Ident, HydroNode, bool)>) -> Self {
+    pub fn new(expr: DebugExpr, singleton_refs: Vec<(HydroNode, bool)>) -> Self {
         Self {
             expr,
             singleton_refs,
@@ -148,7 +153,7 @@ impl ClosureExpr {
             singleton_refs: self
                 .singleton_refs
                 .iter()
-                .map(|(ident, node, is_mut)| (ident.clone(), node.deep_clone(seen_tees), *is_mut))
+                .map(|(node, is_mut)| (node.deep_clone(seen_tees), *is_mut))
                 .collect(),
         }
     }
@@ -158,7 +163,7 @@ impl ClosureExpr {
         transform: &mut impl FnMut(&mut HydroNode, &mut SeenSharedNodes),
         seen_tees: &mut SeenSharedNodes,
     ) {
-        for (_ident, ref_node, _is_mut) in self.singleton_refs.iter_mut() {
+        for (ref_node, _is_mut) in self.singleton_refs.iter_mut() {
             transform(ref_node, seen_tees);
         }
     }
@@ -174,16 +179,11 @@ impl ClosureExpr {
         if self.singleton_refs.is_empty() {
             self.expr.0.to_token_stream()
         } else {
-            let ref_idents = (0..self.singleton_refs.len())
-                .map(|_| ident_stack.pop().unwrap())
-                .collect::<Vec<_>>()
-                .into_iter()
-                .rev()
-                .collect::<Vec<_>>();
+            let ref_idents = ident_stack.drain(ident_stack.len() - self.singleton_refs.len()..);
 
             let mut let_bindings = Vec::new();
-            for ((local_ident, node, is_mut), ref_ident) in
-                self.singleton_refs.iter().zip(ref_idents.iter())
+            for ((i, (node, is_mut)), ref_ident) in
+                self.singleton_refs.iter().enumerate().zip(ref_idents)
             {
                 let HydroNode::Singleton { inner, .. } = node else {
                     panic!("singleton_refs should only contain HydroNode::Singleton");
@@ -200,8 +200,9 @@ impl ClosureExpr {
                 };
 
                 // TODO(mingwei): proper spanning?
-                let group_lit = proc_macro2::Literal::u32_unsuffixed(group);
+                let local_ident = singleton_ref_ident(i);
                 let hash = proc_macro2::Punct::new('#', proc_macro2::Spacing::Alone);
+                let group_lit = proc_macro2::Literal::u32_unsuffixed(group);
                 let mut_token = is_mut.then(|| quote!(mut));
                 let binding = quote! {
                     let #local_ident = #hash {#group_lit} #mut_token #ref_ident;

--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -179,6 +179,12 @@ impl ClosureExpr {
         if self.singleton_refs.is_empty() {
             self.expr.0.to_token_stream()
         } else {
+            assert!(
+                ident_stack.len() >= self.singleton_refs.len(),
+                "ident_stack has {} entries but expected at least {} for singleton_refs",
+                ident_stack.len(),
+                self.singleton_refs.len()
+            );
             let ref_idents = ident_stack.drain(ident_stack.len() - self.singleton_refs.len()..);
 
             let mut let_bindings = Vec::new();

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -904,7 +904,9 @@ where
     where
         F: Fn(T) -> Option<U> + 'a,
     {
-        let f = f.splice_fn1_ctx(&self.location).into();
+        let f = crate::singleton_ref::with_singleton_capture(|| {
+            f.splice_fn1_ctx(&self.location).into()
+        });
         Stream::new(
             self.location.clone(),
             HydroNode::FilterMap {

--- a/hydro_lang/src/singleton_ref.rs
+++ b/hydro_lang/src/singleton_ref.rs
@@ -97,7 +97,7 @@ where
     L: Location<'a>,
 {
     fn to_tokens_helper(self, _ctx: &L) -> (QuoteTokens, ()) {
-        let ident =SINGLETON_REFS.with(|cell| {
+        let ident = SINGLETON_REFS.with(|cell| {
             let mut guard = cell.borrow_mut();
             let refs = guard.as_mut().expect(
                 "SingletonRef used inside q!() but no singleton capture scope is active. \

--- a/hydro_lang/src/singleton_ref.rs
+++ b/hydro_lang/src/singleton_ref.rs
@@ -60,9 +60,18 @@ impl<T, L, const IS_MUT: bool> Clone for SingletonRef<'_, '_, T, L, IS_MUT> {
 }
 
 // Thread-local storage for singleton references captured during `q!()` expansion.
-// Maps local ident name -> (SharedNode, is_mut) for each singleton captured in the current closure.
+// Stores the HydroNode `(SharedNode, is_mut)` for each singleton captured in the current closure.
+// The index in the Vec determines the ident name via `singleton_ref_ident`.
 thread_local! {
-    static SINGLETON_REFS: RefCell<Option<Vec<(syn::Ident, HydroNode, bool)>>> = const { RefCell::new(None) };
+    static SINGLETON_REFS: RefCell<Option<Vec<(HydroNode, bool)>>> = const { RefCell::new(None) };
+}
+
+/// Returns the canonical ident for a singleton ref at the given index within a closure.
+pub(crate) fn singleton_ref_ident(index: usize) -> syn::Ident {
+    syn::Ident::new(
+        &format!("__hydro_singleton_ref_{}", index),
+        Span::call_site(),
+    )
 }
 
 /// Activate the singleton reference capture context. Must be called before `q!()` expansion
@@ -83,23 +92,20 @@ pub fn with_singleton_capture(
     crate::compile::ir::ClosureExpr::new(expr, singleton_refs)
 }
 
-static SINGLETON_REF_COUNTER: std::sync::atomic::AtomicUsize =
-    std::sync::atomic::AtomicUsize::new(0);
-
 impl<'a, 'slf, T: 'a, L, const IS_MUT: bool> SingletonRef<'a, 'slf, T, L, IS_MUT>
 where
     L: Location<'a>,
 {
     fn to_tokens_helper(self, _ctx: &L) -> (QuoteTokens, ()) {
-        let id = SINGLETON_REF_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let ident = syn::Ident::new(&format!("__hydro_singleton_ref_{}", id), Span::call_site());
-
-        SINGLETON_REFS.with(|cell| {
+        let ident =SINGLETON_REFS.with(|cell| {
             let mut guard = cell.borrow_mut();
             let refs = guard.as_mut().expect(
                 "SingletonRef used inside q!() but no singleton capture scope is active. \
                  This is a bug — singleton capture should be set up by the operator that uses q!().",
             );
+
+            let index = refs.len();
+            let ident = singleton_ref_ident(index);
 
             let metadata = self.ir_node.borrow().metadata().clone();
 
@@ -119,13 +125,14 @@ where
             };
 
             refs.push((
-                ident.clone(),
                 HydroNode::Singleton {
                     inner: SharedNode(Rc::clone(&inner.0)),
                     metadata,
                 },
                 IS_MUT,
             ));
+
+            ident
         });
 
         (

--- a/hydro_test/src/cluster/compartmentalized_paxos.rs
+++ b/hydro_test/src/cluster/compartmentalized_paxos.rs
@@ -56,7 +56,7 @@ impl<'a> PaxosLike<'a> for CoreCompartmentalizedPaxos<'a> {
         ballot.map(q!(|ballot| ballot.proposer_id))
     }
 
-    fn build<P: PaxosPayload>(
+    fn build<P: PaxosPayload + 'a>(
         self,
         with_ballot: impl FnOnce(
             Stream<Ballot, Cluster<'a, Self::PaxosIn>, Unbounded>,
@@ -103,7 +103,7 @@ impl<'a> PaxosLike<'a> for CoreCompartmentalizedPaxos<'a> {
     clippy::too_many_arguments,
     reason = "internal paxos code // TODO"
 )]
-pub fn compartmentalized_paxos_core<'a, P: PaxosPayload>(
+pub fn compartmentalized_paxos_core<'a, P: PaxosPayload + 'a>(
     proposers: &Cluster<'a, Proposer>,
     proxy_leaders: &Cluster<'a, ProxyLeader>,
     acceptors: &Cluster<'a, Acceptor>,

--- a/hydro_test/src/cluster/paxos.rs
+++ b/hydro_test/src/cluster/paxos.rs
@@ -94,7 +94,7 @@ impl<'a> PaxosLike<'a> for CorePaxos<'a> {
         ballot.map(q!(|ballot| ballot.proposer_id))
     }
 
-    fn build<P: PaxosPayload>(
+    fn build<P: PaxosPayload + 'a>(
         self,
         with_ballot: impl FnOnce(
             Stream<Ballot, Cluster<'a, Self::PaxosIn>, Unbounded>,
@@ -133,7 +133,7 @@ impl<'a> PaxosLike<'a> for CorePaxos<'a> {
 /// non-deterministically dropped. The stream of ballots is also non-deterministic because
 /// leaders are elected in a non-deterministic process.
 #[expect(clippy::type_complexity, reason = "internal paxos code // TODO")]
-pub fn paxos_core<'a, P: PaxosPayload>(
+pub fn paxos_core<'a, P: PaxosPayload + 'a>(
     proposers: &Cluster<'a, Proposer>,
     acceptors: &Cluster<'a, Acceptor>,
     a_checkpoint: Optional<usize, Cluster<'a, Acceptor>, Unbounded>,
@@ -629,20 +629,20 @@ pub fn recommit_after_leader_election<'a, P: PaxosPayload>(
             }
         }, commutative = manual_proof!(/** TODO */)))
         .map(q!(|(count, entry)| (count, entry.unwrap())));
+    let p_ballot_ref = p_ballot.by_ref();
+    let p_p1b_max_checkpoint_ref = p_p1b_max_checkpoint.by_ref();
     let p_log_to_try_commit = p_p1b_highest_entries_and_count
         .clone()
         .entries()
-        .cross_singleton(p_ballot.clone())
-        .cross_singleton(p_p1b_max_checkpoint.clone())
-        .filter_map(q!(move |(((slot, (count, entry)), ballot), checkpoint)| {
+        .filter_map(q!(move |(slot, (count, entry))| {
             if count > f {
                 return None;
-            } else if let Some(checkpoint) = checkpoint
+            } else if let Some(checkpoint) = *p_p1b_max_checkpoint_ref
                 && slot <= checkpoint
             {
                 return None;
             }
-            Some(((slot, ballot), entry.value))
+            Some(((slot, p_ballot_ref.clone()), entry.value))
         }));
     let p_max_slot = p_p1b_highest_entries_and_count.clone().keys().max();
     let p_proposed_slots = p_p1b_highest_entries_and_count.clone().keys();
@@ -657,8 +657,7 @@ pub fn recommit_after_leader_election<'a, P: PaxosPayload>(
             }
         }))
         .filter_not_in(p_proposed_slots)
-        .cross_singleton(p_ballot.clone())
-        .map(q!(move |(slot, ballot)| ((slot, ballot), None)));
+        .map(q!(move |slot| ((slot, p_ballot_ref.clone()), None)));
 
     (p_log_to_try_commit.chain(p_log_holes), p_max_slot)
 }
@@ -719,10 +718,10 @@ fn sequence_payload<'a, P: PaxosPayload>(
             .filter_if(p_is_leader.clone()),
     );
 
+    let p_ballot_ref = p_ballot.by_ref();
     let payloads_to_send = indexed_payloads
-        .cross_singleton(p_ballot.clone())
-        .map(q!(|((slot, payload), ballot)| (
-            (slot, ballot),
+        .map(q!(|(slot, payload)| (
+            (slot, p_ballot_ref.clone()),
             Some(payload)
         )))
         .chain(p_log_to_recommit)
@@ -770,7 +769,7 @@ fn sequence_payload<'a, P: PaxosPayload>(
 }
 
 // Proposer logic to send p2as, outputting the next slot and the p2as to send to acceptors.
-pub fn index_payloads<'a, L: Location<'a>, P: PaxosPayload>(
+pub fn index_payloads<'a, L: Location<'a> + 'a, P: PaxosPayload>(
     p_max_slot: Optional<usize, Tick<L>, Bounded>,
     c_to_proposers: Stream<P, Tick<L>, Bounded>,
 ) -> Stream<(usize, P), Tick<L::DropConsistency>, Bounded> {
@@ -783,11 +782,11 @@ pub fn index_payloads<'a, L: Location<'a>, P: PaxosPayload>(
         let next_slot_after_reconciling_p1bs = updated_max_slot.map(q!(|s| s + 1));
         let base_slot = next_slot_after_reconciling_p1bs.unwrap_or(next_slot);
 
+        let base_slot_ref = base_slot.by_ref();
         let indexed_payloads = payload_batch
             .enumerate()
-            .cross_singleton(base_slot.clone())
-            .map(q!(|((index, payload), base_slot)| (
-                base_slot + index,
+            .map(q!(|(index, payload)| (
+                *base_slot_ref + index,
                 payload
             )));
 
@@ -835,19 +834,21 @@ pub fn acceptor_p2<'a, P: PaxosPayload, S: Clone>(
     );
     // .inspect(q!(|min_seq| println!("Acceptor new checkpoint: {:?}", min_seq)));
 
-    let a_p2as_to_place_in_log = p_to_acceptors_p2a_batch
-        .clone()
-        .cross_singleton(a_max_ballot.clone()) // Don't consider p2as if the current ballot is higher
-        .filter_map(q!(|(p2a, max_ballot)|
-            if p2a.ballot >= max_ballot {
-                Some((p2a.slot, LogValue {
-                    ballot: p2a.ballot,
-                    value: p2a.value,
-                }))
+    let a_max_ballot_ref = a_max_ballot.by_ref();
+    let a_p2as_to_place_in_log =
+        p_to_acceptors_p2a_batch
+            .clone()
+            .filter_map(q!(|p2a| if p2a.ballot >= *a_max_ballot_ref {
+                Some((
+                    p2a.slot,
+                    LogValue {
+                        ballot: p2a.ballot,
+                        value: p2a.value,
+                    },
+                ))
             } else {
                 None
-            }
-        ));
+            }));
     let a_log = a_p2as_to_place_in_log.across_ticks(|s| {
         s.into_keyed().reduce_watermark(
             a_checkpoint.clone(),
@@ -873,18 +874,20 @@ pub fn acceptor_p2<'a, P: PaxosPayload, S: Clone>(
     );
 
     let a_to_proposers_p2b = p_to_acceptors_p2a_batch
-        .cross_singleton(a_max_ballot)
-        .map(q!(|(p2a, max_ballot)| (
-            p2a.sender,
+        .map(q!(|p2a| {
+            let max_ballot = a_max_ballot_ref.clone();
             (
-                (p2a.slot, p2a.ballot.clone()),
-                if p2a.ballot == max_ballot {
-                    Ok(())
-                } else {
-                    Err(max_ballot)
-                }
+                p2a.sender,
+                (
+                    (p2a.slot, p2a.ballot.clone()),
+                    if p2a.ballot == max_ballot {
+                        Ok(())
+                    } else {
+                        Err(max_ballot)
+                    },
+                ),
             )
-        )))
+        }))
         .all_ticks()
         .demux(proposers, TCP.fail_stop().bincode())
         .values();

--- a/hydro_test/src/cluster/paxos_with_client.rs
+++ b/hydro_test/src/cluster/paxos_with_client.rs
@@ -30,7 +30,7 @@ pub trait PaxosLike<'a>: Sized {
     /// During leader-reelection, the latest known leader may be stale, which may
     /// result in non-deterministic dropping of payloads.
     #[expect(clippy::type_complexity, reason = "internal paxos code // TODO")]
-    fn build<P: PaxosPayload>(
+    fn build<P: PaxosPayload + 'a>(
         self,
         payload_generator: impl FnOnce(
             Stream<Self::Ballot, Cluster<'a, Self::PaxosIn>, Unbounded>,
@@ -45,7 +45,7 @@ pub trait PaxosLike<'a>: Sized {
     /// result in non-deterministic dropping of payloads. Also, payloads across
     /// clients will be arbitrarily interleaved as they arrive at the leader.
     #[expect(clippy::type_complexity, reason = "internal paxos code // TODO")]
-    fn with_client<C: 'a, P: PaxosPayload>(
+    fn with_client<C: 'a, P: PaxosPayload + 'a>(
         self,
         clients: &Cluster<'a, C>,
         payloads: Stream<P, Cluster<'a, C>, Unbounded>,

--- a/hydro_test/src/cluster/snapshots-nightly/paxos_ir.snap
+++ b/hydro_test/src/cluster/snapshots-nightly/paxos_ir.snap
@@ -1,5 +1,6 @@
 ---
 source: hydro_test/src/cluster/paxos_bench.rs
+assertion_line: 211
 expression: built.ir()
 ---
 [
@@ -3614,6 +3615,28 @@ expression: built.ir()
         },
         op_metadata: HydroIrOpMetadata,
     },
+    Null {
+        input: Singleton {
+            inner: <shared 19>: Tee {
+                inner: <shared 4>,
+                metadata: HydroIrMetadata {
+                    location_id: Tick(16, Cluster(loc1v1)),
+                    collection_kind: Singleton {
+                        bound: Bounded,
+                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                    },
+                },
+            },
+            metadata: HydroIrMetadata {
+                location_id: Tick(16, Cluster(loc1v1)),
+                collection_kind: Singleton {
+                    bound: Bounded,
+                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                },
+            },
+        },
+        op_metadata: HydroIrOpMetadata,
+    },
     CycleSink {
         cycle_id: CycleId(
             12,
@@ -3679,20 +3702,62 @@ expression: built.ir()
                                                                                                     },
                                                                                                 },
                                                                                             },
+                            inner: <shared 20>: Map {
+                                f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let base_slot_ref__free = __hydro_singleton_ref_3 ; | (index , payload) | (* base_slot_ref__free + index , payload) }),
+                                input: Enumerate {
+                                    input: Batch {
+                                        inner: YieldConcat {
+                                            inner: Map {
+                                                f: stageleft :: runtime_support :: fn1_type_hint :: < ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , bool) , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | (d , _) | d }),
+                                                input: CrossSingleton {
+                                                    left: Batch {
+                                                        inner: ObserveNonDet {
+                                                            inner: Map {
+                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
+                                                                input: Cast {
+                                                                    inner: Network {
+                                                                        name: None,
+                                                                        networking_info: Tcp {
+                                                                            fault: FailStop,
+                                                                        },
+                                                                        serialize_fn: Some(
+                                                                            hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
+                                                                        ),
+                                                                        instantiate_fn: <network instantiate>,
+                                                                        deserialize_fn: Some(
+                                                                            | res | { let (id , b) = res . unwrap () ; (hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos_bench :: Client > :: from_tagless (id as hydro_lang :: __staged :: location :: TaglessMemberId) , hydro_lang :: runtime_support :: bincode :: deserialize :: < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > (& b) . unwrap ()) },
+                                                                        ),
+                                                                        input: Cast {
+                                                                            inner: Map {
+                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_with_client :: * ; move | (payload , leader_id) | (leader_id , payload) }),
+                                                                                input: YieldConcat {
+                                                                                    inner: CrossSingleton {
+                                                                                        left: Tee {
+                                                                                            inner: <shared 15>,
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_id: Tick(11, Cluster(loc3v1)),
                                                                                                 collection_kind: Stream {
                                                                                                     bound: Bounded,
                                                                                                     order: TotalOrder,
                                                                                                     retry: ExactlyOnce,
-                                                                                                    element_type: ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >),
+                                                                                                    element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
+                                                                                                },
+                                                                                            },
+                                                                                        },
+                                                                                        right: Tee {
+                                                                                            inner: <shared 17>,
+                                                                                            metadata: HydroIrMetadata {
+                                                                                                location_id: Tick(12, Cluster(loc3v1)),
+                                                                                                collection_kind: Optional {
+                                                                                                    bound: Bounded,
+                                                                                                    element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                                                                                 },
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Cluster(loc3v1),
+                                                                                            location_id: Tick(12, Cluster(loc3v1)),
                                                                                             collection_kind: Stream {
-                                                                                                bound: Unbounded,
+                                                                                                bound: Bounded,
                                                                                                 order: TotalOrder,
                                                                                                 retry: ExactlyOnce,
                                                                                                 element_type: ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >),
@@ -3705,39 +3770,39 @@ expression: built.ir()
                                                                                             bound: Unbounded,
                                                                                             order: TotalOrder,
                                                                                             retry: ExactlyOnce,
-                                                                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
+                                                                                            element_type: ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >),
                                                                                         },
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_id: Cluster(loc3v1),
-                                                                                    collection_kind: KeyedStream {
+                                                                                    collection_kind: Stream {
                                                                                         bound: Unbounded,
-                                                                                        value_order: TotalOrder,
-                                                                                        value_retry: ExactlyOnce,
-                                                                                        key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
-                                                                                        value_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
+                                                                                        order: TotalOrder,
+                                                                                        retry: ExactlyOnce,
+                                                                                        element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
                                                                                     },
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Cluster(loc1v1),
+                                                                                location_id: Cluster(loc3v1),
                                                                                 collection_kind: KeyedStream {
                                                                                     bound: Unbounded,
                                                                                     value_order: TotalOrder,
                                                                                     value_retry: ExactlyOnce,
-                                                                                    key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >,
+                                                                                    key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                                                                     value_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
                                                                                 },
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
                                                                             location_id: Cluster(loc1v1),
-                                                                            collection_kind: Stream {
+                                                                            collection_kind: KeyedStream {
                                                                                 bound: Unbounded,
-                                                                                order: NoOrder,
-                                                                                retry: ExactlyOnce,
-                                                                                element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
+                                                                                value_order: TotalOrder,
+                                                                                value_retry: ExactlyOnce,
+                                                                                key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >,
+                                                                                value_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
                                                                             },
                                                                         },
                                                                     },
@@ -3747,25 +3812,26 @@ expression: built.ir()
                                                                             bound: Unbounded,
                                                                             order: NoOrder,
                                                                             retry: ExactlyOnce,
-                                                                            element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
+                                                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
                                                                         },
                                                                     },
                                                                 },
-                                                                trusted: false,
                                                                 metadata: HydroIrMetadata {
                                                                     location_id: Cluster(loc1v1),
                                                                     collection_kind: Stream {
                                                                         bound: Unbounded,
-                                                                        order: TotalOrder,
+                                                                        order: NoOrder,
                                                                         retry: ExactlyOnce,
                                                                         element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
                                                                     },
                                                                 },
                                                             },
+                                                            trusted: false,
                                                             metadata: HydroIrMetadata {
                                                                 location_id: Tick(15, Cluster(loc1v1)),
+                                                                location_id: Cluster(loc1v1),
                                                                 collection_kind: Stream {
-                                                                    bound: Bounded,
+                                                                    bound: Unbounded,
                                                                     order: TotalOrder,
                                                                     retry: ExactlyOnce,
                                                                     element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
@@ -3783,10 +3849,25 @@ expression: built.ir()
                                                                         element_type: bool,
                                                                     },
                                                                 },
+                                                        metadata: HydroIrMetadata {
+                                                            location_id: Tick(16, Cluster(loc1v1)),
+                                                            collection_kind: Stream {
+                                                                bound: Bounded,
+                                                                order: TotalOrder,
+                                                                retry: ExactlyOnce,
+                                                                element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
                                                             },
+                                                        },
+                                                    },
+                                                    right: Filter {
+                                                        f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | b | * b }),
+                                                        input: Tee {
+                                                            inner: <shared 13>,
                                                             metadata: HydroIrMetadata {
                                                                 location_id: Tick(15, Cluster(loc1v1)),
                                                                 collection_kind: Optional {
+                                                                location_id: Tick(16, Cluster(loc1v1)),
+                                                                collection_kind: Singleton {
                                                                     bound: Bounded,
                                                                     element_type: bool,
                                                                 },
@@ -3795,10 +3876,10 @@ expression: built.ir()
                                                         metadata: HydroIrMetadata {
                                                             location_id: Tick(15, Cluster(loc1v1)),
                                                             collection_kind: Stream {
+                                                            location_id: Tick(16, Cluster(loc1v1)),
+                                                            collection_kind: Optional {
                                                                 bound: Bounded,
-                                                                order: TotalOrder,
-                                                                retry: ExactlyOnce,
-                                                                element_type: ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , bool),
+                                                                element_type: bool,
                                                             },
                                                         },
                                                     },
@@ -3808,14 +3889,15 @@ expression: built.ir()
                                                             bound: Bounded,
                                                             order: TotalOrder,
                                                             retry: ExactlyOnce,
-                                                            element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
+                                                            element_type: ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , bool),
                                                         },
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
                                                     location_id: Atomic(Tick(15, Cluster(loc1v1))),
+                                                    location_id: Tick(16, Cluster(loc1v1)),
                                                     collection_kind: Stream {
-                                                        bound: Unbounded,
+                                                        bound: Bounded,
                                                         order: TotalOrder,
                                                         retry: ExactlyOnce,
                                                         element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
@@ -3824,8 +3906,9 @@ expression: built.ir()
                                             },
                                             metadata: HydroIrMetadata {
                                                 location_id: Tick(15, Cluster(loc1v1)),
+                                                location_id: Atomic(Tick(16, Cluster(loc1v1))),
                                                 collection_kind: Stream {
-                                                    bound: Bounded,
+                                                    bound: Unbounded,
                                                     order: TotalOrder,
                                                     retry: ExactlyOnce,
                                                     element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
@@ -4150,6 +4233,7 @@ expression: built.ir()
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: usize,
+                                                element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
                                             },
                                         },
                                     },
@@ -4159,7 +4243,7 @@ expression: built.ir()
                                             bound: Bounded,
                                             order: TotalOrder,
                                             retry: ExactlyOnce,
-                                            element_type: ((usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , usize),
+                                            element_type: (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
                                         },
                                     },
                                 },
@@ -4191,8 +4275,300 @@ expression: built.ir()
                             },
                         },
                     },
-                    right: Tee {
-                        inner: <shared 20>,
+                    right: Singleton {
+                        inner: <shared 21>: Cast {
+                            inner: ChainFirst {
+                                first: Map {
+                                    f: stageleft :: runtime_support :: fn1_type_hint :: < usize , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | s | s + 1 }),
+                                    input: Batch {
+                                        inner: YieldConcat {
+                                            inner: Tee {
+                                                inner: <shared 22>: Reduce {
+                                                    f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | curr , new | { if new > * curr { * curr = new ; } } }),
+                                                    input: ObserveNonDet {
+                                                        inner: Map {
+                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
+                                                            input: Cast {
+                                                                inner: Cast {
+                                                                    inner: Tee {
+                                                                        inner: <shared 23>: Map {
+                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)) , (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (count , entry) | (count , entry . unwrap ()) }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
+                                                                            input: FoldKeyed {
+                                                                                init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | | (0 , None) }),
+                                                                                acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | curr_entry , new_entry | { if let Some (curr_entry_payload) = & mut curr_entry . 1 { let same_values = new_entry . value == curr_entry_payload . value ; let higher_ballot = new_entry . ballot > curr_entry_payload . ballot ; if same_values { curr_entry . 0 += 1 ; } if higher_ballot { curr_entry_payload . ballot = new_entry . ballot ; if ! same_values { curr_entry . 0 = 1 ; curr_entry_payload . value = new_entry . value ; } } } else { * curr_entry = (1 , Some (new_entry)) ; } } }),
+                                                                                input: Cast {
+                                                                                    inner: FlatMap {
+                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | d | d }),
+                                                                                        input: Map {
+                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (_checkpoint , log) | log }),
+                                                                                            input: Tee {
+                                                                                                inner: <shared 24>: FlatMap {
+                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | v }),
+                                                                                                    input: Cast {
+                                                                                                        inner: Tee {
+                                                                                                            inner: <shared 14>,
+                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                location_id: Tick(16, Cluster(loc1v1)),
+                                                                                                                collection_kind: Optional {
+                                                                                                                    bound: Bounded,
+                                                                                                                    element_type: std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >,
+                                                                                                                },
+                                                                                                            },
+                                                                                                        },
+                                                                                                        metadata: HydroIrMetadata {
+                                                                                                            location_id: Tick(16, Cluster(loc1v1)),
+                                                                                                            collection_kind: Stream {
+                                                                                                                bound: Bounded,
+                                                                                                                order: TotalOrder,
+                                                                                                                retry: ExactlyOnce,
+                                                                                                                element_type: std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >,
+                                                                                                            },
+                                                                                                        },
+                                                                                                    },
+                                                                                                    metadata: HydroIrMetadata {
+                                                                                                        location_id: Tick(16, Cluster(loc1v1)),
+                                                                                                        collection_kind: Stream {
+                                                                                                            bound: Bounded,
+                                                                                                            order: NoOrder,
+                                                                                                            retry: ExactlyOnce,
+                                                                                                            element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
+                                                                                                        },
+                                                                                                    },
+                                                                                                },
+                                                                                                metadata: HydroIrMetadata {
+                                                                                                    location_id: Tick(16, Cluster(loc1v1)),
+                                                                                                    collection_kind: Stream {
+                                                                                                        bound: Bounded,
+                                                                                                        order: NoOrder,
+                                                                                                        retry: ExactlyOnce,
+                                                                                                        element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
+                                                                                                    },
+                                                                                                },
+                                                                                            },
+                                                                                            metadata: HydroIrMetadata {
+                                                                                                location_id: Tick(16, Cluster(loc1v1)),
+                                                                                                collection_kind: Stream {
+                                                                                                    bound: Bounded,
+                                                                                                    order: NoOrder,
+                                                                                                    retry: ExactlyOnce,
+                                                                                                    element_type: std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >,
+                                                                                                },
+                                                                                            },
+                                                                                        },
+                                                                                        metadata: HydroIrMetadata {
+                                                                                            location_id: Tick(16, Cluster(loc1v1)),
+                                                                                            collection_kind: Stream {
+                                                                                                bound: Bounded,
+                                                                                                order: NoOrder,
+                                                                                                retry: ExactlyOnce,
+                                                                                                element_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                            },
+                                                                                        },
+                                                                                    },
+                                                                                    metadata: HydroIrMetadata {
+                                                                                        location_id: Tick(16, Cluster(loc1v1)),
+                                                                                        collection_kind: KeyedStream {
+                                                                                            bound: Bounded,
+                                                                                            value_order: NoOrder,
+                                                                                            value_retry: ExactlyOnce,
+                                                                                            key_type: usize,
+                                                                                            value_type: hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >,
+                                                                                        },
+                                                                                    },
+                                                                                },
+                                                                                metadata: HydroIrMetadata {
+                                                                                    location_id: Tick(16, Cluster(loc1v1)),
+                                                                                    collection_kind: KeyedSingleton {
+                                                                                        bound: Bounded,
+                                                                                        key_type: usize,
+                                                                                        value_type: (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
+                                                                                    },
+                                                                                },
+                                                                            },
+                                                                            metadata: HydroIrMetadata {
+                                                                                location_id: Tick(16, Cluster(loc1v1)),
+                                                                                collection_kind: KeyedSingleton {
+                                                                                    bound: Bounded,
+                                                                                    key_type: usize,
+                                                                                    value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                },
+                                                                            },
+                                                                        },
+                                                                        metadata: HydroIrMetadata {
+                                                                            location_id: Tick(16, Cluster(loc1v1)),
+                                                                            collection_kind: KeyedSingleton {
+                                                                                bound: Bounded,
+                                                                                key_type: usize,
+                                                                                value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                            },
+                                                                        },
+                                                                    },
+                                                                    metadata: HydroIrMetadata {
+                                                                        location_id: Tick(16, Cluster(loc1v1)),
+                                                                        collection_kind: KeyedStream {
+                                                                            bound: Bounded,
+                                                                            value_order: TotalOrder,
+                                                                            value_retry: ExactlyOnce,
+                                                                            key_type: usize,
+                                                                            value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                        },
+                                                                    },
+                                                                },
+                                                                metadata: HydroIrMetadata {
+                                                                    location_id: Tick(16, Cluster(loc1v1)),
+                                                                    collection_kind: Stream {
+                                                                        bound: Bounded,
+                                                                        order: NoOrder,
+                                                                        retry: ExactlyOnce,
+                                                                        element_type: (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)),
+                                                                    },
+                                                                },
+                                                            },
+                                                            metadata: HydroIrMetadata {
+                                                                location_id: Tick(16, Cluster(loc1v1)),
+                                                                collection_kind: Stream {
+                                                                    bound: Bounded,
+                                                                    order: NoOrder,
+                                                                    retry: ExactlyOnce,
+                                                                    element_type: usize,
+                                                                },
+                                                            },
+                                                        },
+                                                        trusted: true,
+                                                        metadata: HydroIrMetadata {
+                                                            location_id: Tick(16, Cluster(loc1v1)),
+                                                            collection_kind: Stream {
+                                                                bound: Bounded,
+                                                                order: TotalOrder,
+                                                                retry: ExactlyOnce,
+                                                                element_type: usize,
+                                                            },
+                                                        },
+                                                    },
+                                                    metadata: HydroIrMetadata {
+                                                        location_id: Tick(16, Cluster(loc1v1)),
+                                                        collection_kind: Optional {
+                                                            bound: Bounded,
+                                                            element_type: usize,
+                                                        },
+                                                    },
+                                                },
+                                                metadata: HydroIrMetadata {
+                                                    location_id: Tick(16, Cluster(loc1v1)),
+                                                    collection_kind: Optional {
+                                                        bound: Bounded,
+                                                        element_type: usize,
+                                                    },
+                                                },
+                                            },
+                                            metadata: HydroIrMetadata {
+                                                location_id: Atomic(Tick(16, Cluster(loc1v1))),
+                                                collection_kind: Optional {
+                                                    bound: Unbounded,
+                                                    element_type: usize,
+                                                },
+                                            },
+                                        },
+                                        metadata: HydroIrMetadata {
+                                            location_id: Tick(16, Cluster(loc1v1)),
+                                            collection_kind: Optional {
+                                                bound: Bounded,
+                                                element_type: usize,
+                                            },
+                                        },
+                                    },
+                                    metadata: HydroIrMetadata {
+                                        location_id: Tick(16, Cluster(loc1v1)),
+                                        collection_kind: Optional {
+                                            bound: Bounded,
+                                            element_type: usize,
+                                        },
+                                    },
+                                },
+                                second: Cast {
+                                    inner: Cast {
+                                        inner: ChainFirst {
+                                            first: DeferTick {
+                                                input: CycleSource {
+                                                    cycle_id: CycleId(
+                                                        12,
+                                                    ),
+                                                    metadata: HydroIrMetadata {
+                                                        location_id: Tick(16, Cluster(loc1v1)),
+                                                        collection_kind: Singleton {
+                                                            bound: Bounded,
+                                                            element_type: usize,
+                                                        },
+                                                    },
+                                                },
+                                                metadata: HydroIrMetadata {
+                                                    location_id: Tick(16, Cluster(loc1v1)),
+                                                    collection_kind: Optional {
+                                                        bound: Bounded,
+                                                        element_type: usize,
+                                                    },
+                                                },
+                                            },
+                                            second: Cast {
+                                                inner: SingletonSource {
+                                                    value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; 0 },
+                                                    first_tick_only: false,
+                                                    metadata: HydroIrMetadata {
+                                                        location_id: Tick(16, Cluster(loc1v1)),
+                                                        collection_kind: Singleton {
+                                                            bound: Bounded,
+                                                            element_type: usize,
+                                                        },
+                                                    },
+                                                },
+                                                metadata: HydroIrMetadata {
+                                                    location_id: Tick(16, Cluster(loc1v1)),
+                                                    collection_kind: Optional {
+                                                        bound: Bounded,
+                                                        element_type: usize,
+                                                    },
+                                                },
+                                            },
+                                            metadata: HydroIrMetadata {
+                                                location_id: Tick(16, Cluster(loc1v1)),
+                                                collection_kind: Optional {
+                                                    bound: Bounded,
+                                                    element_type: usize,
+                                                },
+                                            },
+                                        },
+                                        metadata: HydroIrMetadata {
+                                            location_id: Tick(16, Cluster(loc1v1)),
+                                            collection_kind: Singleton {
+                                                bound: Bounded,
+                                                element_type: usize,
+                                            },
+                                        },
+                                    },
+                                    metadata: HydroIrMetadata {
+                                        location_id: Tick(16, Cluster(loc1v1)),
+                                        collection_kind: Optional {
+                                            bound: Bounded,
+                                            element_type: usize,
+                                        },
+                                    },
+                                },
+                                metadata: HydroIrMetadata {
+                                    location_id: Tick(16, Cluster(loc1v1)),
+                                    collection_kind: Optional {
+                                        bound: Bounded,
+                                        element_type: usize,
+                                    },
+                                },
+                            },
+                            metadata: HydroIrMetadata {
+                                location_id: Tick(16, Cluster(loc1v1)),
+                                collection_kind: Singleton {
+                                    bound: Bounded,
+                                    element_type: usize,
+                                },
+                            },
+                        },
                         metadata: HydroIrMetadata {
                             location_id: Tick(15, Cluster(loc1v1)),
                             collection_kind: Singleton {
@@ -4227,13 +4603,35 @@ expression: built.ir()
         },
         op_metadata: HydroIrOpMetadata,
     },
+    Null {
+        input: Singleton {
+            inner: <shared 25>: Tee {
+                inner: <shared 10>,
+                metadata: HydroIrMetadata {
+                    location_id: Tick(2, Cluster(loc2v1)),
+                    collection_kind: Singleton {
+                        bound: Bounded,
+                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                    },
+                },
+            },
+            metadata: HydroIrMetadata {
+                location_id: Tick(2, Cluster(loc2v1)),
+                collection_kind: Singleton {
+                    bound: Bounded,
+                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                },
+            },
+        },
+        op_metadata: HydroIrOpMetadata,
+    },
     CycleSink {
         cycle_id: CycleId(
             13,
         ),
         input: AntiJoin {
             pos: Tee {
-                inner: <shared 24>: Chain {
+                inner: <shared 26>: Chain {
                     first: DeferTick {
                         input: CycleSource {
                             cycle_id: CycleId(
@@ -4261,7 +4659,7 @@ expression: built.ir()
                     },
                     second: Batch {
                         inner: Tee {
-                            inner: <shared 25>: Map {
+                            inner: <shared 27>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
                                 input: Cast {
                                     inner: Network {
@@ -4279,91 +4677,82 @@ expression: built.ir()
                                         input: Cast {
                                             inner: YieldConcat {
                                                 inner: Map {
-                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (p2a , max_ballot) | (p2a . sender , ((p2a . slot , p2a . ballot . clone ()) , if p2a . ballot == max_ballot { Ok (()) } else { Err (max_ballot) })) }),
-                                                    input: CrossSingleton {
-                                                        left: Tee {
-                                                            inner: <shared 26>: Batch {
-                                                                inner: Map {
-                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >) , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                                                    input: Cast {
-                                                                        inner: Network {
-                                                                            name: None,
-                                                                            networking_info: Tcp {
-                                                                                fault: FailStop,
-                                                                            },
-                                                                            serialize_fn: Some(
-                                                                                hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
-                                                                            ),
-                                                                            instantiate_fn: <network instantiate>,
-                                                                            deserialize_fn: Some(
-                                                                                | res | { let (id , b) = res . unwrap () ; (hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless (id as hydro_lang :: __staged :: location :: TaglessMemberId) , hydro_lang :: runtime_support :: bincode :: deserialize :: < hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > > (& b) . unwrap ()) },
-                                                                            ),
-                                                                            input: YieldConcat {
-                                                                                inner: Cast {
-                                                                                    inner: CrossProduct {
-                                                                                        left: ObserveNonDet {
-                                                                                            inner: Map {
-                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                                                                input: Cast {
-                                                                                                    inner: Cast {
-                                                                                                        inner: Filter {
-                                                                                                            f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | b | * b }) ; { let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) } }),
-                                                                                                            input: Batch {
-                                                                                                                inner: FoldKeyed {
-                                                                                                                    init: stageleft :: runtime_support :: fn0_type_hint :: < bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | | false }),
-                                                                                                                    acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < bool , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | present , event | { match event { MembershipEvent :: Joined => * present = true , MembershipEvent :: Left => * present = false , } } }),
-                                                                                                                    input: Cast {
-                                                                                                                        inner: Map {
-                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | (k , v) | (MemberId :: from_tagless (k) , v) }),
-                                                                                                                            input: Source {
-                                                                                                                                source: ClusterMembers(
-                                                                                                                                    Cluster(loc2v1),
-                                                                                                                                    Uninit,
-                                                                                                                                ),
-                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                    location_id: Cluster(loc1v1),
-                                                                                                                                    collection_kind: Stream {
-                                                                                                                                        bound: Unbounded,
-                                                                                                                                        order: TotalOrder,
-                                                                                                                                        retry: ExactlyOnce,
-                                                                                                                                        element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
-                                                                                                                                    },
-                                                                                                                                },
-                                                                                                                            },
+                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let a_max_ballot_ref__free = __hydro_singleton_ref_6 ; | p2a | { let max_ballot = a_max_ballot_ref__free . clone () ; (p2a . sender , ((p2a . slot , p2a . ballot . clone ()) , if p2a . ballot == max_ballot { Ok (()) } else { Err (max_ballot) })) } }),
+                                                    input: Tee {
+                                                        inner: <shared 28>: Batch {
+                                                            inner: Map {
+                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >) , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
+                                                                input: Cast {
+                                                                    inner: Network {
+                                                                        name: None,
+                                                                        networking_info: Tcp {
+                                                                            fault: FailStop,
+                                                                        },
+                                                                        serialize_fn: Some(
+                                                                            hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
+                                                                        ),
+                                                                        instantiate_fn: <network instantiate>,
+                                                                        deserialize_fn: Some(
+                                                                            | res | { let (id , b) = res . unwrap () ; (hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless (id as hydro_lang :: __staged :: location :: TaglessMemberId) , hydro_lang :: runtime_support :: bincode :: deserialize :: < hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > > (& b) . unwrap ()) },
+                                                                        ),
+                                                                        input: YieldConcat {
+                                                                            inner: Cast {
+                                                                                inner: CrossProduct {
+                                                                                    left: ObserveNonDet {
+                                                                                        inner: Map {
+                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
+                                                                                            input: Cast {
+                                                                                                inner: Cast {
+                                                                                                    inner: Filter {
+                                                                                                        f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | b | * b }) ; { let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) } }),
+                                                                                                        input: Batch {
+                                                                                                            inner: FoldKeyed {
+                                                                                                                init: stageleft :: runtime_support :: fn0_type_hint :: < bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | | false }),
+                                                                                                                acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < bool , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | present , event | { match event { MembershipEvent :: Joined => * present = true , MembershipEvent :: Left => * present = false , } } }),
+                                                                                                                input: Cast {
+                                                                                                                    inner: Map {
+                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | (k , v) | (MemberId :: from_tagless (k) , v) }),
+                                                                                                                        input: Source {
+                                                                                                                            source: ClusterMembers(
+                                                                                                                                Cluster(loc2v1),
+                                                                                                                                Uninit,
+                                                                                                                            ),
                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                 location_id: Cluster(loc1v1),
                                                                                                                                 collection_kind: Stream {
                                                                                                                                     bound: Unbounded,
                                                                                                                                     order: TotalOrder,
                                                                                                                                     retry: ExactlyOnce,
-                                                                                                                                    element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
+                                                                                                                                    element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
                                                                                                                                 },
                                                                                                                             },
                                                                                                                         },
                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                             location_id: Cluster(loc1v1),
-                                                                                                                            collection_kind: KeyedStream {
+                                                                                                                            collection_kind: Stream {
                                                                                                                                 bound: Unbounded,
-                                                                                                                                value_order: TotalOrder,
-                                                                                                                                value_retry: ExactlyOnce,
-                                                                                                                                key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
-                                                                                                                                value_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent,
+                                                                                                                                order: TotalOrder,
+                                                                                                                                retry: ExactlyOnce,
+                                                                                                                                element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
                                                                                                                             },
                                                                                                                         },
                                                                                                                     },
                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                         location_id: Cluster(loc1v1),
-                                                                                                                        collection_kind: KeyedSingleton {
+                                                                                                                        collection_kind: KeyedStream {
                                                                                                                             bound: Unbounded,
+                                                                                                                            value_order: TotalOrder,
+                                                                                                                            value_retry: ExactlyOnce,
                                                                                                                             key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
-                                                                                                                            value_type: bool,
+                                                                                                                            value_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent,
                                                                                                                         },
                                                                                                                     },
                                                                                                                 },
                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                     location_id: Tick(13, Cluster(loc1v1)),
+                                                                                                                    location_id: Cluster(loc1v1),
                                                                                                                     collection_kind: KeyedSingleton {
-                                                                                                                        bound: Bounded,
+                                                                                                                        bound: Unbounded,
                                                                                                                         key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
                                                                                                                         value_type: bool,
                                                                                                                     },
@@ -4381,9 +4770,9 @@ expression: built.ir()
                                                                                                         metadata: HydroIrMetadata {
                                                                                                             location_id: Tick(13, Cluster(loc1v1)),
                                                                                                             collection_kind: KeyedStream {
+                                                                                                            location_id: Tick(14, Cluster(loc1v1)),
+                                                                                                            collection_kind: KeyedSingleton {
                                                                                                                 bound: Bounded,
-                                                                                                                value_order: TotalOrder,
-                                                                                                                value_retry: ExactlyOnce,
                                                                                                                 key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
                                                                                                                 value_type: bool,
                                                                                                             },
@@ -4392,10 +4781,13 @@ expression: built.ir()
                                                                                                     metadata: HydroIrMetadata {
                                                                                                         location_id: Tick(13, Cluster(loc1v1)),
                                                                                                         collection_kind: Stream {
+                                                                                                        location_id: Tick(14, Cluster(loc1v1)),
+                                                                                                        collection_kind: KeyedStream {
                                                                                                             bound: Bounded,
-                                                                                                            order: NoOrder,
-                                                                                                            retry: ExactlyOnce,
-                                                                                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool),
+                                                                                                            value_order: TotalOrder,
+                                                                                                            value_retry: ExactlyOnce,
+                                                                                                            key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
+                                                                                                            value_type: bool,
                                                                                                         },
                                                                                                     },
                                                                                                 },
@@ -4405,16 +4797,15 @@ expression: built.ir()
                                                                                                         bound: Bounded,
                                                                                                         order: NoOrder,
                                                                                                         retry: ExactlyOnce,
-                                                                                                        element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
+                                                                                                        element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool),
                                                                                                     },
                                                                                                 },
                                                                                             },
-                                                                                            trusted: true,
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_id: Tick(13, Cluster(loc1v1)),
                                                                                                 collection_kind: Stream {
                                                                                                     bound: Bounded,
-                                                                                                    order: TotalOrder,
+                                                                                                    order: NoOrder,
                                                                                                     retry: ExactlyOnce,
                                                                                                     element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
                                                                                                 },
@@ -4457,6 +4848,33 @@ expression: built.ir()
                                                                                                                                             },
                                                                                                                                         },
                                                                                                                                     },
+                                                                                        trusted: true,
+                                                                                        metadata: HydroIrMetadata {
+                                                                                            location_id: Tick(14, Cluster(loc1v1)),
+                                                                                            collection_kind: Stream {
+                                                                                                bound: Bounded,
+                                                                                                order: TotalOrder,
+                                                                                                retry: ExactlyOnce,
+                                                                                                element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
+                                                                                            },
+                                                                                        },
+                                                                                    },
+                                                                                    right: Batch {
+                                                                                        inner: Map {
+                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless ((__hydro_lang_cluster_self_id_loc1v1) . clone ()) ; move | ((slot , ballot) , value) | P2a { sender : CLUSTER_SELF_ID__free . clone () , ballot , slot , value } }),
+                                                                                            input: EndAtomic {
+                                                                                                inner: Tee {
+                                                                                                    inner: <shared 29>: YieldConcat {
+                                                                                                        inner: Map {
+                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , bool) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | (d , _) | d }),
+                                                                                                            input: CrossSingleton {
+                                                                                                                left: Chain {
+                                                                                                                    first: Map {
+                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let p_ballot_ref__free = __hydro_singleton_ref_4 ; | (slot , payload) | ((slot , p_ballot_ref__free . clone ()) , Some (payload)) }),
+                                                                                                                        input: Batch {
+                                                                                                                            inner: YieldConcat {
+                                                                                                                                inner: Tee {
+                                                                                                                                    inner: <shared 20>,
                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                         location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                                         collection_kind: Stream {
@@ -4467,22 +4885,64 @@ expression: built.ir()
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                 },
-                                                                                                                                right: Cast {
+                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                    location_id: Atomic(Tick(16, Cluster(loc1v1))),
+                                                                                                                                    collection_kind: Stream {
+                                                                                                                                        bound: Unbounded,
+                                                                                                                                        order: TotalOrder,
+                                                                                                                                        retry: ExactlyOnce,
+                                                                                                                                        element_type: (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
+                                                                                                                                    },
+                                                                                                                                },
+                                                                                                                            },
+                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                location_id: Tick(16, Cluster(loc1v1)),
+                                                                                                                                collection_kind: Stream {
+                                                                                                                                    bound: Bounded,
+                                                                                                                                    order: TotalOrder,
+                                                                                                                                    retry: ExactlyOnce,
+                                                                                                                                    element_type: (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
+                                                                                                                                },
+                                                                                                                            },
+                                                                                                                        },
+                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                            location_id: Tick(16, Cluster(loc1v1)),
+                                                                                                                            collection_kind: Stream {
+                                                                                                                                bound: Bounded,
+                                                                                                                                order: TotalOrder,
+                                                                                                                                retry: ExactlyOnce,
+                                                                                                                                element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                                                            },
+                                                                                                                        },
+                                                                                                                    },
+                                                                                                                    second: Chain {
+                                                                                                                        first: FilterMap {
+                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , core :: option :: Option < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let f__free = 1usize ; let p_ballot_ref__free = __hydro_singleton_ref_0 ; let p_p1b_max_checkpoint_ref__free = __hydro_singleton_ref_1 ; move | (slot , (count , entry)) | { if count > f__free { return None ; } else if let Some (checkpoint) = * p_p1b_max_checkpoint_ref__free && slot <= checkpoint { return None ; } Some (((slot , p_ballot_ref__free . clone ()) , entry . value)) } }),
+                                                                                                                            input: Cast {
+                                                                                                                                inner: Cast {
                                                                                                                                     inner: Tee {
-                                                                                                                                        inner: <shared 4>,
+                                                                                                                                        inner: <shared 23>,
                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                             location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                                             collection_kind: Singleton {
+                                                                                                                                            location_id: Tick(16, Cluster(loc1v1)),
+                                                                                                                                            collection_kind: KeyedSingleton {
                                                                                                                                                 bound: Bounded,
-                                                                                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                                                                                key_type: usize,
+                                                                                                                                                value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
                                                                                                                                             },
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                         location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                                         collection_kind: Optional {
+                                                                                                                                        location_id: Tick(16, Cluster(loc1v1)),
+                                                                                                                                        collection_kind: KeyedStream {
                                                                                                                                             bound: Bounded,
-                                                                                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                                                                            value_order: TotalOrder,
+                                                                                                                                            value_retry: ExactlyOnce,
+                                                                                                                                            key_type: usize,
+                                                                                                                                            value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                 },
@@ -4490,9 +4950,9 @@ expression: built.ir()
                                                                                                                                     location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                                     collection_kind: Stream {
                                                                                                                                         bound: Bounded,
-                                                                                                                                        order: TotalOrder,
+                                                                                                                                        order: NoOrder,
                                                                                                                                         retry: ExactlyOnce,
-                                                                                                                                        element_type: ((usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                                                                                        element_type: (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)),
                                                                                                                                     },
                                                                                                                                 },
                                                                                                                             },
@@ -4500,27 +4960,132 @@ expression: built.ir()
                                                                                                                                 location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                                 collection_kind: Stream {
                                                                                                                                     bound: Bounded,
-                                                                                                                                    order: TotalOrder,
+                                                                                                                                    order: NoOrder,
                                                                                                                                     retry: ExactlyOnce,
                                                                                                                                     element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
                                                                                                                                 },
                                                                                                                             },
                                                                                                                         },
-                                                                                                                        second: Chain {
-                                                                                                                            first: FilterMap {
-                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (((usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < usize >) , core :: option :: Option < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let f__free = 1usize ; move | (((slot , (count , entry)) , ballot) , checkpoint) | { if count > f__free { return None ; } else if let Some (checkpoint) = checkpoint && slot <= checkpoint { return None ; } Some (((slot , ballot) , entry . value)) } }),
-                                                                                                                                input: CrossSingleton {
-                                                                                                                                    left: CrossSingleton {
-                                                                                                                                        left: Cast {
-                                                                                                                                            inner: Cast {
-                                                                                                                                                inner: Tee {
-                                                                                                                                                    inner: <shared 22>,
+                                                                                                                        second: Map {
+                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < usize , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let p_ballot_ref__free = __hydro_singleton_ref_2 ; move | slot | ((slot , p_ballot_ref__free . clone ()) , None) }),
+                                                                                                                            input: Difference {
+                                                                                                                                pos: FlatMap {
+                                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , core :: option :: Option < usize >) , std :: ops :: Range < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (max_slot , checkpoint) | { if let Some (checkpoint) = checkpoint { (checkpoint + 1) .. max_slot } else { 0 .. max_slot } } }),
+                                                                                                                                    input: Cast {
+                                                                                                                                        inner: CrossSingleton {
+                                                                                                                                            left: Tee {
+                                                                                                                                                inner: <shared 22>,
+                                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                                    location_id: Tick(16, Cluster(loc1v1)),
+                                                                                                                                                    collection_kind: Optional {
+                                                                                                                                                        bound: Bounded,
+                                                                                                                                                        element_type: usize,
+                                                                                                                                                    },
+                                                                                                                                                },
+                                                                                                                                            },
+                                                                                                                                            right: Cast {
+                                                                                                                                                inner: Singleton {
+                                                                                                                                                    inner: <shared 30>: Cast {
+                                                                                                                                                        inner: ChainFirst {
+                                                                                                                                                            first: Map {
+                                                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < usize , core :: option :: Option < usize > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
+                                                                                                                                                                input: Reduce {
+                                                                                                                                                                    f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | curr , new | { if new > * curr { * curr = new ; } } }),
+                                                                                                                                                                    input: ObserveNonDet {
+                                                                                                                                                                        inner: FilterMap {
+                                                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (checkpoint , _log) | checkpoint }),
+                                                                                                                                                                            input: Tee {
+                                                                                                                                                                                inner: <shared 24>,
+                                                                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                                                                    location_id: Tick(16, Cluster(loc1v1)),
+                                                                                                                                                                                    collection_kind: Stream {
+                                                                                                                                                                                        bound: Bounded,
+                                                                                                                                                                                        order: NoOrder,
+                                                                                                                                                                                        retry: ExactlyOnce,
+                                                                                                                                                                                        element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
+                                                                                                                                                                                    },
+                                                                                                                                                                                },
+                                                                                                                                                                            },
+                                                                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                                                                location_id: Tick(16, Cluster(loc1v1)),
+                                                                                                                                                                                collection_kind: Stream {
+                                                                                                                                                                                    bound: Bounded,
+                                                                                                                                                                                    order: NoOrder,
+                                                                                                                                                                                    retry: ExactlyOnce,
+                                                                                                                                                                                    element_type: usize,
+                                                                                                                                                                                },
+                                                                                                                                                                            },
+                                                                                                                                                                        },
+                                                                                                                                                                        trusted: true,
+                                                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                                                            location_id: Tick(16, Cluster(loc1v1)),
+                                                                                                                                                                            collection_kind: Stream {
+                                                                                                                                                                                bound: Bounded,
+                                                                                                                                                                                order: TotalOrder,
+                                                                                                                                                                                retry: ExactlyOnce,
+                                                                                                                                                                                element_type: usize,
+                                                                                                                                                                            },
+                                                                                                                                                                        },
+                                                                                                                                                                    },
+                                                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                                                        location_id: Tick(16, Cluster(loc1v1)),
+                                                                                                                                                                        collection_kind: Optional {
+                                                                                                                                                                            bound: Bounded,
+                                                                                                                                                                            element_type: usize,
+                                                                                                                                                                        },
+                                                                                                                                                                    },
+                                                                                                                                                                },
+                                                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                                                    location_id: Tick(16, Cluster(loc1v1)),
+                                                                                                                                                                    collection_kind: Optional {
+                                                                                                                                                                        bound: Bounded,
+                                                                                                                                                                        element_type: core :: option :: Option < usize >,
+                                                                                                                                                                    },
+                                                                                                                                                                },
+                                                                                                                                                            },
+                                                                                                                                                            second: Cast {
+                                                                                                                                                                inner: SingletonSource {
+                                                                                                                                                                    value: :: std :: option :: Option :: None,
+                                                                                                                                                                    first_tick_only: false,
+                                                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                                                        location_id: Tick(16, Cluster(loc1v1)),
+                                                                                                                                                                        collection_kind: Singleton {
+                                                                                                                                                                            bound: Bounded,
+                                                                                                                                                                            element_type: core :: option :: Option < usize >,
+                                                                                                                                                                        },
+                                                                                                                                                                    },
+                                                                                                                                                                },
+                                                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                                                    location_id: Tick(16, Cluster(loc1v1)),
+                                                                                                                                                                    collection_kind: Optional {
+                                                                                                                                                                        bound: Bounded,
+                                                                                                                                                                        element_type: core :: option :: Option < usize >,
+                                                                                                                                                                    },
+                                                                                                                                                                },
+                                                                                                                                                            },
+                                                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                                                location_id: Tick(16, Cluster(loc1v1)),
+                                                                                                                                                                collection_kind: Optional {
+                                                                                                                                                                    bound: Bounded,
+                                                                                                                                                                    element_type: core :: option :: Option < usize >,
+                                                                                                                                                                },
+                                                                                                                                                            },
+                                                                                                                                                        },
+                                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                                            location_id: Tick(16, Cluster(loc1v1)),
+                                                                                                                                                            collection_kind: Singleton {
+                                                                                                                                                                bound: Bounded,
+                                                                                                                                                                element_type: core :: option :: Option < usize >,
+                                                                                                                                                            },
+                                                                                                                                                        },
+                                                                                                                                                    },
                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                         location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                                                         collection_kind: KeyedSingleton {
+                                                                                                                                                        location_id: Tick(16, Cluster(loc1v1)),
+                                                                                                                                                        collection_kind: Singleton {
                                                                                                                                                             bound: Bounded,
-                                                                                                                                                            key_type: usize,
-                                                                                                                                                            value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                                                                                            element_type: core :: option :: Option < usize >,
                                                                                                                                                         },
                                                                                                                                                     },
                                                                                                                                                 },
@@ -4530,6 +5095,51 @@ expression: built.ir()
                                                                                                                                                         bound: Bounded,
                                                                                                                                                         value_order: TotalOrder,
                                                                                                                                                         value_retry: ExactlyOnce,
+                                                                                                                                                    location_id: Tick(16, Cluster(loc1v1)),
+                                                                                                                                                    collection_kind: Optional {
+                                                                                                                                                        bound: Bounded,
+                                                                                                                                                        element_type: core :: option :: Option < usize >,
+                                                                                                                                                    },
+                                                                                                                                                },
+                                                                                                                                            },
+                                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                                location_id: Tick(16, Cluster(loc1v1)),
+                                                                                                                                                collection_kind: Optional {
+                                                                                                                                                    bound: Bounded,
+                                                                                                                                                    element_type: (usize , core :: option :: Option < usize >),
+                                                                                                                                                },
+                                                                                                                                            },
+                                                                                                                                        },
+                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                            location_id: Tick(16, Cluster(loc1v1)),
+                                                                                                                                            collection_kind: Stream {
+                                                                                                                                                bound: Bounded,
+                                                                                                                                                order: TotalOrder,
+                                                                                                                                                retry: ExactlyOnce,
+                                                                                                                                                element_type: (usize , core :: option :: Option < usize >),
+                                                                                                                                            },
+                                                                                                                                        },
+                                                                                                                                    },
+                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                        location_id: Tick(16, Cluster(loc1v1)),
+                                                                                                                                        collection_kind: Stream {
+                                                                                                                                            bound: Bounded,
+                                                                                                                                            order: TotalOrder,
+                                                                                                                                            retry: ExactlyOnce,
+                                                                                                                                            element_type: usize,
+                                                                                                                                        },
+                                                                                                                                    },
+                                                                                                                                },
+                                                                                                                                neg: Map {
+                                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
+                                                                                                                                    input: Cast {
+                                                                                                                                        inner: Cast {
+                                                                                                                                            inner: Tee {
+                                                                                                                                                inner: <shared 23>,
+                                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                                    location_id: Tick(16, Cluster(loc1v1)),
+                                                                                                                                                    collection_kind: KeyedSingleton {
+                                                                                                                                                        bound: Bounded,
                                                                                                                                                         key_type: usize,
                                                                                                                                                         value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
                                                                                                                                                     },
@@ -4561,6 +5171,13 @@ expression: built.ir()
                                                                                                                                                 collection_kind: Optional {
                                                                                                                                                     bound: Bounded,
                                                                                                                                                     element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                                                                                location_id: Tick(16, Cluster(loc1v1)),
+                                                                                                                                                collection_kind: KeyedStream {
+                                                                                                                                                    bound: Bounded,
+                                                                                                                                                    value_order: TotalOrder,
+                                                                                                                                                    value_retry: ExactlyOnce,
+                                                                                                                                                    key_type: usize,
+                                                                                                                                                    value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
                                                                                                                                                 },
                                                                                                                                             },
                                                                                                                                         },
@@ -4683,6 +5300,7 @@ expression: built.ir()
                                                                                                                                             collection_kind: Optional {
                                                                                                                                                 bound: Bounded,
                                                                                                                                                 element_type: core :: option :: Option < usize >,
+                                                                                                                                                element_type: (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)),
                                                                                                                                             },
                                                                                                                                         },
                                                                                                                                     },
@@ -4853,6 +5471,7 @@ expression: built.ir()
                                                                                                                                             order: TotalOrder,
                                                                                                                                             retry: ExactlyOnce,
                                                                                                                                             element_type: (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                                                                                            element_type: usize,
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                 },
@@ -4862,7 +5481,7 @@ expression: built.ir()
                                                                                                                                         bound: Bounded,
                                                                                                                                         order: TotalOrder,
                                                                                                                                         retry: ExactlyOnce,
-                                                                                                                                        element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                                                                        element_type: usize,
                                                                                                                                     },
                                                                                                                                 },
                                                                                                                             },
@@ -4870,7 +5489,7 @@ expression: built.ir()
                                                                                                                                 location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                                 collection_kind: Stream {
                                                                                                                                     bound: Bounded,
-                                                                                                                                    order: NoOrder,
+                                                                                                                                    order: TotalOrder,
                                                                                                                                     retry: ExactlyOnce,
                                                                                                                                     element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
                                                                                                                                 },
@@ -4912,7 +5531,27 @@ expression: built.ir()
                                                                                                                             bound: Bounded,
                                                                                                                             order: NoOrder,
                                                                                                                             retry: ExactlyOnce,
-                                                                                                                            element_type: (((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , bool),
+                                                                                                                            element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                                                        },
+                                                                                                                    },
+                                                                                                                },
+                                                                                                                right: Filter {
+                                                                                                                    f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | b | * b }),
+                                                                                                                    input: Tee {
+                                                                                                                        inner: <shared 13>,
+                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                            location_id: Tick(16, Cluster(loc1v1)),
+                                                                                                                            collection_kind: Singleton {
+                                                                                                                                bound: Bounded,
+                                                                                                                                element_type: bool,
+                                                                                                                            },
+                                                                                                                        },
+                                                                                                                    },
+                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                        location_id: Tick(16, Cluster(loc1v1)),
+                                                                                                                        collection_kind: Optional {
+                                                                                                                            bound: Bounded,
+                                                                                                                            element_type: bool,
                                                                                                                         },
                                                                                                                     },
                                                                                                                 },
@@ -4922,14 +5561,15 @@ expression: built.ir()
                                                                                                                         bound: Bounded,
                                                                                                                         order: NoOrder,
                                                                                                                         retry: ExactlyOnce,
-                                                                                                                        element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                                                        element_type: (((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , bool),
                                                                                                                     },
                                                                                                                 },
                                                                                                             },
                                                                                                             metadata: HydroIrMetadata {
                                                                                                                 location_id: Atomic(Tick(15, Cluster(loc1v1))),
+                                                                                                                location_id: Tick(16, Cluster(loc1v1)),
                                                                                                                 collection_kind: Stream {
-                                                                                                                    bound: Unbounded,
+                                                                                                                    bound: Bounded,
                                                                                                                     order: NoOrder,
                                                                                                                     retry: ExactlyOnce,
                                                                                                                     element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
@@ -4947,7 +5587,7 @@ expression: built.ir()
                                                                                                         },
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
-                                                                                                        location_id: Cluster(loc1v1),
+                                                                                                        location_id: Atomic(Tick(16, Cluster(loc1v1))),
                                                                                                         collection_kind: Stream {
                                                                                                             bound: Unbounded,
                                                                                                             order: NoOrder,
@@ -4962,14 +5602,15 @@ expression: built.ir()
                                                                                                         bound: Unbounded,
                                                                                                         order: NoOrder,
                                                                                                         retry: ExactlyOnce,
-                                                                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
+                                                                                                        element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
                                                                                                     },
                                                                                                 },
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_id: Tick(13, Cluster(loc1v1)),
+                                                                                                location_id: Cluster(loc1v1),
                                                                                                 collection_kind: Stream {
-                                                                                                    bound: Bounded,
+                                                                                                    bound: Unbounded,
                                                                                                     order: NoOrder,
                                                                                                     retry: ExactlyOnce,
                                                                                                     element_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
@@ -4982,25 +5623,26 @@ expression: built.ir()
                                                                                                 bound: Bounded,
                                                                                                 order: NoOrder,
                                                                                                 retry: ExactlyOnce,
-                                                                                                element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >),
+                                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                                                                             },
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_id: Tick(13, Cluster(loc1v1)),
                                                                                         collection_kind: KeyedStream {
+                                                                                        location_id: Tick(14, Cluster(loc1v1)),
+                                                                                        collection_kind: Stream {
                                                                                             bound: Bounded,
-                                                                                            value_order: NoOrder,
-                                                                                            value_retry: ExactlyOnce,
-                                                                                            key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
-                                                                                            value_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
+                                                                                            order: NoOrder,
+                                                                                            retry: ExactlyOnce,
+                                                                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >),
                                                                                         },
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Cluster(loc1v1),
+                                                                                    location_id: Tick(14, Cluster(loc1v1)),
                                                                                     collection_kind: KeyedStream {
-                                                                                        bound: Unbounded,
+                                                                                        bound: Bounded,
                                                                                         value_order: NoOrder,
                                                                                         value_retry: ExactlyOnce,
                                                                                         key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
@@ -5009,23 +5651,24 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Cluster(loc2v1),
+                                                                                location_id: Cluster(loc1v1),
                                                                                 collection_kind: KeyedStream {
                                                                                     bound: Unbounded,
                                                                                     value_order: NoOrder,
                                                                                     value_retry: ExactlyOnce,
-                                                                                    key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
+                                                                                    key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
                                                                                     value_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                                                                 },
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
                                                                             location_id: Cluster(loc2v1),
-                                                                            collection_kind: Stream {
+                                                                            collection_kind: KeyedStream {
                                                                                 bound: Unbounded,
-                                                                                order: NoOrder,
-                                                                                retry: ExactlyOnce,
-                                                                                element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >),
+                                                                                value_order: NoOrder,
+                                                                                value_retry: ExactlyOnce,
+                                                                                key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
+                                                                                value_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                                                             },
                                                                         },
                                                                     },
@@ -5035,14 +5678,14 @@ expression: built.ir()
                                                                             bound: Unbounded,
                                                                             order: NoOrder,
                                                                             retry: ExactlyOnce,
-                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
+                                                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >),
                                                                         },
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(2, Cluster(loc2v1)),
+                                                                    location_id: Cluster(loc2v1),
                                                                     collection_kind: Stream {
-                                                                        bound: Bounded,
+                                                                        bound: Unbounded,
                                                                         order: NoOrder,
                                                                         retry: ExactlyOnce,
                                                                         element_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
@@ -5059,32 +5702,13 @@ expression: built.ir()
                                                                 },
                                                             },
                                                         },
-                                                        right: Cast {
-                                                            inner: Tee {
-                                                                inner: <shared 10>,
-                                                                metadata: HydroIrMetadata {
-                                                                    location_id: Tick(2, Cluster(loc2v1)),
-                                                                    collection_kind: Singleton {
-                                                                        bound: Bounded,
-                                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                    },
-                                                                },
-                                                            },
-                                                            metadata: HydroIrMetadata {
-                                                                location_id: Tick(2, Cluster(loc2v1)),
-                                                                collection_kind: Optional {
-                                                                    bound: Bounded,
-                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                },
-                                                            },
-                                                        },
                                                         metadata: HydroIrMetadata {
                                                             location_id: Tick(2, Cluster(loc2v1)),
                                                             collection_kind: Stream {
                                                                 bound: Bounded,
                                                                 order: NoOrder,
                                                                 retry: ExactlyOnce,
-                                                                element_type: (hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                                             },
                                                         },
                                                     },
@@ -5191,19 +5815,19 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <shared 29>: Map {
+                inner: <shared 31>: Map {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (usize , usize)) , (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
                     input: Cast {
                         inner: Cast {
                             inner: Filter {
                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (usize , usize)) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < (usize , usize) , bool > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; let max__free = 3usize ; move | (success , error) | (success + error) >= max__free }) ; { let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) } }),
                                 input: Tee {
-                                    inner: <shared 30>: FoldKeyed {
+                                    inner: <shared 32>: FoldKeyed {
                                         init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | | (0 , 0) }),
                                         acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } } }),
                                         input: Cast {
                                             inner: Tee {
-                                                inner: <shared 24>,
+                                                inner: <shared 26>,
                                                 metadata: HydroIrMetadata {
                                                     location_id: Tick(14, Cluster(loc1v1)),
                                                     collection_kind: Stream {
@@ -5311,12 +5935,12 @@ expression: built.ir()
         ),
         input: Difference {
             pos: Tee {
-                inner: <shared 31>: FilterMap {
+                inner: <shared 33>: FilterMap {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (usize , usize)) , core :: option :: Option < (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; let min__free = 2usize ; move | (key , (success , _error)) | if success >= min__free { Some (key) } else { None } }),
                     input: Cast {
                         inner: Cast {
                             inner: Tee {
-                                inner: <shared 30>,
+                                inner: <shared 32>,
                                 metadata: HydroIrMetadata {
                                     location_id: Tick(14, Cluster(loc1v1)),
                                     collection_kind: KeyedSingleton {
@@ -5368,7 +5992,7 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <shared 29>,
+                inner: <shared 31>,
                 metadata: HydroIrMetadata {
                     location_id: Tick(14, Cluster(loc1v1)),
                     collection_kind: Stream {
@@ -5397,7 +6021,7 @@ expression: built.ir()
         ),
         input: AntiJoin {
             pos: Tee {
-                inner: <shared 32>: Chain {
+                inner: <shared 34>: Chain {
                     first: DeferTick {
                         input: CycleSource {
                             cycle_id: CycleId(
@@ -5427,7 +6051,7 @@ expression: built.ir()
                         inner: YieldConcat {
                             inner: Batch {
                                 inner: Tee {
-                                    inner: <shared 27>,
+                                    inner: <shared 29>,
                                     metadata: HydroIrMetadata {
                                         location_id: Atomic(Tick(15, Cluster(loc1v1))),
                                         collection_kind: Stream {
@@ -5491,13 +6115,13 @@ expression: built.ir()
             neg: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ()) , (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: request_response :: * ; | (key , _) | key }),
                 input: Tee {
-                    inner: <shared 33>: Batch {
+                    inner: <shared 35>: Batch {
                         inner: Map {
                             f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ()) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | k | (k , ()) }),
                             input: YieldConcat {
                                 inner: Difference {
                                     pos: Tee {
-                                        inner: <shared 31>,
+                                        inner: <shared 33>,
                                         metadata: HydroIrMetadata {
                                             location_id: Tick(14, Cluster(loc1v1)),
                                             collection_kind: Stream {
@@ -5605,6 +6229,28 @@ expression: built.ir()
         },
         op_metadata: HydroIrOpMetadata,
     },
+    Null {
+        input: Singleton {
+            inner: <shared 36>: Tee {
+                inner: <shared 4>,
+                metadata: HydroIrMetadata {
+                    location_id: Tick(16, Cluster(loc1v1)),
+                    collection_kind: Singleton {
+                        bound: Bounded,
+                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                    },
+                },
+            },
+            metadata: HydroIrMetadata {
+                location_id: Tick(16, Cluster(loc1v1)),
+                collection_kind: Singleton {
+                    bound: Bounded,
+                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                },
+            },
+        },
+        op_metadata: HydroIrOpMetadata,
+    },
     CycleSink {
         cycle_id: CycleId(
             4,
@@ -5618,7 +6264,7 @@ expression: built.ir()
                                 first: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < usize , core :: option :: Option < usize > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                     input: Tee {
-                                        inner: <shared 34>: Batch {
+                                        inner: <shared 37>: Batch {
                                             inner: CycleSource {
                                                 cycle_id: CycleId(
                                                     2,
@@ -5703,46 +6349,16 @@ expression: built.ir()
                                                 inner: Cast {
                                                     inner: YieldConcat {
                                                         inner: FilterMap {
-                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (p2a , max_ballot) | if p2a . ballot >= max_ballot { Some ((p2a . slot , LogValue { ballot : p2a . ballot , value : p2a . value , })) } else { None } }),
-                                                            input: CrossSingleton {
-                                                                left: Tee {
-                                                                    inner: <shared 26>,
-                                                                    metadata: HydroIrMetadata {
-                                                                        location_id: Tick(2, Cluster(loc2v1)),
-                                                                        collection_kind: Stream {
-                                                                            bound: Bounded,
-                                                                            order: NoOrder,
-                                                                            retry: ExactlyOnce,
-                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
-                                                                        },
-                                                                    },
-                                                                },
-                                                                right: Cast {
-                                                                    inner: Tee {
-                                                                        inner: <shared 10>,
-                                                                        metadata: HydroIrMetadata {
-                                                                            location_id: Tick(2, Cluster(loc2v1)),
-                                                                            collection_kind: Singleton {
-                                                                                bound: Bounded,
-                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                            },
-                                                                        },
-                                                                    },
-                                                                    metadata: HydroIrMetadata {
-                                                                        location_id: Tick(2, Cluster(loc2v1)),
-                                                                        collection_kind: Optional {
-                                                                            bound: Bounded,
-                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                        },
-                                                                    },
-                                                                },
+                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , core :: option :: Option < (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let a_max_ballot_ref__free = __hydro_singleton_ref_5 ; | p2a | if p2a . ballot >= * a_max_ballot_ref__free { Some ((p2a . slot , LogValue { ballot : p2a . ballot , value : p2a . value , })) } else { None } }),
+                                                            input: Tee {
+                                                                inner: <shared 28>,
                                                                 metadata: HydroIrMetadata {
                                                                     location_id: Tick(2, Cluster(loc2v1)),
                                                                     collection_kind: Stream {
                                                                         bound: Bounded,
                                                                         order: NoOrder,
                                                                         retry: ExactlyOnce,
-                                                                        element_type: (hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                                                     },
                                                                 },
                                                             },
@@ -5790,7 +6406,7 @@ expression: built.ir()
                                                 },
                                             },
                                             watermark: Tee {
-                                                inner: <shared 34>,
+                                                inner: <shared 37>,
                                                 metadata: HydroIrMetadata {
                                                     location_id: Tick(2, Cluster(loc2v1)),
                                                     collection_kind: Optional {
@@ -5889,7 +6505,7 @@ expression: built.ir()
             input: FilterMap {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , core :: option :: Option < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | (key , res) | match res { Ok (_) => None , Err (e) => Some ((key , e)) , } }),
                 input: Tee {
-                    inner: <shared 25>,
+                    inner: <shared 27>,
                     metadata: HydroIrMetadata {
                         location_id: Cluster(loc1v1),
                         collection_kind: Stream {
@@ -6006,7 +6622,7 @@ expression: built.ir()
                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; | (sorted_payload , highest_seq) | sorted_payload . seq > * highest_seq }),
                 input: CrossSingleton {
                     left: Tee {
-                        inner: <shared 35>: Sort {
+                        inner: <shared 38>: Sort {
                             input: Chain {
                                 first: Batch {
                                     inner: Map {
@@ -6158,7 +6774,7 @@ expression: built.ir()
                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , ())) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , ())) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: request_response :: * ; | (key , (meta , resp)) | (key , (meta , resp)) }),
                                                                                     input: JoinHalf {
                                                                                         left: Tee {
-                                                                                            inner: <shared 32>,
+                                                                                            inner: <shared 34>,
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_id: Tick(15, Cluster(loc1v1)),
                                                                                                 collection_kind: Stream {
@@ -6170,7 +6786,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         right: Tee {
-                                                                                            inner: <shared 33>,
+                                                                                            inner: <shared 35>,
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_id: Tick(15, Cluster(loc1v1)),
                                                                                                 collection_kind: Stream {
@@ -6381,12 +6997,12 @@ expression: built.ir()
                     },
                     right: Cast {
                         inner: Tee {
-                            inner: <shared 36>: Fold {
+                            inner: <shared 39>: Fold {
                                 init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; | | 0 }),
                                 acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; | new_next_slot , (sorted_payload , next_slot) | { if sorted_payload . seq == std :: cmp :: max (* new_next_slot , next_slot) { * new_next_slot = sorted_payload . seq + 1 ; } } }),
                                 input: CrossSingleton {
                                     left: Tee {
-                                        inner: <shared 35>,
+                                        inner: <shared 38>,
                                         metadata: HydroIrMetadata {
                                             location_id: Tick(17, Cluster(loc5v1)),
                                             collection_kind: Stream {
@@ -6536,7 +7152,7 @@ expression: built.ir()
             17,
         ),
         input: Tee {
-            inner: <shared 37>: Map {
+            inner: <shared 40>: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: collections :: hash_map :: HashMap < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; | (_kv_store , next_slot) | next_slot }),
                 input: Batch {
                     inner: Fold {
@@ -6544,13 +7160,13 @@ expression: built.ir()
                         acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (std :: collections :: hash_map :: HashMap < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; | (kv_store , next_slot) , payload | { if let Some (kv) = payload . kv { kv_store . insert (kv . key , kv . value) ; } * next_slot = payload . seq + 1 ; } }),
                         input: YieldConcat {
                             inner: Tee {
-                                inner: <shared 38>: Map {
+                                inner: <shared 41>: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; | (sorted_payload , _) | { sorted_payload } }),
                                     input: Filter {
                                         f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; | (sorted_payload , highest_seq) | sorted_payload . seq < * highest_seq }),
                                         input: CrossSingleton {
                                             left: Tee {
-                                                inner: <shared 35>,
+                                                inner: <shared 38>,
                                                 metadata: HydroIrMetadata {
                                                     location_id: Tick(17, Cluster(loc5v1)),
                                                     collection_kind: Stream {
@@ -6563,7 +7179,7 @@ expression: built.ir()
                                             },
                                             right: Cast {
                                                 inner: Tee {
-                                                    inner: <shared 36>,
+                                                    inner: <shared 39>,
                                                     metadata: HydroIrMetadata {
                                                         location_id: Tick(17, Cluster(loc5v1)),
                                                         collection_kind: Singleton {
@@ -6669,7 +7285,7 @@ expression: built.ir()
             18,
         ),
         input: Tee {
-            inner: <shared 39>: FilterMap {
+            inner: <shared 42>: FilterMap {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (core :: option :: Option < usize > , usize) , core :: option :: Option < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; let checkpoint_frequency__free = 1000usize ; move | (max_checkpointed_seq , next_slot) | if max_checkpointed_seq . map (| m | next_slot - m >= checkpoint_frequency__free) . unwrap_or (true) { Some (next_slot) } else { None } }),
                 input: Cast {
                     inner: CrossSingleton {
@@ -6788,7 +7404,7 @@ expression: built.ir()
                                 first: DeferTick {
                                     input: Cast {
                                         inner: Tee {
-                                            inner: <shared 37>,
+                                            inner: <shared 40>,
                                             metadata: HydroIrMetadata {
                                                 location_id: Tick(17, Cluster(loc5v1)),
                                                 collection_kind: Singleton {
@@ -6899,7 +7515,7 @@ expression: built.ir()
                                 left: Cast {
                                     inner: Cast {
                                         inner: Tee {
-                                            inner: <shared 40>: Batch {
+                                            inner: <shared 43>: Batch {
                                                 inner: ReduceKeyed {
                                                     f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; | curr_seq , seq | { if seq > * curr_seq { * curr_seq = seq ; } } }),
                                                     input: Network {
@@ -7040,7 +7656,7 @@ expression: built.ir()
                                                                         inner: YieldConcat {
                                                                             inner: Cast {
                                                                                 inner: Tee {
-                                                                                    inner: <shared 39>,
+                                                                                    inner: <shared 42>,
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_id: Tick(17, Cluster(loc5v1)),
                                                                                         collection_kind: Optional {
@@ -7181,7 +7797,7 @@ expression: built.ir()
                                                 inner: Cast {
                                                     inner: Cast {
                                                         inner: Tee {
-                                                            inner: <shared 40>,
+                                                            inner: <shared 43>,
                                                             metadata: HydroIrMetadata {
                                                                 location_id: Tick(19, Cluster(loc2v1)),
                                                                 collection_kind: KeyedSingleton {
@@ -7312,7 +7928,7 @@ expression: built.ir()
         ),
         input: AntiJoin {
             pos: Tee {
-                inner: <shared 41>: Chain {
+                inner: <shared 44>: Chain {
                     first: DeferTick {
                         input: CycleSource {
                             cycle_id: CycleId(
@@ -7340,7 +7956,7 @@ expression: built.ir()
                     },
                     second: Batch {
                         inner: Tee {
-                            inner: <shared 42>: Map {
+                            inner: <shared 45>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica > , ((u32 , i32) , core :: result :: Result < () , () >)) , ((u32 , i32) , core :: result :: Result < () , () >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
                                 input: Cast {
                                     inner: Network {
@@ -7362,7 +7978,7 @@ expression: built.ir()
                                                     inner: FilterMap {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; | payload | payload . kv }),
                                                         input: Tee {
-                                                            inner: <shared 38>,
+                                                            inner: <shared 41>,
                                                             metadata: HydroIrMetadata {
                                                                 location_id: Tick(17, Cluster(loc5v1)),
                                                                 collection_kind: Stream {
@@ -7486,17 +8102,17 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <shared 43>: FilterMap {
+                inner: <shared 46>: FilterMap {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < ((u32 , i32) , (usize , usize)) , core :: option :: Option < (u32 , i32) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; let min__free = 2usize ; move | (key , (success , _error)) | if success >= min__free { Some (key) } else { None } }),
                     input: Cast {
                         inner: Cast {
                             inner: Tee {
-                                inner: <shared 44>: FoldKeyed {
+                                inner: <shared 47>: FoldKeyed {
                                     init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | | (0 , 0) }),
                                     acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < () , () > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } } }),
                                     input: Cast {
                                         inner: Tee {
-                                            inner: <shared 41>,
+                                            inner: <shared 44>,
                                             metadata: HydroIrMetadata {
                                                 location_id: Tick(20, Cluster(loc3v1)),
                                                 collection_kind: Stream {
@@ -7624,7 +8240,7 @@ expression: built.ir()
         input: FilterMap {
             f: stageleft :: runtime_support :: fn1_type_hint :: < ((u32 , i32) , core :: result :: Result < () , () >) , core :: option :: Option < ((u32 , i32) , ()) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | (key , res) | match res { Ok (_) => None , Err (e) => Some ((key , e)) , } }),
             input: Tee {
-                inner: <shared 42>,
+                inner: <shared 45>,
                 metadata: HydroIrMetadata {
                     location_id: Cluster(loc3v1),
                     collection_kind: Stream {
@@ -7652,10 +8268,10 @@ expression: built.ir()
             1,
         ),
         input: Tee {
-            inner: <shared 45>: Cast {
+            inner: <shared 48>: Cast {
                 inner: YieldConcat {
                     inner: Tee {
-                        inner: <shared 43>,
+                        inner: <shared 46>,
                         metadata: HydroIrMetadata {
                             location_id: Tick(20, Cluster(loc3v1)),
                             collection_kind: Stream {
@@ -7710,11 +8326,11 @@ expression: built.ir()
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (new , old) | { old . borrow_mut () . add (new) . expect ("Error adding value to histogram") ; old } }),
                     input: CrossSingleton {
                         left: Tee {
-                            inner: <shared 46>: Fold {
+                            inner: <shared 49>: Fold {
                                 init: stageleft :: runtime_support :: fn0_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; move | | Histogram :: < u64 > :: new (3) . unwrap () }),
                                 acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , core :: time :: Duration , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; move | latencies , latency | { latencies . record (latency . as_nanos () as u64) . unwrap () ; } }),
                                 input: Tee {
-                                    inner: <shared 47>: Batch {
+                                    inner: <shared 50>: Batch {
                                         inner: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , (i32 , core :: time :: Duration)) , core :: time :: Duration > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; | (_virtual_client_id , (_output , latency)) | latency }),
                                             input: Cast {
@@ -7803,7 +8419,7 @@ expression: built.ir()
                                                                                             input: ObserveNonDet {
                                                                                                 inner: Batch {
                                                                                                     inner: Tee {
-                                                                                                        inner: <shared 45>,
+                                                                                                        inner: <shared 48>,
                                                                                                         metadata: HydroIrMetadata {
                                                                                                             location_id: Cluster(loc3v1),
                                                                                                             collection_kind: KeyedStream {
@@ -8006,11 +8622,11 @@ expression: built.ir()
                             },
                         },
                         right: Tee {
-                            inner: <shared 48>: Map {
+                            inner: <shared 51>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
                                 input: CrossSingleton {
                                     left: Tee {
-                                        inner: <shared 49>: Cast {
+                                        inner: <shared 52>: Cast {
                                             inner: ChainFirst {
                                                 first: DeferTick {
                                                     input: CycleSource {
@@ -8088,7 +8704,7 @@ expression: built.ir()
                                                         input: Map {
                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                             input: Tee {
-                                                                inner: <shared 50>: Reduce {
+                                                                inner: <shared 53>: Reduce {
                                                                     f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
                                                                     input: FlatMap {
                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | d | d }),
@@ -8268,7 +8884,7 @@ expression: built.ir()
                     inner: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | histogram | Rc :: new (RefCell :: new (histogram)) }),
                         input: Tee {
-                            inner: <shared 46>,
+                            inner: <shared 49>,
                             metadata: HydroIrMetadata {
                                 location_id: Tick(22, Cluster(loc3v1)),
                                 collection_kind: Singleton {
@@ -8321,12 +8937,12 @@ expression: built.ir()
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , usize) , usize > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (new , old) | new + old }),
                     input: CrossSingleton {
                         left: Tee {
-                            inner: <shared 51>: Fold {
+                            inner: <shared 54>: Fold {
                                 init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | | 0usize }),
                                 acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , core :: time :: Duration , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | count , _ | * count += 1 }),
                                 input: ObserveNonDet {
                                     inner: Tee {
-                                        inner: <shared 47>,
+                                        inner: <shared 50>,
                                         metadata: HydroIrMetadata {
                                             location_id: Tick(22, Cluster(loc3v1)),
                                             collection_kind: Stream {
@@ -8365,11 +8981,11 @@ expression: built.ir()
                             },
                         },
                         right: Tee {
-                            inner: <shared 52>: Map {
+                            inner: <shared 55>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
                                 input: CrossSingleton {
                                     left: Tee {
-                                        inner: <shared 53>: Cast {
+                                        inner: <shared 56>: Cast {
                                             inner: ChainFirst {
                                                 first: DeferTick {
                                                     input: CycleSource {
@@ -8447,7 +9063,7 @@ expression: built.ir()
                                                         input: Map {
                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                             input: Tee {
-                                                                inner: <shared 50>,
+                                                                inner: <shared 53>,
                                                                 metadata: HydroIrMetadata {
                                                                     location_id: Tick(22, Cluster(loc3v1)),
                                                                     collection_kind: Optional {
@@ -8566,7 +9182,7 @@ expression: built.ir()
                 },
                 second: Cast {
                     inner: Tee {
-                        inner: <shared 51>,
+                        inner: <shared 54>,
                         metadata: HydroIrMetadata {
                             location_id: Tick(22, Cluster(loc3v1)),
                             collection_kind: Singleton {
@@ -8612,7 +9228,7 @@ expression: built.ir()
                     left: Cast {
                         inner: CrossSingleton {
                             left: Tee {
-                                inner: <shared 54>: Cast {
+                                inner: <shared 57>: Cast {
                                     inner: ChainFirst {
                                         first: DeferTick {
                                             input: CycleSource {
@@ -8713,7 +9329,7 @@ expression: built.ir()
                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
                                                                                         input: CrossSingleton {
                                                                                             left: Tee {
-                                                                                                inner: <shared 49>,
+                                                                                                inner: <shared 52>,
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_id: Tick(22, Cluster(loc3v1)),
                                                                                                     collection_kind: Singleton {
@@ -8733,7 +9349,7 @@ expression: built.ir()
                                                                                                                 input: Map {
                                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                                                                                     input: Tee {
-                                                                                                                        inner: <shared 50>,
+                                                                                                                        inner: <shared 53>,
                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                             location_id: Tick(22, Cluster(loc3v1)),
                                                                                                                             collection_kind: Optional {
@@ -9002,7 +9618,7 @@ expression: built.ir()
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                 input: DeferTick {
                                     input: Tee {
-                                        inner: <shared 55>: Reduce {
+                                        inner: <shared 58>: Reduce {
                                             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
                                             input: FlatMap {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | d | d }),
@@ -9179,7 +9795,7 @@ expression: built.ir()
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
                                                 input: CrossSingleton {
                                                     left: Tee {
-                                                        inner: <shared 53>,
+                                                        inner: <shared 56>,
                                                         metadata: HydroIrMetadata {
                                                             location_id: Tick(22, Cluster(loc3v1)),
                                                             collection_kind: Singleton {
@@ -9199,7 +9815,7 @@ expression: built.ir()
                                                                         input: Map {
                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                                             input: Tee {
-                                                                                inner: <shared 50>,
+                                                                                inner: <shared 53>,
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_id: Tick(22, Cluster(loc3v1)),
                                                                                     collection_kind: Optional {
@@ -9368,7 +9984,7 @@ expression: built.ir()
                         f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
                         input: CrossSingleton {
                             left: Tee {
-                                inner: <shared 56>: Cast {
+                                inner: <shared 59>: Cast {
                                     inner: ChainFirst {
                                         first: DeferTick {
                                             input: CycleSource {
@@ -9446,7 +10062,7 @@ expression: built.ir()
                                                 input: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                     input: Tee {
-                                                        inner: <shared 55>,
+                                                        inner: <shared 58>,
                                                         metadata: HydroIrMetadata {
                                                             location_id: Tick(23, Process(loc4v1)),
                                                             collection_kind: Optional {
@@ -9577,7 +10193,7 @@ expression: built.ir()
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
                     input: CrossSingleton {
                         left: Tee {
-                            inner: <shared 56>,
+                            inner: <shared 59>,
                             metadata: HydroIrMetadata {
                                 location_id: Tick(23, Process(loc4v1)),
                                 collection_kind: Singleton {
@@ -9597,7 +10213,7 @@ expression: built.ir()
                                             input: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                 input: Tee {
-                                                    inner: <shared 55>,
+                                                    inner: <shared 58>,
                                                     metadata: HydroIrMetadata {
                                                         location_id: Tick(23, Process(loc4v1)),
                                                         collection_kind: Optional {
@@ -9722,7 +10338,7 @@ expression: built.ir()
                         f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
                         input: CrossSingleton {
                             left: Tee {
-                                inner: <shared 54>,
+                                inner: <shared 57>,
                                 metadata: HydroIrMetadata {
                                     location_id: Tick(23, Process(loc4v1)),
                                     collection_kind: Singleton {
@@ -9742,7 +10358,7 @@ expression: built.ir()
                                                 input: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                     input: Tee {
-                                                        inner: <shared 55>,
+                                                        inner: <shared 58>,
                                                         metadata: HydroIrMetadata {
                                                             location_id: Tick(23, Process(loc4v1)),
                                                             collection_kind: Optional {

--- a/hydro_test/src/cluster/snapshots-nightly/paxos_ir@acceptor_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots-nightly/paxos_ir@acceptor_mermaid.snap
@@ -1,5 +1,6 @@
 ---
 source: hydro_test/src/cluster/paxos_bench.rs
+assertion_line: 231
 expression: "preview.dfir_for(&acceptors).to_mermaid(&WriteConfig\n{\n    no_subgraphs: true, no_pull_push: true, no_handoffs: true,\n    op_text_no_imports: true, ..WriteConfig::default()\n})"
 ---
 %%{init:{'theme':'base','themeVariables':{'clusterBkg':'#ddd','clusterBorder':'#888'}}}%%
@@ -25,21 +26,20 @@ linkStyle default stroke:#aaa
 15v1["<div style=text-align:center>(15v1)</div> <code><br>map({<br>    |((ballot, max_ballot), log)| (<br>        ballot.proposer_id.clone(),<br>        (<br>            ballot.clone(),<br>            if ballot == max_ballot { Ok(log) } else { Err(max_ballot) },<br>        ),<br>    )<br>})</code>"]:::otherClass
 16v1["<div style=text-align:center>(16v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
 17v1["<div style=text-align:center>(17v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-18v1["<div style=text-align:center>(18v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
-19v1["<div style=text-align:center>(19v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Proposer,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            hydro_test::__staged::cluster::paxos::P2a&lt;<br>                (<br>                    u32,<br>                    (<br>                        hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                            hydro_test::__staged::cluster::paxos_bench::Client,<br>                        &gt;,<br>                        i32,<br>                    ),<br>                ),<br>                hydro_test::__staged::cluster::paxos::Proposer,<br>            &gt;,<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
-20v1["<div style=text-align:center>(20v1)</div> <code><br>map({<br>    |(_, v)| v<br>})</code>"]:::otherClass
-21v1["<div style=text-align:center>(21v1)</div> <code><br>tee()</code>"]:::otherClass
-22v1["<div style=text-align:center>(22v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-23v1["<div style=text-align:center>(23v1)</div> <code><br>map({<br>    |(p2a, max_ballot)| (<br>        p2a.sender,<br>        (<br>            (p2a.slot, p2a.ballot.clone()),<br>            if p2a.ballot == max_ballot { Ok(()) } else { Err(max_ballot) },<br>        ),<br>    )<br>})</code>"]:::otherClass
-24v1["<div style=text-align:center>(24v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
-25v1["<div style=text-align:center>(25v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-26v1["<div style=text-align:center>(26v1)</div> <code><br>tee()</code>"]:::otherClass
-27v1["<div style=text-align:center>(27v1)</div> <code><br>map({<br>    |v| Some(v)<br>})</code>"]:::otherClass
-28v1["<div style=text-align:center>(28v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
-29v1["<div style=text-align:center>(29v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
-30v1["<div style=text-align:center>(30v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-31v1["<div style=text-align:center>(31v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-32v1["<div style=text-align:center>(32v1)</div> <code><br>filter_map({<br>    |(p2a, max_ballot)| {<br>        if p2a.ballot &gt;= max_ballot {<br>            Some((<br>                p2a.slot,<br>                LogValue {<br>                    ballot: p2a.ballot,<br>                    value: p2a.value,<br>                },<br>            ))<br>        } else {<br>            None<br>        }<br>    }<br>})</code>"]:::otherClass
+19v1["<div style=text-align:center>(19v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
+20v1["<div style=text-align:center>(20v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
+21v1["<div style=text-align:center>(21v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Proposer,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            hydro_test::__staged::cluster::paxos::P2a&lt;<br>                (<br>                    u32,<br>                    (<br>                        hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                            hydro_test::__staged::cluster::paxos_bench::Client,<br>                        &gt;,<br>                        i32,<br>                    ),<br>                ),<br>                hydro_test::__staged::cluster::paxos::Proposer,<br>            &gt;,<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
+22v1["<div style=text-align:center>(22v1)</div> <code><br>map({<br>    |(_, v)| v<br>})</code>"]:::otherClass
+23v1["<div style=text-align:center>(23v1)</div> <code><br>tee()</code>"]:::otherClass
+24v1["<div style=text-align:center>(24v1)</div> <code><br>map({<br>    let __hydro_singleton_ref_6 = stream_391;<br>    {<br>        let a_max_ballot_ref__free = __hydro_singleton_ref_6;<br>        |p2a| {<br>            let max_ballot = a_max_ballot_ref__free.clone();<br>            (<br>                p2a.sender,<br>                (<br>                    (p2a.slot, p2a.ballot.clone()),<br>                    if p2a.ballot == max_ballot { Ok(()) } else { Err(max_ballot) },<br>                ),<br>            )<br>        }<br>    }<br>})</code>"]:::otherClass
+25v1["<div style=text-align:center>(25v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+26v1["<div style=text-align:center>(26v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+27v1["<div style=text-align:center>(27v1)</div> <code><br>tee()</code>"]:::otherClass
+28v1["<div style=text-align:center>(28v1)</div> <code><br>map({<br>    |v| Some(v)<br>})</code>"]:::otherClass
+29v1["<div style=text-align:center>(29v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
+30v1["<div style=text-align:center>(30v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
+31v1["<div style=text-align:center>(31v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+32v1["<div style=text-align:center>(32v1)</div> <code><br>filter_map({<br>    let __hydro_singleton_ref_5 = stream_391;<br>    {<br>        let a_max_ballot_ref__free = __hydro_singleton_ref_5;<br>        |p2a| {<br>            if p2a.ballot &gt;= *a_max_ballot_ref__free {<br>                Some((<br>                    p2a.slot,<br>                    LogValue {<br>                        ballot: p2a.ballot,<br>                        value: p2a.value,<br>                    },<br>                ))<br>            } else {<br>                None<br>            }<br>        }<br>    }<br>})</code>"]:::otherClass
 33v1["<div style=text-align:center>(33v1)</div> <code><br>chain()</code>"]:::otherClass
 34v1["<div style=text-align:center>(34v1)</div> <code><br>map(|x| (Some(x), None))</code>"]:::otherClass
 35v1["<div style=text-align:center>(35v1)</div> <code><br>map(|watermark| (None, Some(watermark)))</code>"]:::otherClass
@@ -77,50 +77,50 @@ linkStyle default stroke:#aaa
 14v1-->15v1
 16v1-->17v1
 15v1-->16v1
-18v1-->19v1
-19v1-->20v1
+12v1-->19v1
 20v1-->21v1
-21v1-->|input|22v1
-12v1--x|single|22v1; linkStyle 21 stroke:red
+21v1-->22v1
 22v1-->23v1
-24v1-->25v1
 23v1-->24v1
-52v1-->26v1
-26v1-->27v1
-28v1-->29v1
-27v1--x|0|30v1; linkStyle 28 stroke:red
-29v1-->|1|30v1
-21v1-->|input|31v1
-12v1--x|single|31v1; linkStyle 31 stroke:red
-31v1-->32v1
-34v1--x|0|33v1; linkStyle 33 stroke:red
+25v1-->26v1
+24v1-->25v1
+52v1-->27v1
+27v1-->28v1
+29v1-->30v1
+28v1--x|0|31v1; linkStyle 27 stroke:red
+30v1-->|1|31v1
+23v1-->32v1
+34v1--x|0|33v1; linkStyle 30 stroke:red
 32v1-->34v1
 35v1-->|1|33v1
-26v1-->35v1
+27v1-->35v1
 36v1-->37v1
-33v1--x36v1; linkStyle 38 stroke:red
-37v1--x38v1; linkStyle 39 stroke:red
-30v1-->|input|39v1
-38v1--x|single|39v1; linkStyle 41 stroke:red
+33v1--x36v1; linkStyle 35 stroke:red
+37v1--x38v1; linkStyle 36 stroke:red
+31v1-->|input|39v1
+38v1--x|single|39v1; linkStyle 38 stroke:red
 39v1-->40v1
 41v1-->42v1
-42v1--x43v1; linkStyle 44 stroke:red
+42v1--x43v1; linkStyle 41 stroke:red
 43v1-->44v1
-44v1--x45v1; linkStyle 46 stroke:red
+44v1--x45v1; linkStyle 43 stroke:red
 45v1-->46v1
 46v1-->47v1
 44v1-->|input|48v1
-47v1--x|single|48v1; linkStyle 50 stroke:red
+47v1--x|single|48v1; linkStyle 47 stroke:red
 48v1-->49v1
 49v1-->50v1
-50v1--x51v1; linkStyle 53 stroke:red
+50v1--x51v1; linkStyle 50 stroke:red
 51v1-->52v1
+18v1--x24v1; linkStyle 52 stroke:red
+18v1--x32v1; linkStyle 53 stroke:red
 2v1
 16v1
 17v1
-24v1
-25v1
+19v1
 35v1
+25v1
+26v1
 34v1
 subgraph var_cycle_2 ["var <tt>cycle_2</tt>"]
     style var_cycle_2 fill:transparent
@@ -132,6 +132,8 @@ subgraph var_cycle_4 ["var <tt>cycle_4</tt>"]
 end
 subgraph var_reduce_keyed_watermark_chain_524 ["var <tt>reduce_keyed_watermark_chain_524</tt>"]
     style var_reduce_keyed_watermark_chain_524 fill:transparent
+subgraph var_reduce_keyed_watermark_chain_521 ["var <tt>reduce_keyed_watermark_chain_521</tt>"]
+    style var_reduce_keyed_watermark_chain_521 fill:transparent
     33v1
 end
 subgraph var_stream_162 ["var <tt>stream_162</tt>"]
@@ -189,9 +191,15 @@ subgraph var_stream_454 ["var <tt>stream_454</tt>"]
     18v1
     19v1
 end
+subgraph var_stream_454 ["var <tt>stream_454</tt>"]
+    style var_stream_454 fill:transparent
+    20v1
+    21v1
+end
 subgraph var_stream_456 ["var <tt>stream_456</tt>"]
     style var_stream_456 fill:transparent
     20v1
+    22v1
 end
 subgraph var_stream_458 ["var <tt>stream_458</tt>"]
     style var_stream_458 fill:transparent
@@ -217,13 +225,29 @@ subgraph var_stream_511 ["var <tt>stream_511</tt>"]
     style var_stream_511 fill:transparent
     28v1
     29v1
+subgraph var_stream_459 ["var <tt>stream_459</tt>"]
+    style var_stream_459 fill:transparent
+    24v1
+end
+subgraph var_stream_508 ["var <tt>stream_508</tt>"]
+    style var_stream_508 fill:transparent
+    27v1
 end
 subgraph var_stream_513 ["var <tt>stream_513</tt>"]
     style var_stream_513 fill:transparent
+subgraph var_stream_509 ["var <tt>stream_509</tt>"]
+    style var_stream_509 fill:transparent
+    28v1
+end
+subgraph var_stream_510 ["var <tt>stream_510</tt>"]
+    style var_stream_510 fill:transparent
+    29v1
     30v1
 end
 subgraph var_stream_518 ["var <tt>stream_518</tt>"]
     style var_stream_518 fill:transparent
+subgraph var_stream_512 ["var <tt>stream_512</tt>"]
+    style var_stream_512 fill:transparent
     31v1
 end
 subgraph var_stream_519 ["var <tt>stream_519</tt>"]
@@ -232,19 +256,31 @@ subgraph var_stream_519 ["var <tt>stream_519</tt>"]
 end
 subgraph var_stream_524 ["var <tt>stream_524</tt>"]
     style var_stream_524 fill:transparent
+subgraph var_stream_516 ["var <tt>stream_516</tt>"]
+    style var_stream_516 fill:transparent
+    32v1
+end
+subgraph var_stream_521 ["var <tt>stream_521</tt>"]
+    style var_stream_521 fill:transparent
     36v1
     37v1
 end
 subgraph var_stream_528 ["var <tt>stream_528</tt>"]
     style var_stream_528 fill:transparent
+subgraph var_stream_525 ["var <tt>stream_525</tt>"]
+    style var_stream_525 fill:transparent
     38v1
 end
 subgraph var_stream_529 ["var <tt>stream_529</tt>"]
     style var_stream_529 fill:transparent
+subgraph var_stream_526 ["var <tt>stream_526</tt>"]
+    style var_stream_526 fill:transparent
     39v1
 end
 subgraph var_stream_641 ["var <tt>stream_641</tt>"]
     style var_stream_641 fill:transparent
+subgraph var_stream_638 ["var <tt>stream_638</tt>"]
+    style var_stream_638 fill:transparent
     41v1
     42v1
 end
@@ -254,6 +290,12 @@ subgraph var_stream_642 ["var <tt>stream_642</tt>"]
 end
 subgraph var_stream_644 ["var <tt>stream_644</tt>"]
     style var_stream_644 fill:transparent
+subgraph var_stream_639 ["var <tt>stream_639</tt>"]
+    style var_stream_639 fill:transparent
+    43v1
+end
+subgraph var_stream_641 ["var <tt>stream_641</tt>"]
+    style var_stream_641 fill:transparent
     44v1
 end
 subgraph var_stream_651 ["var <tt>stream_651</tt>"]
@@ -267,20 +309,42 @@ end
 subgraph var_stream_653 ["var <tt>stream_653</tt>"]
     style var_stream_653 fill:transparent
     47v1
+subgraph var_stream_648 ["var <tt>stream_648</tt>"]
+    style var_stream_648 fill:transparent
+    45v1
 end
 subgraph var_stream_654 ["var <tt>stream_654</tt>"]
     style var_stream_654 fill:transparent
     48v1
+subgraph var_stream_649 ["var <tt>stream_649</tt>"]
+    style var_stream_649 fill:transparent
+    46v1
 end
 subgraph var_stream_655 ["var <tt>stream_655</tt>"]
     style var_stream_655 fill:transparent
     49v1
+subgraph var_stream_650 ["var <tt>stream_650</tt>"]
+    style var_stream_650 fill:transparent
+    47v1
 end
 subgraph var_stream_656 ["var <tt>stream_656</tt>"]
     style var_stream_656 fill:transparent
     50v1
+subgraph var_stream_651 ["var <tt>stream_651</tt>"]
+    style var_stream_651 fill:transparent
+    48v1
+end
+subgraph var_stream_652 ["var <tt>stream_652</tt>"]
+    style var_stream_652 fill:transparent
+    49v1
 end
 subgraph var_stream_658 ["var <tt>stream_658</tt>"]
     style var_stream_658 fill:transparent
+subgraph var_stream_653 ["var <tt>stream_653</tt>"]
+    style var_stream_653 fill:transparent
+    50v1
+end
+subgraph var_stream_655 ["var <tt>stream_655</tt>"]
+    style var_stream_655 fill:transparent
     51v1
 end

--- a/hydro_test/src/cluster/snapshots-nightly/paxos_ir@proposer_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots-nightly/paxos_ir@proposer_mermaid.snap
@@ -1,5 +1,6 @@
 ---
 source: hydro_test/src/cluster/paxos_bench.rs
+assertion_line: 218
 expression: "preview.dfir_for(&proposers).to_mermaid(&WriteConfig\n{\n    no_subgraphs: true, no_pull_push: true, no_handoffs: true,\n    op_text_no_imports: true, ..WriteConfig::default()\n})"
 ---
 %%{init:{'theme':'base','themeVariables':{'clusterBkg':'#ddd','clusterBorder':'#888'}}}%%
@@ -163,119 +164,114 @@ linkStyle default stroke:#aaa
 153v1["<div style=text-align:center>(153v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
 154v1["<div style=text-align:center>(154v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
 155v1["<div style=text-align:center>(155v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-156v1["<div style=text-align:center>(156v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
-157v1["<div style=text-align:center>(157v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos_bench::Client,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            (<br>                u32,<br>                (<br>                    hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                        hydro_test::__staged::cluster::paxos_bench::Client,<br>                    &gt;,<br>                    i32,<br>                ),<br>            ),<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
-158v1["<div style=text-align:center>(158v1)</div> <code><br>map({<br>    |(_, v)| v<br>})</code>"]:::otherClass
-159v1["<div style=text-align:center>(159v1)</div> <code><br>filter({<br>    |b| *b<br>})</code>"]:::otherClass
-160v1["<div style=text-align:center>(160v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-161v1["<div style=text-align:center>(161v1)</div> <code><br>map({<br>    |(d, _)| d<br>})</code>"]:::otherClass
-162v1["<div style=text-align:center>(162v1)</div> <code><br>enumerate::&lt;'tick&gt;()</code>"]:::otherClass
-163v1["<div style=text-align:center>(163v1)</div> <code><br>flat_map({<br>    |v| v<br>})</code>"]:::otherClass
+157v1["<div style=text-align:center>(157v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
+158v1["<div style=text-align:center>(158v1)</div> <code><br>flat_map({<br>    |v| v<br>})</code>"]:::otherClass
+159v1["<div style=text-align:center>(159v1)</div> <code><br>tee()</code>"]:::otherClass
+160v1["<div style=text-align:center>(160v1)</div> <code><br>map({<br>    |(_checkpoint, log)| log<br>})</code>"]:::otherClass
+161v1["<div style=text-align:center>(161v1)</div> <code><br>flat_map({<br>    |d| d<br>})</code>"]:::otherClass
+162v1["<div style=text-align:center>(162v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        || (0, None)<br>    },<br>    {<br>        |curr_entry, new_entry| {<br>            if let Some(curr_entry_payload) = &amp;mut curr_entry.1 {<br>                let same_values = new_entry.value == curr_entry_payload.value;<br>                let higher_ballot = new_entry.ballot &gt; curr_entry_payload.ballot;<br>                if same_values {<br>                    curr_entry.0 += 1;<br>                }<br>                if higher_ballot {<br>                    curr_entry_payload.ballot = new_entry.ballot;<br>                    if !same_values {<br>                        curr_entry.0 = 1;<br>                        curr_entry_payload.value = new_entry.value;<br>                    }<br>                }<br>            } else {<br>                *curr_entry = (1, Some(new_entry));<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
+163v1["<div style=text-align:center>(163v1)</div> <code><br>map({<br>    let f__free = {<br>        |(count, entry)| (count, entry.unwrap())<br>    };<br>    {<br>        let orig = f__free;<br>        move |(k, v)| (k, orig(v))<br>    }<br>})</code>"]:::otherClass
 164v1["<div style=text-align:center>(164v1)</div> <code><br>tee()</code>"]:::otherClass
-165v1["<div style=text-align:center>(165v1)</div> <code><br>map({<br>    |(_checkpoint, log)| log<br>})</code>"]:::otherClass
-166v1["<div style=text-align:center>(166v1)</div> <code><br>flat_map({<br>    |d| d<br>})</code>"]:::otherClass
-167v1["<div style=text-align:center>(167v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        || (0, None)<br>    },<br>    {<br>        |curr_entry, new_entry| {<br>            if let Some(curr_entry_payload) = &amp;mut curr_entry.1 {<br>                let same_values = new_entry.value == curr_entry_payload.value;<br>                let higher_ballot = new_entry.ballot &gt; curr_entry_payload.ballot;<br>                if same_values {<br>                    curr_entry.0 += 1;<br>                }<br>                if higher_ballot {<br>                    curr_entry_payload.ballot = new_entry.ballot;<br>                    if !same_values {<br>                        curr_entry.0 = 1;<br>                        curr_entry_payload.value = new_entry.value;<br>                    }<br>                }<br>            } else {<br>                *curr_entry = (1, Some(new_entry));<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
-168v1["<div style=text-align:center>(168v1)</div> <code><br>map({<br>    let f__free = {<br>        |(count, entry)| (count, entry.unwrap())<br>    };<br>    {<br>        let orig = f__free;<br>        move |(k, v)| (k, orig(v))<br>    }<br>})</code>"]:::otherClass
-169v1["<div style=text-align:center>(169v1)</div> <code><br>tee()</code>"]:::otherClass
-170v1["<div style=text-align:center>(170v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
-171v1["<div style=text-align:center>(171v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    |curr, new| {<br>        if new &gt; *curr {<br>            *curr = new;<br>        }<br>    }<br>})</code>"]:::otherClass
-172v1["<div style=text-align:center>(172v1)</div> <code><br>tee()</code>"]:::otherClass
-173v1["<div style=text-align:center>(173v1)</div> <code><br>map({<br>    |s| s + 1<br>})</code>"]:::otherClass
-174v1["<div style=text-align:center>(174v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-175v1["<div style=text-align:center>(175v1)</div> <code><br>source_iter([<br>    {<br>        0<br>    },<br>])</code>"]:::otherClass
-176v1["<div style=text-align:center>(176v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
-177v1["<div style=text-align:center>(177v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-178v1["<div style=text-align:center>(178v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-179v1["<div style=text-align:center>(179v1)</div> <code><br>tee()</code>"]:::otherClass
-180v1["<div style=text-align:center>(180v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-181v1["<div style=text-align:center>(181v1)</div> <code><br>map({<br>    |((index, payload), base_slot)| (base_slot + index, payload)<br>})</code>"]:::otherClass
-182v1["<div style=text-align:center>(182v1)</div> <code><br>tee()</code>"]:::otherClass
-183v1["<div style=text-align:center>(183v1)</div> <code><br>fold::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        || 0usize<br>    },<br>    {<br>        |count, _| *count += 1<br>    },<br>)</code>"]:::otherClass
-184v1["<div style=text-align:center>(184v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-185v1["<div style=text-align:center>(185v1)</div> <code><br>map({<br>    |(num_payloads, base_slot)| base_slot + num_payloads<br>})</code>"]:::otherClass
-186v1["<div style=text-align:center>(186v1)</div> <code><br>identity::&lt;usize&gt;()</code>"]:::otherClass
-187v1["<div style=text-align:center>(187v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-188v1["<div style=text-align:center>(188v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
-189v1["<div style=text-align:center>(189v1)</div> <code><br>map({<br>    |(k, v)| (MemberId::from_tagless(k), v)<br>})</code>"]:::otherClass
-190v1["<div style=text-align:center>(190v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        || false<br>    },<br>    {<br>        |present, event| {<br>            match event {<br>                MembershipEvent::Joined =&gt; *present = true,<br>                MembershipEvent::Left =&gt; *present = false,<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
-191v1["<div style=text-align:center>(191v1)</div> <code><br>filter({<br>    let f__free = {<br>        |b| *b<br>    };<br>    {<br>        let orig = f__free;<br>        move |t: &amp;(_, _)| orig(&amp;t.1)<br>    }<br>})</code>"]:::otherClass
-192v1["<div style=text-align:center>(192v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
-193v1["<div style=text-align:center>(193v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-194v1["<div style=text-align:center>(194v1)</div> <code><br>map({<br>    |((slot, payload), ballot)| ((slot, ballot), Some(payload))<br>})</code>"]:::otherClass
-195v1["<div style=text-align:center>(195v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+165v1["<div style=text-align:center>(165v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
+166v1["<div style=text-align:center>(166v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    |curr, new| {<br>        if new &gt; *curr {<br>            *curr = new;<br>        }<br>    }<br>})</code>"]:::otherClass
+167v1["<div style=text-align:center>(167v1)</div> <code><br>tee()</code>"]:::otherClass
+168v1["<div style=text-align:center>(168v1)</div> <code><br>map({<br>    |s| s + 1<br>})</code>"]:::otherClass
+169v1["<div style=text-align:center>(169v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+170v1["<div style=text-align:center>(170v1)</div> <code><br>source_iter([<br>    {<br>        0<br>    },<br>])</code>"]:::otherClass
+171v1["<div style=text-align:center>(171v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
+172v1["<div style=text-align:center>(172v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+173v1["<div style=text-align:center>(173v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+175v1["<div style=text-align:center>(175v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
+176v1["<div style=text-align:center>(176v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos_bench::Client,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            (<br>                u32,<br>                (<br>                    hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                        hydro_test::__staged::cluster::paxos_bench::Client,<br>                    &gt;,<br>                    i32,<br>                ),<br>            ),<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
+177v1["<div style=text-align:center>(177v1)</div> <code><br>map({<br>    |(_, v)| v<br>})</code>"]:::otherClass
+178v1["<div style=text-align:center>(178v1)</div> <code><br>filter({<br>    |b| *b<br>})</code>"]:::otherClass
+179v1["<div style=text-align:center>(179v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+180v1["<div style=text-align:center>(180v1)</div> <code><br>map({<br>    |(d, _)| d<br>})</code>"]:::otherClass
+181v1["<div style=text-align:center>(181v1)</div> <code><br>enumerate::&lt;'tick&gt;()</code>"]:::otherClass
+182v1["<div style=text-align:center>(182v1)</div> <code><br>map({<br>    let __hydro_singleton_ref_3 = stream_364;<br>    {<br>        let base_slot_ref__free = __hydro_singleton_ref_3;<br>        |(index, payload)| (*base_slot_ref__free + index, payload)<br>    }<br>})</code>"]:::otherClass
+183v1["<div style=text-align:center>(183v1)</div> <code><br>tee()</code>"]:::otherClass
+184v1["<div style=text-align:center>(184v1)</div> <code><br>fold::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        || 0usize<br>    },<br>    {<br>        |count, _| *count += 1<br>    },<br>)</code>"]:::otherClass
+185v1["<div style=text-align:center>(185v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+186v1["<div style=text-align:center>(186v1)</div> <code><br>map({<br>    |(num_payloads, base_slot)| base_slot + num_payloads<br>})</code>"]:::otherClass
+187v1["<div style=text-align:center>(187v1)</div> <code><br>identity::&lt;usize&gt;()</code>"]:::otherClass
+188v1["<div style=text-align:center>(188v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+189v1["<div style=text-align:center>(189v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
+190v1["<div style=text-align:center>(190v1)</div> <code><br>map({<br>    |(k, v)| (MemberId::from_tagless(k), v)<br>})</code>"]:::otherClass
+191v1["<div style=text-align:center>(191v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        || false<br>    },<br>    {<br>        |present, event| {<br>            match event {<br>                MembershipEvent::Joined =&gt; *present = true,<br>                MembershipEvent::Left =&gt; *present = false,<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
+192v1["<div style=text-align:center>(192v1)</div> <code><br>filter({<br>    let f__free = {<br>        |b| *b<br>    };<br>    {<br>        let orig = f__free;<br>        move |t: &amp;(_, _)| orig(&amp;t.1)<br>    }<br>})</code>"]:::otherClass
+193v1["<div style=text-align:center>(193v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
+195v1["<div style=text-align:center>(195v1)</div> <code><br>map({<br>    let __hydro_singleton_ref_4 = stream_407;<br>    {<br>        let p_ballot_ref__free = __hydro_singleton_ref_4;<br>        |(slot, payload)| ((slot, p_ballot_ref__free.clone()), Some(payload))<br>    }<br>})</code>"]:::otherClass
 196v1["<div style=text-align:center>(196v1)</div> <code><br>filter_map({<br>    |(checkpoint, _log)| checkpoint<br>})</code>"]:::otherClass
 197v1["<div style=text-align:center>(197v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    |curr, new| {<br>        if new &gt; *curr {<br>            *curr = new;<br>        }<br>    }<br>})</code>"]:::otherClass
 198v1["<div style=text-align:center>(198v1)</div> <code><br>map({<br>    |v| Some(v)<br>})</code>"]:::otherClass
 199v1["<div style=text-align:center>(199v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
 200v1["<div style=text-align:center>(200v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
 201v1["<div style=text-align:center>(201v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-202v1["<div style=text-align:center>(202v1)</div> <code><br>tee()</code>"]:::otherClass
-203v1["<div style=text-align:center>(203v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-204v1["<div style=text-align:center>(204v1)</div> <code><br>filter_map({<br>    let f__free = 1usize;<br>    move |(((slot, (count, entry)), ballot), checkpoint)| {<br>        if count &gt; f__free {<br>            return None;<br>        } else if let Some(checkpoint) = checkpoint &amp;&amp; slot &lt;= checkpoint {<br>            return None;<br>        }<br>        Some(((slot, ballot), entry.value))<br>    }<br>})</code>"]:::otherClass
-205v1["<div style=text-align:center>(205v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-206v1["<div style=text-align:center>(206v1)</div> <code><br>flat_map({<br>    |(max_slot, checkpoint)| {<br>        if let Some(checkpoint) = checkpoint {<br>            (checkpoint + 1)..max_slot<br>        } else {<br>            0..max_slot<br>        }<br>    }<br>})</code>"]:::otherClass
-207v1["<div style=text-align:center>(207v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
-208v1["<div style=text-align:center>(208v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-209v1["<div style=text-align:center>(209v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-210v1["<div style=text-align:center>(210v1)</div> <code><br>map({<br>    move |(slot, ballot)| ((slot, ballot), None)<br>})</code>"]:::otherClass
-211v1["<div style=text-align:center>(211v1)</div> <code><br>chain()</code>"]:::otherClass
-212v1["<div style=text-align:center>(212v1)</div> <code><br>chain()</code>"]:::otherClass
-213v1["<div style=text-align:center>(213v1)</div> <code><br>filter({<br>    |b| *b<br>})</code>"]:::otherClass
-214v1["<div style=text-align:center>(214v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-215v1["<div style=text-align:center>(215v1)</div> <code><br>map({<br>    |(d, _)| d<br>})</code>"]:::otherClass
-216v1["<div style=text-align:center>(216v1)</div> <code><br>tee()</code>"]:::otherClass
-217v1["<div style=text-align:center>(217v1)</div> <code><br>map({<br>    let CLUSTER_SELF_ID__free = hydro_lang::__staged::location::MemberId::&lt;<br>        hydro_test::__staged::cluster::paxos::Proposer,<br>    &gt;::from_tagless((__hydro_lang_cluster_self_id_loc1v1).clone());<br>    move |((slot, ballot), value)| P2a {<br>        sender: CLUSTER_SELF_ID__free.clone(),<br>        ballot,<br>        slot,<br>        value,<br>    }<br>})</code>"]:::otherClass
-218v1["<div style=text-align:center>(218v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-219v1["<div style=text-align:center>(219v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
-220v1["<div style=text-align:center>(220v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-221v1["<div style=text-align:center>(221v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
-222v1["<div style=text-align:center>(222v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Acceptor,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            (<br>                (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>                core::result::Result&lt;<br>                    (),<br>                    hydro_test::__staged::cluster::paxos::Ballot,<br>                &gt;,<br>            ),<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
-223v1["<div style=text-align:center>(223v1)</div> <code><br>map({<br>    |(_, v)| v<br>})</code>"]:::otherClass
+203v1["<div style=text-align:center>(203v1)</div> <code><br>filter_map({<br>    let __hydro_singleton_ref_0 = stream_334;<br>    let __hydro_singleton_ref_1 = stream_422;<br>    {<br>        let f__free = 1usize;<br>        let p_ballot_ref__free = __hydro_singleton_ref_0;<br>        let p_p1b_max_checkpoint_ref__free = __hydro_singleton_ref_1;<br>        move |(slot, (count, entry))| {<br>            if count &gt; f__free {<br>                return None;<br>            } else if let Some(checkpoint) = *p_p1b_max_checkpoint_ref__free<br>                &amp;&amp; slot &lt;= checkpoint<br>            {<br>                return None;<br>            }<br>            Some(((slot, p_ballot_ref__free.clone()), entry.value))<br>        }<br>    }<br>})</code>"]:::otherClass
+204v1["<div style=text-align:center>(204v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+205v1["<div style=text-align:center>(205v1)</div> <code><br>flat_map({<br>    |(max_slot, checkpoint)| {<br>        if let Some(checkpoint) = checkpoint {<br>            (checkpoint + 1)..max_slot<br>        } else {<br>            0..max_slot<br>        }<br>    }<br>})</code>"]:::otherClass
+206v1["<div style=text-align:center>(206v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
+207v1["<div style=text-align:center>(207v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+208v1["<div style=text-align:center>(208v1)</div> <code><br>map({<br>    let __hydro_singleton_ref_2 = stream_334;<br>    {<br>        let p_ballot_ref__free = __hydro_singleton_ref_2;<br>        move |slot| ((slot, p_ballot_ref__free.clone()), None)<br>    }<br>})</code>"]:::otherClass
+209v1["<div style=text-align:center>(209v1)</div> <code><br>chain()</code>"]:::otherClass
+210v1["<div style=text-align:center>(210v1)</div> <code><br>chain()</code>"]:::otherClass
+211v1["<div style=text-align:center>(211v1)</div> <code><br>filter({<br>    |b| *b<br>})</code>"]:::otherClass
+212v1["<div style=text-align:center>(212v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+213v1["<div style=text-align:center>(213v1)</div> <code><br>map({<br>    |(d, _)| d<br>})</code>"]:::otherClass
+214v1["<div style=text-align:center>(214v1)</div> <code><br>tee()</code>"]:::otherClass
+215v1["<div style=text-align:center>(215v1)</div> <code><br>map({<br>    let CLUSTER_SELF_ID__free = hydro_lang::__staged::location::MemberId::&lt;<br>        hydro_test::__staged::cluster::paxos::Proposer,<br>    &gt;::from_tagless((__hydro_lang_cluster_self_id_loc1v1).clone());<br>    move |((slot, ballot), value)| P2a {<br>        sender: CLUSTER_SELF_ID__free.clone(),<br>        ballot,<br>        slot,<br>        value,<br>    }<br>})</code>"]:::otherClass
+216v1["<div style=text-align:center>(216v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+217v1["<div style=text-align:center>(217v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+218v1["<div style=text-align:center>(218v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+219v1["<div style=text-align:center>(219v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
+220v1["<div style=text-align:center>(220v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Acceptor,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            (<br>                (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>                core::result::Result&lt;<br>                    (),<br>                    hydro_test::__staged::cluster::paxos::Ballot,<br>                &gt;,<br>            ),<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
+221v1["<div style=text-align:center>(221v1)</div> <code><br>map({<br>    |(_, v)| v<br>})</code>"]:::otherClass
+222v1["<div style=text-align:center>(222v1)</div> <code><br>tee()</code>"]:::otherClass
+223v1["<div style=text-align:center>(223v1)</div> <code><br>chain()</code>"]:::otherClass
 224v1["<div style=text-align:center>(224v1)</div> <code><br>tee()</code>"]:::otherClass
-225v1["<div style=text-align:center>(225v1)</div> <code><br>chain()</code>"]:::otherClass
+225v1["<div style=text-align:center>(225v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        move || (0, 0)<br>    },<br>    {<br>        move |accum, value| {<br>            if value.is_ok() {<br>                accum.0 += 1;<br>            } else {<br>                accum.1 += 1;<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
 226v1["<div style=text-align:center>(226v1)</div> <code><br>tee()</code>"]:::otherClass
-227v1["<div style=text-align:center>(227v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        move || (0, 0)<br>    },<br>    {<br>        move |accum, value| {<br>            if value.is_ok() {<br>                accum.0 += 1;<br>            } else {<br>                accum.1 += 1;<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
-228v1["<div style=text-align:center>(228v1)</div> <code><br>tee()</code>"]:::otherClass
-229v1["<div style=text-align:center>(229v1)</div> <code><br>filter({<br>    let f__free = {<br>        let max__free = 3usize;<br>        move |(success, error)| (success + error) &gt;= max__free<br>    };<br>    {<br>        let orig = f__free;<br>        move |t: &amp;(_, _)| orig(&amp;t.1)<br>    }<br>})</code>"]:::otherClass
-230v1["<div style=text-align:center>(230v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
-231v1["<div style=text-align:center>(231v1)</div> <code><br>tee()</code>"]:::otherClass
-232v1["<div style=text-align:center>(232v1)</div> <code><br>anti_join::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-233v1["<div style=text-align:center>(233v1)</div> <code><br>identity::&lt;<br>    (<br>        (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>        core::result::Result&lt;(), hydro_test::__staged::cluster::paxos::Ballot&gt;,<br>    ),<br>&gt;()</code>"]:::otherClass
-234v1["<div style=text-align:center>(234v1)</div> <code><br>filter_map({<br>    let min__free = 2usize;<br>    move |(key, (success, _error))| {<br>        if success &gt;= min__free { Some(key) } else { None }<br>    }<br>})</code>"]:::otherClass
-235v1["<div style=text-align:center>(235v1)</div> <code><br>tee()</code>"]:::otherClass
-236v1["<div style=text-align:center>(236v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-237v1["<div style=text-align:center>(237v1)</div> <code><br>identity::&lt;(usize, hydro_test::__staged::cluster::paxos::Ballot)&gt;()</code>"]:::otherClass
-238v1["<div style=text-align:center>(238v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-239v1["<div style=text-align:center>(239v1)</div> <code><br>chain()</code>"]:::otherClass
-240v1["<div style=text-align:center>(240v1)</div> <code><br>tee()</code>"]:::otherClass
-241v1["<div style=text-align:center>(241v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-242v1["<div style=text-align:center>(242v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-243v1["<div style=text-align:center>(243v1)</div> <code><br>map({<br>    |k| (k, ())<br>})</code>"]:::otherClass
-244v1["<div style=text-align:center>(244v1)</div> <code><br>tee()</code>"]:::otherClass
-245v1["<div style=text-align:center>(245v1)</div> <code><br>map({<br>    |(key, _)| key<br>})</code>"]:::otherClass
-246v1["<div style=text-align:center>(246v1)</div> <code><br>anti_join::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-247v1["<div style=text-align:center>(247v1)</div> <code><br>identity::&lt;<br>    (<br>        (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>        core::option::Option&lt;<br>            (<br>                u32,<br>                (<br>                    hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                        hydro_test::__staged::cluster::paxos_bench::Client,<br>                    &gt;,<br>                    i32,<br>                ),<br>            ),<br>        &gt;,<br>    ),<br>&gt;()</code>"]:::otherClass
-248v1["<div style=text-align:center>(248v1)</div> <code><br>filter_map({<br>    move |(key, res)| match res {<br>        Ok(_) =&gt; None,<br>        Err(e) =&gt; Some((key, e)),<br>    }<br>})</code>"]:::otherClass
-249v1["<div style=text-align:center>(249v1)</div> <code><br>map({<br>    |(_, ballot)| ballot<br>})</code>"]:::otherClass
-250v1["<div style=text-align:center>(250v1)</div> <code><br>identity::&lt;hydro_test::__staged::cluster::paxos::Ballot&gt;()</code>"]:::otherClass
-251v1["<div style=text-align:center>(251v1)</div> <code><br>filter({<br>    |b| *b<br>})</code>"]:::otherClass
-252v1["<div style=text-align:center>(252v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-253v1["<div style=text-align:center>(253v1)</div> <code><br>map({<br>    |(d, _)| d<br>})</code>"]:::otherClass
-254v1["<div style=text-align:center>(254v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
-255v1["<div style=text-align:center>(255v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
-256v1["<div style=text-align:center>(256v1)</div> <code><br>map({<br>    |(k, v)| (MemberId::from_tagless(k), v)<br>})</code>"]:::otherClass
-257v1["<div style=text-align:center>(257v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        || false<br>    },<br>    {<br>        |present, event| {<br>            match event {<br>                MembershipEvent::Joined =&gt; *present = true,<br>                MembershipEvent::Left =&gt; *present = false,<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
-258v1["<div style=text-align:center>(258v1)</div> <code><br>filter({<br>    let f__free = {<br>        |b| *b<br>    };<br>    {<br>        let orig = f__free;<br>        move |t: &amp;(_, _)| orig(&amp;t.1)<br>    }<br>})</code>"]:::otherClass
-259v1["<div style=text-align:center>(259v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
-260v1["<div style=text-align:center>(260v1)</div> <code><br>join_multiset_half::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-261v1["<div style=text-align:center>(261v1)</div> <code><br>map({<br>    |(key, (meta, resp))| (key, (meta, resp))<br>})</code>"]:::otherClass
-262v1["<div style=text-align:center>(262v1)</div> <code><br>map({<br>    |((slot, _ballot), (value, _))| (slot, value)<br>})</code>"]:::otherClass
-263v1["<div style=text-align:center>(263v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-264v1["<div style=text-align:center>(264v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
-265v1["<div style=text-align:center>(265v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+227v1["<div style=text-align:center>(227v1)</div> <code><br>filter({<br>    let f__free = {<br>        let max__free = 3usize;<br>        move |(success, error)| (success + error) &gt;= max__free<br>    };<br>    {<br>        let orig = f__free;<br>        move |t: &amp;(_, _)| orig(&amp;t.1)<br>    }<br>})</code>"]:::otherClass
+228v1["<div style=text-align:center>(228v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
+229v1["<div style=text-align:center>(229v1)</div> <code><br>tee()</code>"]:::otherClass
+230v1["<div style=text-align:center>(230v1)</div> <code><br>anti_join::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+231v1["<div style=text-align:center>(231v1)</div> <code><br>identity::&lt;<br>    (<br>        (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>        core::result::Result&lt;(), hydro_test::__staged::cluster::paxos::Ballot&gt;,<br>    ),<br>&gt;()</code>"]:::otherClass
+232v1["<div style=text-align:center>(232v1)</div> <code><br>filter_map({<br>    let min__free = 2usize;<br>    move |(key, (success, _error))| {<br>        if success &gt;= min__free { Some(key) } else { None }<br>    }<br>})</code>"]:::otherClass
+233v1["<div style=text-align:center>(233v1)</div> <code><br>tee()</code>"]:::otherClass
+234v1["<div style=text-align:center>(234v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+235v1["<div style=text-align:center>(235v1)</div> <code><br>identity::&lt;(usize, hydro_test::__staged::cluster::paxos::Ballot)&gt;()</code>"]:::otherClass
+236v1["<div style=text-align:center>(236v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+237v1["<div style=text-align:center>(237v1)</div> <code><br>chain()</code>"]:::otherClass
+238v1["<div style=text-align:center>(238v1)</div> <code><br>tee()</code>"]:::otherClass
+239v1["<div style=text-align:center>(239v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+240v1["<div style=text-align:center>(240v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+241v1["<div style=text-align:center>(241v1)</div> <code><br>map({<br>    |k| (k, ())<br>})</code>"]:::otherClass
+242v1["<div style=text-align:center>(242v1)</div> <code><br>tee()</code>"]:::otherClass
+243v1["<div style=text-align:center>(243v1)</div> <code><br>map({<br>    |(key, _)| key<br>})</code>"]:::otherClass
+244v1["<div style=text-align:center>(244v1)</div> <code><br>anti_join::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+245v1["<div style=text-align:center>(245v1)</div> <code><br>identity::&lt;<br>    (<br>        (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>        core::option::Option&lt;<br>            (<br>                u32,<br>                (<br>                    hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                        hydro_test::__staged::cluster::paxos_bench::Client,<br>                    &gt;,<br>                    i32,<br>                ),<br>            ),<br>        &gt;,<br>    ),<br>&gt;()</code>"]:::otherClass
+246v1["<div style=text-align:center>(246v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
+247v1["<div style=text-align:center>(247v1)</div> <code><br>filter_map({<br>    move |(key, res)| match res {<br>        Ok(_) =&gt; None,<br>        Err(e) =&gt; Some((key, e)),<br>    }<br>})</code>"]:::otherClass
+248v1["<div style=text-align:center>(248v1)</div> <code><br>map({<br>    |(_, ballot)| ballot<br>})</code>"]:::otherClass
+249v1["<div style=text-align:center>(249v1)</div> <code><br>identity::&lt;hydro_test::__staged::cluster::paxos::Ballot&gt;()</code>"]:::otherClass
+250v1["<div style=text-align:center>(250v1)</div> <code><br>filter({<br>    |b| *b<br>})</code>"]:::otherClass
+251v1["<div style=text-align:center>(251v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+252v1["<div style=text-align:center>(252v1)</div> <code><br>map({<br>    |(d, _)| d<br>})</code>"]:::otherClass
+253v1["<div style=text-align:center>(253v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
+254v1["<div style=text-align:center>(254v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
+255v1["<div style=text-align:center>(255v1)</div> <code><br>map({<br>    |(k, v)| (MemberId::from_tagless(k), v)<br>})</code>"]:::otherClass
+256v1["<div style=text-align:center>(256v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        || false<br>    },<br>    {<br>        |present, event| {<br>            match event {<br>                MembershipEvent::Joined =&gt; *present = true,<br>                MembershipEvent::Left =&gt; *present = false,<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
+257v1["<div style=text-align:center>(257v1)</div> <code><br>filter({<br>    let f__free = {<br>        |b| *b<br>    };<br>    {<br>        let orig = f__free;<br>        move |t: &amp;(_, _)| orig(&amp;t.1)<br>    }<br>})</code>"]:::otherClass
+258v1["<div style=text-align:center>(258v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
+259v1["<div style=text-align:center>(259v1)</div> <code><br>join_multiset_half::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+260v1["<div style=text-align:center>(260v1)</div> <code><br>map({<br>    |(key, (meta, resp))| (key, (meta, resp))<br>})</code>"]:::otherClass
+261v1["<div style=text-align:center>(261v1)</div> <code><br>map({<br>    |((slot, _ballot), (value, _))| (slot, value)<br>})</code>"]:::otherClass
+262v1["<div style=text-align:center>(262v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+263v1["<div style=text-align:center>(263v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+264v1["<div style=text-align:center>(264v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
 1v1-->2v1
 132v1--x|0|3v1; linkStyle 1 stroke:red
-250v1-->|1|3v1
+249v1-->|1|3v1
 3v1--x|0|4v1; linkStyle 3 stroke:red
 50v1-->|1|4v1
 4v1--x5v1; linkStyle 5 stroke:red
@@ -441,135 +437,130 @@ linkStyle default stroke:#aaa
 152v1-->|1|153v1
 154v1-->155v1
 153v1-->154v1
-156v1-->157v1
-157v1-->158v1
-128v1-->159v1
-158v1-->|input|160v1
-159v1--x|single|160v1; linkStyle 172 stroke:red
+25v1-->157v1
+117v1-->158v1
+158v1-->159v1
+159v1-->160v1
 160v1-->161v1
-161v1-->162v1
-117v1-->163v1
+161v1--x162v1; linkStyle 173 stroke:red
+162v1-->163v1
 163v1-->164v1
 164v1-->165v1
-165v1-->166v1
-166v1--x167v1; linkStyle 179 stroke:red
+165v1--x166v1; linkStyle 177 stroke:red
+166v1-->167v1
 167v1-->168v1
-168v1-->169v1
-169v1-->170v1
-170v1--x171v1; linkStyle 183 stroke:red
-171v1-->172v1
-172v1-->173v1
-186v1--o174v1; linkStyle 186 stroke:red
+187v1--o169v1; linkStyle 180 stroke:red
+170v1-->171v1
+169v1--x|0|172v1; linkStyle 182 stroke:red
+171v1-->|1|172v1
+168v1--x|0|173v1; linkStyle 184 stroke:red
+172v1-->|1|173v1
+173v1--x|single|185v1; linkStyle 186 stroke:red
 175v1-->176v1
-174v1--x|0|177v1; linkStyle 188 stroke:red
-176v1-->|1|177v1
-173v1--x|0|178v1; linkStyle 190 stroke:red
-177v1-->|1|178v1
-178v1-->179v1
-162v1-->|input|180v1
-179v1--x|single|180v1; linkStyle 194 stroke:red
+176v1-->177v1
+128v1-->178v1
+177v1-->|input|179v1
+178v1--x|single|179v1; linkStyle 191 stroke:red
+179v1-->180v1
 180v1-->181v1
 181v1-->182v1
-182v1--x183v1; linkStyle 197 stroke:red
-183v1-->|input|184v1
-179v1--x|single|184v1; linkStyle 199 stroke:red
-184v1-->185v1
+182v1-->183v1
+183v1--x184v1; linkStyle 196 stroke:red
+184v1-->|input|185v1
 185v1-->186v1
-233v1--o187v1; linkStyle 202 stroke:red
-188v1-->189v1
-189v1--x190v1; linkStyle 204 stroke:red
-190v1-->191v1
+186v1-->187v1
+231v1--o188v1; linkStyle 200 stroke:red
+189v1-->190v1
+190v1--x191v1; linkStyle 202 stroke:red
 191v1-->192v1
-182v1-->|input|193v1
-25v1--x|single|193v1; linkStyle 208 stroke:red
-193v1-->194v1
-169v1-->|input|195v1
-25v1--x|single|195v1; linkStyle 211 stroke:red
-164v1-->196v1
-196v1--x197v1; linkStyle 213 stroke:red
+192v1-->193v1
+25v1-->246v1
+183v1-->195v1
+159v1-->196v1
+196v1--x197v1; linkStyle 208 stroke:red
 197v1-->198v1
 199v1-->200v1
-198v1--x|0|201v1; linkStyle 216 stroke:red
+198v1--x|0|201v1; linkStyle 211 stroke:red
 200v1-->|1|201v1
-201v1-->202v1
-195v1-->|input|203v1
-202v1--x|single|203v1; linkStyle 220 stroke:red
-203v1-->204v1
-172v1-->|input|205v1
-202v1--x|single|205v1; linkStyle 223 stroke:red
-205v1-->206v1
-169v1-->207v1
-206v1-->|pos|208v1
-207v1--x|neg|208v1; linkStyle 227 stroke:red
-208v1-->|input|209v1
-25v1--x|single|209v1; linkStyle 229 stroke:red
-209v1-->210v1
-204v1--x|0|211v1; linkStyle 231 stroke:red
-210v1-->|1|211v1
-194v1--x|0|212v1; linkStyle 233 stroke:red
-211v1-->|1|212v1
-128v1-->213v1
-212v1-->|input|214v1
-213v1--x|single|214v1; linkStyle 237 stroke:red
+201v1--x|single|204v1; linkStyle 213 stroke:red
+164v1-->203v1
+167v1-->|input|204v1
+204v1-->205v1
+164v1-->206v1
+205v1-->|pos|207v1
+206v1--x|neg|207v1; linkStyle 219 stroke:red
+207v1-->208v1
+203v1--x|0|209v1; linkStyle 221 stroke:red
+208v1-->|1|209v1
+195v1--x|0|210v1; linkStyle 223 stroke:red
+209v1-->|1|210v1
+128v1-->211v1
+210v1-->|input|212v1
+211v1--x|single|212v1; linkStyle 227 stroke:red
+212v1-->213v1
+213v1-->214v1
 214v1-->215v1
-215v1-->216v1
+193v1-->|0|216v1
+215v1-->|1|216v1
+217v1-->218v1
 216v1-->217v1
-192v1-->|0|218v1
-217v1-->|1|218v1
 219v1-->220v1
-218v1-->219v1
+220v1-->221v1
 221v1-->222v1
-222v1-->223v1
+188v1--x|0|223v1; linkStyle 238 stroke:red
+222v1-->|1|223v1
 223v1-->224v1
-187v1--x|0|225v1; linkStyle 248 stroke:red
-224v1-->|1|225v1
+224v1--x225v1; linkStyle 241 stroke:red
 225v1-->226v1
-226v1--x227v1; linkStyle 251 stroke:red
+226v1-->227v1
 227v1-->228v1
 228v1-->229v1
-229v1-->230v1
+224v1-->|pos|230v1
+229v1--x|neg|230v1; linkStyle 247 stroke:red
 230v1-->231v1
-226v1-->|pos|232v1
-231v1--x|neg|232v1; linkStyle 257 stroke:red
+226v1-->232v1
 232v1-->233v1
-228v1-->234v1
+233v1-->|pos|234v1
+229v1--x|neg|234v1; linkStyle 252 stroke:red
 234v1-->235v1
-235v1-->|pos|236v1
-231v1--x|neg|236v1; linkStyle 262 stroke:red
-236v1-->237v1
-247v1--o238v1; linkStyle 264 stroke:red
-238v1--x|0|239v1; linkStyle 265 stroke:red
-216v1-->|1|239v1
-239v1-->240v1
-237v1--o241v1; linkStyle 268 stroke:red
-235v1-->|pos|242v1
-241v1--x|neg|242v1; linkStyle 270 stroke:red
+245v1--o236v1; linkStyle 254 stroke:red
+236v1--x|0|237v1; linkStyle 255 stroke:red
+214v1-->|1|237v1
+237v1-->238v1
+235v1--o239v1; linkStyle 258 stroke:red
+233v1-->|pos|240v1
+239v1--x|neg|240v1; linkStyle 260 stroke:red
+240v1-->241v1
+241v1-->242v1
 242v1-->243v1
-243v1-->244v1
+238v1-->|pos|244v1
+243v1--x|neg|244v1; linkStyle 265 stroke:red
 244v1-->245v1
-240v1-->|pos|246v1
-245v1--x|neg|246v1; linkStyle 275 stroke:red
-246v1-->247v1
-224v1-->248v1
+222v1-->247v1
+247v1-->248v1
 248v1-->249v1
-249v1-->250v1
-149v1-->251v1
-25v1-->|input|252v1
-251v1--x|single|252v1; linkStyle 282 stroke:red
+149v1-->250v1
+25v1-->|input|251v1
+250v1--x|single|251v1; linkStyle 272 stroke:red
+251v1-->252v1
 252v1-->253v1
-253v1-->254v1
-255v1-->256v1
-256v1--x257v1; linkStyle 286 stroke:red
+254v1-->255v1
+255v1--x256v1; linkStyle 276 stroke:red
+256v1-->257v1
 257v1-->258v1
-258v1-->259v1
-240v1-->|probe|260v1
-244v1--x|build|260v1; linkStyle 290 stroke:red
+238v1-->|probe|259v1
+242v1--x|build|259v1; linkStyle 280 stroke:red
+259v1-->260v1
 260v1-->261v1
-261v1-->262v1
-259v1-->|0|263v1
-262v1-->|1|263v1
-264v1-->265v1
+258v1-->|0|262v1
+261v1-->|1|262v1
 263v1-->264v1
+262v1-->263v1
+174v1--x182v1; linkStyle 287 stroke:red
+194v1--x195v1; linkStyle 288 stroke:red
+156v1--x203v1; linkStyle 289 stroke:red
+202v1--x203v1; linkStyle 290 stroke:red
+156v1--x208v1; linkStyle 291 stroke:red
 2v1
 44v1
 45v1
@@ -577,34 +568,36 @@ linkStyle default stroke:#aaa
 87v1
 154v1
 155v1
-219v1
-220v1
-254v1
+157v1
+217v1
+218v1
+246v1
+253v1
+263v1
 264v1
-265v1
 subgraph var_cycle_10 ["var <tt>cycle_10</tt>"]
     style var_cycle_10 fill:transparent
     105v1
 end
 subgraph var_cycle_12 ["var <tt>cycle_12</tt>"]
     style var_cycle_12 fill:transparent
-    186v1
+    187v1
 end
 subgraph var_cycle_13 ["var <tt>cycle_13</tt>"]
     style var_cycle_13 fill:transparent
-    233v1
+    231v1
 end
 subgraph var_cycle_14 ["var <tt>cycle_14</tt>"]
     style var_cycle_14 fill:transparent
-    237v1
+    235v1
 end
 subgraph var_cycle_15 ["var <tt>cycle_15</tt>"]
     style var_cycle_15 fill:transparent
-    247v1
+    245v1
 end
 subgraph var_cycle_3 ["var <tt>cycle_3</tt>"]
     style var_cycle_3 fill:transparent
-    250v1
+    249v1
 end
 subgraph var_cycle_5 ["var <tt>cycle_5</tt>"]
     style var_cycle_5 fill:transparent
@@ -1033,9 +1026,30 @@ subgraph var_stream_337 ["var <tt>stream_337</tt>"]
     156v1
     157v1
 end
+subgraph var_stream_338 ["var <tt>stream_338</tt>"]
+    style var_stream_338 fill:transparent
+    158v1
+end
 subgraph var_stream_339 ["var <tt>stream_339</tt>"]
     style var_stream_339 fill:transparent
     158v1
+    159v1
+end
+subgraph var_stream_340 ["var <tt>stream_340</tt>"]
+    style var_stream_340 fill:transparent
+    160v1
+end
+subgraph var_stream_341 ["var <tt>stream_341</tt>"]
+    style var_stream_341 fill:transparent
+    161v1
+end
+subgraph var_stream_343 ["var <tt>stream_343</tt>"]
+    style var_stream_343 fill:transparent
+    162v1
+end
+subgraph var_stream_344 ["var <tt>stream_344</tt>"]
+    style var_stream_344 fill:transparent
+    163v1
 end
 subgraph var_stream_343 ["var <tt>stream_343</tt>"]
     style var_stream_343 fill:transparent
@@ -1048,6 +1062,11 @@ end
 subgraph var_stream_345 ["var <tt>stream_345</tt>"]
     style var_stream_345 fill:transparent
     161v1
+    164v1
+end
+subgraph var_stream_348 ["var <tt>stream_348</tt>"]
+    style var_stream_348 fill:transparent
+    165v1
 end
 subgraph var_stream_348 ["var <tt>stream_348</tt>"]
     style var_stream_348 fill:transparent
@@ -1064,14 +1083,21 @@ end
 subgraph var_stream_352 ["var <tt>stream_352</tt>"]
     style var_stream_352 fill:transparent
     164v1
+subgraph var_stream_350 ["var <tt>stream_350</tt>"]
+    style var_stream_350 fill:transparent
+    166v1
 end
 subgraph var_stream_353 ["var <tt>stream_353</tt>"]
     style var_stream_353 fill:transparent
     165v1
+subgraph var_stream_351 ["var <tt>stream_351</tt>"]
+    style var_stream_351 fill:transparent
+    167v1
 end
 subgraph var_stream_354 ["var <tt>stream_354</tt>"]
     style var_stream_354 fill:transparent
     166v1
+    168v1
 end
 subgraph var_stream_356 ["var <tt>stream_356</tt>"]
     style var_stream_356 fill:transparent
@@ -1080,10 +1106,19 @@ end
 subgraph var_stream_357 ["var <tt>stream_357</tt>"]
     style var_stream_357 fill:transparent
     168v1
+    169v1
 end
 subgraph var_stream_358 ["var <tt>stream_358</tt>"]
     style var_stream_358 fill:transparent
     169v1
+subgraph var_stream_357 ["var <tt>stream_357</tt>"]
+    style var_stream_357 fill:transparent
+    170v1
+    171v1
+end
+subgraph var_stream_359 ["var <tt>stream_359</tt>"]
+    style var_stream_359 fill:transparent
+    172v1
 end
 subgraph var_stream_36 ["var <tt>stream_36</tt>"]
     style var_stream_36 fill:transparent
@@ -1116,6 +1151,17 @@ subgraph var_stream_370 ["var <tt>stream_370</tt>"]
 end
 subgraph var_stream_372 ["var <tt>stream_372</tt>"]
     style var_stream_372 fill:transparent
+subgraph var_stream_362 ["var <tt>stream_362</tt>"]
+    style var_stream_362 fill:transparent
+    173v1
+end
+subgraph var_stream_371 ["var <tt>stream_371</tt>"]
+    style var_stream_371 fill:transparent
+    175v1
+    176v1
+end
+subgraph var_stream_373 ["var <tt>stream_373</tt>"]
+    style var_stream_373 fill:transparent
     177v1
 end
 subgraph var_stream_375 ["var <tt>stream_375</tt>"]
@@ -1124,6 +1170,10 @@ subgraph var_stream_375 ["var <tt>stream_375</tt>"]
 end
 subgraph var_stream_377 ["var <tt>stream_377</tt>"]
     style var_stream_377 fill:transparent
+    179v1
+end
+subgraph var_stream_378 ["var <tt>stream_378</tt>"]
+    style var_stream_378 fill:transparent
     179v1
 end
 subgraph var_stream_379 ["var <tt>stream_379</tt>"]
@@ -1137,6 +1187,7 @@ end
 subgraph var_stream_381 ["var <tt>stream_381</tt>"]
     style var_stream_381 fill:transparent
     182v1
+    180v1
 end
 subgraph var_stream_382 ["var <tt>stream_382</tt>"]
     style var_stream_382 fill:transparent
@@ -1149,6 +1200,9 @@ end
 subgraph var_stream_386 ["var <tt>stream_386</tt>"]
     style var_stream_386 fill:transparent
     185v1
+subgraph var_stream_385 ["var <tt>stream_385</tt>"]
+    style var_stream_385 fill:transparent
+    184v1
 end
 subgraph var_stream_388 ["var <tt>stream_388</tt>"]
     style var_stream_388 fill:transparent
@@ -1161,6 +1215,9 @@ end
 subgraph var_stream_39 ["var <tt>stream_39</tt>"]
     style var_stream_39 fill:transparent
     8v1
+subgraph var_stream_387 ["var <tt>stream_387</tt>"]
+    style var_stream_387 fill:transparent
+    185v1
 end
 subgraph var_stream_390 ["var <tt>stream_390</tt>"]
     style var_stream_390 fill:transparent
@@ -1169,13 +1226,38 @@ end
 subgraph var_stream_392 ["var <tt>stream_392</tt>"]
     style var_stream_392 fill:transparent
     190v1
+subgraph var_stream_389 ["var <tt>stream_389</tt>"]
+    style var_stream_389 fill:transparent
+    186v1
 end
 subgraph var_stream_394 ["var <tt>stream_394</tt>"]
     style var_stream_394 fill:transparent
     191v1
+    188v1
+end
+subgraph var_stream_396 ["var <tt>stream_396</tt>"]
+    style var_stream_396 fill:transparent
+    189v1
 end
 subgraph var_stream_397 ["var <tt>stream_397</tt>"]
     style var_stream_397 fill:transparent
+    190v1
+end
+subgraph var_stream_397 ["var <tt>stream_397</tt>"]
+    style var_stream_397 fill:transparent
+    192v1
+subgraph var_stream_399 ["var <tt>stream_399</tt>"]
+    style var_stream_399 fill:transparent
+    191v1
+end
+subgraph var_stream_404 ["var <tt>stream_404</tt>"]
+    style var_stream_404 fill:transparent
+subgraph var_stream_40 ["var <tt>stream_40</tt>"]
+    style var_stream_40 fill:transparent
+    8v1
+end
+subgraph var_stream_401 ["var <tt>stream_401</tt>"]
+    style var_stream_401 fill:transparent
     192v1
 end
 subgraph var_stream_404 ["var <tt>stream_404</tt>"]
@@ -1193,6 +1275,9 @@ end
 subgraph var_stream_413 ["var <tt>stream_413</tt>"]
     style var_stream_413 fill:transparent
     196v1
+subgraph var_stream_411 ["var <tt>stream_411</tt>"]
+    style var_stream_411 fill:transparent
+    195v1
 end
 subgraph var_stream_415 ["var <tt>stream_415</tt>"]
     style var_stream_415 fill:transparent
@@ -1201,6 +1286,13 @@ end
 subgraph var_stream_416 ["var <tt>stream_416</tt>"]
     style var_stream_416 fill:transparent
     198v1
+subgraph var_stream_414 ["var <tt>stream_414</tt>"]
+    style var_stream_414 fill:transparent
+    196v1
+end
+subgraph var_stream_416 ["var <tt>stream_416</tt>"]
+    style var_stream_416 fill:transparent
+    197v1
 end
 subgraph var_stream_417 ["var <tt>stream_417</tt>"]
     style var_stream_417 fill:transparent
@@ -1210,10 +1302,19 @@ end
 subgraph var_stream_419 ["var <tt>stream_419</tt>"]
     style var_stream_419 fill:transparent
     201v1
+    198v1
+end
+subgraph var_stream_418 ["var <tt>stream_418</tt>"]
+    style var_stream_418 fill:transparent
+    199v1
+    200v1
 end
 subgraph var_stream_421 ["var <tt>stream_421</tt>"]
     style var_stream_421 fill:transparent
     202v1
+subgraph var_stream_420 ["var <tt>stream_420</tt>"]
+    style var_stream_420 fill:transparent
+    201v1
 end
 subgraph var_stream_423 ["var <tt>stream_423</tt>"]
     style var_stream_423 fill:transparent
@@ -1221,6 +1322,12 @@ subgraph var_stream_423 ["var <tt>stream_423</tt>"]
 end
 subgraph var_stream_424 ["var <tt>stream_424</tt>"]
     style var_stream_424 fill:transparent
+subgraph var_stream_426 ["var <tt>stream_426</tt>"]
+    style var_stream_426 fill:transparent
+    203v1
+end
+subgraph var_stream_431 ["var <tt>stream_431</tt>"]
+    style var_stream_431 fill:transparent
     204v1
 end
 subgraph var_stream_428 ["var <tt>stream_428</tt>"]
@@ -1229,14 +1336,24 @@ subgraph var_stream_428 ["var <tt>stream_428</tt>"]
 end
 subgraph var_stream_430 ["var <tt>stream_430</tt>"]
     style var_stream_430 fill:transparent
+subgraph var_stream_433 ["var <tt>stream_433</tt>"]
+    style var_stream_433 fill:transparent
+    205v1
+end
+subgraph var_stream_437 ["var <tt>stream_437</tt>"]
+    style var_stream_437 fill:transparent
     206v1
 end
 subgraph var_stream_434 ["var <tt>stream_434</tt>"]
     style var_stream_434 fill:transparent
+subgraph var_stream_438 ["var <tt>stream_438</tt>"]
+    style var_stream_438 fill:transparent
     207v1
 end
 subgraph var_stream_435 ["var <tt>stream_435</tt>"]
     style var_stream_435 fill:transparent
+subgraph var_stream_439 ["var <tt>stream_439</tt>"]
+    style var_stream_439 fill:transparent
     208v1
 end
 subgraph var_stream_438 ["var <tt>stream_438</tt>"]
@@ -1255,6 +1372,8 @@ subgraph var_stream_441 ["var <tt>stream_441</tt>"]
     style var_stream_441 fill:transparent
     212v1
 end
+    210v1
+end
 subgraph var_stream_443 ["var <tt>stream_443</tt>"]
     style var_stream_443 fill:transparent
     213v1
@@ -1262,14 +1381,22 @@ end
 subgraph var_stream_444 ["var <tt>stream_444</tt>"]
     style var_stream_444 fill:transparent
     214v1
+    211v1
+end
+subgraph var_stream_444 ["var <tt>stream_444</tt>"]
+    style var_stream_444 fill:transparent
+    212v1
 end
 subgraph var_stream_445 ["var <tt>stream_445</tt>"]
     style var_stream_445 fill:transparent
     215v1
 end
+    213v1
+end
 subgraph var_stream_447 ["var <tt>stream_447</tt>"]
     style var_stream_447 fill:transparent
     216v1
+    214v1
 end
 subgraph var_stream_449 ["var <tt>stream_449</tt>"]
     style var_stream_449 fill:transparent
@@ -1278,14 +1405,29 @@ end
 subgraph var_stream_45 ["var <tt>stream_45</tt>"]
     style var_stream_45 fill:transparent
     9v1
+    215v1
 end
 subgraph var_stream_451 ["var <tt>stream_451</tt>"]
     style var_stream_451 fill:transparent
     218v1
+    216v1
 end
 subgraph var_stream_465 ["var <tt>stream_465</tt>"]
     style var_stream_465 fill:transparent
     221v1
+    222v1
+end
+subgraph var_stream_462 ["var <tt>stream_462</tt>"]
+    style var_stream_462 fill:transparent
+    219v1
+    220v1
+end
+subgraph var_stream_464 ["var <tt>stream_464</tt>"]
+    style var_stream_464 fill:transparent
+    221v1
+end
+subgraph var_stream_465 ["var <tt>stream_465</tt>"]
+    style var_stream_465 fill:transparent
     222v1
 end
 subgraph var_stream_467 ["var <tt>stream_467</tt>"]
@@ -1303,10 +1445,24 @@ end
 subgraph var_stream_470 ["var <tt>stream_470</tt>"]
     style var_stream_470 fill:transparent
     225v1
+subgraph var_stream_468 ["var <tt>stream_468</tt>"]
+    style var_stream_468 fill:transparent
+    224v1
+end
+subgraph var_stream_471 ["var <tt>stream_471</tt>"]
+    style var_stream_471 fill:transparent
+    225v1
+end
+subgraph var_stream_472 ["var <tt>stream_472</tt>"]
+    style var_stream_472 fill:transparent
+    226v1
 end
 subgraph var_stream_471 ["var <tt>stream_471</tt>"]
     style var_stream_471 fill:transparent
     226v1
+subgraph var_stream_473 ["var <tt>stream_473</tt>"]
+    style var_stream_473 fill:transparent
+    227v1
 end
 subgraph var_stream_474 ["var <tt>stream_474</tt>"]
     style var_stream_474 fill:transparent
@@ -1319,6 +1475,15 @@ end
 subgraph var_stream_476 ["var <tt>stream_476</tt>"]
     style var_stream_476 fill:transparent
     229v1
+    228v1
+end
+subgraph var_stream_477 ["var <tt>stream_477</tt>"]
+    style var_stream_477 fill:transparent
+    229v1
+end
+subgraph var_stream_478 ["var <tt>stream_478</tt>"]
+    style var_stream_478 fill:transparent
+    230v1
 end
 subgraph var_stream_479 ["var <tt>stream_479</tt>"]
     style var_stream_479 fill:transparent
@@ -1336,6 +1501,17 @@ end
 subgraph var_stream_481 ["var <tt>stream_481</tt>"]
     style var_stream_481 fill:transparent
     232v1
+subgraph var_stream_482 ["var <tt>stream_482</tt>"]
+    style var_stream_482 fill:transparent
+    232v1
+end
+subgraph var_stream_483 ["var <tt>stream_483</tt>"]
+    style var_stream_483 fill:transparent
+    233v1
+end
+subgraph var_stream_485 ["var <tt>stream_485</tt>"]
+    style var_stream_485 fill:transparent
+    234v1
 end
 subgraph var_stream_485 ["var <tt>stream_485</tt>"]
     style var_stream_485 fill:transparent
@@ -1348,9 +1524,23 @@ end
 subgraph var_stream_488 ["var <tt>stream_488</tt>"]
     style var_stream_488 fill:transparent
     236v1
+subgraph var_stream_487 ["var <tt>stream_487</tt>"]
+    style var_stream_487 fill:transparent
+    236v1
+end
+subgraph var_stream_49 ["var <tt>stream_49</tt>"]
+    style var_stream_49 fill:transparent
+    11v1
+    12v1
 end
 subgraph var_stream_490 ["var <tt>stream_490</tt>"]
     style var_stream_490 fill:transparent
+subgraph var_stream_492 ["var <tt>stream_492</tt>"]
+    style var_stream_492 fill:transparent
+    237v1
+end
+subgraph var_stream_493 ["var <tt>stream_493</tt>"]
+    style var_stream_493 fill:transparent
     238v1
 end
 subgraph var_stream_495 ["var <tt>stream_495</tt>"]
@@ -1359,11 +1549,24 @@ subgraph var_stream_495 ["var <tt>stream_495</tt>"]
 end
 subgraph var_stream_496 ["var <tt>stream_496</tt>"]
     style var_stream_496 fill:transparent
+subgraph var_stream_496 ["var <tt>stream_496</tt>"]
+    style var_stream_496 fill:transparent
+    239v1
+end
+subgraph var_stream_497 ["var <tt>stream_497</tt>"]
+    style var_stream_497 fill:transparent
     240v1
 end
 subgraph var_stream_499 ["var <tt>stream_499</tt>"]
     style var_stream_499 fill:transparent
     241v1
+subgraph var_stream_499 ["var <tt>stream_499</tt>"]
+    style var_stream_499 fill:transparent
+    241v1
+end
+subgraph var_stream_501 ["var <tt>stream_501</tt>"]
+    style var_stream_501 fill:transparent
+    242v1
 end
 subgraph var_stream_50 ["var <tt>stream_50</tt>"]
     style var_stream_50 fill:transparent
@@ -1384,6 +1587,7 @@ end
 subgraph var_stream_505 ["var <tt>stream_505</tt>"]
     style var_stream_505 fill:transparent
     245v1
+    243v1
 end
 subgraph var_stream_506 ["var <tt>stream_506</tt>"]
     style var_stream_506 fill:transparent
@@ -1391,11 +1595,36 @@ subgraph var_stream_506 ["var <tt>stream_506</tt>"]
 end
 subgraph var_stream_52 ["var <tt>stream_52</tt>"]
     style var_stream_52 fill:transparent
+subgraph var_stream_503 ["var <tt>stream_503</tt>"]
+    style var_stream_503 fill:transparent
+    244v1
+end
+subgraph var_stream_51 ["var <tt>stream_51</tt>"]
+    style var_stream_51 fill:transparent
+    13v1
+end
+subgraph var_stream_53 ["var <tt>stream_53</tt>"]
+    style var_stream_53 fill:transparent
     14v1
 end
 subgraph var_stream_534 ["var <tt>stream_534</tt>"]
     style var_stream_534 fill:transparent
     248v1
+subgraph var_stream_531 ["var <tt>stream_531</tt>"]
+    style var_stream_531 fill:transparent
+    247v1
+end
+subgraph var_stream_532 ["var <tt>stream_532</tt>"]
+    style var_stream_532 fill:transparent
+    248v1
+end
+subgraph var_stream_535 ["var <tt>stream_535</tt>"]
+    style var_stream_535 fill:transparent
+    250v1
+end
+subgraph var_stream_536 ["var <tt>stream_536</tt>"]
+    style var_stream_536 fill:transparent
+    251v1
 end
 subgraph var_stream_535 ["var <tt>stream_535</tt>"]
     style var_stream_535 fill:transparent
@@ -1416,6 +1645,21 @@ end
 subgraph var_stream_540 ["var <tt>stream_540</tt>"]
     style var_stream_540 fill:transparent
     253v1
+subgraph var_stream_537 ["var <tt>stream_537</tt>"]
+    style var_stream_537 fill:transparent
+    252v1
+end
+subgraph var_stream_541 ["var <tt>stream_541</tt>"]
+    style var_stream_541 fill:transparent
+    254v1
+end
+subgraph var_stream_542 ["var <tt>stream_542</tt>"]
+    style var_stream_542 fill:transparent
+    255v1
+end
+subgraph var_stream_544 ["var <tt>stream_544</tt>"]
+    style var_stream_544 fill:transparent
+    256v1
 end
 subgraph var_stream_544 ["var <tt>stream_544</tt>"]
     style var_stream_544 fill:transparent
@@ -1427,6 +1671,9 @@ subgraph var_stream_545 ["var <tt>stream_545</tt>"]
 end
 subgraph var_stream_547 ["var <tt>stream_547</tt>"]
     style var_stream_547 fill:transparent
+    257v1
+subgraph var_stream_546 ["var <tt>stream_546</tt>"]
+    style var_stream_546 fill:transparent
     257v1
 end
 subgraph var_stream_549 ["var <tt>stream_549</tt>"]
@@ -1440,6 +1687,19 @@ end
 subgraph var_stream_552 ["var <tt>stream_552</tt>"]
     style var_stream_552 fill:transparent
     259v1
+    15v1
+end
+subgraph var_stream_553 ["var <tt>stream_553</tt>"]
+    style var_stream_553 fill:transparent
+    259v1
+end
+subgraph var_stream_554 ["var <tt>stream_554</tt>"]
+    style var_stream_554 fill:transparent
+    260v1
+end
+subgraph var_stream_556 ["var <tt>stream_556</tt>"]
+    style var_stream_556 fill:transparent
+    261v1
 end
 subgraph var_stream_556 ["var <tt>stream_556</tt>"]
     style var_stream_556 fill:transparent
@@ -1451,6 +1711,9 @@ subgraph var_stream_557 ["var <tt>stream_557</tt>"]
 end
 subgraph var_stream_559 ["var <tt>stream_559</tt>"]
     style var_stream_559 fill:transparent
+    262v1
+subgraph var_stream_558 ["var <tt>stream_558</tt>"]
+    style var_stream_558 fill:transparent
     262v1
 end
 subgraph var_stream_56 ["var <tt>stream_56</tt>"]

--- a/hydro_test/src/cluster/snapshots/paxos_ir.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir.snap
@@ -3614,6 +3614,28 @@ expression: built.ir()
         },
         op_metadata: HydroIrOpMetadata,
     },
+    Null {
+        input: Singleton {
+            inner: <shared 19>: Tee {
+                inner: <shared 4>,
+                metadata: HydroIrMetadata {
+                    location_id: Tick(15, Cluster(loc1v1)),
+                    collection_kind: Singleton {
+                        bound: Bounded,
+                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                    },
+                },
+            },
+            metadata: HydroIrMetadata {
+                location_id: Tick(15, Cluster(loc1v1)),
+                collection_kind: Singleton {
+                    bound: Bounded,
+                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                },
+            },
+        },
+        op_metadata: HydroIrOpMetadata,
+    },
     CycleSink {
         cycle_id: CycleId(
             12,
@@ -3626,73 +3648,62 @@ expression: built.ir()
                         init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | | 0usize }),
                         acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | count , _ | * count += 1 }),
                         input: Tee {
-                            inner: <shared 19>: Map {
-                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , usize) , (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | ((index , payload) , base_slot) | (base_slot + index , payload) }),
-                                input: CrossSingleton {
-                                    left: Enumerate {
-                                        input: Batch {
-                                            inner: YieldConcat {
-                                                inner: Map {
-                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , bool) , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | (d , _) | d }),
-                                                    input: CrossSingleton {
-                                                        left: Batch {
-                                                            inner: ObserveNonDet {
-                                                                inner: Map {
-                                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                                                    input: Cast {
-                                                                        inner: Network {
-                                                                            name: None,
-                                                                            networking_info: Tcp {
-                                                                                fault: FailStop,
-                                                                            },
-                                                                            serialize_fn: Some(
-                                                                                hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
-                                                                            ),
-                                                                            instantiate_fn: <network instantiate>,
-                                                                            deserialize_fn: Some(
-                                                                                | res | { let (id , b) = res . unwrap () ; (hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos_bench :: Client > :: from_tagless (id as hydro_lang :: __staged :: location :: TaglessMemberId) , hydro_lang :: runtime_support :: bincode :: deserialize :: < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > (& b) . unwrap ()) },
-                                                                            ),
-                                                                            input: Cast {
-                                                                                inner: Map {
-                                                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_with_client :: * ; move | (payload , leader_id) | (leader_id , payload) }),
-                                                                                    input: YieldConcat {
-                                                                                        inner: CrossSingleton {
-                                                                                            left: Tee {
-                                                                                                inner: <shared 15>,
-                                                                                                metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(11, Cluster(loc3v1)),
-                                                                                                    collection_kind: Stream {
-                                                                                                        bound: Bounded,
-                                                                                                        order: TotalOrder,
-                                                                                                        retry: ExactlyOnce,
-                                                                                                        element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
-                                                                                                    },
-                                                                                                },
-                                                                                            },
-                                                                                            right: Tee {
-                                                                                                inner: <shared 17>,
-                                                                                                metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(11, Cluster(loc3v1)),
-                                                                                                    collection_kind: Optional {
-                                                                                                        bound: Bounded,
-                                                                                                        element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
-                                                                                                    },
-                                                                                                },
-                                                                                            },
+                            inner: <shared 20>: Map {
+                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let base_slot_ref__free = __hydro_singleton_ref_0 ; | (index , payload) | (* base_slot_ref__free + index , payload) }),
+                                input: Enumerate {
+                                    input: Batch {
+                                        inner: YieldConcat {
+                                            inner: Map {
+                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , bool) , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | (d , _) | d }),
+                                                input: CrossSingleton {
+                                                    left: Batch {
+                                                        inner: ObserveNonDet {
+                                                            inner: Map {
+                                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
+                                                                input: Cast {
+                                                                    inner: Network {
+                                                                        name: None,
+                                                                        networking_info: Tcp {
+                                                                            fault: FailStop,
+                                                                        },
+                                                                        serialize_fn: Some(
+                                                                            hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
+                                                                        ),
+                                                                        instantiate_fn: <network instantiate>,
+                                                                        deserialize_fn: Some(
+                                                                            | res | { let (id , b) = res . unwrap () ; (hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos_bench :: Client > :: from_tagless (id as hydro_lang :: __staged :: location :: TaglessMemberId) , hydro_lang :: runtime_support :: bincode :: deserialize :: < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > (& b) . unwrap ()) },
+                                                                        ),
+                                                                        input: Cast {
+                                                                            inner: Map {
+                                                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_with_client :: * ; move | (payload , leader_id) | (leader_id , payload) }),
+                                                                                input: YieldConcat {
+                                                                                    inner: CrossSingleton {
+                                                                                        left: Tee {
+                                                                                            inner: <shared 15>,
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_id: Tick(11, Cluster(loc3v1)),
                                                                                                 collection_kind: Stream {
                                                                                                     bound: Bounded,
                                                                                                     order: TotalOrder,
                                                                                                     retry: ExactlyOnce,
-                                                                                                    element_type: ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >),
+                                                                                                    element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
+                                                                                                },
+                                                                                            },
+                                                                                        },
+                                                                                        right: Tee {
+                                                                                            inner: <shared 17>,
+                                                                                            metadata: HydroIrMetadata {
+                                                                                                location_id: Tick(11, Cluster(loc3v1)),
+                                                                                                collection_kind: Optional {
+                                                                                                    bound: Bounded,
+                                                                                                    element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                                                                                 },
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Cluster(loc3v1),
+                                                                                            location_id: Tick(11, Cluster(loc3v1)),
                                                                                             collection_kind: Stream {
-                                                                                                bound: Unbounded,
+                                                                                                bound: Bounded,
                                                                                                 order: TotalOrder,
                                                                                                 retry: ExactlyOnce,
                                                                                                 element_type: ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >),
@@ -3705,39 +3716,39 @@ expression: built.ir()
                                                                                             bound: Unbounded,
                                                                                             order: TotalOrder,
                                                                                             retry: ExactlyOnce,
-                                                                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
+                                                                                            element_type: ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >),
                                                                                         },
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_id: Cluster(loc3v1),
-                                                                                    collection_kind: KeyedStream {
+                                                                                    collection_kind: Stream {
                                                                                         bound: Unbounded,
-                                                                                        value_order: TotalOrder,
-                                                                                        value_retry: ExactlyOnce,
-                                                                                        key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
-                                                                                        value_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
+                                                                                        order: TotalOrder,
+                                                                                        retry: ExactlyOnce,
+                                                                                        element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
                                                                                     },
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Cluster(loc1v1),
+                                                                                location_id: Cluster(loc3v1),
                                                                                 collection_kind: KeyedStream {
                                                                                     bound: Unbounded,
                                                                                     value_order: TotalOrder,
                                                                                     value_retry: ExactlyOnce,
-                                                                                    key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >,
+                                                                                    key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                                                                     value_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
                                                                                 },
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
                                                                             location_id: Cluster(loc1v1),
-                                                                            collection_kind: Stream {
+                                                                            collection_kind: KeyedStream {
                                                                                 bound: Unbounded,
-                                                                                order: NoOrder,
-                                                                                retry: ExactlyOnce,
-                                                                                element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
+                                                                                value_order: TotalOrder,
+                                                                                value_retry: ExactlyOnce,
+                                                                                key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >,
+                                                                                value_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
                                                                             },
                                                                         },
                                                                     },
@@ -3747,48 +3758,28 @@ expression: built.ir()
                                                                             bound: Unbounded,
                                                                             order: NoOrder,
                                                                             retry: ExactlyOnce,
-                                                                            element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
+                                                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
                                                                         },
                                                                     },
                                                                 },
-                                                                trusted: false,
                                                                 metadata: HydroIrMetadata {
                                                                     location_id: Cluster(loc1v1),
                                                                     collection_kind: Stream {
                                                                         bound: Unbounded,
-                                                                        order: TotalOrder,
+                                                                        order: NoOrder,
                                                                         retry: ExactlyOnce,
                                                                         element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
                                                                     },
                                                                 },
                                                             },
+                                                            trusted: false,
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                location_id: Cluster(loc1v1),
                                                                 collection_kind: Stream {
-                                                                    bound: Bounded,
+                                                                    bound: Unbounded,
                                                                     order: TotalOrder,
                                                                     retry: ExactlyOnce,
                                                                     element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
-                                                                },
-                                                            },
-                                                        },
-                                                        right: Filter {
-                                                            f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | b | * b }),
-                                                            input: Tee {
-                                                                inner: <shared 13>,
-                                                                metadata: HydroIrMetadata {
-                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                    collection_kind: Singleton {
-                                                                        bound: Bounded,
-                                                                        element_type: bool,
-                                                                    },
-                                                                },
-                                                            },
-                                                            metadata: HydroIrMetadata {
-                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                collection_kind: Optional {
-                                                                    bound: Bounded,
-                                                                    element_type: bool,
                                                                 },
                                                             },
                                                         },
@@ -3798,7 +3789,27 @@ expression: built.ir()
                                                                 bound: Bounded,
                                                                 order: TotalOrder,
                                                                 retry: ExactlyOnce,
-                                                                element_type: ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , bool),
+                                                                element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
+                                                            },
+                                                        },
+                                                    },
+                                                    right: Filter {
+                                                        f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | b | * b }),
+                                                        input: Tee {
+                                                            inner: <shared 13>,
+                                                            metadata: HydroIrMetadata {
+                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                collection_kind: Singleton {
+                                                                    bound: Bounded,
+                                                                    element_type: bool,
+                                                                },
+                                                            },
+                                                        },
+                                                        metadata: HydroIrMetadata {
+                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                            collection_kind: Optional {
+                                                                bound: Bounded,
+                                                                element_type: bool,
                                                             },
                                                         },
                                                     },
@@ -3808,14 +3819,14 @@ expression: built.ir()
                                                             bound: Bounded,
                                                             order: TotalOrder,
                                                             retry: ExactlyOnce,
-                                                            element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
+                                                            element_type: ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , bool),
                                                         },
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Atomic(Tick(15, Cluster(loc1v1))),
+                                                    location_id: Tick(15, Cluster(loc1v1)),
                                                     collection_kind: Stream {
-                                                        bound: Unbounded,
+                                                        bound: Bounded,
                                                         order: TotalOrder,
                                                         retry: ExactlyOnce,
                                                         element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
@@ -3823,9 +3834,9 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                location_id: Atomic(Tick(15, Cluster(loc1v1))),
                                                 collection_kind: Stream {
-                                                    bound: Bounded,
+                                                    bound: Unbounded,
                                                     order: TotalOrder,
                                                     retry: ExactlyOnce,
                                                     element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
@@ -3838,318 +3849,7 @@ expression: built.ir()
                                                 bound: Bounded,
                                                 order: TotalOrder,
                                                 retry: ExactlyOnce,
-                                                element_type: (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
-                                            },
-                                        },
-                                    },
-                                    right: Cast {
-                                        inner: Tee {
-                                            inner: <shared 20>: Cast {
-                                                inner: ChainFirst {
-                                                    first: Map {
-                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < usize , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | s | s + 1 }),
-                                                        input: Batch {
-                                                            inner: YieldConcat {
-                                                                inner: Tee {
-                                                                    inner: <shared 21>: Reduce {
-                                                                        f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | curr , new | { if new > * curr { * curr = new ; } } }),
-                                                                        input: ObserveNonDet {
-                                                                            inner: Map {
-                                                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                                                input: Cast {
-                                                                                    inner: Cast {
-                                                                                        inner: Tee {
-                                                                                            inner: <shared 22>: Map {
-                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)) , (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (count , entry) | (count , entry . unwrap ()) }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
-                                                                                                input: FoldKeyed {
-                                                                                                    init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | | (0 , None) }),
-                                                                                                    acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | curr_entry , new_entry | { if let Some (curr_entry_payload) = & mut curr_entry . 1 { let same_values = new_entry . value == curr_entry_payload . value ; let higher_ballot = new_entry . ballot > curr_entry_payload . ballot ; if same_values { curr_entry . 0 += 1 ; } if higher_ballot { curr_entry_payload . ballot = new_entry . ballot ; if ! same_values { curr_entry . 0 = 1 ; curr_entry_payload . value = new_entry . value ; } } } else { * curr_entry = (1 , Some (new_entry)) ; } } }),
-                                                                                                    input: Cast {
-                                                                                                        inner: FlatMap {
-                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | d | d }),
-                                                                                                            input: Map {
-                                                                                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (_checkpoint , log) | log }),
-                                                                                                                input: Tee {
-                                                                                                                    inner: <shared 23>: FlatMap {
-                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | v }),
-                                                                                                                        input: Cast {
-                                                                                                                            inner: Tee {
-                                                                                                                                inner: <shared 14>,
-                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                    collection_kind: Optional {
-                                                                                                                                        bound: Bounded,
-                                                                                                                                        element_type: std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >,
-                                                                                                                                    },
-                                                                                                                                },
-                                                                                                                            },
-                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                collection_kind: Stream {
-                                                                                                                                    bound: Bounded,
-                                                                                                                                    order: TotalOrder,
-                                                                                                                                    retry: ExactlyOnce,
-                                                                                                                                    element_type: std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >,
-                                                                                                                                },
-                                                                                                                            },
-                                                                                                                        },
-                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                            collection_kind: Stream {
-                                                                                                                                bound: Bounded,
-                                                                                                                                order: NoOrder,
-                                                                                                                                retry: ExactlyOnce,
-                                                                                                                                element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
-                                                                                                                            },
-                                                                                                                        },
-                                                                                                                    },
-                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                        collection_kind: Stream {
-                                                                                                                            bound: Bounded,
-                                                                                                                            order: NoOrder,
-                                                                                                                            retry: ExactlyOnce,
-                                                                                                                            element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
-                                                                                                                        },
-                                                                                                                    },
-                                                                                                                },
-                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                    collection_kind: Stream {
-                                                                                                                        bound: Bounded,
-                                                                                                                        order: NoOrder,
-                                                                                                                        retry: ExactlyOnce,
-                                                                                                                        element_type: std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >,
-                                                                                                                    },
-                                                                                                                },
-                                                                                                            },
-                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                collection_kind: Stream {
-                                                                                                                    bound: Bounded,
-                                                                                                                    order: NoOrder,
-                                                                                                                    retry: ExactlyOnce,
-                                                                                                                    element_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
-                                                                                                                },
-                                                                                                            },
-                                                                                                        },
-                                                                                                        metadata: HydroIrMetadata {
-                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                            collection_kind: KeyedStream {
-                                                                                                                bound: Bounded,
-                                                                                                                value_order: NoOrder,
-                                                                                                                value_retry: ExactlyOnce,
-                                                                                                                key_type: usize,
-                                                                                                                value_type: hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >,
-                                                                                                            },
-                                                                                                        },
-                                                                                                    },
-                                                                                                    metadata: HydroIrMetadata {
-                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                        collection_kind: KeyedSingleton {
-                                                                                                            bound: Bounded,
-                                                                                                            key_type: usize,
-                                                                                                            value_type: (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
-                                                                                                        },
-                                                                                                    },
-                                                                                                },
-                                                                                                metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                    collection_kind: KeyedSingleton {
-                                                                                                        bound: Bounded,
-                                                                                                        key_type: usize,
-                                                                                                        value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
-                                                                                                    },
-                                                                                                },
-                                                                                            },
-                                                                                            metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                collection_kind: KeyedSingleton {
-                                                                                                    bound: Bounded,
-                                                                                                    key_type: usize,
-                                                                                                    value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
-                                                                                                },
-                                                                                            },
-                                                                                        },
-                                                                                        metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                            collection_kind: KeyedStream {
-                                                                                                bound: Bounded,
-                                                                                                value_order: TotalOrder,
-                                                                                                value_retry: ExactlyOnce,
-                                                                                                key_type: usize,
-                                                                                                value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
-                                                                                            },
-                                                                                        },
-                                                                                    },
-                                                                                    metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                        collection_kind: Stream {
-                                                                                            bound: Bounded,
-                                                                                            order: NoOrder,
-                                                                                            retry: ExactlyOnce,
-                                                                                            element_type: (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)),
-                                                                                        },
-                                                                                    },
-                                                                                },
-                                                                                metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                    collection_kind: Stream {
-                                                                                        bound: Bounded,
-                                                                                        order: NoOrder,
-                                                                                        retry: ExactlyOnce,
-                                                                                        element_type: usize,
-                                                                                    },
-                                                                                },
-                                                                            },
-                                                                            trusted: true,
-                                                                            metadata: HydroIrMetadata {
-                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                collection_kind: Stream {
-                                                                                    bound: Bounded,
-                                                                                    order: TotalOrder,
-                                                                                    retry: ExactlyOnce,
-                                                                                    element_type: usize,
-                                                                                },
-                                                                            },
-                                                                        },
-                                                                        metadata: HydroIrMetadata {
-                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                            collection_kind: Optional {
-                                                                                bound: Bounded,
-                                                                                element_type: usize,
-                                                                            },
-                                                                        },
-                                                                    },
-                                                                    metadata: HydroIrMetadata {
-                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                        collection_kind: Optional {
-                                                                            bound: Bounded,
-                                                                            element_type: usize,
-                                                                        },
-                                                                    },
-                                                                },
-                                                                metadata: HydroIrMetadata {
-                                                                    location_id: Atomic(Tick(15, Cluster(loc1v1))),
-                                                                    collection_kind: Optional {
-                                                                        bound: Unbounded,
-                                                                        element_type: usize,
-                                                                    },
-                                                                },
-                                                            },
-                                                            metadata: HydroIrMetadata {
-                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                collection_kind: Optional {
-                                                                    bound: Bounded,
-                                                                    element_type: usize,
-                                                                },
-                                                            },
-                                                        },
-                                                        metadata: HydroIrMetadata {
-                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                            collection_kind: Optional {
-                                                                bound: Bounded,
-                                                                element_type: usize,
-                                                            },
-                                                        },
-                                                    },
-                                                    second: Cast {
-                                                        inner: Cast {
-                                                            inner: ChainFirst {
-                                                                first: DeferTick {
-                                                                    input: CycleSource {
-                                                                        cycle_id: CycleId(
-                                                                            12,
-                                                                        ),
-                                                                        metadata: HydroIrMetadata {
-                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                            collection_kind: Singleton {
-                                                                                bound: Bounded,
-                                                                                element_type: usize,
-                                                                            },
-                                                                        },
-                                                                    },
-                                                                    metadata: HydroIrMetadata {
-                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                        collection_kind: Optional {
-                                                                            bound: Bounded,
-                                                                            element_type: usize,
-                                                                        },
-                                                                    },
-                                                                },
-                                                                second: Cast {
-                                                                    inner: SingletonSource {
-                                                                        value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; 0 },
-                                                                        first_tick_only: false,
-                                                                        metadata: HydroIrMetadata {
-                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                            collection_kind: Singleton {
-                                                                                bound: Bounded,
-                                                                                element_type: usize,
-                                                                            },
-                                                                        },
-                                                                    },
-                                                                    metadata: HydroIrMetadata {
-                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                        collection_kind: Optional {
-                                                                            bound: Bounded,
-                                                                            element_type: usize,
-                                                                        },
-                                                                    },
-                                                                },
-                                                                metadata: HydroIrMetadata {
-                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                    collection_kind: Optional {
-                                                                        bound: Bounded,
-                                                                        element_type: usize,
-                                                                    },
-                                                                },
-                                                            },
-                                                            metadata: HydroIrMetadata {
-                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                collection_kind: Singleton {
-                                                                    bound: Bounded,
-                                                                    element_type: usize,
-                                                                },
-                                                            },
-                                                        },
-                                                        metadata: HydroIrMetadata {
-                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                            collection_kind: Optional {
-                                                                bound: Bounded,
-                                                                element_type: usize,
-                                                            },
-                                                        },
-                                                    },
-                                                    metadata: HydroIrMetadata {
-                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                        collection_kind: Optional {
-                                                            bound: Bounded,
-                                                            element_type: usize,
-                                                        },
-                                                    },
-                                                },
-                                                metadata: HydroIrMetadata {
-                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                    collection_kind: Singleton {
-                                                        bound: Bounded,
-                                                        element_type: usize,
-                                                    },
-                                                },
-                                            },
-                                            metadata: HydroIrMetadata {
-                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                collection_kind: Singleton {
-                                                    bound: Bounded,
-                                                    element_type: usize,
-                                                },
-                                            },
-                                        },
-                                        metadata: HydroIrMetadata {
-                                            location_id: Tick(15, Cluster(loc1v1)),
-                                            collection_kind: Optional {
-                                                bound: Bounded,
-                                                element_type: usize,
+                                                element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
                                             },
                                         },
                                     },
@@ -4159,7 +3859,7 @@ expression: built.ir()
                                             bound: Bounded,
                                             order: TotalOrder,
                                             retry: ExactlyOnce,
-                                            element_type: ((usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , usize),
+                                            element_type: (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
                                         },
                                     },
                                 },
@@ -4191,8 +3891,300 @@ expression: built.ir()
                             },
                         },
                     },
-                    right: Tee {
-                        inner: <shared 20>,
+                    right: Singleton {
+                        inner: <shared 21>: Cast {
+                            inner: ChainFirst {
+                                first: Map {
+                                    f: stageleft :: runtime_support :: fn1_type_hint :: < usize , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | s | s + 1 }),
+                                    input: Batch {
+                                        inner: YieldConcat {
+                                            inner: Tee {
+                                                inner: <shared 22>: Reduce {
+                                                    f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | curr , new | { if new > * curr { * curr = new ; } } }),
+                                                    input: ObserveNonDet {
+                                                        inner: Map {
+                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
+                                                            input: Cast {
+                                                                inner: Cast {
+                                                                    inner: Tee {
+                                                                        inner: <shared 23>: Map {
+                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)) , (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (count , entry) | (count , entry . unwrap ()) }) ; { let orig = f__free ; move | (k , v) | (k , orig (v)) } }),
+                                                                            input: FoldKeyed {
+                                                                                init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | | (0 , None) }),
+                                                                                acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | curr_entry , new_entry | { if let Some (curr_entry_payload) = & mut curr_entry . 1 { let same_values = new_entry . value == curr_entry_payload . value ; let higher_ballot = new_entry . ballot > curr_entry_payload . ballot ; if same_values { curr_entry . 0 += 1 ; } if higher_ballot { curr_entry_payload . ballot = new_entry . ballot ; if ! same_values { curr_entry . 0 = 1 ; curr_entry_payload . value = new_entry . value ; } } } else { * curr_entry = (1 , Some (new_entry)) ; } } }),
+                                                                                input: Cast {
+                                                                                    inner: FlatMap {
+                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | d | d }),
+                                                                                        input: Map {
+                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (_checkpoint , log) | log }),
+                                                                                            input: Tee {
+                                                                                                inner: <shared 24>: FlatMap {
+                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | v }),
+                                                                                                    input: Cast {
+                                                                                                        inner: Tee {
+                                                                                                            inner: <shared 14>,
+                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                collection_kind: Optional {
+                                                                                                                    bound: Bounded,
+                                                                                                                    element_type: std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >,
+                                                                                                                },
+                                                                                                            },
+                                                                                                        },
+                                                                                                        metadata: HydroIrMetadata {
+                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                            collection_kind: Stream {
+                                                                                                                bound: Bounded,
+                                                                                                                order: TotalOrder,
+                                                                                                                retry: ExactlyOnce,
+                                                                                                                element_type: std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >,
+                                                                                                            },
+                                                                                                        },
+                                                                                                    },
+                                                                                                    metadata: HydroIrMetadata {
+                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                        collection_kind: Stream {
+                                                                                                            bound: Bounded,
+                                                                                                            order: NoOrder,
+                                                                                                            retry: ExactlyOnce,
+                                                                                                            element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
+                                                                                                        },
+                                                                                                    },
+                                                                                                },
+                                                                                                metadata: HydroIrMetadata {
+                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                    collection_kind: Stream {
+                                                                                                        bound: Bounded,
+                                                                                                        order: NoOrder,
+                                                                                                        retry: ExactlyOnce,
+                                                                                                        element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
+                                                                                                    },
+                                                                                                },
+                                                                                            },
+                                                                                            metadata: HydroIrMetadata {
+                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                collection_kind: Stream {
+                                                                                                    bound: Bounded,
+                                                                                                    order: NoOrder,
+                                                                                                    retry: ExactlyOnce,
+                                                                                                    element_type: std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >,
+                                                                                                },
+                                                                                            },
+                                                                                        },
+                                                                                        metadata: HydroIrMetadata {
+                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                            collection_kind: Stream {
+                                                                                                bound: Bounded,
+                                                                                                order: NoOrder,
+                                                                                                retry: ExactlyOnce,
+                                                                                                element_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                            },
+                                                                                        },
+                                                                                    },
+                                                                                    metadata: HydroIrMetadata {
+                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                        collection_kind: KeyedStream {
+                                                                                            bound: Bounded,
+                                                                                            value_order: NoOrder,
+                                                                                            value_retry: ExactlyOnce,
+                                                                                            key_type: usize,
+                                                                                            value_type: hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >,
+                                                                                        },
+                                                                                    },
+                                                                                },
+                                                                                metadata: HydroIrMetadata {
+                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                    collection_kind: KeyedSingleton {
+                                                                                        bound: Bounded,
+                                                                                        key_type: usize,
+                                                                                        value_type: (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
+                                                                                    },
+                                                                                },
+                                                                            },
+                                                                            metadata: HydroIrMetadata {
+                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                collection_kind: KeyedSingleton {
+                                                                                    bound: Bounded,
+                                                                                    key_type: usize,
+                                                                                    value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                },
+                                                                            },
+                                                                        },
+                                                                        metadata: HydroIrMetadata {
+                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                            collection_kind: KeyedSingleton {
+                                                                                bound: Bounded,
+                                                                                key_type: usize,
+                                                                                value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                            },
+                                                                        },
+                                                                    },
+                                                                    metadata: HydroIrMetadata {
+                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                        collection_kind: KeyedStream {
+                                                                            bound: Bounded,
+                                                                            value_order: TotalOrder,
+                                                                            value_retry: ExactlyOnce,
+                                                                            key_type: usize,
+                                                                            value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                        },
+                                                                    },
+                                                                },
+                                                                metadata: HydroIrMetadata {
+                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                    collection_kind: Stream {
+                                                                        bound: Bounded,
+                                                                        order: NoOrder,
+                                                                        retry: ExactlyOnce,
+                                                                        element_type: (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)),
+                                                                    },
+                                                                },
+                                                            },
+                                                            metadata: HydroIrMetadata {
+                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                collection_kind: Stream {
+                                                                    bound: Bounded,
+                                                                    order: NoOrder,
+                                                                    retry: ExactlyOnce,
+                                                                    element_type: usize,
+                                                                },
+                                                            },
+                                                        },
+                                                        trusted: true,
+                                                        metadata: HydroIrMetadata {
+                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                            collection_kind: Stream {
+                                                                bound: Bounded,
+                                                                order: TotalOrder,
+                                                                retry: ExactlyOnce,
+                                                                element_type: usize,
+                                                            },
+                                                        },
+                                                    },
+                                                    metadata: HydroIrMetadata {
+                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                        collection_kind: Optional {
+                                                            bound: Bounded,
+                                                            element_type: usize,
+                                                        },
+                                                    },
+                                                },
+                                                metadata: HydroIrMetadata {
+                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                    collection_kind: Optional {
+                                                        bound: Bounded,
+                                                        element_type: usize,
+                                                    },
+                                                },
+                                            },
+                                            metadata: HydroIrMetadata {
+                                                location_id: Atomic(Tick(15, Cluster(loc1v1))),
+                                                collection_kind: Optional {
+                                                    bound: Unbounded,
+                                                    element_type: usize,
+                                                },
+                                            },
+                                        },
+                                        metadata: HydroIrMetadata {
+                                            location_id: Tick(15, Cluster(loc1v1)),
+                                            collection_kind: Optional {
+                                                bound: Bounded,
+                                                element_type: usize,
+                                            },
+                                        },
+                                    },
+                                    metadata: HydroIrMetadata {
+                                        location_id: Tick(15, Cluster(loc1v1)),
+                                        collection_kind: Optional {
+                                            bound: Bounded,
+                                            element_type: usize,
+                                        },
+                                    },
+                                },
+                                second: Cast {
+                                    inner: Cast {
+                                        inner: ChainFirst {
+                                            first: DeferTick {
+                                                input: CycleSource {
+                                                    cycle_id: CycleId(
+                                                        12,
+                                                    ),
+                                                    metadata: HydroIrMetadata {
+                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                        collection_kind: Singleton {
+                                                            bound: Bounded,
+                                                            element_type: usize,
+                                                        },
+                                                    },
+                                                },
+                                                metadata: HydroIrMetadata {
+                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                    collection_kind: Optional {
+                                                        bound: Bounded,
+                                                        element_type: usize,
+                                                    },
+                                                },
+                                            },
+                                            second: Cast {
+                                                inner: SingletonSource {
+                                                    value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; 0 },
+                                                    first_tick_only: false,
+                                                    metadata: HydroIrMetadata {
+                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                        collection_kind: Singleton {
+                                                            bound: Bounded,
+                                                            element_type: usize,
+                                                        },
+                                                    },
+                                                },
+                                                metadata: HydroIrMetadata {
+                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                    collection_kind: Optional {
+                                                        bound: Bounded,
+                                                        element_type: usize,
+                                                    },
+                                                },
+                                            },
+                                            metadata: HydroIrMetadata {
+                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                collection_kind: Optional {
+                                                    bound: Bounded,
+                                                    element_type: usize,
+                                                },
+                                            },
+                                        },
+                                        metadata: HydroIrMetadata {
+                                            location_id: Tick(15, Cluster(loc1v1)),
+                                            collection_kind: Singleton {
+                                                bound: Bounded,
+                                                element_type: usize,
+                                            },
+                                        },
+                                    },
+                                    metadata: HydroIrMetadata {
+                                        location_id: Tick(15, Cluster(loc1v1)),
+                                        collection_kind: Optional {
+                                            bound: Bounded,
+                                            element_type: usize,
+                                        },
+                                    },
+                                },
+                                metadata: HydroIrMetadata {
+                                    location_id: Tick(15, Cluster(loc1v1)),
+                                    collection_kind: Optional {
+                                        bound: Bounded,
+                                        element_type: usize,
+                                    },
+                                },
+                            },
+                            metadata: HydroIrMetadata {
+                                location_id: Tick(15, Cluster(loc1v1)),
+                                collection_kind: Singleton {
+                                    bound: Bounded,
+                                    element_type: usize,
+                                },
+                            },
+                        },
                         metadata: HydroIrMetadata {
                             location_id: Tick(15, Cluster(loc1v1)),
                             collection_kind: Singleton {
@@ -4227,13 +4219,35 @@ expression: built.ir()
         },
         op_metadata: HydroIrOpMetadata,
     },
+    Null {
+        input: Singleton {
+            inner: <shared 25>: Tee {
+                inner: <shared 10>,
+                metadata: HydroIrMetadata {
+                    location_id: Tick(2, Cluster(loc2v1)),
+                    collection_kind: Singleton {
+                        bound: Bounded,
+                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                    },
+                },
+            },
+            metadata: HydroIrMetadata {
+                location_id: Tick(2, Cluster(loc2v1)),
+                collection_kind: Singleton {
+                    bound: Bounded,
+                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                },
+            },
+        },
+        op_metadata: HydroIrOpMetadata,
+    },
     CycleSink {
         cycle_id: CycleId(
             13,
         ),
         input: AntiJoin {
             pos: Tee {
-                inner: <shared 24>: Chain {
+                inner: <shared 26>: Chain {
                     first: DeferTick {
                         input: CycleSource {
                             cycle_id: CycleId(
@@ -4261,7 +4275,7 @@ expression: built.ir()
                     },
                     second: Batch {
                         inner: Tee {
-                            inner: <shared 25>: Map {
+                            inner: <shared 27>: Map {
                                 f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
                                 input: Cast {
                                     inner: Network {
@@ -4279,91 +4293,81 @@ expression: built.ir()
                                         input: Cast {
                                             inner: YieldConcat {
                                                 inner: Map {
-                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (p2a , max_ballot) | (p2a . sender , ((p2a . slot , p2a . ballot . clone ()) , if p2a . ballot == max_ballot { Ok (()) } else { Err (max_ballot) })) }),
-                                                    input: CrossSingleton {
-                                                        left: Tee {
-                                                            inner: <shared 26>: Batch {
-                                                                inner: Map {
-                                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >) , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
-                                                                    input: Cast {
-                                                                        inner: Network {
-                                                                            name: None,
-                                                                            networking_info: Tcp {
-                                                                                fault: FailStop,
-                                                                            },
-                                                                            serialize_fn: Some(
-                                                                                hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
-                                                                            ),
-                                                                            instantiate_fn: <network instantiate>,
-                                                                            deserialize_fn: Some(
-                                                                                | res | { let (id , b) = res . unwrap () ; (hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless (id as hydro_lang :: __staged :: location :: TaglessMemberId) , hydro_lang :: runtime_support :: bincode :: deserialize :: < hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > > (& b) . unwrap ()) },
-                                                                            ),
-                                                                            input: YieldConcat {
-                                                                                inner: Cast {
-                                                                                    inner: CrossProduct {
-                                                                                        left: ObserveNonDet {
-                                                                                            inner: Map {
-                                                                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                                                                input: Cast {
-                                                                                                    inner: Cast {
-                                                                                                        inner: Filter {
-                                                                                                            f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | b | * b }) ; { let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) } }),
-                                                                                                            input: Batch {
-                                                                                                                inner: FoldKeyed {
-                                                                                                                    init: stageleft :: runtime_support :: fn0_type_hint :: < bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | | false }),
-                                                                                                                    acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < bool , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | present , event | { match event { MembershipEvent :: Joined => * present = true , MembershipEvent :: Left => * present = false , } } }),
-                                                                                                                    input: Cast {
-                                                                                                                        inner: Map {
-                                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | (k , v) | (MemberId :: from_tagless (k) , v) }),
-                                                                                                                            input: Source {
-                                                                                                                                source: ClusterMembers(
-                                                                                                                                    Cluster(loc2v1),
-                                                                                                                                    Uninit,
-                                                                                                                                ),
-                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                    location_id: Cluster(loc1v1),
-                                                                                                                                    collection_kind: Stream {
-                                                                                                                                        bound: Unbounded,
-                                                                                                                                        order: TotalOrder,
-                                                                                                                                        retry: ExactlyOnce,
-                                                                                                                                        element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
-                                                                                                                                    },
-                                                                                                                                },
-                                                                                                                            },
+                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let a_max_ballot_ref__free = __hydro_singleton_ref_0 ; | p2a | { let max_ballot = a_max_ballot_ref__free . clone () ; (p2a . sender , ((p2a . slot , p2a . ballot . clone ()) , if p2a . ballot == max_ballot { Ok (()) } else { Err (max_ballot) } ,) ,) } }),
+                                                    input: Tee {
+                                                        inner: <shared 28>: Batch {
+                                                            inner: Map {
+                                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >) , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
+                                                                input: Cast {
+                                                                    inner: Network {
+                                                                        name: None,
+                                                                        networking_info: Tcp {
+                                                                            fault: FailStop,
+                                                                        },
+                                                                        serialize_fn: Some(
+                                                                            hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
+                                                                        ),
+                                                                        instantiate_fn: <network instantiate>,
+                                                                        deserialize_fn: Some(
+                                                                            | res | { let (id , b) = res . unwrap () ; (hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless (id as hydro_lang :: __staged :: location :: TaglessMemberId) , hydro_lang :: runtime_support :: bincode :: deserialize :: < hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > > (& b) . unwrap ()) },
+                                                                        ),
+                                                                        input: YieldConcat {
+                                                                            inner: Cast {
+                                                                                inner: CrossProduct {
+                                                                                    left: ObserveNonDet {
+                                                                                        inner: Map {
+                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
+                                                                                            input: Cast {
+                                                                                                inner: Cast {
+                                                                                                    inner: Filter {
+                                                                                                        f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | b | * b }) ; { let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) } }),
+                                                                                                        input: Batch {
+                                                                                                            inner: FoldKeyed {
+                                                                                                                init: stageleft :: runtime_support :: fn0_type_hint :: < bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | | false }),
+                                                                                                                acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < bool , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | present , event | { match event { MembershipEvent :: Joined => * present = true , MembershipEvent :: Left => * present = false , } } }),
+                                                                                                                input: Cast {
+                                                                                                                    inner: Map {
+                                                                                                                        f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | (k , v) | (MemberId :: from_tagless (k) , v) }),
+                                                                                                                        input: Source {
+                                                                                                                            source: ClusterMembers(
+                                                                                                                                Cluster(loc2v1),
+                                                                                                                                Uninit,
+                                                                                                                            ),
                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                 location_id: Cluster(loc1v1),
                                                                                                                                 collection_kind: Stream {
                                                                                                                                     bound: Unbounded,
                                                                                                                                     order: TotalOrder,
                                                                                                                                     retry: ExactlyOnce,
-                                                                                                                                    element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
+                                                                                                                                    element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
                                                                                                                                 },
                                                                                                                             },
                                                                                                                         },
                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                             location_id: Cluster(loc1v1),
-                                                                                                                            collection_kind: KeyedStream {
+                                                                                                                            collection_kind: Stream {
                                                                                                                                 bound: Unbounded,
-                                                                                                                                value_order: TotalOrder,
-                                                                                                                                value_retry: ExactlyOnce,
-                                                                                                                                key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
-                                                                                                                                value_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent,
+                                                                                                                                order: TotalOrder,
+                                                                                                                                retry: ExactlyOnce,
+                                                                                                                                element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
                                                                                                                             },
                                                                                                                         },
                                                                                                                     },
                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                         location_id: Cluster(loc1v1),
-                                                                                                                        collection_kind: KeyedSingleton {
+                                                                                                                        collection_kind: KeyedStream {
                                                                                                                             bound: Unbounded,
+                                                                                                                            value_order: TotalOrder,
+                                                                                                                            value_retry: ExactlyOnce,
                                                                                                                             key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
-                                                                                                                            value_type: bool,
+                                                                                                                            value_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent,
                                                                                                                         },
                                                                                                                     },
                                                                                                                 },
                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(13, Cluster(loc1v1)),
+                                                                                                                    location_id: Cluster(loc1v1),
                                                                                                                     collection_kind: KeyedSingleton {
-                                                                                                                        bound: Bounded,
+                                                                                                                        bound: Unbounded,
                                                                                                                         key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
                                                                                                                         value_type: bool,
                                                                                                                     },
@@ -4380,10 +4384,8 @@ expression: built.ir()
                                                                                                         },
                                                                                                         metadata: HydroIrMetadata {
                                                                                                             location_id: Tick(13, Cluster(loc1v1)),
-                                                                                                            collection_kind: KeyedStream {
+                                                                                                            collection_kind: KeyedSingleton {
                                                                                                                 bound: Bounded,
-                                                                                                                value_order: TotalOrder,
-                                                                                                                value_retry: ExactlyOnce,
                                                                                                                 key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
                                                                                                                 value_type: bool,
                                                                                                             },
@@ -4391,11 +4393,12 @@ expression: built.ir()
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
                                                                                                         location_id: Tick(13, Cluster(loc1v1)),
-                                                                                                        collection_kind: Stream {
+                                                                                                        collection_kind: KeyedStream {
                                                                                                             bound: Bounded,
-                                                                                                            order: NoOrder,
-                                                                                                            retry: ExactlyOnce,
-                                                                                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool),
+                                                                                                            value_order: TotalOrder,
+                                                                                                            value_retry: ExactlyOnce,
+                                                                                                            key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
+                                                                                                            value_type: bool,
                                                                                                         },
                                                                                                     },
                                                                                                 },
@@ -4405,58 +4408,47 @@ expression: built.ir()
                                                                                                         bound: Bounded,
                                                                                                         order: NoOrder,
                                                                                                         retry: ExactlyOnce,
-                                                                                                        element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
+                                                                                                        element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool),
                                                                                                     },
                                                                                                 },
                                                                                             },
-                                                                                            trusted: true,
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_id: Tick(13, Cluster(loc1v1)),
                                                                                                 collection_kind: Stream {
                                                                                                     bound: Bounded,
-                                                                                                    order: TotalOrder,
+                                                                                                    order: NoOrder,
                                                                                                     retry: ExactlyOnce,
                                                                                                     element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
                                                                                                 },
                                                                                             },
                                                                                         },
-                                                                                        right: Batch {
-                                                                                            inner: Map {
-                                                                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless ((__hydro_lang_cluster_self_id_loc1v1) . clone ()) ; move | ((slot , ballot) , value) | P2a { sender : CLUSTER_SELF_ID__free . clone () , ballot , slot , value } }),
-                                                                                                input: EndAtomic {
-                                                                                                    inner: Tee {
-                                                                                                        inner: <shared 27>: YieldConcat {
-                                                                                                            inner: Map {
-                                                                                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , bool) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | (d , _) | d }),
-                                                                                                                input: CrossSingleton {
-                                                                                                                    left: Chain {
-                                                                                                                        first: Map {
-                                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | ((slot , payload) , ballot) | ((slot , ballot) , Some (payload)) }),
-                                                                                                                            input: CrossSingleton {
-                                                                                                                                left: Batch {
-                                                                                                                                    inner: YieldConcat {
-                                                                                                                                        inner: Tee {
-                                                                                                                                            inner: <shared 19>,
-                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                collection_kind: Stream {
-                                                                                                                                                    bound: Bounded,
-                                                                                                                                                    order: TotalOrder,
-                                                                                                                                                    retry: ExactlyOnce,
-                                                                                                                                                    element_type: (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                        },
-                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                            location_id: Atomic(Tick(15, Cluster(loc1v1))),
-                                                                                                                                            collection_kind: Stream {
-                                                                                                                                                bound: Unbounded,
-                                                                                                                                                order: TotalOrder,
-                                                                                                                                                retry: ExactlyOnce,
-                                                                                                                                                element_type: (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
-                                                                                                                                            },
-                                                                                                                                        },
-                                                                                                                                    },
+                                                                                        trusted: true,
+                                                                                        metadata: HydroIrMetadata {
+                                                                                            location_id: Tick(13, Cluster(loc1v1)),
+                                                                                            collection_kind: Stream {
+                                                                                                bound: Bounded,
+                                                                                                order: TotalOrder,
+                                                                                                retry: ExactlyOnce,
+                                                                                                element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
+                                                                                            },
+                                                                                        },
+                                                                                    },
+                                                                                    right: Batch {
+                                                                                        inner: Map {
+                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let CLUSTER_SELF_ID__free = hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless ((__hydro_lang_cluster_self_id_loc1v1) . clone ()) ; move | ((slot , ballot) , value) | P2a { sender : CLUSTER_SELF_ID__free . clone () , ballot , slot , value } }),
+                                                                                            input: EndAtomic {
+                                                                                                inner: Tee {
+                                                                                                    inner: <shared 29>: YieldConcat {
+                                                                                                        inner: Map {
+                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , bool) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | (d , _) | d }),
+                                                                                                            input: CrossSingleton {
+                                                                                                                left: Chain {
+                                                                                                                    first: Map {
+                                                                                                                        f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let p_ballot_ref__free = __hydro_singleton_ref_0 ; | (slot , payload) | ((slot , p_ballot_ref__free . clone ()) , Some (payload)) }),
+                                                                                                                        input: Batch {
+                                                                                                                            inner: YieldConcat {
+                                                                                                                                inner: Tee {
+                                                                                                                                    inner: <shared 20>,
                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                         location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                                         collection_kind: Stream {
@@ -4467,32 +4459,13 @@ expression: built.ir()
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                 },
-                                                                                                                                right: Cast {
-                                                                                                                                    inner: Tee {
-                                                                                                                                        inner: <shared 4>,
-                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                            collection_kind: Singleton {
-                                                                                                                                                bound: Bounded,
-                                                                                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                                                            },
-                                                                                                                                        },
-                                                                                                                                    },
-                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                        collection_kind: Optional {
-                                                                                                                                            bound: Bounded,
-                                                                                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                                                        },
-                                                                                                                                    },
-                                                                                                                                },
                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                    location_id: Atomic(Tick(15, Cluster(loc1v1))),
                                                                                                                                     collection_kind: Stream {
-                                                                                                                                        bound: Bounded,
+                                                                                                                                        bound: Unbounded,
                                                                                                                                         order: TotalOrder,
                                                                                                                                         retry: ExactlyOnce,
-                                                                                                                                        element_type: ((usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                                                                                        element_type: (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
                                                                                                                                     },
                                                                                                                                 },
                                                                                                                             },
@@ -4502,197 +4475,44 @@ expression: built.ir()
                                                                                                                                     bound: Bounded,
                                                                                                                                     order: TotalOrder,
                                                                                                                                     retry: ExactlyOnce,
-                                                                                                                                    element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                                                                    element_type: (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
                                                                                                                                 },
                                                                                                                             },
                                                                                                                         },
-                                                                                                                        second: Chain {
-                                                                                                                            first: FilterMap {
-                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (((usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < usize >) , core :: option :: Option < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let f__free = 1usize ; move | (((slot , (count , entry)) , ballot) , checkpoint) | { if count > f__free { return None ; } else if let Some (checkpoint) = checkpoint && slot <= checkpoint { return None ; } Some (((slot , ballot) , entry . value)) } }),
-                                                                                                                                input: CrossSingleton {
-                                                                                                                                    left: CrossSingleton {
-                                                                                                                                        left: Cast {
-                                                                                                                                            inner: Cast {
-                                                                                                                                                inner: Tee {
-                                                                                                                                                    inner: <shared 22>,
-                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                        collection_kind: KeyedSingleton {
-                                                                                                                                                            bound: Bounded,
-                                                                                                                                                            key_type: usize,
-                                                                                                                                                            value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                },
-                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                    collection_kind: KeyedStream {
-                                                                                                                                                        bound: Bounded,
-                                                                                                                                                        value_order: TotalOrder,
-                                                                                                                                                        value_retry: ExactlyOnce,
-                                                                                                                                                        key_type: usize,
-                                                                                                                                                        value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
-                                                                                                                                                    },
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                collection_kind: Stream {
-                                                                                                                                                    bound: Bounded,
-                                                                                                                                                    order: NoOrder,
-                                                                                                                                                    retry: ExactlyOnce,
-                                                                                                                                                    element_type: (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)),
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                        },
-                                                                                                                                        right: Cast {
-                                                                                                                                            inner: Tee {
-                                                                                                                                                inner: <shared 4>,
-                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                    collection_kind: Singleton {
-                                                                                                                                                        bound: Bounded,
-                                                                                                                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                                                                    },
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                collection_kind: Optional {
-                                                                                                                                                    bound: Bounded,
-                                                                                                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                        },
+                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                            collection_kind: Stream {
+                                                                                                                                bound: Bounded,
+                                                                                                                                order: TotalOrder,
+                                                                                                                                retry: ExactlyOnce,
+                                                                                                                                element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                                                            },
+                                                                                                                        },
+                                                                                                                    },
+                                                                                                                    second: Chain {
+                                                                                                                        first: FilterMap {
+                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , core :: option :: Option < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let f__free = 1usize ; let p_ballot_ref__free = __hydro_singleton_ref_0 ; let p_p1b_max_checkpoint_ref__free = __hydro_singleton_ref_1 ; move | (slot , (count , entry)) | { if count > f__free { return None ; } else if let Some (checkpoint) = * p_p1b_max_checkpoint_ref__free && slot <= checkpoint { return None ; } Some (((slot , p_ballot_ref__free . clone ()) , entry . value)) } }),
+                                                                                                                            input: Cast {
+                                                                                                                                inner: Cast {
+                                                                                                                                    inner: Tee {
+                                                                                                                                        inner: <shared 23>,
                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                             location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                            collection_kind: Stream {
+                                                                                                                                            collection_kind: KeyedSingleton {
                                                                                                                                                 bound: Bounded,
-                                                                                                                                                order: NoOrder,
-                                                                                                                                                retry: ExactlyOnce,
-                                                                                                                                                element_type: ((usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , hydro_test :: __staged :: cluster :: paxos :: Ballot),
-                                                                                                                                            },
-                                                                                                                                        },
-                                                                                                                                    },
-                                                                                                                                    right: Cast {
-                                                                                                                                        inner: Tee {
-                                                                                                                                            inner: <shared 28>: Cast {
-                                                                                                                                                inner: ChainFirst {
-                                                                                                                                                    first: Map {
-                                                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < usize , core :: option :: Option < usize > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
-                                                                                                                                                        input: Reduce {
-                                                                                                                                                            f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | curr , new | { if new > * curr { * curr = new ; } } }),
-                                                                                                                                                            input: ObserveNonDet {
-                                                                                                                                                                inner: FilterMap {
-                                                                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (checkpoint , _log) | checkpoint }),
-                                                                                                                                                                    input: Tee {
-                                                                                                                                                                        inner: <shared 23>,
-                                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                            collection_kind: Stream {
-                                                                                                                                                                                bound: Bounded,
-                                                                                                                                                                                order: NoOrder,
-                                                                                                                                                                                retry: ExactlyOnce,
-                                                                                                                                                                                element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
-                                                                                                                                                                            },
-                                                                                                                                                                        },
-                                                                                                                                                                    },
-                                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                        collection_kind: Stream {
-                                                                                                                                                                            bound: Bounded,
-                                                                                                                                                                            order: NoOrder,
-                                                                                                                                                                            retry: ExactlyOnce,
-                                                                                                                                                                            element_type: usize,
-                                                                                                                                                                        },
-                                                                                                                                                                    },
-                                                                                                                                                                },
-                                                                                                                                                                trusted: true,
-                                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                    collection_kind: Stream {
-                                                                                                                                                                        bound: Bounded,
-                                                                                                                                                                        order: TotalOrder,
-                                                                                                                                                                        retry: ExactlyOnce,
-                                                                                                                                                                        element_type: usize,
-                                                                                                                                                                    },
-                                                                                                                                                                },
-                                                                                                                                                            },
-                                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                collection_kind: Optional {
-                                                                                                                                                                    bound: Bounded,
-                                                                                                                                                                    element_type: usize,
-                                                                                                                                                                },
-                                                                                                                                                            },
-                                                                                                                                                        },
-                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                            collection_kind: Optional {
-                                                                                                                                                                bound: Bounded,
-                                                                                                                                                                element_type: core :: option :: Option < usize >,
-                                                                                                                                                            },
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                    second: Cast {
-                                                                                                                                                        inner: SingletonSource {
-                                                                                                                                                            value: :: std :: option :: Option :: None,
-                                                                                                                                                            first_tick_only: false,
-                                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                collection_kind: Singleton {
-                                                                                                                                                                    bound: Bounded,
-                                                                                                                                                                    element_type: core :: option :: Option < usize >,
-                                                                                                                                                                },
-                                                                                                                                                            },
-                                                                                                                                                        },
-                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                            collection_kind: Optional {
-                                                                                                                                                                bound: Bounded,
-                                                                                                                                                                element_type: core :: option :: Option < usize >,
-                                                                                                                                                            },
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                        collection_kind: Optional {
-                                                                                                                                                            bound: Bounded,
-                                                                                                                                                            element_type: core :: option :: Option < usize >,
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                },
-                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                    collection_kind: Singleton {
-                                                                                                                                                        bound: Bounded,
-                                                                                                                                                        element_type: core :: option :: Option < usize >,
-                                                                                                                                                    },
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                collection_kind: Singleton {
-                                                                                                                                                    bound: Bounded,
-                                                                                                                                                    element_type: core :: option :: Option < usize >,
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                        },
-                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                            collection_kind: Optional {
-                                                                                                                                                bound: Bounded,
-                                                                                                                                                element_type: core :: option :: Option < usize >,
+                                                                                                                                                key_type: usize,
+                                                                                                                                                value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
                                                                                                                                             },
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                         location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                        collection_kind: Stream {
+                                                                                                                                        collection_kind: KeyedStream {
                                                                                                                                             bound: Bounded,
-                                                                                                                                            order: NoOrder,
-                                                                                                                                            retry: ExactlyOnce,
-                                                                                                                                            element_type: (((usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < usize >),
+                                                                                                                                            value_order: TotalOrder,
+                                                                                                                                            value_retry: ExactlyOnce,
+                                                                                                                                            key_type: usize,
+                                                                                                                                            value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                 },
@@ -4702,34 +4522,120 @@ expression: built.ir()
                                                                                                                                         bound: Bounded,
                                                                                                                                         order: NoOrder,
                                                                                                                                         retry: ExactlyOnce,
-                                                                                                                                        element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                                                                        element_type: (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)),
                                                                                                                                     },
                                                                                                                                 },
                                                                                                                             },
-                                                                                                                            second: Map {
-                                                                                                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; move | (slot , ballot) | ((slot , ballot) , None) }),
-                                                                                                                                input: CrossSingleton {
-                                                                                                                                    left: Difference {
-                                                                                                                                        pos: FlatMap {
-                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , core :: option :: Option < usize >) , std :: ops :: Range < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (max_slot , checkpoint) | { if let Some (checkpoint) = checkpoint { (checkpoint + 1) .. max_slot } else { 0 .. max_slot } } }),
-                                                                                                                                            input: Cast {
-                                                                                                                                                inner: CrossSingleton {
-                                                                                                                                                    left: Tee {
-                                                                                                                                                        inner: <shared 21>,
-                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                            collection_kind: Optional {
-                                                                                                                                                                bound: Bounded,
-                                                                                                                                                                element_type: usize,
-                                                                                                                                                            },
-                                                                                                                                                        },
+                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                collection_kind: Stream {
+                                                                                                                                    bound: Bounded,
+                                                                                                                                    order: NoOrder,
+                                                                                                                                    retry: ExactlyOnce,
+                                                                                                                                    element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                                                                },
+                                                                                                                            },
+                                                                                                                        },
+                                                                                                                        second: Map {
+                                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < usize , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let p_ballot_ref__free = __hydro_singleton_ref_0 ; move | slot | ((slot , p_ballot_ref__free . clone ()) , None) }),
+                                                                                                                            input: Difference {
+                                                                                                                                pos: FlatMap {
+                                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , core :: option :: Option < usize >) , std :: ops :: Range < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (max_slot , checkpoint) | { if let Some (checkpoint) = checkpoint { (checkpoint + 1) .. max_slot } else { 0 .. max_slot } } }),
+                                                                                                                                    input: Cast {
+                                                                                                                                        inner: CrossSingleton {
+                                                                                                                                            left: Tee {
+                                                                                                                                                inner: <shared 22>,
+                                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                    collection_kind: Optional {
+                                                                                                                                                        bound: Bounded,
+                                                                                                                                                        element_type: usize,
                                                                                                                                                     },
-                                                                                                                                                    right: Cast {
-                                                                                                                                                        inner: Tee {
-                                                                                                                                                            inner: <shared 28>,
+                                                                                                                                                },
+                                                                                                                                            },
+                                                                                                                                            right: Cast {
+                                                                                                                                                inner: Singleton {
+                                                                                                                                                    inner: <shared 30>: Cast {
+                                                                                                                                                        inner: ChainFirst {
+                                                                                                                                                            first: Map {
+                                                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < usize , core :: option :: Option < usize > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
+                                                                                                                                                                input: Reduce {
+                                                                                                                                                                    f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | curr , new | { if new > * curr { * curr = new ; } } }),
+                                                                                                                                                                    input: ObserveNonDet {
+                                                                                                                                                                        inner: FilterMap {
+                                                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (checkpoint , _log) | checkpoint }),
+                                                                                                                                                                            input: Tee {
+                                                                                                                                                                                inner: <shared 24>,
+                                                                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                                    collection_kind: Stream {
+                                                                                                                                                                                        bound: Bounded,
+                                                                                                                                                                                        order: NoOrder,
+                                                                                                                                                                                        retry: ExactlyOnce,
+                                                                                                                                                                                        element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
+                                                                                                                                                                                    },
+                                                                                                                                                                                },
+                                                                                                                                                                            },
+                                                                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                                collection_kind: Stream {
+                                                                                                                                                                                    bound: Bounded,
+                                                                                                                                                                                    order: NoOrder,
+                                                                                                                                                                                    retry: ExactlyOnce,
+                                                                                                                                                                                    element_type: usize,
+                                                                                                                                                                                },
+                                                                                                                                                                            },
+                                                                                                                                                                        },
+                                                                                                                                                                        trusted: true,
+                                                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                            collection_kind: Stream {
+                                                                                                                                                                                bound: Bounded,
+                                                                                                                                                                                order: TotalOrder,
+                                                                                                                                                                                retry: ExactlyOnce,
+                                                                                                                                                                                element_type: usize,
+                                                                                                                                                                            },
+                                                                                                                                                                        },
+                                                                                                                                                                    },
+                                                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                        collection_kind: Optional {
+                                                                                                                                                                            bound: Bounded,
+                                                                                                                                                                            element_type: usize,
+                                                                                                                                                                        },
+                                                                                                                                                                    },
+                                                                                                                                                                },
+                                                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                    collection_kind: Optional {
+                                                                                                                                                                        bound: Bounded,
+                                                                                                                                                                        element_type: core :: option :: Option < usize >,
+                                                                                                                                                                    },
+                                                                                                                                                                },
+                                                                                                                                                            },
+                                                                                                                                                            second: Cast {
+                                                                                                                                                                inner: SingletonSource {
+                                                                                                                                                                    value: :: std :: option :: Option :: None,
+                                                                                                                                                                    first_tick_only: false,
+                                                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                        collection_kind: Singleton {
+                                                                                                                                                                            bound: Bounded,
+                                                                                                                                                                            element_type: core :: option :: Option < usize >,
+                                                                                                                                                                        },
+                                                                                                                                                                    },
+                                                                                                                                                                },
+                                                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                    collection_kind: Optional {
+                                                                                                                                                                        bound: Bounded,
+                                                                                                                                                                        element_type: core :: option :: Option < usize >,
+                                                                                                                                                                    },
+                                                                                                                                                                },
+                                                                                                                                                            },
                                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                                 location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                collection_kind: Singleton {
+                                                                                                                                                                collection_kind: Optional {
                                                                                                                                                                     bound: Bounded,
                                                                                                                                                                     element_type: core :: option :: Option < usize >,
                                                                                                                                                                 },
@@ -4737,7 +4643,7 @@ expression: built.ir()
                                                                                                                                                         },
                                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                                             location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                            collection_kind: Optional {
+                                                                                                                                                            collection_kind: Singleton {
                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                 element_type: core :: option :: Option < usize >,
                                                                                                                                                             },
@@ -4745,75 +4651,25 @@ expression: built.ir()
                                                                                                                                                     },
                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                         location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                        collection_kind: Optional {
+                                                                                                                                                        collection_kind: Singleton {
                                                                                                                                                             bound: Bounded,
-                                                                                                                                                            element_type: (usize , core :: option :: Option < usize >),
+                                                                                                                                                            element_type: core :: option :: Option < usize >,
                                                                                                                                                         },
                                                                                                                                                     },
                                                                                                                                                 },
                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                     location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                    collection_kind: Stream {
+                                                                                                                                                    collection_kind: Optional {
                                                                                                                                                         bound: Bounded,
-                                                                                                                                                        order: TotalOrder,
-                                                                                                                                                        retry: ExactlyOnce,
-                                                                                                                                                        element_type: (usize , core :: option :: Option < usize >),
+                                                                                                                                                        element_type: core :: option :: Option < usize >,
                                                                                                                                                     },
                                                                                                                                                 },
                                                                                                                                             },
                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                 location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                collection_kind: Stream {
+                                                                                                                                                collection_kind: Optional {
                                                                                                                                                     bound: Bounded,
-                                                                                                                                                    order: TotalOrder,
-                                                                                                                                                    retry: ExactlyOnce,
-                                                                                                                                                    element_type: usize,
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                        },
-                                                                                                                                        neg: Map {
-                                                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                                                                                                            input: Cast {
-                                                                                                                                                inner: Cast {
-                                                                                                                                                    inner: Tee {
-                                                                                                                                                        inner: <shared 22>,
-                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                            collection_kind: KeyedSingleton {
-                                                                                                                                                                bound: Bounded,
-                                                                                                                                                                key_type: usize,
-                                                                                                                                                                value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
-                                                                                                                                                            },
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                        collection_kind: KeyedStream {
-                                                                                                                                                            bound: Bounded,
-                                                                                                                                                            value_order: TotalOrder,
-                                                                                                                                                            value_retry: ExactlyOnce,
-                                                                                                                                                            key_type: usize,
-                                                                                                                                                            value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                },
-                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                    collection_kind: Stream {
-                                                                                                                                                        bound: Bounded,
-                                                                                                                                                        order: NoOrder,
-                                                                                                                                                        retry: ExactlyOnce,
-                                                                                                                                                        element_type: (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)),
-                                                                                                                                                    },
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                collection_kind: Stream {
-                                                                                                                                                    bound: Bounded,
-                                                                                                                                                    order: NoOrder,
-                                                                                                                                                    retry: ExactlyOnce,
-                                                                                                                                                    element_type: usize,
+                                                                                                                                                    element_type: (usize , core :: option :: Option < usize >),
                                                                                                                                                 },
                                                                                                                                             },
                                                                                                                                         },
@@ -4823,26 +4679,7 @@ expression: built.ir()
                                                                                                                                                 bound: Bounded,
                                                                                                                                                 order: TotalOrder,
                                                                                                                                                 retry: ExactlyOnce,
-                                                                                                                                                element_type: usize,
-                                                                                                                                            },
-                                                                                                                                        },
-                                                                                                                                    },
-                                                                                                                                    right: Cast {
-                                                                                                                                        inner: Tee {
-                                                                                                                                            inner: <shared 4>,
-                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                collection_kind: Singleton {
-                                                                                                                                                    bound: Bounded,
-                                                                                                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                        },
-                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                            collection_kind: Optional {
-                                                                                                                                                bound: Bounded,
-                                                                                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                                                                                element_type: (usize , core :: option :: Option < usize >),
                                                                                                                                             },
                                                                                                                                         },
                                                                                                                                     },
@@ -4852,7 +4689,53 @@ expression: built.ir()
                                                                                                                                             bound: Bounded,
                                                                                                                                             order: TotalOrder,
                                                                                                                                             retry: ExactlyOnce,
-                                                                                                                                            element_type: (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                                                                                            element_type: usize,
+                                                                                                                                        },
+                                                                                                                                    },
+                                                                                                                                },
+                                                                                                                                neg: Map {
+                                                                                                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
+                                                                                                                                    input: Cast {
+                                                                                                                                        inner: Cast {
+                                                                                                                                            inner: Tee {
+                                                                                                                                                inner: <shared 23>,
+                                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                    collection_kind: KeyedSingleton {
+                                                                                                                                                        bound: Bounded,
+                                                                                                                                                        key_type: usize,
+                                                                                                                                                        value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                                                                                    },
+                                                                                                                                                },
+                                                                                                                                            },
+                                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                collection_kind: KeyedStream {
+                                                                                                                                                    bound: Bounded,
+                                                                                                                                                    value_order: TotalOrder,
+                                                                                                                                                    value_retry: ExactlyOnce,
+                                                                                                                                                    key_type: usize,
+                                                                                                                                                    value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                                                                                },
+                                                                                                                                            },
+                                                                                                                                        },
+                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                            collection_kind: Stream {
+                                                                                                                                                bound: Bounded,
+                                                                                                                                                order: NoOrder,
+                                                                                                                                                retry: ExactlyOnce,
+                                                                                                                                                element_type: (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)),
+                                                                                                                                            },
+                                                                                                                                        },
+                                                                                                                                    },
+                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                        collection_kind: Stream {
+                                                                                                                                            bound: Bounded,
+                                                                                                                                            order: NoOrder,
+                                                                                                                                            retry: ExactlyOnce,
+                                                                                                                                            element_type: usize,
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                 },
@@ -4862,7 +4745,7 @@ expression: built.ir()
                                                                                                                                         bound: Bounded,
                                                                                                                                         order: TotalOrder,
                                                                                                                                         retry: ExactlyOnce,
-                                                                                                                                        element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                                                                        element_type: usize,
                                                                                                                                     },
                                                                                                                                 },
                                                                                                                             },
@@ -4870,7 +4753,7 @@ expression: built.ir()
                                                                                                                                 location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                                 collection_kind: Stream {
                                                                                                                                     bound: Bounded,
-                                                                                                                                    order: NoOrder,
+                                                                                                                                    order: TotalOrder,
                                                                                                                                     retry: ExactlyOnce,
                                                                                                                                     element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
                                                                                                                                 },
@@ -4886,21 +4769,23 @@ expression: built.ir()
                                                                                                                             },
                                                                                                                         },
                                                                                                                     },
-                                                                                                                    right: Filter {
-                                                                                                                        f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | b | * b }),
-                                                                                                                        input: Tee {
-                                                                                                                            inner: <shared 13>,
-                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                collection_kind: Singleton {
-                                                                                                                                    bound: Bounded,
-                                                                                                                                    element_type: bool,
-                                                                                                                                },
-                                                                                                                            },
+                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                        collection_kind: Stream {
+                                                                                                                            bound: Bounded,
+                                                                                                                            order: NoOrder,
+                                                                                                                            retry: ExactlyOnce,
+                                                                                                                            element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
                                                                                                                         },
+                                                                                                                    },
+                                                                                                                },
+                                                                                                                right: Filter {
+                                                                                                                    f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | b | * b }),
+                                                                                                                    input: Tee {
+                                                                                                                        inner: <shared 13>,
                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                             location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                            collection_kind: Optional {
+                                                                                                                            collection_kind: Singleton {
                                                                                                                                 bound: Bounded,
                                                                                                                                 element_type: bool,
                                                                                                                             },
@@ -4908,11 +4793,9 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                         location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                        collection_kind: Stream {
+                                                                                                                        collection_kind: Optional {
                                                                                                                             bound: Bounded,
-                                                                                                                            order: NoOrder,
-                                                                                                                            retry: ExactlyOnce,
-                                                                                                                            element_type: (((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , bool),
+                                                                                                                            element_type: bool,
                                                                                                                         },
                                                                                                                     },
                                                                                                                 },
@@ -4922,14 +4805,14 @@ expression: built.ir()
                                                                                                                         bound: Bounded,
                                                                                                                         order: NoOrder,
                                                                                                                         retry: ExactlyOnce,
-                                                                                                                        element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                                                        element_type: (((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , bool),
                                                                                                                     },
                                                                                                                 },
                                                                                                             },
                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                location_id: Atomic(Tick(15, Cluster(loc1v1))),
+                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                 collection_kind: Stream {
-                                                                                                                    bound: Unbounded,
+                                                                                                                    bound: Bounded,
                                                                                                                     order: NoOrder,
                                                                                                                     retry: ExactlyOnce,
                                                                                                                     element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
@@ -4947,7 +4830,7 @@ expression: built.ir()
                                                                                                         },
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
-                                                                                                        location_id: Cluster(loc1v1),
+                                                                                                        location_id: Atomic(Tick(15, Cluster(loc1v1))),
                                                                                                         collection_kind: Stream {
                                                                                                             bound: Unbounded,
                                                                                                             order: NoOrder,
@@ -4962,14 +4845,14 @@ expression: built.ir()
                                                                                                         bound: Unbounded,
                                                                                                         order: NoOrder,
                                                                                                         retry: ExactlyOnce,
-                                                                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
+                                                                                                        element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
                                                                                                     },
                                                                                                 },
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(13, Cluster(loc1v1)),
+                                                                                                location_id: Cluster(loc1v1),
                                                                                                 collection_kind: Stream {
-                                                                                                    bound: Bounded,
+                                                                                                    bound: Unbounded,
                                                                                                     order: NoOrder,
                                                                                                     retry: ExactlyOnce,
                                                                                                     element_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
@@ -4982,25 +4865,24 @@ expression: built.ir()
                                                                                                 bound: Bounded,
                                                                                                 order: NoOrder,
                                                                                                 retry: ExactlyOnce,
-                                                                                                element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >),
+                                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                                                                             },
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_id: Tick(13, Cluster(loc1v1)),
-                                                                                        collection_kind: KeyedStream {
+                                                                                        collection_kind: Stream {
                                                                                             bound: Bounded,
-                                                                                            value_order: NoOrder,
-                                                                                            value_retry: ExactlyOnce,
-                                                                                            key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
-                                                                                            value_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
+                                                                                            order: NoOrder,
+                                                                                            retry: ExactlyOnce,
+                                                                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >),
                                                                                         },
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Cluster(loc1v1),
+                                                                                    location_id: Tick(13, Cluster(loc1v1)),
                                                                                     collection_kind: KeyedStream {
-                                                                                        bound: Unbounded,
+                                                                                        bound: Bounded,
                                                                                         value_order: NoOrder,
                                                                                         value_retry: ExactlyOnce,
                                                                                         key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
@@ -5009,23 +4891,24 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Cluster(loc2v1),
+                                                                                location_id: Cluster(loc1v1),
                                                                                 collection_kind: KeyedStream {
                                                                                     bound: Unbounded,
                                                                                     value_order: NoOrder,
                                                                                     value_retry: ExactlyOnce,
-                                                                                    key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
+                                                                                    key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
                                                                                     value_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                                                                 },
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
                                                                             location_id: Cluster(loc2v1),
-                                                                            collection_kind: Stream {
+                                                                            collection_kind: KeyedStream {
                                                                                 bound: Unbounded,
-                                                                                order: NoOrder,
-                                                                                retry: ExactlyOnce,
-                                                                                element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >),
+                                                                                value_order: NoOrder,
+                                                                                value_retry: ExactlyOnce,
+                                                                                key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
+                                                                                value_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                                                             },
                                                                         },
                                                                     },
@@ -5035,14 +4918,14 @@ expression: built.ir()
                                                                             bound: Unbounded,
                                                                             order: NoOrder,
                                                                             retry: ExactlyOnce,
-                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
+                                                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >),
                                                                         },
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(2, Cluster(loc2v1)),
+                                                                    location_id: Cluster(loc2v1),
                                                                     collection_kind: Stream {
-                                                                        bound: Bounded,
+                                                                        bound: Unbounded,
                                                                         order: NoOrder,
                                                                         retry: ExactlyOnce,
                                                                         element_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
@@ -5059,32 +4942,13 @@ expression: built.ir()
                                                                 },
                                                             },
                                                         },
-                                                        right: Cast {
-                                                            inner: Tee {
-                                                                inner: <shared 10>,
-                                                                metadata: HydroIrMetadata {
-                                                                    location_id: Tick(2, Cluster(loc2v1)),
-                                                                    collection_kind: Singleton {
-                                                                        bound: Bounded,
-                                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                    },
-                                                                },
-                                                            },
-                                                            metadata: HydroIrMetadata {
-                                                                location_id: Tick(2, Cluster(loc2v1)),
-                                                                collection_kind: Optional {
-                                                                    bound: Bounded,
-                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                },
-                                                            },
-                                                        },
                                                         metadata: HydroIrMetadata {
                                                             location_id: Tick(2, Cluster(loc2v1)),
                                                             collection_kind: Stream {
                                                                 bound: Bounded,
                                                                 order: NoOrder,
                                                                 retry: ExactlyOnce,
-                                                                element_type: (hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                                             },
                                                         },
                                                     },
@@ -5191,19 +5055,19 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <shared 29>: Map {
+                inner: <shared 31>: Map {
                     f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (usize , usize)) , (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
                     input: Cast {
                         inner: Cast {
                             inner: Filter {
                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (usize , usize)) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < (usize , usize) , bool > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; let max__free = 3usize ; move | (success , error) | (success + error) >= max__free }) ; { let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) } }),
                                 input: Tee {
-                                    inner: <shared 30>: FoldKeyed {
+                                    inner: <shared 32>: FoldKeyed {
                                         init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | | (0 , 0) }),
                                         acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } } }),
                                         input: Cast {
                                             inner: Tee {
-                                                inner: <shared 24>,
+                                                inner: <shared 26>,
                                                 metadata: HydroIrMetadata {
                                                     location_id: Tick(14, Cluster(loc1v1)),
                                                     collection_kind: Stream {
@@ -5311,12 +5175,12 @@ expression: built.ir()
         ),
         input: Difference {
             pos: Tee {
-                inner: <shared 31>: FilterMap {
+                inner: <shared 33>: FilterMap {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (usize , usize)) , core :: option :: Option < (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; let min__free = 2usize ; move | (key , (success , _error)) | if success >= min__free { Some (key) } else { None } }),
                     input: Cast {
                         inner: Cast {
                             inner: Tee {
-                                inner: <shared 30>,
+                                inner: <shared 32>,
                                 metadata: HydroIrMetadata {
                                     location_id: Tick(14, Cluster(loc1v1)),
                                     collection_kind: KeyedSingleton {
@@ -5368,7 +5232,7 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <shared 29>,
+                inner: <shared 31>,
                 metadata: HydroIrMetadata {
                     location_id: Tick(14, Cluster(loc1v1)),
                     collection_kind: Stream {
@@ -5397,7 +5261,7 @@ expression: built.ir()
         ),
         input: AntiJoin {
             pos: Tee {
-                inner: <shared 32>: Chain {
+                inner: <shared 34>: Chain {
                     first: DeferTick {
                         input: CycleSource {
                             cycle_id: CycleId(
@@ -5427,7 +5291,7 @@ expression: built.ir()
                         inner: YieldConcat {
                             inner: Batch {
                                 inner: Tee {
-                                    inner: <shared 27>,
+                                    inner: <shared 29>,
                                     metadata: HydroIrMetadata {
                                         location_id: Atomic(Tick(15, Cluster(loc1v1))),
                                         collection_kind: Stream {
@@ -5491,13 +5355,13 @@ expression: built.ir()
             neg: Map {
                 f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ()) , (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: request_response :: * ; | (key , _) | key }),
                 input: Tee {
-                    inner: <shared 33>: Batch {
+                    inner: <shared 35>: Batch {
                         inner: Map {
                             f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ()) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | k | (k , ()) }),
                             input: YieldConcat {
                                 inner: Difference {
                                     pos: Tee {
-                                        inner: <shared 31>,
+                                        inner: <shared 33>,
                                         metadata: HydroIrMetadata {
                                             location_id: Tick(14, Cluster(loc1v1)),
                                             collection_kind: Stream {
@@ -5605,6 +5469,28 @@ expression: built.ir()
         },
         op_metadata: HydroIrOpMetadata,
     },
+    Null {
+        input: Singleton {
+            inner: <shared 36>: Tee {
+                inner: <shared 4>,
+                metadata: HydroIrMetadata {
+                    location_id: Tick(15, Cluster(loc1v1)),
+                    collection_kind: Singleton {
+                        bound: Bounded,
+                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                    },
+                },
+            },
+            metadata: HydroIrMetadata {
+                location_id: Tick(15, Cluster(loc1v1)),
+                collection_kind: Singleton {
+                    bound: Bounded,
+                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                },
+            },
+        },
+        op_metadata: HydroIrOpMetadata,
+    },
     CycleSink {
         cycle_id: CycleId(
             4,
@@ -5618,7 +5504,7 @@ expression: built.ir()
                                 first: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < usize , core :: option :: Option < usize > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                     input: Tee {
-                                        inner: <shared 34>: Batch {
+                                        inner: <shared 37>: Batch {
                                             inner: CycleSource {
                                                 cycle_id: CycleId(
                                                     2,
@@ -5703,46 +5589,16 @@ expression: built.ir()
                                                 inner: Cast {
                                                     inner: YieldConcat {
                                                         inner: FilterMap {
-                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; | (p2a , max_ballot) | if p2a . ballot >= max_ballot { Some ((p2a . slot , LogValue { ballot : p2a . ballot , value : p2a . value , })) } else { None } }),
-                                                            input: CrossSingleton {
-                                                                left: Tee {
-                                                                    inner: <shared 26>,
-                                                                    metadata: HydroIrMetadata {
-                                                                        location_id: Tick(2, Cluster(loc2v1)),
-                                                                        collection_kind: Stream {
-                                                                            bound: Bounded,
-                                                                            order: NoOrder,
-                                                                            retry: ExactlyOnce,
-                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
-                                                                        },
-                                                                    },
-                                                                },
-                                                                right: Cast {
-                                                                    inner: Tee {
-                                                                        inner: <shared 10>,
-                                                                        metadata: HydroIrMetadata {
-                                                                            location_id: Tick(2, Cluster(loc2v1)),
-                                                                            collection_kind: Singleton {
-                                                                                bound: Bounded,
-                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                            },
-                                                                        },
-                                                                    },
-                                                                    metadata: HydroIrMetadata {
-                                                                        location_id: Tick(2, Cluster(loc2v1)),
-                                                                        collection_kind: Optional {
-                                                                            bound: Bounded,
-                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                        },
-                                                                    },
-                                                                },
+                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , core :: option :: Option < (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; let a_max_ballot_ref__free = __hydro_singleton_ref_0 ; | p2a | if p2a . ballot >= * a_max_ballot_ref__free { Some ((p2a . slot , LogValue { ballot : p2a . ballot , value : p2a . value , } ,)) } else { None } }),
+                                                            input: Tee {
+                                                                inner: <shared 28>,
                                                                 metadata: HydroIrMetadata {
                                                                     location_id: Tick(2, Cluster(loc2v1)),
                                                                     collection_kind: Stream {
                                                                         bound: Bounded,
                                                                         order: NoOrder,
                                                                         retry: ExactlyOnce,
-                                                                        element_type: (hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                                                     },
                                                                 },
                                                             },
@@ -5790,7 +5646,7 @@ expression: built.ir()
                                                 },
                                             },
                                             watermark: Tee {
-                                                inner: <shared 34>,
+                                                inner: <shared 37>,
                                                 metadata: HydroIrMetadata {
                                                     location_id: Tick(2, Cluster(loc2v1)),
                                                     collection_kind: Optional {
@@ -5889,7 +5745,7 @@ expression: built.ir()
             input: FilterMap {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , core :: option :: Option < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | (key , res) | match res { Ok (_) => None , Err (e) => Some ((key , e)) , } }),
                 input: Tee {
-                    inner: <shared 25>,
+                    inner: <shared 27>,
                     metadata: HydroIrMetadata {
                         location_id: Cluster(loc1v1),
                         collection_kind: Stream {
@@ -6006,7 +5862,7 @@ expression: built.ir()
                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; | (sorted_payload , highest_seq) | sorted_payload . seq > * highest_seq }),
                 input: CrossSingleton {
                     left: Tee {
-                        inner: <shared 35>: Sort {
+                        inner: <shared 38>: Sort {
                             input: Chain {
                                 first: Batch {
                                     inner: Map {
@@ -6158,7 +6014,7 @@ expression: built.ir()
                                                                                     f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , ())) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , ())) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: request_response :: * ; | (key , (meta , resp)) | (key , (meta , resp)) }),
                                                                                     input: JoinHalf {
                                                                                         left: Tee {
-                                                                                            inner: <shared 32>,
+                                                                                            inner: <shared 34>,
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_id: Tick(15, Cluster(loc1v1)),
                                                                                                 collection_kind: Stream {
@@ -6170,7 +6026,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         right: Tee {
-                                                                                            inner: <shared 33>,
+                                                                                            inner: <shared 35>,
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_id: Tick(15, Cluster(loc1v1)),
                                                                                                 collection_kind: Stream {
@@ -6381,12 +6237,12 @@ expression: built.ir()
                     },
                     right: Cast {
                         inner: Tee {
-                            inner: <shared 36>: Fold {
+                            inner: <shared 39>: Fold {
                                 init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; | | 0 }),
                                 acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; | new_next_slot , (sorted_payload , next_slot) | { if sorted_payload . seq == std :: cmp :: max (* new_next_slot , next_slot) { * new_next_slot = sorted_payload . seq + 1 ; } } }),
                                 input: CrossSingleton {
                                     left: Tee {
-                                        inner: <shared 35>,
+                                        inner: <shared 38>,
                                         metadata: HydroIrMetadata {
                                             location_id: Tick(17, Cluster(loc5v1)),
                                             collection_kind: Stream {
@@ -6536,7 +6392,7 @@ expression: built.ir()
             17,
         ),
         input: Tee {
-            inner: <shared 37>: Map {
+            inner: <shared 40>: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: collections :: hash_map :: HashMap < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; | (_kv_store , next_slot) | next_slot }),
                 input: Batch {
                     inner: Fold {
@@ -6544,13 +6400,13 @@ expression: built.ir()
                         acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (std :: collections :: hash_map :: HashMap < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; | (kv_store , next_slot) , payload | { if let Some (kv) = payload . kv { kv_store . insert (kv . key , kv . value) ; } * next_slot = payload . seq + 1 ; } }),
                         input: YieldConcat {
                             inner: Tee {
-                                inner: <shared 38>: Map {
+                                inner: <shared 41>: Map {
                                     f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; | (sorted_payload , _) | { sorted_payload } }),
                                     input: Filter {
                                         f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; | (sorted_payload , highest_seq) | sorted_payload . seq < * highest_seq }),
                                         input: CrossSingleton {
                                             left: Tee {
-                                                inner: <shared 35>,
+                                                inner: <shared 38>,
                                                 metadata: HydroIrMetadata {
                                                     location_id: Tick(17, Cluster(loc5v1)),
                                                     collection_kind: Stream {
@@ -6563,7 +6419,7 @@ expression: built.ir()
                                             },
                                             right: Cast {
                                                 inner: Tee {
-                                                    inner: <shared 36>,
+                                                    inner: <shared 39>,
                                                     metadata: HydroIrMetadata {
                                                         location_id: Tick(17, Cluster(loc5v1)),
                                                         collection_kind: Singleton {
@@ -6669,7 +6525,7 @@ expression: built.ir()
             18,
         ),
         input: Tee {
-            inner: <shared 39>: FilterMap {
+            inner: <shared 42>: FilterMap {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (core :: option :: Option < usize > , usize) , core :: option :: Option < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; let checkpoint_frequency__free = 1000usize ; move | (max_checkpointed_seq , next_slot) | if max_checkpointed_seq . map (| m | next_slot - m >= checkpoint_frequency__free) . unwrap_or (true) { Some (next_slot) } else { None } }),
                 input: Cast {
                     inner: CrossSingleton {
@@ -6788,7 +6644,7 @@ expression: built.ir()
                                 first: DeferTick {
                                     input: Cast {
                                         inner: Tee {
-                                            inner: <shared 37>,
+                                            inner: <shared 40>,
                                             metadata: HydroIrMetadata {
                                                 location_id: Tick(17, Cluster(loc5v1)),
                                                 collection_kind: Singleton {
@@ -6899,7 +6755,7 @@ expression: built.ir()
                                 left: Cast {
                                     inner: Cast {
                                         inner: Tee {
-                                            inner: <shared 40>: Batch {
+                                            inner: <shared 43>: Batch {
                                                 inner: ReduceKeyed {
                                                     f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; | curr_seq , seq | { if seq > * curr_seq { * curr_seq = seq ; } } }),
                                                     input: Network {
@@ -7040,7 +6896,7 @@ expression: built.ir()
                                                                         inner: YieldConcat {
                                                                             inner: Cast {
                                                                                 inner: Tee {
-                                                                                    inner: <shared 39>,
+                                                                                    inner: <shared 42>,
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_id: Tick(17, Cluster(loc5v1)),
                                                                                         collection_kind: Optional {
@@ -7181,7 +7037,7 @@ expression: built.ir()
                                                 inner: Cast {
                                                     inner: Cast {
                                                         inner: Tee {
-                                                            inner: <shared 40>,
+                                                            inner: <shared 43>,
                                                             metadata: HydroIrMetadata {
                                                                 location_id: Tick(19, Cluster(loc2v1)),
                                                                 collection_kind: KeyedSingleton {
@@ -7312,7 +7168,7 @@ expression: built.ir()
         ),
         input: AntiJoin {
             pos: Tee {
-                inner: <shared 41>: Chain {
+                inner: <shared 44>: Chain {
                     first: DeferTick {
                         input: CycleSource {
                             cycle_id: CycleId(
@@ -7340,7 +7196,7 @@ expression: built.ir()
                     },
                     second: Batch {
                         inner: Tee {
-                            inner: <shared 42>: Map {
+                            inner: <shared 45>: Map {
                                 f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica > , ((u32 , i32) , core :: result :: Result < () , () >)) , ((u32 , i32) , core :: result :: Result < () , () >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; | (_ , v) | v }),
                                 input: Cast {
                                     inner: Network {
@@ -7362,7 +7218,7 @@ expression: built.ir()
                                                     inner: FilterMap {
                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; | payload | payload . kv }),
                                                         input: Tee {
-                                                            inner: <shared 38>,
+                                                            inner: <shared 41>,
                                                             metadata: HydroIrMetadata {
                                                                 location_id: Tick(17, Cluster(loc5v1)),
                                                                 collection_kind: Stream {
@@ -7486,17 +7342,17 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <shared 43>: FilterMap {
+                inner: <shared 46>: FilterMap {
                     f: stageleft :: runtime_support :: fn1_type_hint :: < ((u32 , i32) , (usize , usize)) , core :: option :: Option < (u32 , i32) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; let min__free = 2usize ; move | (key , (success , _error)) | if success >= min__free { Some (key) } else { None } }),
                     input: Cast {
                         inner: Cast {
                             inner: Tee {
-                                inner: <shared 44>: FoldKeyed {
+                                inner: <shared 47>: FoldKeyed {
                                     init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | | (0 , 0) }),
                                     acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < () , () > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } } }),
                                     input: Cast {
                                         inner: Tee {
-                                            inner: <shared 41>,
+                                            inner: <shared 44>,
                                             metadata: HydroIrMetadata {
                                                 location_id: Tick(20, Cluster(loc3v1)),
                                                 collection_kind: Stream {
@@ -7624,7 +7480,7 @@ expression: built.ir()
         input: FilterMap {
             f: stageleft :: runtime_support :: fn1_type_hint :: < ((u32 , i32) , core :: result :: Result < () , () >) , core :: option :: Option < ((u32 , i32) , ()) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; move | (key , res) | match res { Ok (_) => None , Err (e) => Some ((key , e)) , } }),
             input: Tee {
-                inner: <shared 42>,
+                inner: <shared 45>,
                 metadata: HydroIrMetadata {
                     location_id: Cluster(loc3v1),
                     collection_kind: Stream {
@@ -7652,10 +7508,10 @@ expression: built.ir()
             1,
         ),
         input: Tee {
-            inner: <shared 45>: Cast {
+            inner: <shared 48>: Cast {
                 inner: YieldConcat {
                     inner: Tee {
-                        inner: <shared 43>,
+                        inner: <shared 46>,
                         metadata: HydroIrMetadata {
                             location_id: Tick(20, Cluster(loc3v1)),
                             collection_kind: Stream {
@@ -7710,11 +7566,11 @@ expression: built.ir()
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (new , old) | { old . borrow_mut () . add (new) . expect ("Error adding value to histogram") ; old } }),
                     input: CrossSingleton {
                         left: Tee {
-                            inner: <shared 46>: Fold {
+                            inner: <shared 49>: Fold {
                                 init: stageleft :: runtime_support :: fn0_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; move | | Histogram :: < u64 > :: new (3) . unwrap () }),
                                 acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , core :: time :: Duration , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; move | latencies , latency | { latencies . record (latency . as_nanos () as u64) . unwrap () ; } }),
                                 input: Tee {
-                                    inner: <shared 47>: Batch {
+                                    inner: <shared 50>: Batch {
                                         inner: Map {
                                             f: stageleft :: runtime_support :: fnmut1_type_hint :: < (u32 , (i32 , core :: time :: Duration)) , core :: time :: Duration > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; | (_virtual_client_id , (_output , latency)) | latency }),
                                             input: Cast {
@@ -7803,7 +7659,7 @@ expression: built.ir()
                                                                                             input: ObserveNonDet {
                                                                                                 inner: Batch {
                                                                                                     inner: Tee {
-                                                                                                        inner: <shared 45>,
+                                                                                                        inner: <shared 48>,
                                                                                                         metadata: HydroIrMetadata {
                                                                                                             location_id: Cluster(loc3v1),
                                                                                                             collection_kind: KeyedStream {
@@ -8006,11 +7862,11 @@ expression: built.ir()
                             },
                         },
                         right: Tee {
-                            inner: <shared 48>: Map {
+                            inner: <shared 51>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
                                 input: CrossSingleton {
                                     left: Tee {
-                                        inner: <shared 49>: Cast {
+                                        inner: <shared 52>: Cast {
                                             inner: ChainFirst {
                                                 first: DeferTick {
                                                     input: CycleSource {
@@ -8088,7 +7944,7 @@ expression: built.ir()
                                                         input: Map {
                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                             input: Tee {
-                                                                inner: <shared 50>: Reduce {
+                                                                inner: <shared 53>: Reduce {
                                                                     f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
                                                                     input: FlatMap {
                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | d | d }),
@@ -8268,7 +8124,7 @@ expression: built.ir()
                     inner: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | histogram | Rc :: new (RefCell :: new (histogram)) }),
                         input: Tee {
-                            inner: <shared 46>,
+                            inner: <shared 49>,
                             metadata: HydroIrMetadata {
                                 location_id: Tick(22, Cluster(loc3v1)),
                                 collection_kind: Singleton {
@@ -8321,12 +8177,12 @@ expression: built.ir()
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , usize) , usize > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; | (new , old) | new + old }),
                     input: CrossSingleton {
                         left: Tee {
-                            inner: <shared 51>: Fold {
+                            inner: <shared 54>: Fold {
                                 init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | | 0usize }),
                                 acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , core :: time :: Duration , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | count , _ | * count += 1 }),
                                 input: ObserveNonDet {
                                     inner: Tee {
-                                        inner: <shared 47>,
+                                        inner: <shared 50>,
                                         metadata: HydroIrMetadata {
                                             location_id: Tick(22, Cluster(loc3v1)),
                                             collection_kind: Stream {
@@ -8365,11 +8221,11 @@ expression: built.ir()
                             },
                         },
                         right: Tee {
-                            inner: <shared 52>: Map {
+                            inner: <shared 55>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
                                 input: CrossSingleton {
                                     left: Tee {
-                                        inner: <shared 53>: Cast {
+                                        inner: <shared 56>: Cast {
                                             inner: ChainFirst {
                                                 first: DeferTick {
                                                     input: CycleSource {
@@ -8447,7 +8303,7 @@ expression: built.ir()
                                                         input: Map {
                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                             input: Tee {
-                                                                inner: <shared 50>,
+                                                                inner: <shared 53>,
                                                                 metadata: HydroIrMetadata {
                                                                     location_id: Tick(22, Cluster(loc3v1)),
                                                                     collection_kind: Optional {
@@ -8566,7 +8422,7 @@ expression: built.ir()
                 },
                 second: Cast {
                     inner: Tee {
-                        inner: <shared 51>,
+                        inner: <shared 54>,
                         metadata: HydroIrMetadata {
                             location_id: Tick(22, Cluster(loc3v1)),
                             collection_kind: Singleton {
@@ -8612,7 +8468,7 @@ expression: built.ir()
                     left: Cast {
                         inner: CrossSingleton {
                             left: Tee {
-                                inner: <shared 54>: Cast {
+                                inner: <shared 57>: Cast {
                                     inner: ChainFirst {
                                         first: DeferTick {
                                             input: CycleSource {
@@ -8713,7 +8569,7 @@ expression: built.ir()
                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
                                                                                         input: CrossSingleton {
                                                                                             left: Tee {
-                                                                                                inner: <shared 49>,
+                                                                                                inner: <shared 52>,
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_id: Tick(22, Cluster(loc3v1)),
                                                                                                     collection_kind: Singleton {
@@ -8733,7 +8589,7 @@ expression: built.ir()
                                                                                                                 input: Map {
                                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                                                                                     input: Tee {
-                                                                                                                        inner: <shared 50>,
+                                                                                                                        inner: <shared 53>,
                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                             location_id: Tick(22, Cluster(loc3v1)),
                                                                                                                             collection_kind: Optional {
@@ -9002,7 +8858,7 @@ expression: built.ir()
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | v | Some (v) }),
                                 input: DeferTick {
                                     input: Tee {
-                                        inner: <shared 55>: Reduce {
+                                        inner: <shared 58>: Reduce {
                                             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | _ , _ | { } }),
                                             input: FlatMap {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; | d | d }),
@@ -9179,7 +9035,7 @@ expression: built.ir()
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
                                                 input: CrossSingleton {
                                                     left: Tee {
-                                                        inner: <shared 53>,
+                                                        inner: <shared 56>,
                                                         metadata: HydroIrMetadata {
                                                             location_id: Tick(22, Cluster(loc3v1)),
                                                             collection_kind: Singleton {
@@ -9199,7 +9055,7 @@ expression: built.ir()
                                                                         input: Map {
                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                                             input: Tee {
-                                                                                inner: <shared 50>,
+                                                                                inner: <shared 53>,
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_id: Tick(22, Cluster(loc3v1)),
                                                                                     collection_kind: Optional {
@@ -9368,7 +9224,7 @@ expression: built.ir()
                         f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
                         input: CrossSingleton {
                             left: Tee {
-                                inner: <shared 56>: Cast {
+                                inner: <shared 59>: Cast {
                                     inner: ChainFirst {
                                         first: DeferTick {
                                             input: CycleSource {
@@ -9446,7 +9302,7 @@ expression: built.ir()
                                                 input: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                     input: Tee {
-                                                        inner: <shared 55>,
+                                                        inner: <shared 58>,
                                                         metadata: HydroIrMetadata {
                                                             location_id: Tick(23, Process(loc4v1)),
                                                             collection_kind: Optional {
@@ -9577,7 +9433,7 @@ expression: built.ir()
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
                     input: CrossSingleton {
                         left: Tee {
-                            inner: <shared 56>,
+                            inner: <shared 59>,
                             metadata: HydroIrMetadata {
                                 location_id: Tick(23, Process(loc4v1)),
                                 collection_kind: Singleton {
@@ -9597,7 +9453,7 @@ expression: built.ir()
                                             input: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                 input: Tee {
-                                                    inner: <shared 55>,
+                                                    inner: <shared 58>,
                                                     metadata: HydroIrMetadata {
                                                         location_id: Tick(23, Process(loc4v1)),
                                                         collection_kind: Optional {
@@ -9722,7 +9578,7 @@ expression: built.ir()
                         f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; | (d , _) | d }),
                         input: CrossSingleton {
                             left: Tee {
-                                inner: <shared 54>,
+                                inner: <shared 57>,
                                 metadata: HydroIrMetadata {
                                     location_id: Tick(23, Process(loc4v1)),
                                     collection_kind: Singleton {
@@ -9742,7 +9598,7 @@ expression: built.ir()
                                                 input: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; | _ | () }),
                                                     input: Tee {
-                                                        inner: <shared 55>,
+                                                        inner: <shared 58>,
                                                         metadata: HydroIrMetadata {
                                                             location_id: Tick(23, Process(loc4v1)),
                                                             collection_kind: Optional {

--- a/hydro_test/src/cluster/snapshots/paxos_ir@acceptor_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir@acceptor_mermaid.snap
@@ -25,21 +25,20 @@ linkStyle default stroke:#aaa
 15v1["<div style=text-align:center>(15v1)</div> <code><br>map({<br>    |((ballot, max_ballot), log)| (<br>        ballot.proposer_id.clone(),<br>        (<br>            ballot.clone(),<br>            if ballot == max_ballot { Ok(log) } else { Err(max_ballot) },<br>        ),<br>    )<br>})</code>"]:::otherClass
 16v1["<div style=text-align:center>(16v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
 17v1["<div style=text-align:center>(17v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-18v1["<div style=text-align:center>(18v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
-19v1["<div style=text-align:center>(19v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Proposer,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            hydro_test::__staged::cluster::paxos::P2a&lt;<br>                (<br>                    u32,<br>                    (<br>                        hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                            hydro_test::__staged::cluster::paxos_bench::Client,<br>                        &gt;,<br>                        i32,<br>                    ),<br>                ),<br>                hydro_test::__staged::cluster::paxos::Proposer,<br>            &gt;,<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
-20v1["<div style=text-align:center>(20v1)</div> <code><br>map({<br>    |(_, v)| v<br>})</code>"]:::otherClass
-21v1["<div style=text-align:center>(21v1)</div> <code><br>tee()</code>"]:::otherClass
-22v1["<div style=text-align:center>(22v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-23v1["<div style=text-align:center>(23v1)</div> <code><br>map({<br>    |(p2a, max_ballot)| (<br>        p2a.sender,<br>        (<br>            (p2a.slot, p2a.ballot.clone()),<br>            if p2a.ballot == max_ballot { Ok(()) } else { Err(max_ballot) },<br>        ),<br>    )<br>})</code>"]:::otherClass
-24v1["<div style=text-align:center>(24v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
-25v1["<div style=text-align:center>(25v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-26v1["<div style=text-align:center>(26v1)</div> <code><br>tee()</code>"]:::otherClass
-27v1["<div style=text-align:center>(27v1)</div> <code><br>map({<br>    |v| Some(v)<br>})</code>"]:::otherClass
-28v1["<div style=text-align:center>(28v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
-29v1["<div style=text-align:center>(29v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
-30v1["<div style=text-align:center>(30v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-31v1["<div style=text-align:center>(31v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-32v1["<div style=text-align:center>(32v1)</div> <code><br>filter_map({<br>    |(p2a, max_ballot)| {<br>        if p2a.ballot &gt;= max_ballot {<br>            Some((<br>                p2a.slot,<br>                LogValue {<br>                    ballot: p2a.ballot,<br>                    value: p2a.value,<br>                },<br>            ))<br>        } else {<br>            None<br>        }<br>    }<br>})</code>"]:::otherClass
+19v1["<div style=text-align:center>(19v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
+20v1["<div style=text-align:center>(20v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
+21v1["<div style=text-align:center>(21v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Proposer,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            hydro_test::__staged::cluster::paxos::P2a&lt;<br>                (<br>                    u32,<br>                    (<br>                        hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                            hydro_test::__staged::cluster::paxos_bench::Client,<br>                        &gt;,<br>                        i32,<br>                    ),<br>                ),<br>                hydro_test::__staged::cluster::paxos::Proposer,<br>            &gt;,<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
+22v1["<div style=text-align:center>(22v1)</div> <code><br>map({<br>    |(_, v)| v<br>})</code>"]:::otherClass
+23v1["<div style=text-align:center>(23v1)</div> <code><br>tee()</code>"]:::otherClass
+24v1["<div style=text-align:center>(24v1)</div> <code><br>map({<br>    let __hydro_singleton_ref_0 = stream_389;<br>    {<br>        let a_max_ballot_ref__free = __hydro_singleton_ref_0;<br>        |p2a| {<br>            let max_ballot = a_max_ballot_ref__free.clone();<br>            (<br>                p2a.sender,<br>                (<br>                    (p2a.slot, p2a.ballot.clone()),<br>                    if p2a.ballot == max_ballot { Ok(()) } else { Err(max_ballot) },<br>                ),<br>            )<br>        }<br>    }<br>})</code>"]:::otherClass
+25v1["<div style=text-align:center>(25v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+26v1["<div style=text-align:center>(26v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+27v1["<div style=text-align:center>(27v1)</div> <code><br>tee()</code>"]:::otherClass
+28v1["<div style=text-align:center>(28v1)</div> <code><br>map({<br>    |v| Some(v)<br>})</code>"]:::otherClass
+29v1["<div style=text-align:center>(29v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
+30v1["<div style=text-align:center>(30v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
+31v1["<div style=text-align:center>(31v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+32v1["<div style=text-align:center>(32v1)</div> <code><br>filter_map({<br>    let __hydro_singleton_ref_0 = stream_389;<br>    {<br>        let a_max_ballot_ref__free = __hydro_singleton_ref_0;<br>        |p2a| {<br>            if p2a.ballot &gt;= *a_max_ballot_ref__free {<br>                Some((<br>                    p2a.slot,<br>                    LogValue {<br>                        ballot: p2a.ballot,<br>                        value: p2a.value,<br>                    },<br>                ))<br>            } else {<br>                None<br>            }<br>        }<br>    }<br>})</code>"]:::otherClass
 33v1["<div style=text-align:center>(33v1)</div> <code><br>chain()</code>"]:::otherClass
 34v1["<div style=text-align:center>(34v1)</div> <code><br>map(|x| (Some(x), None))</code>"]:::otherClass
 35v1["<div style=text-align:center>(35v1)</div> <code><br>map(|watermark| (None, Some(watermark)))</code>"]:::otherClass
@@ -77,50 +76,50 @@ linkStyle default stroke:#aaa
 14v1-->15v1
 16v1-->17v1
 15v1-->16v1
-18v1-->19v1
-19v1-->20v1
+12v1-->19v1
 20v1-->21v1
-21v1-->|input|22v1
-12v1--x|single|22v1; linkStyle 21 stroke:red
+21v1-->22v1
 22v1-->23v1
-24v1-->25v1
 23v1-->24v1
-52v1-->26v1
-26v1-->27v1
-28v1-->29v1
-27v1--x|0|30v1; linkStyle 28 stroke:red
-29v1-->|1|30v1
-21v1-->|input|31v1
-12v1--x|single|31v1; linkStyle 31 stroke:red
-31v1-->32v1
-34v1--x|0|33v1; linkStyle 33 stroke:red
+25v1-->26v1
+24v1-->25v1
+52v1-->27v1
+27v1-->28v1
+29v1-->30v1
+28v1--x|0|31v1; linkStyle 27 stroke:red
+30v1-->|1|31v1
+23v1-->32v1
+34v1--x|0|33v1; linkStyle 30 stroke:red
 32v1-->34v1
 35v1-->|1|33v1
-26v1-->35v1
+27v1-->35v1
 36v1-->37v1
-33v1--x36v1; linkStyle 38 stroke:red
-37v1--x38v1; linkStyle 39 stroke:red
-30v1-->|input|39v1
-38v1--x|single|39v1; linkStyle 41 stroke:red
+33v1--x36v1; linkStyle 35 stroke:red
+37v1--x38v1; linkStyle 36 stroke:red
+31v1-->|input|39v1
+38v1--x|single|39v1; linkStyle 38 stroke:red
 39v1-->40v1
 41v1-->42v1
-42v1--x43v1; linkStyle 44 stroke:red
+42v1--x43v1; linkStyle 41 stroke:red
 43v1-->44v1
-44v1--x45v1; linkStyle 46 stroke:red
+44v1--x45v1; linkStyle 43 stroke:red
 45v1-->46v1
 46v1-->47v1
 44v1-->|input|48v1
-47v1--x|single|48v1; linkStyle 50 stroke:red
+47v1--x|single|48v1; linkStyle 47 stroke:red
 48v1-->49v1
 49v1-->50v1
-50v1--x51v1; linkStyle 53 stroke:red
+50v1--x51v1; linkStyle 50 stroke:red
 51v1-->52v1
+18v1--x24v1; linkStyle 52 stroke:red
+18v1--x32v1; linkStyle 53 stroke:red
 2v1
 16v1
 17v1
-24v1
-25v1
+19v1
 35v1
+25v1
+26v1
 34v1
 subgraph var_cycle_2 ["var <tt>cycle_2</tt>"]
     style var_cycle_2 fill:transparent
@@ -130,8 +129,8 @@ subgraph var_cycle_4 ["var <tt>cycle_4</tt>"]
     style var_cycle_4 fill:transparent
     40v1
 end
-subgraph var_reduce_keyed_watermark_chain_524 ["var <tt>reduce_keyed_watermark_chain_524</tt>"]
-    style var_reduce_keyed_watermark_chain_524 fill:transparent
+subgraph var_reduce_keyed_watermark_chain_519 ["var <tt>reduce_keyed_watermark_chain_519</tt>"]
+    style var_reduce_keyed_watermark_chain_519 fill:transparent
     33v1
 end
 subgraph var_stream_162 ["var <tt>stream_162</tt>"]
@@ -184,103 +183,95 @@ subgraph var_stream_24 ["var <tt>stream_24</tt>"]
     style var_stream_24 fill:transparent
     1v1
 end
+subgraph var_stream_452 ["var <tt>stream_452</tt>"]
+    style var_stream_452 fill:transparent
+    20v1
+    21v1
+end
 subgraph var_stream_454 ["var <tt>stream_454</tt>"]
     style var_stream_454 fill:transparent
-    18v1
-    19v1
+    22v1
 end
 subgraph var_stream_456 ["var <tt>stream_456</tt>"]
     style var_stream_456 fill:transparent
-    20v1
-end
-subgraph var_stream_458 ["var <tt>stream_458</tt>"]
-    style var_stream_458 fill:transparent
-    21v1
-end
-subgraph var_stream_461 ["var <tt>stream_461</tt>"]
-    style var_stream_461 fill:transparent
-    22v1
-end
-subgraph var_stream_462 ["var <tt>stream_462</tt>"]
-    style var_stream_462 fill:transparent
     23v1
 end
-subgraph var_stream_509 ["var <tt>stream_509</tt>"]
-    style var_stream_509 fill:transparent
-    26v1
+subgraph var_stream_457 ["var <tt>stream_457</tt>"]
+    style var_stream_457 fill:transparent
+    24v1
+end
+subgraph var_stream_506 ["var <tt>stream_506</tt>"]
+    style var_stream_506 fill:transparent
+    27v1
+end
+subgraph var_stream_507 ["var <tt>stream_507</tt>"]
+    style var_stream_507 fill:transparent
+    28v1
+end
+subgraph var_stream_508 ["var <tt>stream_508</tt>"]
+    style var_stream_508 fill:transparent
+    29v1
+    30v1
 end
 subgraph var_stream_510 ["var <tt>stream_510</tt>"]
     style var_stream_510 fill:transparent
-    27v1
-end
-subgraph var_stream_511 ["var <tt>stream_511</tt>"]
-    style var_stream_511 fill:transparent
-    28v1
-    29v1
-end
-subgraph var_stream_513 ["var <tt>stream_513</tt>"]
-    style var_stream_513 fill:transparent
-    30v1
-end
-subgraph var_stream_518 ["var <tt>stream_518</tt>"]
-    style var_stream_518 fill:transparent
     31v1
+end
+subgraph var_stream_514 ["var <tt>stream_514</tt>"]
+    style var_stream_514 fill:transparent
+    32v1
 end
 subgraph var_stream_519 ["var <tt>stream_519</tt>"]
     style var_stream_519 fill:transparent
-    32v1
-end
-subgraph var_stream_524 ["var <tt>stream_524</tt>"]
-    style var_stream_524 fill:transparent
     36v1
     37v1
 end
-subgraph var_stream_528 ["var <tt>stream_528</tt>"]
-    style var_stream_528 fill:transparent
+subgraph var_stream_523 ["var <tt>stream_523</tt>"]
+    style var_stream_523 fill:transparent
     38v1
 end
-subgraph var_stream_529 ["var <tt>stream_529</tt>"]
-    style var_stream_529 fill:transparent
+subgraph var_stream_524 ["var <tt>stream_524</tt>"]
+    style var_stream_524 fill:transparent
     39v1
 end
-subgraph var_stream_641 ["var <tt>stream_641</tt>"]
-    style var_stream_641 fill:transparent
+subgraph var_stream_636 ["var <tt>stream_636</tt>"]
+    style var_stream_636 fill:transparent
     41v1
     42v1
 end
-subgraph var_stream_642 ["var <tt>stream_642</tt>"]
-    style var_stream_642 fill:transparent
+subgraph var_stream_637 ["var <tt>stream_637</tt>"]
+    style var_stream_637 fill:transparent
     43v1
 end
-subgraph var_stream_644 ["var <tt>stream_644</tt>"]
-    style var_stream_644 fill:transparent
+subgraph var_stream_639 ["var <tt>stream_639</tt>"]
+    style var_stream_639 fill:transparent
     44v1
+end
+subgraph var_stream_646 ["var <tt>stream_646</tt>"]
+    style var_stream_646 fill:transparent
+    45v1
+end
+subgraph var_stream_647 ["var <tt>stream_647</tt>"]
+    style var_stream_647 fill:transparent
+    46v1
+end
+subgraph var_stream_648 ["var <tt>stream_648</tt>"]
+    style var_stream_648 fill:transparent
+    47v1
+end
+subgraph var_stream_649 ["var <tt>stream_649</tt>"]
+    style var_stream_649 fill:transparent
+    48v1
+end
+subgraph var_stream_650 ["var <tt>stream_650</tt>"]
+    style var_stream_650 fill:transparent
+    49v1
 end
 subgraph var_stream_651 ["var <tt>stream_651</tt>"]
     style var_stream_651 fill:transparent
-    45v1
-end
-subgraph var_stream_652 ["var <tt>stream_652</tt>"]
-    style var_stream_652 fill:transparent
-    46v1
+    50v1
 end
 subgraph var_stream_653 ["var <tt>stream_653</tt>"]
     style var_stream_653 fill:transparent
-    47v1
-end
-subgraph var_stream_654 ["var <tt>stream_654</tt>"]
-    style var_stream_654 fill:transparent
-    48v1
-end
-subgraph var_stream_655 ["var <tt>stream_655</tt>"]
-    style var_stream_655 fill:transparent
-    49v1
-end
-subgraph var_stream_656 ["var <tt>stream_656</tt>"]
-    style var_stream_656 fill:transparent
-    50v1
-end
-subgraph var_stream_658 ["var <tt>stream_658</tt>"]
-    style var_stream_658 fill:transparent
     51v1
 end

--- a/hydro_test/src/cluster/snapshots/paxos_ir@proposer_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir@proposer_mermaid.snap
@@ -163,119 +163,114 @@ linkStyle default stroke:#aaa
 153v1["<div style=text-align:center>(153v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
 154v1["<div style=text-align:center>(154v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
 155v1["<div style=text-align:center>(155v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-156v1["<div style=text-align:center>(156v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
-157v1["<div style=text-align:center>(157v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos_bench::Client,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            (<br>                u32,<br>                (<br>                    hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                        hydro_test::__staged::cluster::paxos_bench::Client,<br>                    &gt;,<br>                    i32,<br>                ),<br>            ),<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
-158v1["<div style=text-align:center>(158v1)</div> <code><br>map({<br>    |(_, v)| v<br>})</code>"]:::otherClass
-159v1["<div style=text-align:center>(159v1)</div> <code><br>filter({<br>    |b| *b<br>})</code>"]:::otherClass
-160v1["<div style=text-align:center>(160v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-161v1["<div style=text-align:center>(161v1)</div> <code><br>map({<br>    |(d, _)| d<br>})</code>"]:::otherClass
-162v1["<div style=text-align:center>(162v1)</div> <code><br>enumerate::&lt;'tick&gt;()</code>"]:::otherClass
-163v1["<div style=text-align:center>(163v1)</div> <code><br>flat_map({<br>    |v| v<br>})</code>"]:::otherClass
+157v1["<div style=text-align:center>(157v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
+158v1["<div style=text-align:center>(158v1)</div> <code><br>flat_map({<br>    |v| v<br>})</code>"]:::otherClass
+159v1["<div style=text-align:center>(159v1)</div> <code><br>tee()</code>"]:::otherClass
+160v1["<div style=text-align:center>(160v1)</div> <code><br>map({<br>    |(_checkpoint, log)| log<br>})</code>"]:::otherClass
+161v1["<div style=text-align:center>(161v1)</div> <code><br>flat_map({<br>    |d| d<br>})</code>"]:::otherClass
+162v1["<div style=text-align:center>(162v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        || (0, None)<br>    },<br>    {<br>        |curr_entry, new_entry| {<br>            if let Some(curr_entry_payload) = &amp;mut curr_entry.1 {<br>                let same_values = new_entry.value == curr_entry_payload.value;<br>                let higher_ballot = new_entry.ballot &gt; curr_entry_payload.ballot;<br>                if same_values {<br>                    curr_entry.0 += 1;<br>                }<br>                if higher_ballot {<br>                    curr_entry_payload.ballot = new_entry.ballot;<br>                    if !same_values {<br>                        curr_entry.0 = 1;<br>                        curr_entry_payload.value = new_entry.value;<br>                    }<br>                }<br>            } else {<br>                *curr_entry = (1, Some(new_entry));<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
+163v1["<div style=text-align:center>(163v1)</div> <code><br>map({<br>    let f__free = {<br>        |(count, entry)| (count, entry.unwrap())<br>    };<br>    {<br>        let orig = f__free;<br>        move |(k, v)| (k, orig(v))<br>    }<br>})</code>"]:::otherClass
 164v1["<div style=text-align:center>(164v1)</div> <code><br>tee()</code>"]:::otherClass
-165v1["<div style=text-align:center>(165v1)</div> <code><br>map({<br>    |(_checkpoint, log)| log<br>})</code>"]:::otherClass
-166v1["<div style=text-align:center>(166v1)</div> <code><br>flat_map({<br>    |d| d<br>})</code>"]:::otherClass
-167v1["<div style=text-align:center>(167v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        || (0, None)<br>    },<br>    {<br>        |curr_entry, new_entry| {<br>            if let Some(curr_entry_payload) = &amp;mut curr_entry.1 {<br>                let same_values = new_entry.value == curr_entry_payload.value;<br>                let higher_ballot = new_entry.ballot &gt; curr_entry_payload.ballot;<br>                if same_values {<br>                    curr_entry.0 += 1;<br>                }<br>                if higher_ballot {<br>                    curr_entry_payload.ballot = new_entry.ballot;<br>                    if !same_values {<br>                        curr_entry.0 = 1;<br>                        curr_entry_payload.value = new_entry.value;<br>                    }<br>                }<br>            } else {<br>                *curr_entry = (1, Some(new_entry));<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
-168v1["<div style=text-align:center>(168v1)</div> <code><br>map({<br>    let f__free = {<br>        |(count, entry)| (count, entry.unwrap())<br>    };<br>    {<br>        let orig = f__free;<br>        move |(k, v)| (k, orig(v))<br>    }<br>})</code>"]:::otherClass
-169v1["<div style=text-align:center>(169v1)</div> <code><br>tee()</code>"]:::otherClass
-170v1["<div style=text-align:center>(170v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
-171v1["<div style=text-align:center>(171v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    |curr, new| {<br>        if new &gt; *curr {<br>            *curr = new;<br>        }<br>    }<br>})</code>"]:::otherClass
-172v1["<div style=text-align:center>(172v1)</div> <code><br>tee()</code>"]:::otherClass
-173v1["<div style=text-align:center>(173v1)</div> <code><br>map({<br>    |s| s + 1<br>})</code>"]:::otherClass
-174v1["<div style=text-align:center>(174v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-175v1["<div style=text-align:center>(175v1)</div> <code><br>source_iter([<br>    {<br>        0<br>    },<br>])</code>"]:::otherClass
-176v1["<div style=text-align:center>(176v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
-177v1["<div style=text-align:center>(177v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-178v1["<div style=text-align:center>(178v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-179v1["<div style=text-align:center>(179v1)</div> <code><br>tee()</code>"]:::otherClass
-180v1["<div style=text-align:center>(180v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-181v1["<div style=text-align:center>(181v1)</div> <code><br>map({<br>    |((index, payload), base_slot)| (base_slot + index, payload)<br>})</code>"]:::otherClass
-182v1["<div style=text-align:center>(182v1)</div> <code><br>tee()</code>"]:::otherClass
-183v1["<div style=text-align:center>(183v1)</div> <code><br>fold::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        || 0usize<br>    },<br>    {<br>        |count, _| *count += 1<br>    },<br>)</code>"]:::otherClass
-184v1["<div style=text-align:center>(184v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-185v1["<div style=text-align:center>(185v1)</div> <code><br>map({<br>    |(num_payloads, base_slot)| base_slot + num_payloads<br>})</code>"]:::otherClass
-186v1["<div style=text-align:center>(186v1)</div> <code><br>identity::&lt;usize&gt;()</code>"]:::otherClass
-187v1["<div style=text-align:center>(187v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-188v1["<div style=text-align:center>(188v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
-189v1["<div style=text-align:center>(189v1)</div> <code><br>map({<br>    |(k, v)| (MemberId::from_tagless(k), v)<br>})</code>"]:::otherClass
-190v1["<div style=text-align:center>(190v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        || false<br>    },<br>    {<br>        |present, event| {<br>            match event {<br>                MembershipEvent::Joined =&gt; *present = true,<br>                MembershipEvent::Left =&gt; *present = false,<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
-191v1["<div style=text-align:center>(191v1)</div> <code><br>filter({<br>    let f__free = {<br>        |b| *b<br>    };<br>    {<br>        let orig = f__free;<br>        move |t: &amp;(_, _)| orig(&amp;t.1)<br>    }<br>})</code>"]:::otherClass
-192v1["<div style=text-align:center>(192v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
-193v1["<div style=text-align:center>(193v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-194v1["<div style=text-align:center>(194v1)</div> <code><br>map({<br>    |((slot, payload), ballot)| ((slot, ballot), Some(payload))<br>})</code>"]:::otherClass
-195v1["<div style=text-align:center>(195v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+165v1["<div style=text-align:center>(165v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
+166v1["<div style=text-align:center>(166v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    |curr, new| {<br>        if new &gt; *curr {<br>            *curr = new;<br>        }<br>    }<br>})</code>"]:::otherClass
+167v1["<div style=text-align:center>(167v1)</div> <code><br>tee()</code>"]:::otherClass
+168v1["<div style=text-align:center>(168v1)</div> <code><br>map({<br>    |s| s + 1<br>})</code>"]:::otherClass
+169v1["<div style=text-align:center>(169v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+170v1["<div style=text-align:center>(170v1)</div> <code><br>source_iter([<br>    {<br>        0<br>    },<br>])</code>"]:::otherClass
+171v1["<div style=text-align:center>(171v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
+172v1["<div style=text-align:center>(172v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+173v1["<div style=text-align:center>(173v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+175v1["<div style=text-align:center>(175v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
+176v1["<div style=text-align:center>(176v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos_bench::Client,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            (<br>                u32,<br>                (<br>                    hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                        hydro_test::__staged::cluster::paxos_bench::Client,<br>                    &gt;,<br>                    i32,<br>                ),<br>            ),<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
+177v1["<div style=text-align:center>(177v1)</div> <code><br>map({<br>    |(_, v)| v<br>})</code>"]:::otherClass
+178v1["<div style=text-align:center>(178v1)</div> <code><br>filter({<br>    |b| *b<br>})</code>"]:::otherClass
+179v1["<div style=text-align:center>(179v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+180v1["<div style=text-align:center>(180v1)</div> <code><br>map({<br>    |(d, _)| d<br>})</code>"]:::otherClass
+181v1["<div style=text-align:center>(181v1)</div> <code><br>enumerate::&lt;'tick&gt;()</code>"]:::otherClass
+182v1["<div style=text-align:center>(182v1)</div> <code><br>map({<br>    let __hydro_singleton_ref_0 = stream_362;<br>    {<br>        let base_slot_ref__free = __hydro_singleton_ref_0;<br>        |(index, payload)| (*base_slot_ref__free + index, payload)<br>    }<br>})</code>"]:::otherClass
+183v1["<div style=text-align:center>(183v1)</div> <code><br>tee()</code>"]:::otherClass
+184v1["<div style=text-align:center>(184v1)</div> <code><br>fold::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        || 0usize<br>    },<br>    {<br>        |count, _| *count += 1<br>    },<br>)</code>"]:::otherClass
+185v1["<div style=text-align:center>(185v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+186v1["<div style=text-align:center>(186v1)</div> <code><br>map({<br>    |(num_payloads, base_slot)| base_slot + num_payloads<br>})</code>"]:::otherClass
+187v1["<div style=text-align:center>(187v1)</div> <code><br>identity::&lt;usize&gt;()</code>"]:::otherClass
+188v1["<div style=text-align:center>(188v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+189v1["<div style=text-align:center>(189v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
+190v1["<div style=text-align:center>(190v1)</div> <code><br>map({<br>    |(k, v)| (MemberId::from_tagless(k), v)<br>})</code>"]:::otherClass
+191v1["<div style=text-align:center>(191v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        || false<br>    },<br>    {<br>        |present, event| {<br>            match event {<br>                MembershipEvent::Joined =&gt; *present = true,<br>                MembershipEvent::Left =&gt; *present = false,<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
+192v1["<div style=text-align:center>(192v1)</div> <code><br>filter({<br>    let f__free = {<br>        |b| *b<br>    };<br>    {<br>        let orig = f__free;<br>        move |t: &amp;(_, _)| orig(&amp;t.1)<br>    }<br>})</code>"]:::otherClass
+193v1["<div style=text-align:center>(193v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
+195v1["<div style=text-align:center>(195v1)</div> <code><br>map({<br>    let __hydro_singleton_ref_0 = stream_405;<br>    {<br>        let p_ballot_ref__free = __hydro_singleton_ref_0;<br>        |(slot, payload)| ((slot, p_ballot_ref__free.clone()), Some(payload))<br>    }<br>})</code>"]:::otherClass
 196v1["<div style=text-align:center>(196v1)</div> <code><br>filter_map({<br>    |(checkpoint, _log)| checkpoint<br>})</code>"]:::otherClass
 197v1["<div style=text-align:center>(197v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    |curr, new| {<br>        if new &gt; *curr {<br>            *curr = new;<br>        }<br>    }<br>})</code>"]:::otherClass
 198v1["<div style=text-align:center>(198v1)</div> <code><br>map({<br>    |v| Some(v)<br>})</code>"]:::otherClass
 199v1["<div style=text-align:center>(199v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
 200v1["<div style=text-align:center>(200v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
 201v1["<div style=text-align:center>(201v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-202v1["<div style=text-align:center>(202v1)</div> <code><br>tee()</code>"]:::otherClass
-203v1["<div style=text-align:center>(203v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-204v1["<div style=text-align:center>(204v1)</div> <code><br>filter_map({<br>    let f__free = 1usize;<br>    move |(((slot, (count, entry)), ballot), checkpoint)| {<br>        if count &gt; f__free {<br>            return None;<br>        } else if let Some(checkpoint) = checkpoint &amp;&amp; slot &lt;= checkpoint {<br>            return None;<br>        }<br>        Some(((slot, ballot), entry.value))<br>    }<br>})</code>"]:::otherClass
-205v1["<div style=text-align:center>(205v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-206v1["<div style=text-align:center>(206v1)</div> <code><br>flat_map({<br>    |(max_slot, checkpoint)| {<br>        if let Some(checkpoint) = checkpoint {<br>            (checkpoint + 1)..max_slot<br>        } else {<br>            0..max_slot<br>        }<br>    }<br>})</code>"]:::otherClass
-207v1["<div style=text-align:center>(207v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
-208v1["<div style=text-align:center>(208v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-209v1["<div style=text-align:center>(209v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-210v1["<div style=text-align:center>(210v1)</div> <code><br>map({<br>    move |(slot, ballot)| ((slot, ballot), None)<br>})</code>"]:::otherClass
-211v1["<div style=text-align:center>(211v1)</div> <code><br>chain()</code>"]:::otherClass
-212v1["<div style=text-align:center>(212v1)</div> <code><br>chain()</code>"]:::otherClass
-213v1["<div style=text-align:center>(213v1)</div> <code><br>filter({<br>    |b| *b<br>})</code>"]:::otherClass
-214v1["<div style=text-align:center>(214v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-215v1["<div style=text-align:center>(215v1)</div> <code><br>map({<br>    |(d, _)| d<br>})</code>"]:::otherClass
-216v1["<div style=text-align:center>(216v1)</div> <code><br>tee()</code>"]:::otherClass
-217v1["<div style=text-align:center>(217v1)</div> <code><br>map({<br>    let CLUSTER_SELF_ID__free = hydro_lang::__staged::location::MemberId::&lt;<br>        hydro_test::__staged::cluster::paxos::Proposer,<br>    &gt;::from_tagless((__hydro_lang_cluster_self_id_loc1v1).clone());<br>    move |((slot, ballot), value)| P2a {<br>        sender: CLUSTER_SELF_ID__free.clone(),<br>        ballot,<br>        slot,<br>        value,<br>    }<br>})</code>"]:::otherClass
-218v1["<div style=text-align:center>(218v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-219v1["<div style=text-align:center>(219v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
-220v1["<div style=text-align:center>(220v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-221v1["<div style=text-align:center>(221v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
-222v1["<div style=text-align:center>(222v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Acceptor,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            (<br>                (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>                core::result::Result&lt;<br>                    (),<br>                    hydro_test::__staged::cluster::paxos::Ballot,<br>                &gt;,<br>            ),<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
-223v1["<div style=text-align:center>(223v1)</div> <code><br>map({<br>    |(_, v)| v<br>})</code>"]:::otherClass
+203v1["<div style=text-align:center>(203v1)</div> <code><br>filter_map({<br>    let __hydro_singleton_ref_0 = stream_332;<br>    let __hydro_singleton_ref_1 = stream_420;<br>    {<br>        let f__free = 1usize;<br>        let p_ballot_ref__free = __hydro_singleton_ref_0;<br>        let p_p1b_max_checkpoint_ref__free = __hydro_singleton_ref_1;<br>        move |(slot, (count, entry))| {<br>            if count &gt; f__free {<br>                return None;<br>            } else if let Some(checkpoint) = *p_p1b_max_checkpoint_ref__free<br>                &amp;&amp; slot &lt;= checkpoint<br>            {<br>                return None;<br>            }<br>            Some(((slot, p_ballot_ref__free.clone()), entry.value))<br>        }<br>    }<br>})</code>"]:::otherClass
+204v1["<div style=text-align:center>(204v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+205v1["<div style=text-align:center>(205v1)</div> <code><br>flat_map({<br>    |(max_slot, checkpoint)| {<br>        if let Some(checkpoint) = checkpoint {<br>            (checkpoint + 1)..max_slot<br>        } else {<br>            0..max_slot<br>        }<br>    }<br>})</code>"]:::otherClass
+206v1["<div style=text-align:center>(206v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
+207v1["<div style=text-align:center>(207v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+208v1["<div style=text-align:center>(208v1)</div> <code><br>map({<br>    let __hydro_singleton_ref_0 = stream_332;<br>    {<br>        let p_ballot_ref__free = __hydro_singleton_ref_0;<br>        move |slot| ((slot, p_ballot_ref__free.clone()), None)<br>    }<br>})</code>"]:::otherClass
+209v1["<div style=text-align:center>(209v1)</div> <code><br>chain()</code>"]:::otherClass
+210v1["<div style=text-align:center>(210v1)</div> <code><br>chain()</code>"]:::otherClass
+211v1["<div style=text-align:center>(211v1)</div> <code><br>filter({<br>    |b| *b<br>})</code>"]:::otherClass
+212v1["<div style=text-align:center>(212v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+213v1["<div style=text-align:center>(213v1)</div> <code><br>map({<br>    |(d, _)| d<br>})</code>"]:::otherClass
+214v1["<div style=text-align:center>(214v1)</div> <code><br>tee()</code>"]:::otherClass
+215v1["<div style=text-align:center>(215v1)</div> <code><br>map({<br>    let CLUSTER_SELF_ID__free = hydro_lang::__staged::location::MemberId::&lt;<br>        hydro_test::__staged::cluster::paxos::Proposer,<br>    &gt;::from_tagless((__hydro_lang_cluster_self_id_loc1v1).clone());<br>    move |((slot, ballot), value)| P2a {<br>        sender: CLUSTER_SELF_ID__free.clone(),<br>        ballot,<br>        slot,<br>        value,<br>    }<br>})</code>"]:::otherClass
+216v1["<div style=text-align:center>(216v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+217v1["<div style=text-align:center>(217v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+218v1["<div style=text-align:center>(218v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+219v1["<div style=text-align:center>(219v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
+220v1["<div style=text-align:center>(220v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Acceptor,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            (<br>                (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>                core::result::Result&lt;<br>                    (),<br>                    hydro_test::__staged::cluster::paxos::Ballot,<br>                &gt;,<br>            ),<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
+221v1["<div style=text-align:center>(221v1)</div> <code><br>map({<br>    |(_, v)| v<br>})</code>"]:::otherClass
+222v1["<div style=text-align:center>(222v1)</div> <code><br>tee()</code>"]:::otherClass
+223v1["<div style=text-align:center>(223v1)</div> <code><br>chain()</code>"]:::otherClass
 224v1["<div style=text-align:center>(224v1)</div> <code><br>tee()</code>"]:::otherClass
-225v1["<div style=text-align:center>(225v1)</div> <code><br>chain()</code>"]:::otherClass
+225v1["<div style=text-align:center>(225v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        move || (0, 0)<br>    },<br>    {<br>        move |accum, value| {<br>            if value.is_ok() {<br>                accum.0 += 1;<br>            } else {<br>                accum.1 += 1;<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
 226v1["<div style=text-align:center>(226v1)</div> <code><br>tee()</code>"]:::otherClass
-227v1["<div style=text-align:center>(227v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        move || (0, 0)<br>    },<br>    {<br>        move |accum, value| {<br>            if value.is_ok() {<br>                accum.0 += 1;<br>            } else {<br>                accum.1 += 1;<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
-228v1["<div style=text-align:center>(228v1)</div> <code><br>tee()</code>"]:::otherClass
-229v1["<div style=text-align:center>(229v1)</div> <code><br>filter({<br>    let f__free = {<br>        let max__free = 3usize;<br>        move |(success, error)| (success + error) &gt;= max__free<br>    };<br>    {<br>        let orig = f__free;<br>        move |t: &amp;(_, _)| orig(&amp;t.1)<br>    }<br>})</code>"]:::otherClass
-230v1["<div style=text-align:center>(230v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
-231v1["<div style=text-align:center>(231v1)</div> <code><br>tee()</code>"]:::otherClass
-232v1["<div style=text-align:center>(232v1)</div> <code><br>anti_join::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-233v1["<div style=text-align:center>(233v1)</div> <code><br>identity::&lt;<br>    (<br>        (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>        core::result::Result&lt;(), hydro_test::__staged::cluster::paxos::Ballot&gt;,<br>    ),<br>&gt;()</code>"]:::otherClass
-234v1["<div style=text-align:center>(234v1)</div> <code><br>filter_map({<br>    let min__free = 2usize;<br>    move |(key, (success, _error))| {<br>        if success &gt;= min__free { Some(key) } else { None }<br>    }<br>})</code>"]:::otherClass
-235v1["<div style=text-align:center>(235v1)</div> <code><br>tee()</code>"]:::otherClass
-236v1["<div style=text-align:center>(236v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-237v1["<div style=text-align:center>(237v1)</div> <code><br>identity::&lt;(usize, hydro_test::__staged::cluster::paxos::Ballot)&gt;()</code>"]:::otherClass
-238v1["<div style=text-align:center>(238v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-239v1["<div style=text-align:center>(239v1)</div> <code><br>chain()</code>"]:::otherClass
-240v1["<div style=text-align:center>(240v1)</div> <code><br>tee()</code>"]:::otherClass
-241v1["<div style=text-align:center>(241v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-242v1["<div style=text-align:center>(242v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-243v1["<div style=text-align:center>(243v1)</div> <code><br>map({<br>    |k| (k, ())<br>})</code>"]:::otherClass
-244v1["<div style=text-align:center>(244v1)</div> <code><br>tee()</code>"]:::otherClass
-245v1["<div style=text-align:center>(245v1)</div> <code><br>map({<br>    |(key, _)| key<br>})</code>"]:::otherClass
-246v1["<div style=text-align:center>(246v1)</div> <code><br>anti_join::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-247v1["<div style=text-align:center>(247v1)</div> <code><br>identity::&lt;<br>    (<br>        (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>        core::option::Option&lt;<br>            (<br>                u32,<br>                (<br>                    hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                        hydro_test::__staged::cluster::paxos_bench::Client,<br>                    &gt;,<br>                    i32,<br>                ),<br>            ),<br>        &gt;,<br>    ),<br>&gt;()</code>"]:::otherClass
-248v1["<div style=text-align:center>(248v1)</div> <code><br>filter_map({<br>    move |(key, res)| match res {<br>        Ok(_) =&gt; None,<br>        Err(e) =&gt; Some((key, e)),<br>    }<br>})</code>"]:::otherClass
-249v1["<div style=text-align:center>(249v1)</div> <code><br>map({<br>    |(_, ballot)| ballot<br>})</code>"]:::otherClass
-250v1["<div style=text-align:center>(250v1)</div> <code><br>identity::&lt;hydro_test::__staged::cluster::paxos::Ballot&gt;()</code>"]:::otherClass
-251v1["<div style=text-align:center>(251v1)</div> <code><br>filter({<br>    |b| *b<br>})</code>"]:::otherClass
-252v1["<div style=text-align:center>(252v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-253v1["<div style=text-align:center>(253v1)</div> <code><br>map({<br>    |(d, _)| d<br>})</code>"]:::otherClass
-254v1["<div style=text-align:center>(254v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
-255v1["<div style=text-align:center>(255v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
-256v1["<div style=text-align:center>(256v1)</div> <code><br>map({<br>    |(k, v)| (MemberId::from_tagless(k), v)<br>})</code>"]:::otherClass
-257v1["<div style=text-align:center>(257v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        || false<br>    },<br>    {<br>        |present, event| {<br>            match event {<br>                MembershipEvent::Joined =&gt; *present = true,<br>                MembershipEvent::Left =&gt; *present = false,<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
-258v1["<div style=text-align:center>(258v1)</div> <code><br>filter({<br>    let f__free = {<br>        |b| *b<br>    };<br>    {<br>        let orig = f__free;<br>        move |t: &amp;(_, _)| orig(&amp;t.1)<br>    }<br>})</code>"]:::otherClass
-259v1["<div style=text-align:center>(259v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
-260v1["<div style=text-align:center>(260v1)</div> <code><br>join_multiset_half::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-261v1["<div style=text-align:center>(261v1)</div> <code><br>map({<br>    |(key, (meta, resp))| (key, (meta, resp))<br>})</code>"]:::otherClass
-262v1["<div style=text-align:center>(262v1)</div> <code><br>map({<br>    |((slot, _ballot), (value, _))| (slot, value)<br>})</code>"]:::otherClass
-263v1["<div style=text-align:center>(263v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-264v1["<div style=text-align:center>(264v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
-265v1["<div style=text-align:center>(265v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+227v1["<div style=text-align:center>(227v1)</div> <code><br>filter({<br>    let f__free = {<br>        let max__free = 3usize;<br>        move |(success, error)| (success + error) &gt;= max__free<br>    };<br>    {<br>        let orig = f__free;<br>        move |t: &amp;(_, _)| orig(&amp;t.1)<br>    }<br>})</code>"]:::otherClass
+228v1["<div style=text-align:center>(228v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
+229v1["<div style=text-align:center>(229v1)</div> <code><br>tee()</code>"]:::otherClass
+230v1["<div style=text-align:center>(230v1)</div> <code><br>anti_join::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+231v1["<div style=text-align:center>(231v1)</div> <code><br>identity::&lt;<br>    (<br>        (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>        core::result::Result&lt;(), hydro_test::__staged::cluster::paxos::Ballot&gt;,<br>    ),<br>&gt;()</code>"]:::otherClass
+232v1["<div style=text-align:center>(232v1)</div> <code><br>filter_map({<br>    let min__free = 2usize;<br>    move |(key, (success, _error))| {<br>        if success &gt;= min__free { Some(key) } else { None }<br>    }<br>})</code>"]:::otherClass
+233v1["<div style=text-align:center>(233v1)</div> <code><br>tee()</code>"]:::otherClass
+234v1["<div style=text-align:center>(234v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+235v1["<div style=text-align:center>(235v1)</div> <code><br>identity::&lt;(usize, hydro_test::__staged::cluster::paxos::Ballot)&gt;()</code>"]:::otherClass
+236v1["<div style=text-align:center>(236v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+237v1["<div style=text-align:center>(237v1)</div> <code><br>chain()</code>"]:::otherClass
+238v1["<div style=text-align:center>(238v1)</div> <code><br>tee()</code>"]:::otherClass
+239v1["<div style=text-align:center>(239v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+240v1["<div style=text-align:center>(240v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+241v1["<div style=text-align:center>(241v1)</div> <code><br>map({<br>    |k| (k, ())<br>})</code>"]:::otherClass
+242v1["<div style=text-align:center>(242v1)</div> <code><br>tee()</code>"]:::otherClass
+243v1["<div style=text-align:center>(243v1)</div> <code><br>map({<br>    |(key, _)| key<br>})</code>"]:::otherClass
+244v1["<div style=text-align:center>(244v1)</div> <code><br>anti_join::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+245v1["<div style=text-align:center>(245v1)</div> <code><br>identity::&lt;<br>    (<br>        (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>        core::option::Option&lt;<br>            (<br>                u32,<br>                (<br>                    hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                        hydro_test::__staged::cluster::paxos_bench::Client,<br>                    &gt;,<br>                    i32,<br>                ),<br>            ),<br>        &gt;,<br>    ),<br>&gt;()</code>"]:::otherClass
+246v1["<div style=text-align:center>(246v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
+247v1["<div style=text-align:center>(247v1)</div> <code><br>filter_map({<br>    move |(key, res)| match res {<br>        Ok(_) =&gt; None,<br>        Err(e) =&gt; Some((key, e)),<br>    }<br>})</code>"]:::otherClass
+248v1["<div style=text-align:center>(248v1)</div> <code><br>map({<br>    |(_, ballot)| ballot<br>})</code>"]:::otherClass
+249v1["<div style=text-align:center>(249v1)</div> <code><br>identity::&lt;hydro_test::__staged::cluster::paxos::Ballot&gt;()</code>"]:::otherClass
+250v1["<div style=text-align:center>(250v1)</div> <code><br>filter({<br>    |b| *b<br>})</code>"]:::otherClass
+251v1["<div style=text-align:center>(251v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+252v1["<div style=text-align:center>(252v1)</div> <code><br>map({<br>    |(d, _)| d<br>})</code>"]:::otherClass
+253v1["<div style=text-align:center>(253v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
+254v1["<div style=text-align:center>(254v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
+255v1["<div style=text-align:center>(255v1)</div> <code><br>map({<br>    |(k, v)| (MemberId::from_tagless(k), v)<br>})</code>"]:::otherClass
+256v1["<div style=text-align:center>(256v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        || false<br>    },<br>    {<br>        |present, event| {<br>            match event {<br>                MembershipEvent::Joined =&gt; *present = true,<br>                MembershipEvent::Left =&gt; *present = false,<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
+257v1["<div style=text-align:center>(257v1)</div> <code><br>filter({<br>    let f__free = {<br>        |b| *b<br>    };<br>    {<br>        let orig = f__free;<br>        move |t: &amp;(_, _)| orig(&amp;t.1)<br>    }<br>})</code>"]:::otherClass
+258v1["<div style=text-align:center>(258v1)</div> <code><br>map({<br>    |(k, _)| k<br>})</code>"]:::otherClass
+259v1["<div style=text-align:center>(259v1)</div> <code><br>join_multiset_half::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+260v1["<div style=text-align:center>(260v1)</div> <code><br>map({<br>    |(key, (meta, resp))| (key, (meta, resp))<br>})</code>"]:::otherClass
+261v1["<div style=text-align:center>(261v1)</div> <code><br>map({<br>    |((slot, _ballot), (value, _))| (slot, value)<br>})</code>"]:::otherClass
+262v1["<div style=text-align:center>(262v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+263v1["<div style=text-align:center>(263v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+264v1["<div style=text-align:center>(264v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
 1v1-->2v1
 132v1--x|0|3v1; linkStyle 1 stroke:red
-250v1-->|1|3v1
+249v1-->|1|3v1
 3v1--x|0|4v1; linkStyle 3 stroke:red
 50v1-->|1|4v1
 4v1--x5v1; linkStyle 5 stroke:red
@@ -441,135 +436,130 @@ linkStyle default stroke:#aaa
 152v1-->|1|153v1
 154v1-->155v1
 153v1-->154v1
-156v1-->157v1
-157v1-->158v1
-128v1-->159v1
-158v1-->|input|160v1
-159v1--x|single|160v1; linkStyle 172 stroke:red
+25v1-->157v1
+117v1-->158v1
+158v1-->159v1
+159v1-->160v1
 160v1-->161v1
-161v1-->162v1
-117v1-->163v1
+161v1--x162v1; linkStyle 173 stroke:red
+162v1-->163v1
 163v1-->164v1
 164v1-->165v1
-165v1-->166v1
-166v1--x167v1; linkStyle 179 stroke:red
+165v1--x166v1; linkStyle 177 stroke:red
+166v1-->167v1
 167v1-->168v1
-168v1-->169v1
-169v1-->170v1
-170v1--x171v1; linkStyle 183 stroke:red
-171v1-->172v1
-172v1-->173v1
-186v1--o174v1; linkStyle 186 stroke:red
+187v1--o169v1; linkStyle 180 stroke:red
+170v1-->171v1
+169v1--x|0|172v1; linkStyle 182 stroke:red
+171v1-->|1|172v1
+168v1--x|0|173v1; linkStyle 184 stroke:red
+172v1-->|1|173v1
+173v1--x|single|185v1; linkStyle 186 stroke:red
 175v1-->176v1
-174v1--x|0|177v1; linkStyle 188 stroke:red
-176v1-->|1|177v1
-173v1--x|0|178v1; linkStyle 190 stroke:red
-177v1-->|1|178v1
-178v1-->179v1
-162v1-->|input|180v1
-179v1--x|single|180v1; linkStyle 194 stroke:red
+176v1-->177v1
+128v1-->178v1
+177v1-->|input|179v1
+178v1--x|single|179v1; linkStyle 191 stroke:red
+179v1-->180v1
 180v1-->181v1
 181v1-->182v1
-182v1--x183v1; linkStyle 197 stroke:red
-183v1-->|input|184v1
-179v1--x|single|184v1; linkStyle 199 stroke:red
-184v1-->185v1
+182v1-->183v1
+183v1--x184v1; linkStyle 196 stroke:red
+184v1-->|input|185v1
 185v1-->186v1
-233v1--o187v1; linkStyle 202 stroke:red
-188v1-->189v1
-189v1--x190v1; linkStyle 204 stroke:red
-190v1-->191v1
+186v1-->187v1
+231v1--o188v1; linkStyle 200 stroke:red
+189v1-->190v1
+190v1--x191v1; linkStyle 202 stroke:red
 191v1-->192v1
-182v1-->|input|193v1
-25v1--x|single|193v1; linkStyle 208 stroke:red
-193v1-->194v1
-169v1-->|input|195v1
-25v1--x|single|195v1; linkStyle 211 stroke:red
-164v1-->196v1
-196v1--x197v1; linkStyle 213 stroke:red
+192v1-->193v1
+25v1-->246v1
+183v1-->195v1
+159v1-->196v1
+196v1--x197v1; linkStyle 208 stroke:red
 197v1-->198v1
 199v1-->200v1
-198v1--x|0|201v1; linkStyle 216 stroke:red
+198v1--x|0|201v1; linkStyle 211 stroke:red
 200v1-->|1|201v1
-201v1-->202v1
-195v1-->|input|203v1
-202v1--x|single|203v1; linkStyle 220 stroke:red
-203v1-->204v1
-172v1-->|input|205v1
-202v1--x|single|205v1; linkStyle 223 stroke:red
-205v1-->206v1
-169v1-->207v1
-206v1-->|pos|208v1
-207v1--x|neg|208v1; linkStyle 227 stroke:red
-208v1-->|input|209v1
-25v1--x|single|209v1; linkStyle 229 stroke:red
-209v1-->210v1
-204v1--x|0|211v1; linkStyle 231 stroke:red
-210v1-->|1|211v1
-194v1--x|0|212v1; linkStyle 233 stroke:red
-211v1-->|1|212v1
-128v1-->213v1
-212v1-->|input|214v1
-213v1--x|single|214v1; linkStyle 237 stroke:red
+201v1--x|single|204v1; linkStyle 213 stroke:red
+164v1-->203v1
+167v1-->|input|204v1
+204v1-->205v1
+164v1-->206v1
+205v1-->|pos|207v1
+206v1--x|neg|207v1; linkStyle 219 stroke:red
+207v1-->208v1
+203v1--x|0|209v1; linkStyle 221 stroke:red
+208v1-->|1|209v1
+195v1--x|0|210v1; linkStyle 223 stroke:red
+209v1-->|1|210v1
+128v1-->211v1
+210v1-->|input|212v1
+211v1--x|single|212v1; linkStyle 227 stroke:red
+212v1-->213v1
+213v1-->214v1
 214v1-->215v1
-215v1-->216v1
+193v1-->|0|216v1
+215v1-->|1|216v1
+217v1-->218v1
 216v1-->217v1
-192v1-->|0|218v1
-217v1-->|1|218v1
 219v1-->220v1
-218v1-->219v1
+220v1-->221v1
 221v1-->222v1
-222v1-->223v1
+188v1--x|0|223v1; linkStyle 238 stroke:red
+222v1-->|1|223v1
 223v1-->224v1
-187v1--x|0|225v1; linkStyle 248 stroke:red
-224v1-->|1|225v1
+224v1--x225v1; linkStyle 241 stroke:red
 225v1-->226v1
-226v1--x227v1; linkStyle 251 stroke:red
+226v1-->227v1
 227v1-->228v1
 228v1-->229v1
-229v1-->230v1
+224v1-->|pos|230v1
+229v1--x|neg|230v1; linkStyle 247 stroke:red
 230v1-->231v1
-226v1-->|pos|232v1
-231v1--x|neg|232v1; linkStyle 257 stroke:red
+226v1-->232v1
 232v1-->233v1
-228v1-->234v1
+233v1-->|pos|234v1
+229v1--x|neg|234v1; linkStyle 252 stroke:red
 234v1-->235v1
-235v1-->|pos|236v1
-231v1--x|neg|236v1; linkStyle 262 stroke:red
-236v1-->237v1
-247v1--o238v1; linkStyle 264 stroke:red
-238v1--x|0|239v1; linkStyle 265 stroke:red
-216v1-->|1|239v1
-239v1-->240v1
-237v1--o241v1; linkStyle 268 stroke:red
-235v1-->|pos|242v1
-241v1--x|neg|242v1; linkStyle 270 stroke:red
+245v1--o236v1; linkStyle 254 stroke:red
+236v1--x|0|237v1; linkStyle 255 stroke:red
+214v1-->|1|237v1
+237v1-->238v1
+235v1--o239v1; linkStyle 258 stroke:red
+233v1-->|pos|240v1
+239v1--x|neg|240v1; linkStyle 260 stroke:red
+240v1-->241v1
+241v1-->242v1
 242v1-->243v1
-243v1-->244v1
+238v1-->|pos|244v1
+243v1--x|neg|244v1; linkStyle 265 stroke:red
 244v1-->245v1
-240v1-->|pos|246v1
-245v1--x|neg|246v1; linkStyle 275 stroke:red
-246v1-->247v1
-224v1-->248v1
+222v1-->247v1
+247v1-->248v1
 248v1-->249v1
-249v1-->250v1
-149v1-->251v1
-25v1-->|input|252v1
-251v1--x|single|252v1; linkStyle 282 stroke:red
+149v1-->250v1
+25v1-->|input|251v1
+250v1--x|single|251v1; linkStyle 272 stroke:red
+251v1-->252v1
 252v1-->253v1
-253v1-->254v1
-255v1-->256v1
-256v1--x257v1; linkStyle 286 stroke:red
+254v1-->255v1
+255v1--x256v1; linkStyle 276 stroke:red
+256v1-->257v1
 257v1-->258v1
-258v1-->259v1
-240v1-->|probe|260v1
-244v1--x|build|260v1; linkStyle 290 stroke:red
+238v1-->|probe|259v1
+242v1--x|build|259v1; linkStyle 280 stroke:red
+259v1-->260v1
 260v1-->261v1
-261v1-->262v1
-259v1-->|0|263v1
-262v1-->|1|263v1
-264v1-->265v1
+258v1-->|0|262v1
+261v1-->|1|262v1
 263v1-->264v1
+262v1-->263v1
+174v1--x182v1; linkStyle 287 stroke:red
+194v1--x195v1; linkStyle 288 stroke:red
+156v1--x203v1; linkStyle 289 stroke:red
+202v1--x203v1; linkStyle 290 stroke:red
+156v1--x208v1; linkStyle 291 stroke:red
 2v1
 44v1
 45v1
@@ -577,34 +567,36 @@ linkStyle default stroke:#aaa
 87v1
 154v1
 155v1
-219v1
-220v1
-254v1
+157v1
+217v1
+218v1
+246v1
+253v1
+263v1
 264v1
-265v1
 subgraph var_cycle_10 ["var <tt>cycle_10</tt>"]
     style var_cycle_10 fill:transparent
     105v1
 end
 subgraph var_cycle_12 ["var <tt>cycle_12</tt>"]
     style var_cycle_12 fill:transparent
-    186v1
+    187v1
 end
 subgraph var_cycle_13 ["var <tt>cycle_13</tt>"]
     style var_cycle_13 fill:transparent
-    233v1
+    231v1
 end
 subgraph var_cycle_14 ["var <tt>cycle_14</tt>"]
     style var_cycle_14 fill:transparent
-    237v1
+    235v1
 end
 subgraph var_cycle_15 ["var <tt>cycle_15</tt>"]
     style var_cycle_15 fill:transparent
-    247v1
+    245v1
 end
 subgraph var_cycle_3 ["var <tt>cycle_3</tt>"]
     style var_cycle_3 fill:transparent
-    250v1
+    249v1
 end
 subgraph var_cycle_5 ["var <tt>cycle_5</tt>"]
     style var_cycle_5 fill:transparent
@@ -1028,106 +1020,94 @@ subgraph var_stream_33 ["var <tt>stream_33</tt>"]
     style var_stream_33 fill:transparent
     5v1
 end
+subgraph var_stream_336 ["var <tt>stream_336</tt>"]
+    style var_stream_336 fill:transparent
+    158v1
+end
 subgraph var_stream_337 ["var <tt>stream_337</tt>"]
     style var_stream_337 fill:transparent
-    156v1
-    157v1
+    159v1
+end
+subgraph var_stream_338 ["var <tt>stream_338</tt>"]
+    style var_stream_338 fill:transparent
+    160v1
 end
 subgraph var_stream_339 ["var <tt>stream_339</tt>"]
     style var_stream_339 fill:transparent
-    158v1
+    161v1
+end
+subgraph var_stream_341 ["var <tt>stream_341</tt>"]
+    style var_stream_341 fill:transparent
+    162v1
+end
+subgraph var_stream_342 ["var <tt>stream_342</tt>"]
+    style var_stream_342 fill:transparent
+    163v1
 end
 subgraph var_stream_343 ["var <tt>stream_343</tt>"]
     style var_stream_343 fill:transparent
-    159v1
+    164v1
 end
-subgraph var_stream_344 ["var <tt>stream_344</tt>"]
-    style var_stream_344 fill:transparent
-    160v1
-end
-subgraph var_stream_345 ["var <tt>stream_345</tt>"]
-    style var_stream_345 fill:transparent
-    161v1
+subgraph var_stream_346 ["var <tt>stream_346</tt>"]
+    style var_stream_346 fill:transparent
+    165v1
 end
 subgraph var_stream_348 ["var <tt>stream_348</tt>"]
     style var_stream_348 fill:transparent
-    162v1
+    166v1
+end
+subgraph var_stream_349 ["var <tt>stream_349</tt>"]
+    style var_stream_349 fill:transparent
+    167v1
 end
 subgraph var_stream_35 ["var <tt>stream_35</tt>"]
     style var_stream_35 fill:transparent
     6v1
 end
-subgraph var_stream_351 ["var <tt>stream_351</tt>"]
-    style var_stream_351 fill:transparent
-    163v1
-end
 subgraph var_stream_352 ["var <tt>stream_352</tt>"]
     style var_stream_352 fill:transparent
-    164v1
-end
-subgraph var_stream_353 ["var <tt>stream_353</tt>"]
-    style var_stream_353 fill:transparent
-    165v1
+    168v1
 end
 subgraph var_stream_354 ["var <tt>stream_354</tt>"]
     style var_stream_354 fill:transparent
-    166v1
+    169v1
 end
-subgraph var_stream_356 ["var <tt>stream_356</tt>"]
-    style var_stream_356 fill:transparent
-    167v1
+subgraph var_stream_355 ["var <tt>stream_355</tt>"]
+    style var_stream_355 fill:transparent
+    170v1
+    171v1
 end
 subgraph var_stream_357 ["var <tt>stream_357</tt>"]
     style var_stream_357 fill:transparent
-    168v1
-end
-subgraph var_stream_358 ["var <tt>stream_358</tt>"]
-    style var_stream_358 fill:transparent
-    169v1
+    172v1
 end
 subgraph var_stream_36 ["var <tt>stream_36</tt>"]
     style var_stream_36 fill:transparent
     7v1
 end
-subgraph var_stream_361 ["var <tt>stream_361</tt>"]
-    style var_stream_361 fill:transparent
-    170v1
-end
-subgraph var_stream_363 ["var <tt>stream_363</tt>"]
-    style var_stream_363 fill:transparent
-    171v1
-end
-subgraph var_stream_364 ["var <tt>stream_364</tt>"]
-    style var_stream_364 fill:transparent
-    172v1
-end
-subgraph var_stream_367 ["var <tt>stream_367</tt>"]
-    style var_stream_367 fill:transparent
+subgraph var_stream_360 ["var <tt>stream_360</tt>"]
+    style var_stream_360 fill:transparent
     173v1
 end
 subgraph var_stream_369 ["var <tt>stream_369</tt>"]
     style var_stream_369 fill:transparent
-    174v1
-end
-subgraph var_stream_370 ["var <tt>stream_370</tt>"]
-    style var_stream_370 fill:transparent
     175v1
     176v1
 end
-subgraph var_stream_372 ["var <tt>stream_372</tt>"]
-    style var_stream_372 fill:transparent
+subgraph var_stream_371 ["var <tt>stream_371</tt>"]
+    style var_stream_371 fill:transparent
     177v1
 end
 subgraph var_stream_375 ["var <tt>stream_375</tt>"]
     style var_stream_375 fill:transparent
     178v1
 end
-subgraph var_stream_377 ["var <tt>stream_377</tt>"]
-    style var_stream_377 fill:transparent
+subgraph var_stream_376 ["var <tt>stream_376</tt>"]
+    style var_stream_376 fill:transparent
     179v1
 end
-subgraph var_stream_379 ["var <tt>stream_379</tt>"]
-    style var_stream_379 fill:transparent
+subgraph var_stream_377 ["var <tt>stream_377</tt>"]
+    style var_stream_377 fill:transparent
     180v1
 end
 subgraph var_stream_380 ["var <tt>stream_380</tt>"]
@@ -1142,101 +1122,93 @@ subgraph var_stream_382 ["var <tt>stream_382</tt>"]
     style var_stream_382 fill:transparent
     183v1
 end
-subgraph var_stream_384 ["var <tt>stream_384</tt>"]
-    style var_stream_384 fill:transparent
+subgraph var_stream_383 ["var <tt>stream_383</tt>"]
+    style var_stream_383 fill:transparent
     184v1
 end
-subgraph var_stream_386 ["var <tt>stream_386</tt>"]
-    style var_stream_386 fill:transparent
+subgraph var_stream_385 ["var <tt>stream_385</tt>"]
+    style var_stream_385 fill:transparent
     185v1
 end
-subgraph var_stream_388 ["var <tt>stream_388</tt>"]
-    style var_stream_388 fill:transparent
-    187v1
-end
-subgraph var_stream_389 ["var <tt>stream_389</tt>"]
-    style var_stream_389 fill:transparent
-    188v1
+subgraph var_stream_387 ["var <tt>stream_387</tt>"]
+    style var_stream_387 fill:transparent
+    186v1
 end
 subgraph var_stream_39 ["var <tt>stream_39</tt>"]
     style var_stream_39 fill:transparent
     8v1
 end
-subgraph var_stream_390 ["var <tt>stream_390</tt>"]
-    style var_stream_390 fill:transparent
-    189v1
-end
 subgraph var_stream_392 ["var <tt>stream_392</tt>"]
     style var_stream_392 fill:transparent
-    190v1
+    188v1
 end
 subgraph var_stream_394 ["var <tt>stream_394</tt>"]
     style var_stream_394 fill:transparent
-    191v1
+    189v1
+end
+subgraph var_stream_395 ["var <tt>stream_395</tt>"]
+    style var_stream_395 fill:transparent
+    190v1
 end
 subgraph var_stream_397 ["var <tt>stream_397</tt>"]
     style var_stream_397 fill:transparent
+    191v1
+end
+subgraph var_stream_399 ["var <tt>stream_399</tt>"]
+    style var_stream_399 fill:transparent
     192v1
 end
-subgraph var_stream_404 ["var <tt>stream_404</tt>"]
-    style var_stream_404 fill:transparent
+subgraph var_stream_402 ["var <tt>stream_402</tt>"]
+    style var_stream_402 fill:transparent
     193v1
 end
-subgraph var_stream_405 ["var <tt>stream_405</tt>"]
-    style var_stream_405 fill:transparent
-    194v1
-end
-subgraph var_stream_411 ["var <tt>stream_411</tt>"]
-    style var_stream_411 fill:transparent
+subgraph var_stream_409 ["var <tt>stream_409</tt>"]
+    style var_stream_409 fill:transparent
     195v1
 end
-subgraph var_stream_413 ["var <tt>stream_413</tt>"]
-    style var_stream_413 fill:transparent
+subgraph var_stream_412 ["var <tt>stream_412</tt>"]
+    style var_stream_412 fill:transparent
     196v1
+end
+subgraph var_stream_414 ["var <tt>stream_414</tt>"]
+    style var_stream_414 fill:transparent
+    197v1
 end
 subgraph var_stream_415 ["var <tt>stream_415</tt>"]
     style var_stream_415 fill:transparent
-    197v1
+    198v1
 end
 subgraph var_stream_416 ["var <tt>stream_416</tt>"]
     style var_stream_416 fill:transparent
-    198v1
-end
-subgraph var_stream_417 ["var <tt>stream_417</tt>"]
-    style var_stream_417 fill:transparent
     199v1
     200v1
 end
-subgraph var_stream_419 ["var <tt>stream_419</tt>"]
-    style var_stream_419 fill:transparent
+subgraph var_stream_418 ["var <tt>stream_418</tt>"]
+    style var_stream_418 fill:transparent
     201v1
-end
-subgraph var_stream_421 ["var <tt>stream_421</tt>"]
-    style var_stream_421 fill:transparent
-    202v1
-end
-subgraph var_stream_423 ["var <tt>stream_423</tt>"]
-    style var_stream_423 fill:transparent
-    203v1
 end
 subgraph var_stream_424 ["var <tt>stream_424</tt>"]
     style var_stream_424 fill:transparent
+    203v1
+end
+subgraph var_stream_429 ["var <tt>stream_429</tt>"]
+    style var_stream_429 fill:transparent
     204v1
 end
-subgraph var_stream_428 ["var <tt>stream_428</tt>"]
-    style var_stream_428 fill:transparent
+subgraph var_stream_431 ["var <tt>stream_431</tt>"]
+    style var_stream_431 fill:transparent
     205v1
-end
-subgraph var_stream_430 ["var <tt>stream_430</tt>"]
-    style var_stream_430 fill:transparent
-    206v1
-end
-subgraph var_stream_434 ["var <tt>stream_434</tt>"]
-    style var_stream_434 fill:transparent
-    207v1
 end
 subgraph var_stream_435 ["var <tt>stream_435</tt>"]
     style var_stream_435 fill:transparent
+    206v1
+end
+subgraph var_stream_436 ["var <tt>stream_436</tt>"]
+    style var_stream_436 fill:transparent
+    207v1
+end
+subgraph var_stream_437 ["var <tt>stream_437</tt>"]
+    style var_stream_437 fill:transparent
     208v1
 end
 subgraph var_stream_438 ["var <tt>stream_438</tt>"]
@@ -1247,54 +1219,58 @@ subgraph var_stream_439 ["var <tt>stream_439</tt>"]
     style var_stream_439 fill:transparent
     210v1
 end
-subgraph var_stream_440 ["var <tt>stream_440</tt>"]
-    style var_stream_440 fill:transparent
-    211v1
-end
 subgraph var_stream_441 ["var <tt>stream_441</tt>"]
     style var_stream_441 fill:transparent
+    211v1
+end
+subgraph var_stream_442 ["var <tt>stream_442</tt>"]
+    style var_stream_442 fill:transparent
     212v1
 end
 subgraph var_stream_443 ["var <tt>stream_443</tt>"]
     style var_stream_443 fill:transparent
     213v1
 end
-subgraph var_stream_444 ["var <tt>stream_444</tt>"]
-    style var_stream_444 fill:transparent
-    214v1
-end
 subgraph var_stream_445 ["var <tt>stream_445</tt>"]
     style var_stream_445 fill:transparent
-    215v1
+    214v1
 end
 subgraph var_stream_447 ["var <tt>stream_447</tt>"]
     style var_stream_447 fill:transparent
-    216v1
+    215v1
 end
 subgraph var_stream_449 ["var <tt>stream_449</tt>"]
     style var_stream_449 fill:transparent
-    217v1
+    216v1
 end
 subgraph var_stream_45 ["var <tt>stream_45</tt>"]
     style var_stream_45 fill:transparent
     9v1
 end
-subgraph var_stream_451 ["var <tt>stream_451</tt>"]
-    style var_stream_451 fill:transparent
-    218v1
+subgraph var_stream_460 ["var <tt>stream_460</tt>"]
+    style var_stream_460 fill:transparent
+    219v1
+    220v1
+end
+subgraph var_stream_462 ["var <tt>stream_462</tt>"]
+    style var_stream_462 fill:transparent
+    221v1
+end
+subgraph var_stream_463 ["var <tt>stream_463</tt>"]
+    style var_stream_463 fill:transparent
+    222v1
 end
 subgraph var_stream_465 ["var <tt>stream_465</tt>"]
     style var_stream_465 fill:transparent
-    221v1
-    222v1
-end
-subgraph var_stream_467 ["var <tt>stream_467</tt>"]
-    style var_stream_467 fill:transparent
     223v1
 end
-subgraph var_stream_468 ["var <tt>stream_468</tt>"]
-    style var_stream_468 fill:transparent
+subgraph var_stream_466 ["var <tt>stream_466</tt>"]
+    style var_stream_466 fill:transparent
     224v1
+end
+subgraph var_stream_469 ["var <tt>stream_469</tt>"]
+    style var_stream_469 fill:transparent
+    225v1
 end
 subgraph var_stream_47 ["var <tt>stream_47</tt>"]
     style var_stream_47 fill:transparent
@@ -1302,26 +1278,22 @@ subgraph var_stream_47 ["var <tt>stream_47</tt>"]
 end
 subgraph var_stream_470 ["var <tt>stream_470</tt>"]
     style var_stream_470 fill:transparent
-    225v1
+    226v1
 end
 subgraph var_stream_471 ["var <tt>stream_471</tt>"]
     style var_stream_471 fill:transparent
-    226v1
+    227v1
 end
 subgraph var_stream_474 ["var <tt>stream_474</tt>"]
     style var_stream_474 fill:transparent
-    227v1
+    228v1
 end
 subgraph var_stream_475 ["var <tt>stream_475</tt>"]
     style var_stream_475 fill:transparent
-    228v1
+    229v1
 end
 subgraph var_stream_476 ["var <tt>stream_476</tt>"]
     style var_stream_476 fill:transparent
-    229v1
-end
-subgraph var_stream_479 ["var <tt>stream_479</tt>"]
-    style var_stream_479 fill:transparent
     230v1
 end
 subgraph var_stream_48 ["var <tt>stream_48</tt>"]
@@ -1331,39 +1303,43 @@ subgraph var_stream_48 ["var <tt>stream_48</tt>"]
 end
 subgraph var_stream_480 ["var <tt>stream_480</tt>"]
     style var_stream_480 fill:transparent
-    231v1
+    232v1
 end
 subgraph var_stream_481 ["var <tt>stream_481</tt>"]
     style var_stream_481 fill:transparent
-    232v1
+    233v1
+end
+subgraph var_stream_483 ["var <tt>stream_483</tt>"]
+    style var_stream_483 fill:transparent
+    234v1
 end
 subgraph var_stream_485 ["var <tt>stream_485</tt>"]
     style var_stream_485 fill:transparent
-    234v1
-end
-subgraph var_stream_486 ["var <tt>stream_486</tt>"]
-    style var_stream_486 fill:transparent
-    235v1
-end
-subgraph var_stream_488 ["var <tt>stream_488</tt>"]
-    style var_stream_488 fill:transparent
     236v1
 end
 subgraph var_stream_490 ["var <tt>stream_490</tt>"]
     style var_stream_490 fill:transparent
+    237v1
+end
+subgraph var_stream_491 ["var <tt>stream_491</tt>"]
+    style var_stream_491 fill:transparent
     238v1
+end
+subgraph var_stream_494 ["var <tt>stream_494</tt>"]
+    style var_stream_494 fill:transparent
+    239v1
 end
 subgraph var_stream_495 ["var <tt>stream_495</tt>"]
     style var_stream_495 fill:transparent
-    239v1
-end
-subgraph var_stream_496 ["var <tt>stream_496</tt>"]
-    style var_stream_496 fill:transparent
     240v1
+end
+subgraph var_stream_497 ["var <tt>stream_497</tt>"]
+    style var_stream_497 fill:transparent
+    241v1
 end
 subgraph var_stream_499 ["var <tt>stream_499</tt>"]
     style var_stream_499 fill:transparent
-    241v1
+    242v1
 end
 subgraph var_stream_50 ["var <tt>stream_50</tt>"]
     style var_stream_50 fill:transparent
@@ -1371,43 +1347,39 @@ subgraph var_stream_50 ["var <tt>stream_50</tt>"]
 end
 subgraph var_stream_500 ["var <tt>stream_500</tt>"]
     style var_stream_500 fill:transparent
-    242v1
-end
-subgraph var_stream_502 ["var <tt>stream_502</tt>"]
-    style var_stream_502 fill:transparent
     243v1
 end
-subgraph var_stream_504 ["var <tt>stream_504</tt>"]
-    style var_stream_504 fill:transparent
+subgraph var_stream_501 ["var <tt>stream_501</tt>"]
+    style var_stream_501 fill:transparent
     244v1
-end
-subgraph var_stream_505 ["var <tt>stream_505</tt>"]
-    style var_stream_505 fill:transparent
-    245v1
-end
-subgraph var_stream_506 ["var <tt>stream_506</tt>"]
-    style var_stream_506 fill:transparent
-    246v1
 end
 subgraph var_stream_52 ["var <tt>stream_52</tt>"]
     style var_stream_52 fill:transparent
     14v1
 end
+subgraph var_stream_529 ["var <tt>stream_529</tt>"]
+    style var_stream_529 fill:transparent
+    247v1
+end
+subgraph var_stream_530 ["var <tt>stream_530</tt>"]
+    style var_stream_530 fill:transparent
+    248v1
+end
+subgraph var_stream_533 ["var <tt>stream_533</tt>"]
+    style var_stream_533 fill:transparent
+    250v1
+end
 subgraph var_stream_534 ["var <tt>stream_534</tt>"]
     style var_stream_534 fill:transparent
-    248v1
+    251v1
 end
 subgraph var_stream_535 ["var <tt>stream_535</tt>"]
     style var_stream_535 fill:transparent
-    249v1
-end
-subgraph var_stream_538 ["var <tt>stream_538</tt>"]
-    style var_stream_538 fill:transparent
-    251v1
+    252v1
 end
 subgraph var_stream_539 ["var <tt>stream_539</tt>"]
     style var_stream_539 fill:transparent
-    252v1
+    254v1
 end
 subgraph var_stream_54 ["var <tt>stream_54</tt>"]
     style var_stream_54 fill:transparent
@@ -1415,51 +1387,43 @@ subgraph var_stream_54 ["var <tt>stream_54</tt>"]
 end
 subgraph var_stream_540 ["var <tt>stream_540</tt>"]
     style var_stream_540 fill:transparent
-    253v1
+    255v1
+end
+subgraph var_stream_542 ["var <tt>stream_542</tt>"]
+    style var_stream_542 fill:transparent
+    256v1
 end
 subgraph var_stream_544 ["var <tt>stream_544</tt>"]
     style var_stream_544 fill:transparent
-    255v1
-end
-subgraph var_stream_545 ["var <tt>stream_545</tt>"]
-    style var_stream_545 fill:transparent
-    256v1
+    257v1
 end
 subgraph var_stream_547 ["var <tt>stream_547</tt>"]
     style var_stream_547 fill:transparent
-    257v1
-end
-subgraph var_stream_549 ["var <tt>stream_549</tt>"]
-    style var_stream_549 fill:transparent
     258v1
 end
 subgraph var_stream_55 ["var <tt>stream_55</tt>"]
     style var_stream_55 fill:transparent
     16v1
 end
+subgraph var_stream_551 ["var <tt>stream_551</tt>"]
+    style var_stream_551 fill:transparent
+    259v1
+end
 subgraph var_stream_552 ["var <tt>stream_552</tt>"]
     style var_stream_552 fill:transparent
-    259v1
+    260v1
+end
+subgraph var_stream_554 ["var <tt>stream_554</tt>"]
+    style var_stream_554 fill:transparent
+    261v1
 end
 subgraph var_stream_556 ["var <tt>stream_556</tt>"]
     style var_stream_556 fill:transparent
-    260v1
-end
-subgraph var_stream_557 ["var <tt>stream_557</tt>"]
-    style var_stream_557 fill:transparent
-    261v1
-end
-subgraph var_stream_559 ["var <tt>stream_559</tt>"]
-    style var_stream_559 fill:transparent
     262v1
 end
 subgraph var_stream_56 ["var <tt>stream_56</tt>"]
     style var_stream_56 fill:transparent
     18v1
-end
-subgraph var_stream_561 ["var <tt>stream_561</tt>"]
-    style var_stream_561 fill:transparent
-    263v1
 end
 subgraph var_stream_57 ["var <tt>stream_57</tt>"]
     style var_stream_57 fill:transparent

--- a/hydro_test/src/local/singleton_ref.rs
+++ b/hydro_test/src/local/singleton_ref.rs
@@ -246,6 +246,74 @@ mod tests {
         assert_eq!(results, vec![44, 45]);
     }
 
+    /// Test: two singleton refs of *different incompatible types* captured in one closure.
+    ///
+    /// This catches bugs where singleton refs get mixed up (e.g., wrong ident_stack ordering).
+    /// If ref_a (i32) and ref_b (String) are swapped, the code won't compile or will
+    /// produce a type error at runtime — which is exactly the failure mode we want to guard.
+    #[tokio::test]
+    async fn test_singleton_ref_two_different_types_one_closure() {
+        let mut deployment = Deployment::new();
+
+        let mut builder = FlowBuilder::new();
+        let external = builder.external::<()>();
+        let p1 = builder.process::<()>();
+
+        // Singleton A: i32, fold 0..5 => 10
+        let sum = p1
+            .source_iter(q!(0..5i32))
+            .fold(q!(|| 0i32), q!(|acc: &mut i32, x| *acc += x));
+
+        // Singleton B: String, fold ["hello", " ", "world"] => "hello world"
+        let greeting = p1
+            .source_iter(q!(vec![
+                "hello".to_owned(),
+                " ".to_owned(),
+                "world".to_owned(),
+            ]))
+            .fold(
+                q!(|| String::new()),
+                q!(|acc: &mut String, x| acc.push_str(&x)),
+            );
+
+        let ref_a = sum.by_ref();
+        let ref_b = greeting.by_ref();
+
+        // Capture both refs in one closure — ref_a is &i32, ref_b is &String.
+        // If they get swapped, this won't type-check.
+        let out_port = p1
+            .source_iter(q!(1..=2i32))
+            .map(q!(|x| {
+                let numeric = *ref_a; // should be 10
+                let text = ref_b.clone(); // should be "hello world"
+                format!("{}-{}-{}", text, numeric, x)
+            }))
+            .send_bincode_external(&external);
+
+        let nodes = builder
+            .with_default_optimize()
+            .with_process(&p1, deployment.Localhost())
+            .with_external(&external, deployment.Localhost())
+            .deploy(&mut deployment);
+
+        deployment.deploy().await.unwrap();
+
+        let mut out_recv = nodes.connect(out_port).await;
+
+        deployment.start().await.unwrap();
+
+        let mut results: Vec<String> = Vec::new();
+        for _ in 0..2 {
+            results.push(out_recv.next().await.unwrap());
+        }
+        results.sort();
+        // ref_a = 10, ref_b = "hello world", so results = "hello world-10-1", "hello world-10-2"
+        assert_eq!(
+            results,
+            vec!["hello world-10-1".to_owned(), "hello world-10-2".to_owned()],
+        );
+    }
+
     /// Test: singleton ref inside a filter closure.
     #[tokio::test]
     async fn test_singleton_ref_filter() {


### PR DESCRIPTION
We need to remove the global singleton counter and instead use a local counter.

Converted 6 out of 7 cross_singleton usages in paxos.rs to use the new
by_ref() singleton mechanism:

- recommit_after_leader_election: 3 cross_singleton calls replaced with
  by_ref() captures in filter_map and map closures
- sequence_payload: 1 cross_singleton replaced with by_ref() in map
- index_payloads (sliced!): 1 cross_singleton replaced with by_ref() in map
- acceptor_p2: 2 cross_singleton calls replaced with by_ref() captures
  in filter_map and map closures

Left unchanged:
- acceptor_p1: 2 cross_singleton calls remain because the a_log parameter
  comes from a forward_ref cycle, and by_ref() on cycle sources causes a
  graph partitioning error ("Handoff succ not in subgraph")

Also added + 'a lifetime bounds where required by by_ref() usage:
- PaxosLike::build, PaxosLike::with_client
- paxos_core, index_payloads
- compartmentalized_paxos_core

Updated IR snapshots to reflect the new singleton ref nodes.

Co-authored-by: Infinity 🤖 <infinity@hydro.run>