### PR TITLE
refactor(dfir_lang): remove old singleton mechanism from all operators except reduce[_no_replay]

### DIFF
--- a/dfir_lang/src/graph/ops/all_iterations.rs
+++ b/dfir_lang/src/graph/ops/all_iterations.rs
@@ -12,7 +12,7 @@ pub const ALL_ITERATIONS: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: &(0..=1),
     is_external_input: false,
-    has_singleton_output: true,
+    has_singleton_output: false,
     flo_type: Some(FloType::Unwindowing),
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/all_once.rs
+++ b/dfir_lang/src/graph/ops/all_once.rs
@@ -14,7 +14,7 @@ pub const ALL_ONCE: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: true,
+    has_singleton_output: false,
     flo_type: Some(FloType::Windowing),
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/batch.rs
+++ b/dfir_lang/src/graph/ops/batch.rs
@@ -19,7 +19,7 @@ pub const BATCH: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: true,
+    has_singleton_output: false,
     flo_type: Some(FloType::Windowing),
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/fold.rs
+++ b/dfir_lang/src/graph/ops/fold.rs
@@ -43,7 +43,7 @@ pub const FOLD: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=1),
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: true,
+    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,
@@ -57,13 +57,13 @@ pub const FOLD: OperatorConstraints = OperatorConstraints {
                    is_pull,
                    inputs,
                    outputs,
-                   singleton_output_ident,
                    arguments,
                    ..
                },
                diagnostics| {
         let init_fn = &arguments[0];
         let func = &arguments[1];
+        let singleton_output_ident = wc.make_ident("singleton_output");
 
         let initializer_func_ident = wc.make_ident("initializer_func");
         let init = quote_spanned! {op_span=>

--- a/dfir_lang/src/graph/ops/fold_keyed.rs
+++ b/dfir_lang/src/graph/ops/fold_keyed.rs
@@ -76,7 +76,7 @@ pub const FOLD_KEYED: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=1),
     type_args: &(0..=2),
     is_external_input: false,
-    has_singleton_output: true,
+    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,
@@ -86,7 +86,6 @@ pub const FOLD_KEYED: OperatorConstraints = OperatorConstraints {
                    work_fn_async,
                    ident,
                    inputs,
-                   singleton_output_ident,
                    is_pull,
                    root,
                    op_name,
@@ -127,6 +126,7 @@ pub const FOLD_KEYED: OperatorConstraints = OperatorConstraints {
         let initfn = &arguments[0];
         let aggfn = &arguments[1];
 
+        let singleton_output_ident = wc.make_ident("singleton_output");
         let hashtable_ident = wc.make_ident("hashtable");
 
         let write_prologue = quote_spanned! {op_span=>

--- a/dfir_lang/src/graph/ops/fold_no_replay.rs
+++ b/dfir_lang/src/graph/ops/fold_no_replay.rs
@@ -25,7 +25,7 @@ pub const FOLD_NO_REPLAY: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=1),
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: true,
+    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,
@@ -40,13 +40,13 @@ pub const FOLD_NO_REPLAY: OperatorConstraints = OperatorConstraints {
                    is_pull,
                    inputs,
                    outputs,
-                   singleton_output_ident,
                    arguments,
                    ..
                },
                diagnostics| {
         let init_fn = &arguments[0];
         let func = &arguments[1];
+        let singleton_output_ident = wc.make_ident("singleton_output");
 
         let initializer_func_ident = wc.make_ident("initializer_func");
         let init = quote_spanned! {op_span=>

--- a/dfir_lang/src/graph/ops/lattice_bimorphism.rs
+++ b/dfir_lang/src/graph/ops/lattice_bimorphism.rs
@@ -19,17 +19,17 @@ use super::{
 /// use std::collections::HashSet;
 /// use lattices::set_union::{CartesianProductBimorphism, SetUnionHashSet, SetUnionSingletonSet};
 ///
-/// lhs = source_iter(0..3)
+/// lhs_op = source_iter(0..3)
 ///     -> map(SetUnionSingletonSet::new_from)
 ///     -> state::<'static, SetUnionHashSet<u32>>();
-/// rhs = source_iter(3..5)
+/// rhs_op = source_iter(3..5)
 ///     -> map(SetUnionSingletonSet::new_from)
 ///     -> state::<'static, SetUnionHashSet<u32>>();
 ///
-/// lhs[items] -> [0]my_join;
-/// rhs[items] -> [1]my_join;
-/// lhs[state] -> null();
-/// rhs[state] -> null();
+/// lhs_op[items] -> [0]my_join;
+/// rhs_op[items] -> [1]my_join;
+/// lhs = lhs_op[state] -> singleton();
+/// rhs = rhs_op[state] -> singleton();
 ///
 /// my_join = lattice_bimorphism(CartesianProductBimorphism::<HashSet<_>>::default(), #lhs, #rhs)
 ///     -> assert_eq([SetUnionHashSet::new(HashSet::from_iter([
@@ -79,8 +79,8 @@ pub const LATTICE_BIMORPHISM: OperatorConstraints = OperatorConstraints {
         let write_iterator = quote_spanned! {op_span=>
             let #ident = {
                 let (lhs_state, rhs_state) = (
-                    &#lhs_state,
-                    &#rhs_state,
+                    #lhs_state,
+                    #rhs_state,
                 );
                 #[inline(always)]
                 fn check_inputs<'a, Func, LhsPull, RhsPull, LhsState, RhsState, Output>(

--- a/dfir_lang/src/graph/ops/persist.rs
+++ b/dfir_lang/src/graph/ops/persist.rs
@@ -46,7 +46,7 @@ pub const PERSIST: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_1,
     type_args: &(0..=1),
     is_external_input: false,
-    has_singleton_output: true,
+    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,
@@ -58,7 +58,6 @@ pub const PERSIST: OperatorConstraints = OperatorConstraints {
                    is_pull,
                    inputs,
                    outputs,
-                   singleton_output_ident,
                    op_name,
                    work_fn_async,
                    op_inst:
@@ -86,7 +85,7 @@ pub const PERSIST: OperatorConstraints = OperatorConstraints {
             .map(quote::ToTokens::to_token_stream)
             .unwrap_or(quote_spanned!(op_span=> _));
 
-        let persistdata_ident = singleton_output_ident;
+        let persistdata_ident = wc.make_ident("persistdata");
         let vec_ident = wc.make_ident("persistvec");
         let write_prologue = quote_spanned! {op_span=>
             let mut #persistdata_ident = ::std::vec::Vec::<#generic_type>::new();

--- a/dfir_lang/src/graph/ops/prefix.rs
+++ b/dfir_lang/src/graph/ops/prefix.rs
@@ -19,7 +19,7 @@ pub const PREFIX: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: true,
+    has_singleton_output: false,
     flo_type: Some(FloType::Windowing),
     ports_inn: None,
     ports_out: None,
@@ -32,11 +32,11 @@ pub const PREFIX: OperatorConstraints = OperatorConstraints {
                    ident,
                    is_pull,
                    inputs,
-                   singleton_output_ident,
                    ..
                },
                _diagnostics| {
         assert!(is_pull);
+        let singleton_output_ident = wc.make_ident("singleton_output");
 
         let write_prologue = quote_spanned! {op_span=>
             #[allow(clippy::redundant_closure_call)]

--- a/dfir_lang/src/graph/ops/reduce_keyed.rs
+++ b/dfir_lang/src/graph/ops/reduce_keyed.rs
@@ -65,7 +65,7 @@ pub const REDUCE_KEYED: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=1),
     type_args: &(0..=2),
     is_external_input: false,
-    has_singleton_output: true,
+    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,
@@ -74,7 +74,6 @@ pub const REDUCE_KEYED: OperatorConstraints = OperatorConstraints {
                    op_span,
                    ident,
                    inputs,
-                   singleton_output_ident,
                    is_pull,
                    work_fn_async,
                    root,
@@ -106,6 +105,7 @@ pub const REDUCE_KEYED: OperatorConstraints = OperatorConstraints {
         let input = &inputs[0];
         let aggfn = &arguments[0];
 
+        let singleton_output_ident = wc.make_ident("singleton_output");
         let hashtable_ident = wc.make_ident("hashtable");
 
         let write_prologue = quote_spanned! {op_span=>

--- a/dfir_lang/src/graph/ops/repeat_n.rs
+++ b/dfir_lang/src/graph/ops/repeat_n.rs
@@ -19,7 +19,7 @@ pub const REPEAT_N: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: true,
+    has_singleton_output: false,
     flo_type: Some(FloType::Windowing),
     ports_inn: None,
     ports_out: None,
@@ -33,11 +33,11 @@ pub const REPEAT_N: OperatorConstraints = OperatorConstraints {
                    ident,
                    is_pull,
                    inputs,
-                   singleton_output_ident,
                    ..
                },
                _diagnostics| {
         assert!(is_pull);
+        let singleton_output_ident = wc.make_ident("singleton_output");
 
         let write_prologue = quote_spanned! {op_span=>
             #[allow(clippy::redundant_closure_call)]

--- a/dfir_lang/src/graph/ops/scan.rs
+++ b/dfir_lang/src/graph/ops/scan.rs
@@ -56,7 +56,7 @@ pub const SCAN: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=1),
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: true,
+    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,
@@ -69,12 +69,12 @@ pub const SCAN: OperatorConstraints = OperatorConstraints {
                    inputs,
                    outputs,
                    arguments,
-                   singleton_output_ident,
                    ..
                },
                diagnostics| {
         let init_fn = &arguments[0];
         let func = &arguments[1];
+        let singleton_output_ident = wc.make_ident("singleton_output");
 
         let initializer_func_ident = wc.make_ident("initializer_func");
         let init = quote_spanned! {op_span=>

--- a/dfir_lang/src/graph/ops/scan_async_blocking.rs
+++ b/dfir_lang/src/graph/ops/scan_async_blocking.rs
@@ -45,7 +45,7 @@ pub const SCAN_ASYNC_BLOCKING: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=1),
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: true,
+    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,
@@ -58,12 +58,12 @@ pub const SCAN_ASYNC_BLOCKING: OperatorConstraints = OperatorConstraints {
                    inputs,
                    outputs,
                    arguments,
-                   singleton_output_ident,
                    ..
                },
                diagnostics| {
         let init_fn = &arguments[0];
         let func = &arguments[1];
+        let singleton_output_ident = wc.make_ident("singleton_output");
 
         let initializer_func_ident = wc.make_ident("initializer_func");
         let init = quote_spanned! {op_span=>

--- a/dfir_lang/src/graph/ops/state.rs
+++ b/dfir_lang/src/graph/ops/state.rs
@@ -36,7 +36,7 @@ pub const STATE: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=1),
     type_args: &(0..=1),
     is_external_input: false,
-    has_singleton_output: true,
+    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: Some(|| PortListSpec::Fixed(parse_quote_spanned!(Span::call_site()=> items, state))),

--- a/dfir_lang/src/graph/ops/state_by.rs
+++ b/dfir_lang/src/graph/ops/state_by.rs
@@ -59,19 +59,18 @@ pub const STATE_BY: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=1),
     type_args: &(0..=1),
     is_external_input: false,
-    has_singleton_output: true,
+    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: Some(|| PortListSpec::Fixed(parse_quote!(items, state))),
     input_delaytype_fn: |_| None,
-    write_fn: |&WriteContextArgs {
+    write_fn: |wc @ &WriteContextArgs {
                    root,
                    op_span,
                    ident,
                    inputs: _,
                    outputs,
                    is_pull,
-                   singleton_output_ident,
                    op_name,
                    op_inst:
                        OperatorInstance {
@@ -106,7 +105,7 @@ pub const STATE_BY: OperatorConstraints = OperatorConstraints {
             _ => unreachable!(),
         };
 
-        let state_ident = singleton_output_ident;
+        let state_ident = wc.make_ident("state");
         let factory_fn = &arguments[1];
 
         let write_prologue = quote_spanned! {op_span=>

--- a/dfir_rs/tests/compile-fail/nightly/surface_singleton_mutation.stderr
+++ b/dfir_rs/tests/compile-fail/nightly/surface_singleton_mutation.stderr
@@ -1,5 +1,19 @@
-error[E0594]: cannot assign to data in a `&` reference
- --> tests/compile-fail/nightly/surface_singleton_mutation.rs:9:18
-  |
-9 |                 #max_of_stream2 = 999;
-  |                  ^^^^^^^^^^^^^^^^^^^^ cannot assign
+error[E0308]: mismatched types
+  --> tests/compile-fail/nightly/surface_singleton_mutation.rs:9:35
+   |
+ 3 |       let mut df = dfir_rs::dfir_syntax! {
+   |  __________________-
+ 4 | |         stream2 = source_iter(3..=5);
+ 5 | |         max_of_stream2 = stream2 -> fold(|| 0usize, |a, b| *a = std::cmp::max(*a, b)) -> singleton();
+...  |
+ 9 | |                 #max_of_stream2 = 999;
+   | |                                   ^^^ expected `&usize`, found integer
+...  |
+12 | |             -> for_each(|x| println!("{}", x));
+13 | |     };
+   | |_____- expected due to the type of this binding
+   |
+help: consider borrowing here
+   |
+ 9 |                 #max_of_stream2 = &999;
+   |                                   +

--- a/dfir_rs/tests/compile-fail/stable/surface_singleton_mutation.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_singleton_mutation.stderr
@@ -1,7 +1,19 @@
-error[E0594]: cannot assign to data in a `&` reference
- --> tests/compile-fail/stable/surface_singleton_mutation.rs:9:18
-  |
-8 |             -> map(|x| {
-  |                --- this cannot be written to
-9 |                 #max_of_stream2 = 999;
-  |                  ^^^^^^^^^^^^^^^^^^^^ cannot assign
+error[E0308]: mismatched types
+  --> tests/compile-fail/stable/surface_singleton_mutation.rs:9:35
+   |
+ 3 |       let mut df = dfir_rs::dfir_syntax! {
+   |  __________________-
+ 4 | |         stream2 = source_iter(3..=5);
+ 5 | |         max_of_stream2 = stream2 -> fold(|| 0usize, |a, b| *a = std::cmp::max(*a, b)) -> singleton();
+...  |
+ 9 | |                 #max_of_stream2 = 999;
+   | |                                   ^^^ expected `&usize`, found integer
+...  |
+12 | |             -> for_each(|x| println!("{}", x));
+13 | |     };
+   | |_____- expected due to the type of this binding
+   |
+help: consider borrowing here
+   |
+ 9 |                 #max_of_stream2 = &999;
+   |                                   +

--- a/dfir_rs/tests/compile-fail/surface_singleton_badexpr.rs
+++ b/dfir_rs/tests/compile-fail/surface_singleton_badexpr.rs
@@ -1,7 +1,7 @@
 /// Correct reference but using it wrong (bad expression).
 fn main() {
     let mut df = dfir_rs::dfir_syntax! {
-        my_ref = source_iter(15_u32..=25) -> fold(|| 0, |a, b| *a = std::cmp::max(*a, b));
+        my_ref = source_iter(15_u32..=25) -> fold(|| 0, |a, b| *a = std::cmp::max(*a, b)) -> singleton();
         source_iter(10_u32..=30)
             -> persist()
             -> filter(|value| value <= #my_ref)

--- a/dfir_rs/tests/compile-fail/surface_singleton_mutation.rs
+++ b/dfir_rs/tests/compile-fail/surface_singleton_mutation.rs
@@ -2,7 +2,7 @@
 fn main() {
     let mut df = dfir_rs::dfir_syntax! {
         stream2 = source_iter(3..=5);
-        max_of_stream2 = stream2 -> fold(|| 0usize, |a, b| *a = std::cmp::max(*a, b));
+        max_of_stream2 = stream2 -> fold(|| 0usize, |a, b| *a = std::cmp::max(*a, b)) -> singleton();
 
         source_iter(1..=3)
             -> map(|x| {

--- a/dfir_rs/tests/snapshots/surface_lattice_bimorphism__cartesian_product@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_lattice_bimorphism__cartesian_product@graphvis_dot.snap
@@ -11,8 +11,8 @@ digraph {
     n4v1 [label="(n4v1) source_iter(3..5)", shape=invhouse, fillcolor="#88aaff"]
     n5v1 [label="(n5v1) map(SetUnionSingletonSet::new_from)", shape=invhouse, fillcolor="#88aaff"]
     n6v1 [label="(n6v1) state::<'static, SetUnionHashSet<u32>>()", shape=house, fillcolor="#ffff88"]
-    n7v1 [label="(n7v1) null()", shape=house, fillcolor="#ffff88"]
-    n8v1 [label="(n8v1) null()", shape=house, fillcolor="#ffff88"]
+    n7v1 [label="(n7v1) singleton", shape=parallelogram, fillcolor="#ddddff"]
+    n8v1 [label="(n8v1) singleton", shape=parallelogram, fillcolor="#ddddff"]
     n9v1 [label="(n9v1) lattice_bimorphism(CartesianProductBimorphism::<HashSet<_>>::default(), lhs, rhs)", shape=invhouse, fillcolor="#88aaff"]
     n10v1 [label="(n10v1) for_each(|x| out_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
     n11v1 [label="(n11v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
@@ -28,17 +28,16 @@ digraph {
     n9v1 -> n10v1
     n11v1 -> n9v1 [label="0"]
     n12v1 -> n9v1 [label="1"]
-    n3v1 -> n9v1 [color=red]
-    n6v1 -> n9v1 [color=red]
+    n7v1 -> n9v1 [color=red]
+    n8v1 -> n9v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
         style=filled
         label = "sg_1v1"
-        n7v1
-        subgraph sg_1v1_var_lhs {
+        subgraph sg_1v1_var_lhs_op {
             cluster=true
-            label="var lhs"
+            label="var lhs_op"
             n1v1
             n2v1
             n3v1
@@ -49,10 +48,9 @@ digraph {
         fillcolor="#dddddd"
         style=filled
         label = "sg_2v1"
-        n8v1
-        subgraph sg_2v1_var_rhs {
+        subgraph sg_2v1_var_rhs_op {
             cluster=true
-            label="var rhs"
+            label="var rhs_op"
             n4v1
             n5v1
             n6v1

--- a/dfir_rs/tests/snapshots/surface_lattice_bimorphism__cartesian_product@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_lattice_bimorphism__cartesian_product@graphvis_mermaid.snap
@@ -14,8 +14,8 @@ linkStyle default stroke:#aaa
 4v1[\"(4v1) <code>source_iter(3..5)</code>"/]:::pullClass
 5v1[\"(5v1) <code>map(SetUnionSingletonSet::new_from)</code>"/]:::pullClass
 6v1[/"(6v1) <code>state::&lt;'static, SetUnionHashSet&lt;u32&gt;&gt;()</code>"\]:::pushClass
-7v1[/"(7v1) <code>null()</code>"\]:::pushClass
-8v1[/"(8v1) <code>null()</code>"\]:::pushClass
+7v1["(7v1) <code>singleton</code>"]:::otherClass
+8v1["(8v1) <code>singleton</code>"]:::otherClass
 9v1[\"(9v1) <code>lattice_bimorphism(CartesianProductBimorphism::&lt;HashSet&lt;_&gt;&gt;::default(), lhs, rhs)</code>"/]:::pullClass
 10v1[/"(10v1) <code>for_each(|x| out_send.send(x).unwrap())</code>"\]:::pushClass
 11v1["(11v1) <code>handoff</code>"]:::otherClass
@@ -31,19 +31,17 @@ linkStyle default stroke:#aaa
 9v1-->10v1
 11v1-->|0|9v1
 12v1-->|1|9v1
-3v1--x9v1; linkStyle 11 stroke:red
-6v1--x9v1; linkStyle 12 stroke:red
+7v1--x9v1; linkStyle 11 stroke:red
+8v1--x9v1; linkStyle 12 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
-    7v1
-    subgraph sg_1v1_var_lhs ["var <tt>lhs</tt>"]
+    subgraph sg_1v1_var_lhs_op ["var <tt>lhs_op</tt>"]
         1v1
         2v1
         3v1
     end
 end
 subgraph sg_2v1 ["sg_2v1"]
-    8v1
-    subgraph sg_2v1_var_rhs ["var <tt>rhs</tt>"]
+    subgraph sg_2v1_var_rhs_op ["var <tt>rhs_op</tt>"]
         4v1
         5v1
         6v1

--- a/dfir_rs/tests/snapshots/surface_lattice_bimorphism__cartesian_product_1401@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_lattice_bimorphism__cartesian_product_1401@graphvis_dot.snap
@@ -11,8 +11,8 @@ digraph {
     n4v1 [label="(n4v1) source_iter(1..2)", shape=invhouse, fillcolor="#88aaff"]
     n5v1 [label="(n5v1) map(SetUnionSingletonSet::new_from)", shape=invhouse, fillcolor="#88aaff"]
     n6v1 [label="(n6v1) state::<'static, SetUnionHashSet<u32>>()", shape=house, fillcolor="#ffff88"]
-    n7v1 [label="(n7v1) null()", shape=house, fillcolor="#ffff88"]
-    n8v1 [label="(n8v1) null()", shape=house, fillcolor="#ffff88"]
+    n7v1 [label="(n7v1) singleton", shape=parallelogram, fillcolor="#ddddff"]
+    n8v1 [label="(n8v1) singleton", shape=parallelogram, fillcolor="#ddddff"]
     n9v1 [label="(n9v1) lattice_bimorphism(CartesianProductBimorphism::<HashSet<_>>::default(), lhs, rhs)", shape=invhouse, fillcolor="#88aaff"]
     n10v1 [label="(n10v1) for_each(|x| out_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
     n11v1 [label="(n11v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
@@ -28,17 +28,16 @@ digraph {
     n9v1 -> n10v1
     n11v1 -> n9v1 [label="0"]
     n12v1 -> n9v1 [label="1"]
-    n3v1 -> n9v1 [color=red]
-    n6v1 -> n9v1 [color=red]
+    n7v1 -> n9v1 [color=red]
+    n8v1 -> n9v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
         style=filled
         label = "sg_1v1"
-        n7v1
-        subgraph sg_1v1_var_lhs {
+        subgraph sg_1v1_var_lhs_op {
             cluster=true
-            label="var lhs"
+            label="var lhs_op"
             n1v1
             n2v1
             n3v1
@@ -49,10 +48,9 @@ digraph {
         fillcolor="#dddddd"
         style=filled
         label = "sg_2v1"
-        n8v1
-        subgraph sg_2v1_var_rhs {
+        subgraph sg_2v1_var_rhs_op {
             cluster=true
-            label="var rhs"
+            label="var rhs_op"
             n4v1
             n5v1
             n6v1

--- a/dfir_rs/tests/snapshots/surface_lattice_bimorphism__cartesian_product_1401@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_lattice_bimorphism__cartesian_product_1401@graphvis_mermaid.snap
@@ -14,8 +14,8 @@ linkStyle default stroke:#aaa
 4v1[\"(4v1) <code>source_iter(1..2)</code>"/]:::pullClass
 5v1[\"(5v1) <code>map(SetUnionSingletonSet::new_from)</code>"/]:::pullClass
 6v1[/"(6v1) <code>state::&lt;'static, SetUnionHashSet&lt;u32&gt;&gt;()</code>"\]:::pushClass
-7v1[/"(7v1) <code>null()</code>"\]:::pushClass
-8v1[/"(8v1) <code>null()</code>"\]:::pushClass
+7v1["(7v1) <code>singleton</code>"]:::otherClass
+8v1["(8v1) <code>singleton</code>"]:::otherClass
 9v1[\"(9v1) <code>lattice_bimorphism(CartesianProductBimorphism::&lt;HashSet&lt;_&gt;&gt;::default(), lhs, rhs)</code>"/]:::pullClass
 10v1[/"(10v1) <code>for_each(|x| out_send.send(x).unwrap())</code>"\]:::pushClass
 11v1["(11v1) <code>handoff</code>"]:::otherClass
@@ -31,19 +31,17 @@ linkStyle default stroke:#aaa
 9v1-->10v1
 11v1-->|0|9v1
 12v1-->|1|9v1
-3v1--x9v1; linkStyle 11 stroke:red
-6v1--x9v1; linkStyle 12 stroke:red
+7v1--x9v1; linkStyle 11 stroke:red
+8v1--x9v1; linkStyle 12 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
-    7v1
-    subgraph sg_1v1_var_lhs ["var <tt>lhs</tt>"]
+    subgraph sg_1v1_var_lhs_op ["var <tt>lhs_op</tt>"]
         1v1
         2v1
         3v1
     end
 end
 subgraph sg_2v1 ["sg_2v1"]
-    8v1
-    subgraph sg_2v1_var_rhs ["var <tt>rhs</tt>"]
+    subgraph sg_2v1_var_rhs_op ["var <tt>rhs_op</tt>"]
         4v1
         5v1
         6v1

--- a/dfir_rs/tests/snapshots/surface_lattice_bimorphism__cartesian_product_tick_state@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_lattice_bimorphism__cartesian_product_tick_state@graphvis_dot.snap
@@ -11,8 +11,8 @@ digraph {
     n4v1 [label="(n4v1) source_stream(rhs_recv)", shape=invhouse, fillcolor="#88aaff"]
     n5v1 [label="(n5v1) map(SetUnionSingletonSet::new_from)", shape=invhouse, fillcolor="#88aaff"]
     n6v1 [label="(n6v1) state::<'tick, SetUnionHashSet<u32>>()", shape=house, fillcolor="#ffff88"]
-    n7v1 [label="(n7v1) null()", shape=house, fillcolor="#ffff88"]
-    n8v1 [label="(n8v1) null()", shape=house, fillcolor="#ffff88"]
+    n7v1 [label="(n7v1) singleton", shape=parallelogram, fillcolor="#ddddff"]
+    n8v1 [label="(n8v1) singleton", shape=parallelogram, fillcolor="#ddddff"]
     n9v1 [label="(n9v1) lattice_bimorphism(CartesianProductBimorphism::<HashSet<_>>::default(), lhs, rhs)", shape=invhouse, fillcolor="#88aaff"]
     n10v1 [label="(n10v1) inspect(|x| println!(\"{:?}: {:?}\", context.current_tick(), x))", shape=invhouse, fillcolor="#88aaff"]
     n11v1 [label="(n11v1) for_each(|x| out_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
@@ -30,17 +30,16 @@ digraph {
     n9v1 -> n10v1
     n12v1 -> n9v1 [label="0"]
     n13v1 -> n9v1 [label="1"]
-    n3v1 -> n9v1 [color=red]
-    n6v1 -> n9v1 [color=red]
+    n7v1 -> n9v1 [color=red]
+    n8v1 -> n9v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
         style=filled
         label = "sg_1v1"
-        n7v1
-        subgraph sg_1v1_var_lhs {
+        subgraph sg_1v1_var_lhs_op {
             cluster=true
-            label="var lhs"
+            label="var lhs_op"
             n1v1
             n2v1
             n3v1
@@ -51,10 +50,9 @@ digraph {
         fillcolor="#dddddd"
         style=filled
         label = "sg_2v1"
-        n8v1
-        subgraph sg_2v1_var_rhs {
+        subgraph sg_2v1_var_rhs_op {
             cluster=true
-            label="var rhs"
+            label="var rhs_op"
             n4v1
             n5v1
             n6v1

--- a/dfir_rs/tests/snapshots/surface_lattice_bimorphism__cartesian_product_tick_state@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_lattice_bimorphism__cartesian_product_tick_state@graphvis_mermaid.snap
@@ -14,8 +14,8 @@ linkStyle default stroke:#aaa
 4v1[\"(4v1) <code>source_stream(rhs_recv)</code>"/]:::pullClass
 5v1[\"(5v1) <code>map(SetUnionSingletonSet::new_from)</code>"/]:::pullClass
 6v1[/"(6v1) <code>state::&lt;'tick, SetUnionHashSet&lt;u32&gt;&gt;()</code>"\]:::pushClass
-7v1[/"(7v1) <code>null()</code>"\]:::pushClass
-8v1[/"(8v1) <code>null()</code>"\]:::pushClass
+7v1["(7v1) <code>singleton</code>"]:::otherClass
+8v1["(8v1) <code>singleton</code>"]:::otherClass
 9v1[\"(9v1) <code>lattice_bimorphism(CartesianProductBimorphism::&lt;HashSet&lt;_&gt;&gt;::default(), lhs, rhs)</code>"/]:::pullClass
 10v1[\"(10v1) <code>inspect(|x| println!(&quot;{:?}: {:?}&quot;, context.current_tick(), x))</code>"/]:::pullClass
 11v1[/"(11v1) <code>for_each(|x| out_send.send(x).unwrap())</code>"\]:::pushClass
@@ -33,19 +33,17 @@ linkStyle default stroke:#aaa
 9v1-->10v1
 12v1-->|0|9v1
 13v1-->|1|9v1
-3v1--x9v1; linkStyle 12 stroke:red
-6v1--x9v1; linkStyle 13 stroke:red
+7v1--x9v1; linkStyle 12 stroke:red
+8v1--x9v1; linkStyle 13 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
-    7v1
-    subgraph sg_1v1_var_lhs ["var <tt>lhs</tt>"]
+    subgraph sg_1v1_var_lhs_op ["var <tt>lhs_op</tt>"]
         1v1
         2v1
         3v1
     end
 end
 subgraph sg_2v1 ["sg_2v1"]
-    8v1
-    subgraph sg_2v1_var_rhs ["var <tt>rhs</tt>"]
+    subgraph sg_2v1_var_rhs_op ["var <tt>rhs_op</tt>"]
         4v1
         5v1
         6v1

--- a/dfir_rs/tests/snapshots/surface_lattice_bimorphism__join@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_lattice_bimorphism__join@graphvis_dot.snap
@@ -11,8 +11,8 @@ digraph {
     n4v1 [label="(n4v1) source_iter([(7, 0), (7, 1), (7, 2)])", shape=invhouse, fillcolor="#88aaff"]
     n5v1 [label="(n5v1) map(|(k, v)| MapUnionSingletonMap::new_from((k, SetUnionSingletonSet::new_from(v))))", shape=invhouse, fillcolor="#88aaff"]
     n6v1 [label="(n6v1) state::<'static, MapUnionHashMap<usize, SetUnionHashSet<usize>>>()", shape=house, fillcolor="#ffff88"]
-    n7v1 [label="(n7v1) null()", shape=house, fillcolor="#ffff88"]
-    n8v1 [label="(n8v1) null()", shape=house, fillcolor="#ffff88"]
+    n7v1 [label="(n7v1) singleton", shape=parallelogram, fillcolor="#ddddff"]
+    n8v1 [label="(n8v1) singleton", shape=parallelogram, fillcolor="#ddddff"]
     n9v1 [label="(n9v1) lattice_bimorphism(\l    KeyedBimorphism::<\l        HashMap<_, _>,\l        _,\l    >::new(CartesianProductBimorphism::<HashSet<_>>::default()),\l    lhs,\l    rhs,\l)\l", shape=invhouse, fillcolor="#88aaff"]
     n10v1 [label="(n10v1) for_each(|x| out_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
     n11v1 [label="(n11v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
@@ -28,17 +28,16 @@ digraph {
     n9v1 -> n10v1
     n11v1 -> n9v1 [label="0"]
     n12v1 -> n9v1 [label="1"]
-    n3v1 -> n9v1 [color=red]
-    n6v1 -> n9v1 [color=red]
+    n7v1 -> n9v1 [color=red]
+    n8v1 -> n9v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
         style=filled
         label = "sg_1v1"
-        n7v1
-        subgraph sg_1v1_var_lhs {
+        subgraph sg_1v1_var_lhs_op {
             cluster=true
-            label="var lhs"
+            label="var lhs_op"
             n1v1
             n2v1
             n3v1
@@ -49,10 +48,9 @@ digraph {
         fillcolor="#dddddd"
         style=filled
         label = "sg_2v1"
-        n8v1
-        subgraph sg_2v1_var_rhs {
+        subgraph sg_2v1_var_rhs_op {
             cluster=true
-            label="var rhs"
+            label="var rhs_op"
             n4v1
             n5v1
             n6v1

--- a/dfir_rs/tests/snapshots/surface_lattice_bimorphism__join@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_lattice_bimorphism__join@graphvis_mermaid.snap
@@ -14,8 +14,8 @@ linkStyle default stroke:#aaa
 4v1[\"(4v1) <code>source_iter([(7, 0), (7, 1), (7, 2)])</code>"/]:::pullClass
 5v1[\"(5v1) <code>map(|(k, v)| MapUnionSingletonMap::new_from((k, SetUnionSingletonSet::new_from(v))))</code>"/]:::pullClass
 6v1[/"(6v1) <code>state::&lt;'static, MapUnionHashMap&lt;usize, SetUnionHashSet&lt;usize&gt;&gt;&gt;()</code>"\]:::pushClass
-7v1[/"(7v1) <code>null()</code>"\]:::pushClass
-8v1[/"(8v1) <code>null()</code>"\]:::pushClass
+7v1["(7v1) <code>singleton</code>"]:::otherClass
+8v1["(8v1) <code>singleton</code>"]:::otherClass
 9v1[\"<div style=text-align:center>(9v1)</div> <code>lattice_bimorphism(<br>    KeyedBimorphism::&lt;<br>        HashMap&lt;_, _&gt;,<br>        _,<br>    &gt;::new(CartesianProductBimorphism::&lt;HashSet&lt;_&gt;&gt;::default()),<br>    lhs,<br>    rhs,<br>)</code>"/]:::pullClass
 10v1[/"(10v1) <code>for_each(|x| out_send.send(x).unwrap())</code>"\]:::pushClass
 11v1["(11v1) <code>handoff</code>"]:::otherClass
@@ -31,19 +31,17 @@ linkStyle default stroke:#aaa
 9v1-->10v1
 11v1-->|0|9v1
 12v1-->|1|9v1
-3v1--x9v1; linkStyle 11 stroke:red
-6v1--x9v1; linkStyle 12 stroke:red
+7v1--x9v1; linkStyle 11 stroke:red
+8v1--x9v1; linkStyle 12 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
-    7v1
-    subgraph sg_1v1_var_lhs ["var <tt>lhs</tt>"]
+    subgraph sg_1v1_var_lhs_op ["var <tt>lhs_op</tt>"]
         1v1
         2v1
         3v1
     end
 end
 subgraph sg_2v1 ["sg_2v1"]
-    8v1
-    subgraph sg_2v1_var_rhs ["var <tt>rhs</tt>"]
+    subgraph sg_2v1_var_rhs_op ["var <tt>rhs_op</tt>"]
         4v1
         5v1
         6v1

--- a/dfir_rs/tests/snapshots/surface_lattice_bimorphism_persist_insertion__cartesian_product_multi_tick@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_lattice_bimorphism_persist_insertion__cartesian_product_multi_tick@graphvis_dot.snap
@@ -11,8 +11,8 @@ digraph {
     n4v1 [label="(n4v1) source_stream(rhs_recv)", shape=invhouse, fillcolor="#88aaff"]
     n5v1 [label="(n5v1) map(SetUnionSingletonSet::new_from)", shape=invhouse, fillcolor="#88aaff"]
     n6v1 [label="(n6v1) state::<'static, SetUnionHashSet<u32>>()", shape=house, fillcolor="#ffff88"]
-    n7v1 [label="(n7v1) null()", shape=house, fillcolor="#ffff88"]
-    n8v1 [label="(n8v1) null()", shape=house, fillcolor="#ffff88"]
+    n7v1 [label="(n7v1) singleton", shape=parallelogram, fillcolor="#ddddff"]
+    n8v1 [label="(n8v1) singleton", shape=parallelogram, fillcolor="#ddddff"]
     n9v1 [label="(n9v1) lattice_bimorphism(CartesianProductBimorphism::<HashSet<_>>::default(), lhs, rhs)", shape=invhouse, fillcolor="#88aaff"]
     n10v1 [label="(n10v1) lattice_reduce()", shape=invhouse, fillcolor="#88aaff"]
     n11v1 [label="(n11v1) for_each(|x| out_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
@@ -32,17 +32,16 @@ digraph {
     n12v1 -> n9v1 [label="0"]
     n13v1 -> n9v1 [label="1"]
     n14v1 -> n10v1 [color=red]
-    n3v1 -> n9v1 [color=red]
-    n6v1 -> n9v1 [color=red]
+    n7v1 -> n9v1 [color=red]
+    n8v1 -> n9v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
         style=filled
         label = "sg_1v1"
-        n7v1
-        subgraph sg_1v1_var_lhs {
+        subgraph sg_1v1_var_lhs_op {
             cluster=true
-            label="var lhs"
+            label="var lhs_op"
             n1v1
             n2v1
             n3v1
@@ -53,10 +52,9 @@ digraph {
         fillcolor="#dddddd"
         style=filled
         label = "sg_2v1"
-        n8v1
-        subgraph sg_2v1_var_rhs {
+        subgraph sg_2v1_var_rhs_op {
             cluster=true
-            label="var rhs"
+            label="var rhs_op"
             n4v1
             n5v1
             n6v1

--- a/dfir_rs/tests/snapshots/surface_lattice_bimorphism_persist_insertion__cartesian_product_multi_tick@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_lattice_bimorphism_persist_insertion__cartesian_product_multi_tick@graphvis_mermaid.snap
@@ -14,8 +14,8 @@ linkStyle default stroke:#aaa
 4v1[\"(4v1) <code>source_stream(rhs_recv)</code>"/]:::pullClass
 5v1[\"(5v1) <code>map(SetUnionSingletonSet::new_from)</code>"/]:::pullClass
 6v1[/"(6v1) <code>state::&lt;'static, SetUnionHashSet&lt;u32&gt;&gt;()</code>"\]:::pushClass
-7v1[/"(7v1) <code>null()</code>"\]:::pushClass
-8v1[/"(8v1) <code>null()</code>"\]:::pushClass
+7v1["(7v1) <code>singleton</code>"]:::otherClass
+8v1["(8v1) <code>singleton</code>"]:::otherClass
 9v1[\"(9v1) <code>lattice_bimorphism(CartesianProductBimorphism::&lt;HashSet&lt;_&gt;&gt;::default(), lhs, rhs)</code>"/]:::pullClass
 10v1[\"(10v1) <code>lattice_reduce()</code>"/]:::pullClass
 11v1[/"(11v1) <code>for_each(|x| out_send.send(x).unwrap())</code>"\]:::pushClass
@@ -35,19 +35,17 @@ linkStyle default stroke:#aaa
 12v1-->|0|9v1
 13v1-->|1|9v1
 14v1-->10v1; linkStyle 12 stroke:#060
-3v1--x9v1; linkStyle 13 stroke:red
-6v1--x9v1; linkStyle 14 stroke:red
+7v1--x9v1; linkStyle 13 stroke:red
+8v1--x9v1; linkStyle 14 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
-    7v1
-    subgraph sg_1v1_var_lhs ["var <tt>lhs</tt>"]
+    subgraph sg_1v1_var_lhs_op ["var <tt>lhs_op</tt>"]
         1v1
         2v1
         3v1
     end
 end
 subgraph sg_2v1 ["sg_2v1"]
-    8v1
-    subgraph sg_2v1_var_rhs ["var <tt>rhs</tt>"]
+    subgraph sg_2v1_var_rhs_op ["var <tt>rhs_op</tt>"]
         4v1
         5v1
         6v1

--- a/dfir_rs/tests/snapshots/surface_lattice_bimorphism_persist_insertion__cartesian_product_multi_tick_identity@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_lattice_bimorphism_persist_insertion__cartesian_product_multi_tick_identity@graphvis_dot.snap
@@ -12,8 +12,8 @@ digraph {
     n5v1 [label="(n5v1) map(SetUnionSingletonSet::new_from)", shape=invhouse, fillcolor="#88aaff"]
     n6v1 [label="(n6v1) state::<'static, SetUnionHashSet<u32>>()", shape=house, fillcolor="#ffff88"]
     n7v1 [label="(n7v1) identity()", shape=house, fillcolor="#ffff88"]
-    n8v1 [label="(n8v1) null()", shape=house, fillcolor="#ffff88"]
-    n9v1 [label="(n9v1) null()", shape=house, fillcolor="#ffff88"]
+    n8v1 [label="(n8v1) singleton", shape=parallelogram, fillcolor="#ddddff"]
+    n9v1 [label="(n9v1) singleton", shape=parallelogram, fillcolor="#ddddff"]
     n10v1 [label="(n10v1) lattice_bimorphism(CartesianProductBimorphism::<HashSet<_>>::default(), lhs, rhs)", shape=invhouse, fillcolor="#88aaff"]
     n11v1 [label="(n11v1) lattice_reduce()", shape=invhouse, fillcolor="#88aaff"]
     n12v1 [label="(n12v1) for_each(|x| out_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
@@ -34,17 +34,16 @@ digraph {
     n13v1 -> n10v1 [label="0"]
     n14v1 -> n10v1 [label="1"]
     n15v1 -> n11v1 [color=red]
-    n3v1 -> n10v1 [color=red]
-    n6v1 -> n10v1 [color=red]
+    n8v1 -> n10v1 [color=red]
+    n9v1 -> n10v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
         style=filled
         label = "sg_1v1"
-        n8v1
-        subgraph sg_1v1_var_lhs {
+        subgraph sg_1v1_var_lhs_op {
             cluster=true
-            label="var lhs"
+            label="var lhs_op"
             n1v1
             n2v1
             n3v1
@@ -55,18 +54,17 @@ digraph {
         fillcolor="#dddddd"
         style=filled
         label = "sg_2v1"
-        n9v1
-        subgraph sg_2v1_var_rhs {
-            cluster=true
-            label="var rhs"
-            n4v1
-            n5v1
-            n6v1
-        }
         subgraph sg_2v1_var_rhs_id {
             cluster=true
             label="var rhs_id"
             n7v1
+        }
+        subgraph sg_2v1_var_rhs_op {
+            cluster=true
+            label="var rhs_op"
+            n4v1
+            n5v1
+            n6v1
         }
     }
     subgraph sg_3v1 {

--- a/dfir_rs/tests/snapshots/surface_lattice_bimorphism_persist_insertion__cartesian_product_multi_tick_identity@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_lattice_bimorphism_persist_insertion__cartesian_product_multi_tick_identity@graphvis_mermaid.snap
@@ -15,8 +15,8 @@ linkStyle default stroke:#aaa
 5v1[\"(5v1) <code>map(SetUnionSingletonSet::new_from)</code>"/]:::pullClass
 6v1[/"(6v1) <code>state::&lt;'static, SetUnionHashSet&lt;u32&gt;&gt;()</code>"\]:::pushClass
 7v1[/"(7v1) <code>identity()</code>"\]:::pushClass
-8v1[/"(8v1) <code>null()</code>"\]:::pushClass
-9v1[/"(9v1) <code>null()</code>"\]:::pushClass
+8v1["(8v1) <code>singleton</code>"]:::otherClass
+9v1["(9v1) <code>singleton</code>"]:::otherClass
 10v1[\"(10v1) <code>lattice_bimorphism(CartesianProductBimorphism::&lt;HashSet&lt;_&gt;&gt;::default(), lhs, rhs)</code>"/]:::pullClass
 11v1[\"(11v1) <code>lattice_reduce()</code>"/]:::pullClass
 12v1[/"(12v1) <code>for_each(|x| out_send.send(x).unwrap())</code>"\]:::pushClass
@@ -37,25 +37,23 @@ linkStyle default stroke:#aaa
 13v1-->|0|10v1
 14v1-->|1|10v1
 15v1-->11v1; linkStyle 13 stroke:#060
-3v1--x10v1; linkStyle 14 stroke:red
-6v1--x10v1; linkStyle 15 stroke:red
+8v1--x10v1; linkStyle 14 stroke:red
+9v1--x10v1; linkStyle 15 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
-    8v1
-    subgraph sg_1v1_var_lhs ["var <tt>lhs</tt>"]
+    subgraph sg_1v1_var_lhs_op ["var <tt>lhs_op</tt>"]
         1v1
         2v1
         3v1
     end
 end
 subgraph sg_2v1 ["sg_2v1"]
-    9v1
-    subgraph sg_2v1_var_rhs ["var <tt>rhs</tt>"]
+    subgraph sg_2v1_var_rhs_id ["var <tt>rhs_id</tt>"]
+        7v1
+    end
+    subgraph sg_2v1_var_rhs_op ["var <tt>rhs_op</tt>"]
         4v1
         5v1
         6v1
-    end
-    subgraph sg_2v1_var_rhs_id ["var <tt>rhs_id</tt>"]
-        7v1
     end
 end
 subgraph sg_3v1 ["sg_3v1"]

--- a/dfir_rs/tests/snapshots/surface_lattice_bimorphism_persist_insertion__cartesian_product_multi_tick_tee@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_lattice_bimorphism_persist_insertion__cartesian_product_multi_tick_tee@graphvis_dot.snap
@@ -13,8 +13,8 @@ digraph {
     n6v1 [label="(n6v1) state::<'static, SetUnionHashSet<u32>>()", shape=house, fillcolor="#ffff88"]
     n7v1 [label="(n7v1) tee()", shape=house, fillcolor="#ffff88"]
     n8v1 [label="(n8v1) for_each(|x| println!(\"tee: {:?}\", x))", shape=house, fillcolor="#ffff88"]
-    n9v1 [label="(n9v1) null()", shape=house, fillcolor="#ffff88"]
-    n10v1 [label="(n10v1) null()", shape=house, fillcolor="#ffff88"]
+    n9v1 [label="(n9v1) singleton", shape=parallelogram, fillcolor="#ddddff"]
+    n10v1 [label="(n10v1) singleton", shape=parallelogram, fillcolor="#ddddff"]
     n11v1 [label="(n11v1) lattice_bimorphism(CartesianProductBimorphism::<HashSet<_>>::default(), lhs, rhs)", shape=invhouse, fillcolor="#88aaff"]
     n12v1 [label="(n12v1) lattice_reduce()", shape=invhouse, fillcolor="#88aaff"]
     n13v1 [label="(n13v1) for_each(|x| out_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
@@ -36,17 +36,16 @@ digraph {
     n14v1 -> n11v1 [label="0"]
     n15v1 -> n11v1 [label="1"]
     n16v1 -> n12v1 [color=red]
-    n3v1 -> n11v1 [color=red]
-    n6v1 -> n11v1 [color=red]
+    n9v1 -> n11v1 [color=red]
+    n10v1 -> n11v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
         style=filled
         label = "sg_1v1"
-        n9v1
-        subgraph sg_1v1_var_lhs {
+        subgraph sg_1v1_var_lhs_op {
             cluster=true
-            label="var lhs"
+            label="var lhs_op"
             n1v1
             n2v1
             n3v1
@@ -58,10 +57,9 @@ digraph {
         style=filled
         label = "sg_2v1"
         n8v1
-        n10v1
-        subgraph sg_2v1_var_rhs {
+        subgraph sg_2v1_var_rhs_op {
             cluster=true
-            label="var rhs"
+            label="var rhs_op"
             n4v1
             n5v1
             n6v1

--- a/dfir_rs/tests/snapshots/surface_lattice_bimorphism_persist_insertion__cartesian_product_multi_tick_tee@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_lattice_bimorphism_persist_insertion__cartesian_product_multi_tick_tee@graphvis_mermaid.snap
@@ -16,8 +16,8 @@ linkStyle default stroke:#aaa
 6v1[/"(6v1) <code>state::&lt;'static, SetUnionHashSet&lt;u32&gt;&gt;()</code>"\]:::pushClass
 7v1[/"(7v1) <code>tee()</code>"\]:::pushClass
 8v1[/"(8v1) <code>for_each(|x| println!(&quot;tee: {:?}&quot;, x))</code>"\]:::pushClass
-9v1[/"(9v1) <code>null()</code>"\]:::pushClass
-10v1[/"(10v1) <code>null()</code>"\]:::pushClass
+9v1["(9v1) <code>singleton</code>"]:::otherClass
+10v1["(10v1) <code>singleton</code>"]:::otherClass
 11v1[\"(11v1) <code>lattice_bimorphism(CartesianProductBimorphism::&lt;HashSet&lt;_&gt;&gt;::default(), lhs, rhs)</code>"/]:::pullClass
 12v1[\"(12v1) <code>lattice_reduce()</code>"/]:::pullClass
 13v1[/"(13v1) <code>for_each(|x| out_send.send(x).unwrap())</code>"\]:::pushClass
@@ -39,11 +39,10 @@ linkStyle default stroke:#aaa
 14v1-->|0|11v1
 15v1-->|1|11v1
 16v1-->12v1; linkStyle 14 stroke:#060
-3v1--x11v1; linkStyle 15 stroke:red
-6v1--x11v1; linkStyle 16 stroke:red
+9v1--x11v1; linkStyle 15 stroke:red
+10v1--x11v1; linkStyle 16 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
-    9v1
-    subgraph sg_1v1_var_lhs ["var <tt>lhs</tt>"]
+    subgraph sg_1v1_var_lhs_op ["var <tt>lhs_op</tt>"]
         1v1
         2v1
         3v1
@@ -51,8 +50,7 @@ subgraph sg_1v1 ["sg_1v1"]
 end
 subgraph sg_2v1 ["sg_2v1"]
     8v1
-    10v1
-    subgraph sg_2v1_var_rhs ["var <tt>rhs</tt>"]
+    subgraph sg_2v1_var_rhs_op ["var <tt>rhs_op</tt>"]
         4v1
         5v1
         6v1

--- a/dfir_rs/tests/snapshots/surface_singleton__fold_singleton@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_singleton__fold_singleton@graphvis_dot.snap
@@ -8,20 +8,22 @@ digraph {
     n1v1 [label="(n1v1) source_iter(1..=10)", shape=invhouse, fillcolor="#88aaff"]
     n2v1 [label="(n2v1) source_iter(3..=5)", shape=invhouse, fillcolor="#88aaff"]
     n3v1 [label="(n3v1) fold(|| 0, |a, b| *a = std::cmp::max(*a, b))", shape=invhouse, fillcolor="#88aaff"]
-    n4v1 [label="(n4v1) filter(|&value| { value <= max_of_stream2 })", shape=invhouse, fillcolor="#88aaff"]
-    n5v1 [label="(n5v1) map(|x| (context.current_tick(), x))", shape=invhouse, fillcolor="#88aaff"]
-    n6v1 [label="(n6v1) for_each(|x| filter_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
-    n7v1 [label="(n7v1) map(|x| (context.current_tick(), x))", shape=invhouse, fillcolor="#88aaff"]
-    n8v1 [label="(n8v1) for_each(|x| max_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
-    n9v1 [label="(n9v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n2v1 -> n9v1
+    n4v1 [label="(n4v1) singleton", shape=parallelogram, fillcolor="#ddddff"]
+    n5v1 [label="(n5v1) filter(|&value| { value <= *max_of_stream2 })", shape=invhouse, fillcolor="#88aaff"]
+    n6v1 [label="(n6v1) map(|x| (context.current_tick(), x))", shape=invhouse, fillcolor="#88aaff"]
+    n7v1 [label="(n7v1) for_each(|x| filter_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
+    n8v1 [label="(n8v1) map(|x| (context.current_tick(), x))", shape=invhouse, fillcolor="#88aaff"]
+    n9v1 [label="(n9v1) for_each(|x| max_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
+    n10v1 [label="(n10v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
+    n3v1 -> n4v1
+    n2v1 -> n10v1
+    n6v1 -> n7v1
     n5v1 -> n6v1
-    n4v1 -> n5v1
-    n1v1 -> n4v1
-    n7v1 -> n8v1
-    n3v1 -> n7v1
-    n9v1 -> n3v1 [color=red]
-    n3v1 -> n4v1 [color=red]
+    n1v1 -> n5v1
+    n8v1 -> n9v1
+    n4v1 -> n8v1
+    n10v1 -> n3v1 [color=red]
+    n4v1 -> n5v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
@@ -38,17 +40,10 @@ digraph {
         fillcolor="#dddddd"
         style=filled
         label = "sg_2v1"
-        subgraph sg_2v1_var_filtered_stream1 {
+        subgraph sg_2v1_var_max_of_stream2 {
             cluster=true
-            label="var filtered_stream1"
-            n4v1
-            n5v1
-            n6v1
-        }
-        subgraph sg_2v1_var_stream1 {
-            cluster=true
-            label="var stream1"
-            n1v1
+            label="var max_of_stream2"
+            n3v1
         }
     }
     subgraph sg_3v1 {
@@ -56,12 +51,25 @@ digraph {
         fillcolor="#dddddd"
         style=filled
         label = "sg_3v1"
-        n7v1
-        n8v1
-        subgraph sg_3v1_var_max_of_stream2 {
+        subgraph sg_3v1_var_filtered_stream1 {
             cluster=true
-            label="var max_of_stream2"
-            n3v1
+            label="var filtered_stream1"
+            n5v1
+            n6v1
+            n7v1
         }
+        subgraph sg_3v1_var_stream1 {
+            cluster=true
+            label="var stream1"
+            n1v1
+        }
+    }
+    subgraph sg_4v1 {
+        cluster=true
+        fillcolor="#dddddd"
+        style=filled
+        label = "sg_4v1"
+        n8v1
+        n9v1
     }
 }

--- a/dfir_rs/tests/snapshots/surface_singleton__fold_singleton@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_singleton__fold_singleton@graphvis_mermaid.snap
@@ -11,39 +11,43 @@ linkStyle default stroke:#aaa
 1v1[\"(1v1) <code>source_iter(1..=10)</code>"/]:::pullClass
 2v1[\"(2v1) <code>source_iter(3..=5)</code>"/]:::pullClass
 3v1[\"(3v1) <code>fold(|| 0, |a, b| *a = std::cmp::max(*a, b))</code>"/]:::pullClass
-4v1[\"(4v1) <code>filter(|&amp;value| { value &lt;= max_of_stream2 })</code>"/]:::pullClass
-5v1[\"(5v1) <code>map(|x| (context.current_tick(), x))</code>"/]:::pullClass
-6v1[/"(6v1) <code>for_each(|x| filter_send.send(x).unwrap())</code>"\]:::pushClass
-7v1[\"(7v1) <code>map(|x| (context.current_tick(), x))</code>"/]:::pullClass
-8v1[/"(8v1) <code>for_each(|x| max_send.send(x).unwrap())</code>"\]:::pushClass
-9v1["(9v1) <code>handoff</code>"]:::otherClass
-2v1-->9v1
+4v1["(4v1) <code>singleton</code>"]:::otherClass
+5v1[\"(5v1) <code>filter(|&amp;value| { value &lt;= *max_of_stream2 })</code>"/]:::pullClass
+6v1[\"(6v1) <code>map(|x| (context.current_tick(), x))</code>"/]:::pullClass
+7v1[/"(7v1) <code>for_each(|x| filter_send.send(x).unwrap())</code>"\]:::pushClass
+8v1[\"(8v1) <code>map(|x| (context.current_tick(), x))</code>"/]:::pullClass
+9v1[/"(9v1) <code>for_each(|x| max_send.send(x).unwrap())</code>"\]:::pushClass
+10v1["(10v1) <code>handoff</code>"]:::otherClass
+3v1-->4v1
+2v1-->10v1
+6v1-->7v1
 5v1-->6v1
-4v1-->5v1
-1v1-->4v1
-7v1-->8v1
-3v1-->7v1
-9v1--x3v1; linkStyle 6 stroke:red
-3v1--x4v1; linkStyle 7 stroke:red
+1v1-->5v1
+8v1-->9v1
+4v1-->8v1
+10v1--x3v1; linkStyle 7 stroke:red
+4v1--x5v1; linkStyle 8 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
     subgraph sg_1v1_var_stream2 ["var <tt>stream2</tt>"]
         2v1
     end
 end
 subgraph sg_2v1 ["sg_2v1"]
-    subgraph sg_2v1_var_filtered_stream1 ["var <tt>filtered_stream1</tt>"]
-        4v1
-        5v1
-        6v1
-    end
-    subgraph sg_2v1_var_stream1 ["var <tt>stream1</tt>"]
-        1v1
+    subgraph sg_2v1_var_max_of_stream2 ["var <tt>max_of_stream2</tt>"]
+        3v1
     end
 end
 subgraph sg_3v1 ["sg_3v1"]
-    7v1
-    8v1
-    subgraph sg_3v1_var_max_of_stream2 ["var <tt>max_of_stream2</tt>"]
-        3v1
+    subgraph sg_3v1_var_filtered_stream1 ["var <tt>filtered_stream1</tt>"]
+        5v1
+        6v1
+        7v1
     end
+    subgraph sg_3v1_var_stream1 ["var <tt>stream1</tt>"]
+        1v1
+    end
+end
+subgraph sg_4v1 ["sg_4v1"]
+    8v1
+    9v1
 end

--- a/dfir_rs/tests/snapshots/surface_singleton__fold_singleton_push@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_singleton__fold_singleton_push@graphvis_dot.snap
@@ -7,19 +7,21 @@ digraph {
     edge [fontname="Monaco,Menlo,Consolas,&quot;Droid Sans Mono&quot;,Inconsolata,&quot;Courier New&quot;,monospace"];
     n1v1 [label="(n1v1) source_iter(1..=10)", shape=invhouse, fillcolor="#88aaff"]
     n2v1 [label="(n2v1) source_iter(3..=5)", shape=invhouse, fillcolor="#88aaff"]
-    n3v1 [label="(n3v1) fold(|| 0, |a, b| *a = std::cmp::max(*a, b))", shape=house, fillcolor="#ffff88"]
-    n4v1 [label="(n4v1) persist::<'static>()", shape=invhouse, fillcolor="#88aaff"]
-    n5v1 [label="(n5v1) filter(|&value| { value <= max_of_stream2 })", shape=invhouse, fillcolor="#88aaff"]
-    n6v1 [label="(n6v1) map(|x| (context.current_tick(), x))", shape=invhouse, fillcolor="#88aaff"]
-    n7v1 [label="(n7v1) for_each(|x| filter_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
-    n8v1 [label="(n8v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n2v1 -> n8v1
+    n3v1 [label="(n3v1) fold(|| 0, |a, b| *a = std::cmp::max(*a, b))", shape=invhouse, fillcolor="#88aaff"]
+    n4v1 [label="(n4v1) singleton", shape=parallelogram, fillcolor="#ddddff"]
+    n5v1 [label="(n5v1) persist::<'static>()", shape=invhouse, fillcolor="#88aaff"]
+    n6v1 [label="(n6v1) filter(|&value| { value <= *max_of_stream2 })", shape=invhouse, fillcolor="#88aaff"]
+    n7v1 [label="(n7v1) map(|x| (context.current_tick(), x))", shape=invhouse, fillcolor="#88aaff"]
+    n8v1 [label="(n8v1) for_each(|x| filter_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
+    n9v1 [label="(n9v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
+    n3v1 -> n4v1
+    n2v1 -> n9v1
+    n7v1 -> n8v1
     n6v1 -> n7v1
     n5v1 -> n6v1
-    n4v1 -> n5v1
-    n1v1 -> n4v1
-    n8v1 -> n3v1 [color=red]
-    n3v1 -> n5v1 [color=red]
+    n1v1 -> n5v1
+    n9v1 -> n3v1 [color=red]
+    n4v1 -> n6v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
@@ -50,10 +52,10 @@ digraph {
         subgraph sg_3v1_var_filtered_stream1 {
             cluster=true
             label="var filtered_stream1"
-            n4v1
             n5v1
             n6v1
             n7v1
+            n8v1
         }
         subgraph sg_3v1_var_stream1 {
             cluster=true

--- a/dfir_rs/tests/snapshots/surface_singleton__fold_singleton_push@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_singleton__fold_singleton_push@graphvis_mermaid.snap
@@ -10,19 +10,21 @@ classDef otherClass fill:#fdc,stroke:#000,text-align:left,white-space:pre
 linkStyle default stroke:#aaa
 1v1[\"(1v1) <code>source_iter(1..=10)</code>"/]:::pullClass
 2v1[\"(2v1) <code>source_iter(3..=5)</code>"/]:::pullClass
-3v1[/"(3v1) <code>fold(|| 0, |a, b| *a = std::cmp::max(*a, b))</code>"\]:::pushClass
-4v1[\"(4v1) <code>persist::&lt;'static&gt;()</code>"/]:::pullClass
-5v1[\"(5v1) <code>filter(|&amp;value| { value &lt;= max_of_stream2 })</code>"/]:::pullClass
-6v1[\"(6v1) <code>map(|x| (context.current_tick(), x))</code>"/]:::pullClass
-7v1[/"(7v1) <code>for_each(|x| filter_send.send(x).unwrap())</code>"\]:::pushClass
-8v1["(8v1) <code>handoff</code>"]:::otherClass
-2v1-->8v1
+3v1[\"(3v1) <code>fold(|| 0, |a, b| *a = std::cmp::max(*a, b))</code>"/]:::pullClass
+4v1["(4v1) <code>singleton</code>"]:::otherClass
+5v1[\"(5v1) <code>persist::&lt;'static&gt;()</code>"/]:::pullClass
+6v1[\"(6v1) <code>filter(|&amp;value| { value &lt;= *max_of_stream2 })</code>"/]:::pullClass
+7v1[\"(7v1) <code>map(|x| (context.current_tick(), x))</code>"/]:::pullClass
+8v1[/"(8v1) <code>for_each(|x| filter_send.send(x).unwrap())</code>"\]:::pushClass
+9v1["(9v1) <code>handoff</code>"]:::otherClass
+3v1-->4v1
+2v1-->9v1
+7v1-->8v1
 6v1-->7v1
 5v1-->6v1
-4v1-->5v1
-1v1-->4v1
-8v1--x3v1; linkStyle 5 stroke:red
-3v1--x5v1; linkStyle 6 stroke:red
+1v1-->5v1
+9v1--x3v1; linkStyle 6 stroke:red
+4v1--x6v1; linkStyle 7 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
     subgraph sg_1v1_var_stream2 ["var <tt>stream2</tt>"]
         2v1
@@ -35,10 +37,10 @@ subgraph sg_2v1 ["sg_2v1"]
 end
 subgraph sg_3v1 ["sg_3v1"]
     subgraph sg_3v1_var_filtered_stream1 ["var <tt>filtered_stream1</tt>"]
-        4v1
         5v1
         6v1
         7v1
+        8v1
     end
     subgraph sg_3v1_var_stream1 ["var <tt>stream1</tt>"]
         1v1

--- a/dfir_rs/tests/snapshots/surface_singleton__multi_tick@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_singleton__multi_tick@graphvis_dot.snap
@@ -9,21 +9,21 @@ digraph {
     n2v1 [label="(n2v1) source_iter(3..=5)", shape=invhouse, fillcolor="#88aaff"]
     n3v1 [label="(n3v1) map(Max::new)", shape=invhouse, fillcolor="#88aaff"]
     n4v1 [label="(n4v1) state::<'static, Max<_>>()", shape=house, fillcolor="#ffff88"]
-    n5v1 [label="(n5v1) filter(|value| { value <= max_of_stream2.as_reveal_ref() })", shape=invhouse, fillcolor="#88aaff"]
-    n6v1 [label="(n6v1) map(|x| (context.current_tick(), x))", shape=invhouse, fillcolor="#88aaff"]
-    n7v1 [label="(n7v1) for_each(|x| filter_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
-    n8v1 [label="(n8v1) map(|x: Max<_>| (context.current_tick(), x.into_reveal()))", shape=house, fillcolor="#ffff88"]
-    n9v1 [label="(n9v1) for_each(|x| max_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
-    n10v1 [label="(n10v1) null()", shape=house, fillcolor="#ffff88"]
+    n5v1 [label="(n5v1) singleton", shape=parallelogram, fillcolor="#ddddff"]
+    n6v1 [label="(n6v1) filter(|value| { value <= max_of_stream2.as_reveal_ref() })", shape=invhouse, fillcolor="#88aaff"]
+    n7v1 [label="(n7v1) map(|x| (context.current_tick(), x))", shape=invhouse, fillcolor="#88aaff"]
+    n8v1 [label="(n8v1) for_each(|x| filter_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
+    n9v1 [label="(n9v1) map(|x: Max<_>| (context.current_tick(), x.into_reveal()))", shape=house, fillcolor="#ffff88"]
+    n10v1 [label="(n10v1) for_each(|x| max_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
     n2v1 -> n3v1
     n3v1 -> n4v1
+    n4v1 -> n5v1 [label="state"]
+    n7v1 -> n8v1
     n6v1 -> n7v1
-    n5v1 -> n6v1
-    n1v1 -> n5v1
-    n8v1 -> n9v1
-    n4v1 -> n8v1 [label="items"]
-    n4v1 -> n10v1 [label="state"]
-    n4v1 -> n5v1 [color=red]
+    n1v1 -> n6v1
+    n9v1 -> n10v1
+    n4v1 -> n9v1 [label="items"]
+    n5v1 -> n6v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
@@ -32,9 +32,9 @@ digraph {
         subgraph sg_1v1_var_filtered_stream1 {
             cluster=true
             label="var filtered_stream1"
-            n5v1
             n6v1
             n7v1
+            n8v1
         }
         subgraph sg_1v1_var_stream1 {
             cluster=true
@@ -47,12 +47,11 @@ digraph {
         fillcolor="#dddddd"
         style=filled
         label = "sg_2v1"
-        n8v1
         n9v1
         n10v1
-        subgraph sg_2v1_var_max_of_stream2 {
+        subgraph sg_2v1_var_max_of_stream2_op {
             cluster=true
-            label="var max_of_stream2"
+            label="var max_of_stream2_op"
             n4v1
         }
         subgraph sg_2v1_var_stream2 {

--- a/dfir_rs/tests/snapshots/surface_singleton__multi_tick@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_singleton__multi_tick@graphvis_mermaid.snap
@@ -12,36 +12,35 @@ linkStyle default stroke:#aaa
 2v1[\"(2v1) <code>source_iter(3..=5)</code>"/]:::pullClass
 3v1[\"(3v1) <code>map(Max::new)</code>"/]:::pullClass
 4v1[/"(4v1) <code>state::&lt;'static, Max&lt;_&gt;&gt;()</code>"\]:::pushClass
-5v1[\"(5v1) <code>filter(|value| { value &lt;= max_of_stream2.as_reveal_ref() })</code>"/]:::pullClass
-6v1[\"(6v1) <code>map(|x| (context.current_tick(), x))</code>"/]:::pullClass
-7v1[/"(7v1) <code>for_each(|x| filter_send.send(x).unwrap())</code>"\]:::pushClass
-8v1[/"(8v1) <code>map(|x: Max&lt;_&gt;| (context.current_tick(), x.into_reveal()))</code>"\]:::pushClass
-9v1[/"(9v1) <code>for_each(|x| max_send.send(x).unwrap())</code>"\]:::pushClass
-10v1[/"(10v1) <code>null()</code>"\]:::pushClass
+5v1["(5v1) <code>singleton</code>"]:::otherClass
+6v1[\"(6v1) <code>filter(|value| { value &lt;= max_of_stream2.as_reveal_ref() })</code>"/]:::pullClass
+7v1[\"(7v1) <code>map(|x| (context.current_tick(), x))</code>"/]:::pullClass
+8v1[/"(8v1) <code>for_each(|x| filter_send.send(x).unwrap())</code>"\]:::pushClass
+9v1[/"(9v1) <code>map(|x: Max&lt;_&gt;| (context.current_tick(), x.into_reveal()))</code>"\]:::pushClass
+10v1[/"(10v1) <code>for_each(|x| max_send.send(x).unwrap())</code>"\]:::pushClass
 2v1-->3v1
 3v1-->4v1
+4v1-->|state|5v1
+7v1-->8v1
 6v1-->7v1
-5v1-->6v1
-1v1-->5v1
-8v1-->9v1
-4v1-->|items|8v1
-4v1-->|state|10v1
-4v1--x5v1; linkStyle 8 stroke:red
+1v1-->6v1
+9v1-->10v1
+4v1-->|items|9v1
+5v1--x6v1; linkStyle 8 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
     subgraph sg_1v1_var_filtered_stream1 ["var <tt>filtered_stream1</tt>"]
-        5v1
         6v1
         7v1
+        8v1
     end
     subgraph sg_1v1_var_stream1 ["var <tt>stream1</tt>"]
         1v1
     end
 end
 subgraph sg_2v1 ["sg_2v1"]
-    8v1
     9v1
     10v1
-    subgraph sg_2v1_var_max_of_stream2 ["var <tt>max_of_stream2</tt>"]
+    subgraph sg_2v1_var_max_of_stream2_op ["var <tt>max_of_stream2_op</tt>"]
         4v1
     end
     subgraph sg_2v1_var_stream2 ["var <tt>stream2</tt>"]

--- a/dfir_rs/tests/snapshots/surface_singleton__state@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_singleton__state@graphvis_dot.snap
@@ -9,23 +9,23 @@ digraph {
     n2v1 [label="(n2v1) source_iter(3..=5)", shape=invhouse, fillcolor="#88aaff"]
     n3v1 [label="(n3v1) map(Max::new)", shape=invhouse, fillcolor="#88aaff"]
     n4v1 [label="(n4v1) state::<'static, Max<_>>()", shape=house, fillcolor="#ffff88"]
-    n5v1 [label="(n5v1) persist::<'static>()", shape=invhouse, fillcolor="#88aaff"]
-    n6v1 [label="(n6v1) filter(|value| { value <= max_of_stream2.as_reveal_ref() })", shape=invhouse, fillcolor="#88aaff"]
-    n7v1 [label="(n7v1) map(|x| (context.current_tick(), x))", shape=invhouse, fillcolor="#88aaff"]
-    n8v1 [label="(n8v1) for_each(|x| filter_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
-    n9v1 [label="(n9v1) map(|x: Max<_>| (context.current_tick(), x.into_reveal()))", shape=house, fillcolor="#ffff88"]
-    n10v1 [label="(n10v1) for_each(|x| max_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
-    n11v1 [label="(n11v1) null()", shape=house, fillcolor="#ffff88"]
+    n5v1 [label="(n5v1) singleton", shape=parallelogram, fillcolor="#ddddff"]
+    n6v1 [label="(n6v1) persist::<'static>()", shape=invhouse, fillcolor="#88aaff"]
+    n7v1 [label="(n7v1) filter(|value| { value <= max_of_stream2.as_reveal_ref() })", shape=invhouse, fillcolor="#88aaff"]
+    n8v1 [label="(n8v1) map(|x| (context.current_tick(), x))", shape=invhouse, fillcolor="#88aaff"]
+    n9v1 [label="(n9v1) for_each(|x| filter_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
+    n10v1 [label="(n10v1) map(|x: Max<_>| (context.current_tick(), x.into_reveal()))", shape=house, fillcolor="#ffff88"]
+    n11v1 [label="(n11v1) for_each(|x| max_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
     n2v1 -> n3v1
     n3v1 -> n4v1
+    n4v1 -> n5v1 [label="state"]
+    n8v1 -> n9v1
     n7v1 -> n8v1
     n6v1 -> n7v1
-    n5v1 -> n6v1
-    n1v1 -> n5v1
-    n9v1 -> n10v1
-    n4v1 -> n9v1 [label="items"]
-    n4v1 -> n11v1 [label="state"]
-    n4v1 -> n6v1 [color=red]
+    n1v1 -> n6v1
+    n10v1 -> n11v1
+    n4v1 -> n10v1 [label="items"]
+    n5v1 -> n7v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
@@ -34,10 +34,10 @@ digraph {
         subgraph sg_1v1_var_filtered_stream1 {
             cluster=true
             label="var filtered_stream1"
-            n5v1
             n6v1
             n7v1
             n8v1
+            n9v1
         }
         subgraph sg_1v1_var_stream1 {
             cluster=true
@@ -50,12 +50,11 @@ digraph {
         fillcolor="#dddddd"
         style=filled
         label = "sg_2v1"
-        n9v1
         n10v1
         n11v1
-        subgraph sg_2v1_var_max_of_stream2 {
+        subgraph sg_2v1_var_max_of_stream2_op {
             cluster=true
-            label="var max_of_stream2"
+            label="var max_of_stream2_op"
             n4v1
         }
         subgraph sg_2v1_var_stream2 {

--- a/dfir_rs/tests/snapshots/surface_singleton__state@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_singleton__state@graphvis_mermaid.snap
@@ -12,39 +12,38 @@ linkStyle default stroke:#aaa
 2v1[\"(2v1) <code>source_iter(3..=5)</code>"/]:::pullClass
 3v1[\"(3v1) <code>map(Max::new)</code>"/]:::pullClass
 4v1[/"(4v1) <code>state::&lt;'static, Max&lt;_&gt;&gt;()</code>"\]:::pushClass
-5v1[\"(5v1) <code>persist::&lt;'static&gt;()</code>"/]:::pullClass
-6v1[\"(6v1) <code>filter(|value| { value &lt;= max_of_stream2.as_reveal_ref() })</code>"/]:::pullClass
-7v1[\"(7v1) <code>map(|x| (context.current_tick(), x))</code>"/]:::pullClass
-8v1[/"(8v1) <code>for_each(|x| filter_send.send(x).unwrap())</code>"\]:::pushClass
-9v1[/"(9v1) <code>map(|x: Max&lt;_&gt;| (context.current_tick(), x.into_reveal()))</code>"\]:::pushClass
-10v1[/"(10v1) <code>for_each(|x| max_send.send(x).unwrap())</code>"\]:::pushClass
-11v1[/"(11v1) <code>null()</code>"\]:::pushClass
+5v1["(5v1) <code>singleton</code>"]:::otherClass
+6v1[\"(6v1) <code>persist::&lt;'static&gt;()</code>"/]:::pullClass
+7v1[\"(7v1) <code>filter(|value| { value &lt;= max_of_stream2.as_reveal_ref() })</code>"/]:::pullClass
+8v1[\"(8v1) <code>map(|x| (context.current_tick(), x))</code>"/]:::pullClass
+9v1[/"(9v1) <code>for_each(|x| filter_send.send(x).unwrap())</code>"\]:::pushClass
+10v1[/"(10v1) <code>map(|x: Max&lt;_&gt;| (context.current_tick(), x.into_reveal()))</code>"\]:::pushClass
+11v1[/"(11v1) <code>for_each(|x| max_send.send(x).unwrap())</code>"\]:::pushClass
 2v1-->3v1
 3v1-->4v1
+4v1-->|state|5v1
+8v1-->9v1
 7v1-->8v1
 6v1-->7v1
-5v1-->6v1
-1v1-->5v1
-9v1-->10v1
-4v1-->|items|9v1
-4v1-->|state|11v1
-4v1--x6v1; linkStyle 9 stroke:red
+1v1-->6v1
+10v1-->11v1
+4v1-->|items|10v1
+5v1--x7v1; linkStyle 9 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
     subgraph sg_1v1_var_filtered_stream1 ["var <tt>filtered_stream1</tt>"]
-        5v1
         6v1
         7v1
         8v1
+        9v1
     end
     subgraph sg_1v1_var_stream1 ["var <tt>stream1</tt>"]
         1v1
     end
 end
 subgraph sg_2v1 ["sg_2v1"]
-    9v1
     10v1
     11v1
-    subgraph sg_2v1_var_max_of_stream2 ["var <tt>max_of_stream2</tt>"]
+    subgraph sg_2v1_var_max_of_stream2_op ["var <tt>max_of_stream2_op</tt>"]
         4v1
     end
     subgraph sg_2v1_var_stream2 ["var <tt>stream2</tt>"]

--- a/dfir_rs/tests/surface_lattice_bimorphism.rs
+++ b/dfir_rs/tests/surface_lattice_bimorphism.rs
@@ -16,17 +16,17 @@ pub fn test_cartesian_product() {
     let (out_send, out_recv) = dfir_rs::util::unbounded_channel::<_>();
 
     let mut df = dfir_syntax! {
-        lhs = source_iter(0..3)
+        lhs_op = source_iter(0..3)
             -> map(SetUnionSingletonSet::new_from)
             -> state::<'static, SetUnionHashSet<u32>>();
-        rhs = source_iter(3..5)
+        rhs_op = source_iter(3..5)
             -> map(SetUnionSingletonSet::new_from)
             -> state::<'static, SetUnionHashSet<u32>>();
 
-        lhs[items] -> [0]my_join;
-        rhs[items] -> [1]my_join;
-        lhs[state] -> null();
-        rhs[state] -> null();
+        lhs_op[items] -> [0]my_join;
+        rhs_op[items] -> [1]my_join;
+        lhs = lhs_op[state] -> singleton();
+        rhs = rhs_op[state] -> singleton();
 
         my_join = lattice_bimorphism(CartesianProductBimorphism::<HashSet<_>>::default(), #lhs, #rhs)
             -> for_each(|x| out_send.send(x).unwrap());
@@ -53,17 +53,17 @@ pub fn test_cartesian_product_1401() {
     let (out_send, out_recv) = dfir_rs::util::unbounded_channel::<_>();
 
     let mut df = dfir_syntax! {
-        lhs = source_iter(0..1)
+        lhs_op = source_iter(0..1)
             -> map(SetUnionSingletonSet::new_from)
             -> state::<'static, SetUnionHashSet<u32>>();
-        rhs = source_iter(1..2)
+        rhs_op = source_iter(1..2)
             -> map(SetUnionSingletonSet::new_from)
             -> state::<'static, SetUnionHashSet<u32>>();
 
-        lhs[items] -> [0]my_join;
-        rhs[items] -> [1]my_join;
-        lhs[state] -> null();
-        rhs[state] -> null();
+        lhs_op[items] -> [0]my_join;
+        rhs_op[items] -> [1]my_join;
+        lhs = lhs_op[state] -> singleton();
+        rhs = rhs_op[state] -> singleton();
 
         my_join = lattice_bimorphism(CartesianProductBimorphism::<HashSet<_>>::default(), #lhs, #rhs)
             -> for_each(|x| out_send.send(x).unwrap());
@@ -82,17 +82,17 @@ pub fn test_join() {
     let (out_send, out_recv) = dfir_rs::util::unbounded_channel::<_>();
 
     let mut df = dfir_syntax! {
-        lhs = source_iter([(7, 1), (7, 2)])
+        lhs_op = source_iter([(7, 1), (7, 2)])
             -> map(|(k, v)| MapUnionSingletonMap::new_from((k, SetUnionSingletonSet::new_from(v))))
             -> state::<'static, MapUnionHashMap<usize, SetUnionHashSet<usize>>>();
-        rhs = source_iter([(7, 0), (7, 1), (7, 2)])
+        rhs_op = source_iter([(7, 0), (7, 1), (7, 2)])
             -> map(|(k, v)| MapUnionSingletonMap::new_from((k, SetUnionSingletonSet::new_from(v))))
             -> state::<'static, MapUnionHashMap<usize, SetUnionHashSet<usize>>>();
 
-        lhs[items] -> [0]my_join;
-        rhs[items] -> [1]my_join;
-        lhs[state] -> null();
-        rhs[state] -> null();
+        lhs_op[items] -> [0]my_join;
+        rhs_op[items] -> [1]my_join;
+        lhs = lhs_op[state] -> singleton();
+        rhs = rhs_op[state] -> singleton();
 
         my_join = lattice_bimorphism(KeyedBimorphism::<HashMap<_, _>, _>::new(CartesianProductBimorphism::<HashSet<_>>::default()), #lhs, #rhs)
             -> for_each(|x| out_send.send(x).unwrap());
@@ -125,17 +125,17 @@ pub fn test_cartesian_product_tick_state() {
     let (out_send, mut out_recv) = dfir_rs::util::unbounded_channel::<_>();
 
     let mut df = dfir_syntax! {
-        lhs = source_stream(lhs_recv)
+        lhs_op = source_stream(lhs_recv)
             -> map(SetUnionSingletonSet::new_from)
             -> state::<'tick, SetUnionHashSet<u32>>();
-        rhs = source_stream(rhs_recv)
+        rhs_op = source_stream(rhs_recv)
             -> map(SetUnionSingletonSet::new_from)
             -> state::<'tick, SetUnionHashSet<u32>>();
 
-        lhs[items] -> [0]my_join;
-        rhs[items] -> [1]my_join;
-        lhs[state] -> null();
-        rhs[state] -> null();
+        lhs_op[items] -> [0]my_join;
+        rhs_op[items] -> [1]my_join;
+        lhs = lhs_op[state] -> singleton();
+        rhs = rhs_op[state] -> singleton();
 
         my_join = lattice_bimorphism(CartesianProductBimorphism::<HashSet<_>>::default(), #lhs, #rhs)
             -> inspect(|x| println!("{:?}: {:?}", context.current_tick(), x))
@@ -185,7 +185,7 @@ fn test_ght_join_bimorphism() {
     type MyBim = GhtBimorphism<MyNodeBim>;
 
     let mut hf = dfir_syntax! {
-        lhs = source_iter([
+        lhs_op = source_iter([
                 var_expr!(123, 2, 5, "hello"),
                 var_expr!(50, 1, 1, "hi"),
                 var_expr!(5, 1, 7, "hi"),
@@ -193,7 +193,7 @@ fn test_ght_join_bimorphism() {
             ])
             -> map(|row| MyGhtATrie::new_from([row]))
             -> state::<'tick, MyGhtATrie>();
-        rhs = source_iter([
+        rhs_op = source_iter([
                 var_expr!(5, 1, 8, "hi"),
                 var_expr!(5, 1, 7, "world"),
                 var_expr!(5, 1, 7, "folks"),
@@ -203,10 +203,10 @@ fn test_ght_join_bimorphism() {
             -> map(|row| MyGhtBTrie::new_from([row]))
             -> state::<'tick, MyGhtBTrie>();
 
-        lhs[items] -> [0]my_join;
-        rhs[items] -> [1]my_join;
-        lhs[state] -> null();
-        rhs[state] -> null();
+        lhs_op[items] -> [0]my_join;
+        rhs_op[items] -> [1]my_join;
+        lhs = lhs_op[state] -> singleton();
+        rhs = rhs_op[state] -> singleton();
 
 
         my_join = lattice_bimorphism(MyBim::default(), #lhs, #rhs)

--- a/dfir_rs/tests/surface_lattice_bimorphism_persist_insertion.rs
+++ b/dfir_rs/tests/surface_lattice_bimorphism_persist_insertion.rs
@@ -48,17 +48,17 @@ pub fn test_cartesian_product_multi_tick() {
     let (out_send, out_recv) = dfir_rs::util::unbounded_channel::<_>();
 
     let df = dfir_syntax! {
-        lhs = source_stream(lhs_recv)
+        lhs_op = source_stream(lhs_recv)
             -> map(SetUnionSingletonSet::new_from)
             -> state::<'static, SetUnionHashSet<u32>>();
-        rhs = source_stream(rhs_recv)
+        rhs_op = source_stream(rhs_recv)
             -> map(SetUnionSingletonSet::new_from)
             -> state::<'static, SetUnionHashSet<u32>>();
 
-        lhs[items] -> [0]my_join;
-        rhs[items] -> [1]my_join;
-        lhs[state] -> null();
-        rhs[state] -> null();
+        lhs_op[items] -> [0]my_join;
+        rhs_op[items] -> [1]my_join;
+        lhs = lhs_op[state] -> singleton();
+        rhs = rhs_op[state] -> singleton();
 
         my_join = lattice_bimorphism(CartesianProductBimorphism::<HashSet<_>>::default(), #lhs, #rhs)
             -> lattice_reduce()
@@ -76,18 +76,18 @@ pub fn test_cartesian_product_multi_tick_tee() {
     let (out_send, out_recv) = dfir_rs::util::unbounded_channel::<_>();
 
     let df = dfir_syntax! {
-        lhs = source_stream(lhs_recv)
+        lhs_op = source_stream(lhs_recv)
             -> map(SetUnionSingletonSet::new_from)
             -> state::<'static, SetUnionHashSet<u32>>();
-        rhs = source_stream(rhs_recv)
+        rhs_op = source_stream(rhs_recv)
             -> map(SetUnionSingletonSet::new_from)
             -> state::<'static, SetUnionHashSet<u32>>();
-        rhs_tee = rhs[items] -> tee();
+        rhs_tee = rhs_op[items] -> tee();
         rhs_tee -> for_each(|x| println!("tee: {:?}", x));
-        lhs[state] -> null();
-        rhs[state] -> null();
+        lhs = lhs_op[state] -> singleton();
+        rhs = rhs_op[state] -> singleton();
 
-        lhs[items] -> [0]my_join;
+        lhs_op[items] -> [0]my_join;
         rhs_tee -> [1]my_join;
 
         my_join = lattice_bimorphism(CartesianProductBimorphism::<HashSet<_>>::default(), #lhs, #rhs)
@@ -106,17 +106,17 @@ pub fn test_cartesian_product_multi_tick_identity() {
     let (out_send, out_recv) = dfir_rs::util::unbounded_channel::<_>();
 
     let df = dfir_syntax! {
-        lhs = source_stream(lhs_recv)
+        lhs_op = source_stream(lhs_recv)
             -> map(SetUnionSingletonSet::new_from)
             -> state::<'static, SetUnionHashSet<u32>>();
-        rhs = source_stream(rhs_recv)
+        rhs_op = source_stream(rhs_recv)
             -> map(SetUnionSingletonSet::new_from)
             -> state::<'static, SetUnionHashSet<u32>>();
-        rhs_id = rhs[items] -> identity();
-        lhs[state] -> null();
-        rhs[state] -> null();
+        rhs_id = rhs_op[items] -> identity();
+        lhs = lhs_op[state] -> singleton();
+        rhs = rhs_op[state] -> singleton();
 
-        lhs[items] -> [0]my_join;
+        lhs_op[items] -> [0]my_join;
         rhs_id -> [1]my_join;
 
         my_join = lattice_bimorphism(CartesianProductBimorphism::<HashSet<_>>::default(), #lhs, #rhs)

--- a/dfir_rs/tests/surface_lattice_generalized_hash_trie.rs
+++ b/dfir_rs/tests/surface_lattice_generalized_hash_trie.rs
@@ -52,16 +52,16 @@ fn test_join() {
     type MyBim = GhtBimorphism<MyNodeBim>;
 
     let mut df = dfir_syntax! {
-        R = source_iter(r)
+        R_op = source_iter(r)
             -> map(|t| MyGht::new_from([t]))
             -> state::<MyGht>();
-        S = source_iter(s)
+        S_op = source_iter(s)
             -> map(|t| MyGht::new_from([t]))
             -> state::<MyGht>();
-        R[items] -> [0]my_join;
-        S[items] -> [1]my_join;
-        R[state] -> null();
-        S[state] -> null();
+        R_op[items] -> [0]my_join;
+        S_op[items] -> [1]my_join;
+        R = R_op[state] -> singleton();
+        S = S_op[state] -> singleton();
         my_join = lattice_bimorphism(MyBim::default(), #R, #S)
             -> lattice_reduce()
             -> for_each(|x| out_send.send(x).unwrap());

--- a/dfir_rs/tests/surface_singleton.rs
+++ b/dfir_rs/tests/surface_singleton.rs
@@ -12,7 +12,8 @@ pub fn test_state() {
     let mut df = dfir_rs::dfir_syntax! {
         stream1 = source_iter(1..=10);
         stream2 = source_iter(3..=5) -> map(Max::new);
-        max_of_stream2 = stream2 -> state::<'static, Max<_>>();
+        max_of_stream2_op = stream2 -> state::<'static, Max<_>>();
+        max_of_stream2 = max_of_stream2_op[state] -> singleton();
 
         filtered_stream1 = stream1
             -> persist::<'static>()
@@ -23,10 +24,9 @@ pub fn test_state() {
             -> map(|x| (context.current_tick(), x))
             -> for_each(|x| filter_send.send(x).unwrap());
 
-        max_of_stream2[items]
+        max_of_stream2_op[items]
             -> map(|x: Max<_>| (context.current_tick(), x.into_reveal()))
             -> for_each(|x| max_send.send(x).unwrap());
-        max_of_stream2[state] -> null();
     };
     assert_graphvis_snapshots!(df);
 
@@ -170,12 +170,12 @@ pub fn test_fold_singleton() {
     let mut df = dfir_rs::dfir_syntax! {
         stream1 = source_iter(1..=10);
         stream2 = source_iter(3..=5);
-        max_of_stream2 = stream2 -> fold(|| 0, |a, b| *a = std::cmp::max(*a, b));
+        max_of_stream2 = stream2 -> fold(|| 0, |a, b| *a = std::cmp::max(*a, b)) -> singleton();
 
         filtered_stream1 = stream1
             -> filter(|&value| {
                 // This is not monotonic.
-                value <= #max_of_stream2
+                value <= *#max_of_stream2
             })
             -> map(|x| (context.current_tick(), x))
             -> for_each(|x| filter_send.send(x).unwrap());
@@ -211,13 +211,13 @@ pub fn test_fold_singleton_push() {
     let mut df = dfir_rs::dfir_syntax! {
         stream1 = source_iter(1..=10);
         stream2 = source_iter(3..=5);
-        max_of_stream2 = stream2 -> fold(|| 0, |a, b| *a = std::cmp::max(*a, b));
+        max_of_stream2 = stream2 -> fold(|| 0, |a, b| *a = std::cmp::max(*a, b)) -> singleton();
 
         filtered_stream1 = stream1
             -> persist::<'static>()
             -> filter(|&value| {
                 // This is not monotonic.
-                value <= #max_of_stream2
+                value <= *#max_of_stream2
             })
             -> map(|x| (context.current_tick(), x))
             -> for_each(|x| filter_send.send(x).unwrap());
@@ -323,13 +323,13 @@ pub fn test_scheduling() {
     let mut df = dfir_rs::dfir_syntax! {
         stream1 = source_iter(1..=10);
         stream2 = source_stream(inn_recv);
-        max_of_stream2 = stream2 -> fold(|| 0, |a, b| *a = std::cmp::max(*a, b));
+        max_of_stream2 = stream2 -> fold(|| 0, |a, b| *a = std::cmp::max(*a, b)) -> singleton();
 
         filtered_stream1 = stream1
             -> persist::<'static>()
             -> filter(|&value| {
                 // This is not monotonic.
-                value <= #max_of_stream2
+                value <= *#max_of_stream2
             })
             -> map(|x| (context.current_tick(), x))
             -> for_each(|x| out_send.send(x).unwrap());
@@ -368,7 +368,8 @@ pub fn test_multi_tick() {
     let mut df = dfir_rs::dfir_syntax! {
         stream1 = source_iter(1..=10);
         stream2 = source_iter(3..=5) -> map(Max::new);
-        max_of_stream2 = stream2 -> state::<'static, Max<_>>();
+        max_of_stream2_op = stream2 -> state::<'static, Max<_>>();
+        max_of_stream2 = max_of_stream2_op[state] -> singleton();
 
         filtered_stream1 = stream1
             -> filter(|value| {
@@ -378,10 +379,9 @@ pub fn test_multi_tick() {
             -> map(|x| (context.current_tick(), x))
             -> for_each(|x| filter_send.send(x).unwrap());
 
-        max_of_stream2[items]
+        max_of_stream2_op[items]
             -> map(|x: Max<_>| (context.current_tick(), x.into_reveal()))
             -> for_each(|x| max_send.send(x).unwrap());
-        max_of_stream2[state] -> null();
     };
     assert_graphvis_snapshots!(df);
 


### PR DESCRIPTION
Changed 13 operators in dfir_lang to set `has_singleton_output: false` and
use locally-generated idents instead of the framework-provided
`singleton_output_ident`. This means these operators can no longer be
directly referenced via `#varname` — users must pipe through `singleton()`
handoff instead.

Operators changed:
- state, state_by
- fold, fold_keyed, fold_no_replay
- scan, scan_async_blocking
- persist
- repeat_n, prefix, batch, all_once, all_iterations

Left unchanged (for future `optional()` handoff):
- reduce, reduce_no_replay

Also: migrated dfir_rs tests from old singleton mechanism to singleton() handoff

Migrated tests that previously referenced stateful operators (fold, state)
directly via `#varname` to instead route through the new `singleton()` handoff
mechanism.

Changes:
- `lattice_bimorphism` codegen: removed extra `&` on state arguments since
  `#varname` on singleton() already provides `&T` (was `&#expr` → now `#expr`)
- `lattice_bimorphism` doc example updated to use new pattern
- `surface_lattice_bimorphism.rs`: 5 tests migrated (state → singleton())
- `surface_lattice_bimorphism_persist_insertion.rs`: 3 tests migrated
- `surface_lattice_generalized_hash_trie.rs`: 1 test migrated
- `surface_singleton.rs`: 5 tests migrated (test_state, test_multi_tick use
  `state[state] -> singleton()`; test_fold_singleton, test_fold_singleton_push,
  test_scheduling use `fold(...) -> singleton()`)
- Compile-fail tests updated: surface_singleton_badexpr.rs and
  surface_singleton_mutation.rs now use `-> singleton()`
- Snapshot files updated/deleted as needed

Co-authored-by: Infinity 🤖 <infinity@hydro.run>