### PR TITLE
refactor(hydro_lang): singleton `by_ref()` proper lifetime, update to stageleft 0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5414,9 +5414,9 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stageleft"
-version = "0.13.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2c4e51b7913fbb07d1a575e23618fff6ac4cfd8705865e95e0984b884511ec9"
+checksum = "22031b9d645815e5b3169ade69433c284b48df797882a30e6be87584efec3ef2"
 dependencies = [
  "ctor 0.4.3",
  "parking_lot",
@@ -5429,9 +5429,9 @@ dependencies = [
 
 [[package]]
 name = "stageleft_macro"
-version = "0.13.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f66d0c988d22a7cc51495e8d8a6f46ba5352d1424437b244716bb71c5160a07"
+checksum = "71d26dbe0848def4b7321df73217dbbc8ebf823b8d8bc94c700f3851edb67a25"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -5442,9 +5442,9 @@ dependencies = [
 
 [[package]]
 name = "stageleft_tool"
-version = "0.13.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba88edb18395d26627c6480435a08a30a84056b16ec5e920775716f5f4d92375"
+checksum = "ab9d0ec35c71f510a76f93d5d404983a968c5337dcb9a0161cdfb676d2497256"
 dependencies = [
  "prettyplease",
  "proc-macro-crate 3.4.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,5 +83,5 @@ uninlined_format_args = "allow"
 unused_async = "warn"
 
 [workspace.dependencies]
-stageleft = "0.13.5"
-stageleft_tool = "0.13.5"
+stageleft = "0.14.0"
+stageleft_tool = "0.14.0"

--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -1949,7 +1949,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     /// # }));
     /// # }
     /// ```
-    pub fn fold<A, I: Fn() -> A + 'a, F: Fn(&mut A, V), C, Idemp, M, B2: KeyedSingletonBound>(
+    pub fn fold<A, I: Fn() -> A + 'a, F: 'a + Fn(&mut A, V), C, Idemp, M, B2: KeyedSingletonBound>(
         self,
         init: impl IntoQuotedMut<'a, I, L>,
         comb: impl IntoQuotedMut<'a, F, L, AggFuncAlgebra<C, Idemp, M>>,

--- a/hydro_lang/src/live_collections/singleton.rs
+++ b/hydro_lang/src/live_collections/singleton.rs
@@ -337,24 +337,11 @@ where
     /// # });
     /// # }
     /// ```
-    pub fn by_ref(&self) -> crate::singleton_ref::SingletonRef<'a, T, L>
+    pub fn by_ref(&self) -> crate::singleton_ref::SingletonRef<'a, '_, T, L>
     where
         B: IsBounded,
     {
-        // Wrap in HydroNode::Singleton for materialization + identity tracking.
-        // If already a Singleton node, reuse it. If a Tee (from clone), wrap inner.
-        if !matches!(&*self.ir_node.borrow(), HydroNode::Singleton { .. }) {
-            let orig = self.ir_node.replace(HydroNode::Placeholder);
-            *self.ir_node.borrow_mut() = HydroNode::Singleton {
-                inner: SharedNode(Rc::new(RefCell::new(orig))),
-                metadata: self.location.new_node_metadata(Self::collection_kind()),
-            };
-        }
-        let borrow = self.ir_node.borrow();
-        let HydroNode::Singleton { inner, .. } = &*borrow else {
-            unreachable!()
-        };
-        crate::singleton_ref::SingletonRef::new(Rc::clone(&inner.0))
+        crate::singleton_ref::SingletonRef::new(&self.ir_node)
     }
 
     /// Weakens the consistency of this live collection to not guarantee any consistency across

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -1334,7 +1334,7 @@ where
     ) -> Singleton<A, L, B2>
     where
         I: Fn() -> A + 'a,
-        F: Fn(&mut A, T),
+        F: 'a + Fn(&mut A, T),
         C: ValidCommutativityFor<O>,
         Idemp: ValidIdempotenceFor<R>,
         B: ApplyMonotoneStream<M, B2>,

--- a/hydro_lang/src/singleton_ref.rs
+++ b/hydro_lang/src/singleton_ref.rs
@@ -18,27 +18,23 @@ use crate::location::Location;
 ///
 /// This type is `Copy` (required by `q!()` macro internals).
 /// TODO(mingwei): <https://github.com/hydro-project/stageleft/issues/73>
-pub struct SingletonRef<'a, T, L> {
-    pub(crate) node: *const RefCell<HydroNode>,
-    _phantom: PhantomData<(&'a (), T, L)>,
+pub struct SingletonRef<'a, 'slf, T, L> {
+    /// Will be updated to `HydroNode::Singleton` when used, if not already.
+    pub(crate) ir_node: &'slf RefCell<HydroNode>,
+    _phantom: PhantomData<(&'a T, L)>,
 }
-impl<T, L> SingletonRef<'_, T, L> {
+impl<'slf, T, L> SingletonRef<'_, 'slf, T, L> {
     /// Creates a `SingletonRef` from a shared node.
-    ///
-    /// Note that this will permanently keep the `Rc` alive, intentionally creating a memory leak
-    /// (like [`Box::leak`]).
-    pub(crate) fn new(rc_ptr: Rc<RefCell<HydroNode>>) -> Self {
-        // SAFETY: `rc_ptr` will now never be dropped, and therefore the count cannot reach zero.
-        let node = Rc::into_raw(rc_ptr);
+    pub(crate) fn new(ir_node: &'slf RefCell<HydroNode>) -> Self {
         Self {
-            node,
+            ir_node,
             _phantom: PhantomData,
         }
     }
 }
 
-impl<T, L> Copy for SingletonRef<'_, T, L> {}
-impl<T, L> Clone for SingletonRef<'_, T, L> {
+impl<T, L> Copy for SingletonRef<'_, '_, T, L> {}
+impl<T, L> Clone for SingletonRef<'_, '_, T, L> {
     fn clone(&self) -> Self {
         *self
     }
@@ -71,7 +67,7 @@ pub fn with_singleton_capture(
 static SINGLETON_REF_COUNTER: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
 
-impl<'a, T: 'a, L> FreeVariableWithContextWithProps<L, ()> for SingletonRef<'a, T, L>
+impl<'a, 'slf, T: 'a, L> FreeVariableWithContextWithProps<L, ()> for SingletonRef<'a, 'slf, T, L>
 where
     L: Location<'a>,
 {
@@ -87,18 +83,28 @@ where
                 "SingletonRef used inside q!() but no singleton capture scope is active. \
                  This is a bug — singleton capture should be set up by the operator that uses q!().",
             );
-            // Reconstruct the Rc from the raw pointer.
-            // SAFETY: The `Rc` is leaked by `Rc::into_raw` in `Self::new` and is forever valid.
-            // The created `Rc`s `Drop` must not run, that would remove the original refcount.
-            let rc = unsafe { Rc::from_raw(self.node) };
-            let cloned = rc.clone();
-            std::mem::forget(rc); // Don't decrement the original refcount
 
-            let metadata = cloned.borrow().metadata().clone(); // TODO(mingwei): wrong metadata!
+            let metadata = self.ir_node.borrow().metadata().clone();
+
+            // Wrap in HydroNode::Singleton for materialization + identity tracking. If already a Singleton node,
+            // reuse it.
+            if !matches!(&*self.ir_node.borrow(), HydroNode::Singleton { .. }) {
+                let orig = self.ir_node.replace(HydroNode::Placeholder);
+                *self.ir_node.borrow_mut() = HydroNode::Singleton {
+                    inner: SharedNode(Rc::new(RefCell::new(orig))),
+                    metadata: metadata.clone(),
+                };
+            }
+
+            let borrow: std::cell::Ref<'_, HydroNode> = self.ir_node.borrow();
+            let HydroNode::Singleton { inner, .. } = &*borrow else {
+                unreachable!()
+            };
+
             refs.push((
                 ident.clone(),
                 HydroNode::Singleton {
-                    inner: SharedNode(cloned),
+                    inner: SharedNode(Rc::clone(&inner.0)),
                     metadata,
                 },
             ));

--- a/hydro_std/src/bench_client/mod.rs
+++ b/hydro_std/src/bench_client/mod.rs
@@ -62,7 +62,7 @@ pub fn bench_client<'a, Client, Input, Output>(
 ) -> KeyedStream<u32, (Output, Duration), Cluster<'a, Client>, Unbounded, NoOrder>
 where
     Input: Clone,
-    Output: Clone,
+    Output: 'a + Clone,
 {
     let new_payload_ids = sliced! {
         let num_clients_per_node = use(num_clients_per_node, nondet!(/** This is a constant */));


### PR DESCRIPTION
Blocked on https://github.com/hydro-project/stageleft/pull/77/

Also an improvement in that `by_ref()` is now a no-op if the `SingletonRef` is unused - only changes the IR at quoting time.