### PR TITLE
feat(dfir_lang): Add `optional()` handoff, migrate `reduce()` tests, all `has_singleton_output` are `false`

### DIFF
--- a/dfir_lang/src/graph/flat_graph_builder.rs
+++ b/dfir_lang/src/graph/flat_graph_builder.rs
@@ -867,7 +867,8 @@ impl FlatGraphBuilder {
                     // Validate arity: handoff must have exactly 1 input and 1 output.
                     let op_name = match kind {
                         HandoffKind::Vec => "handoff",
-                        HandoffKind::Option => "singleton",
+                        HandoffKind::Singleton => "singleton",
+                        HandoffKind::Optional => "optional",
                     };
                     let inn_degree = self.flat_graph.node_degree_in(node_id);
                     emit_arity_error(

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -857,8 +857,10 @@ impl DfirGraph {
     /// Resolve the singletons via [`Self::node_singleton_references`] for the given `node_id`.
     /// Returns token streams for each reference:
     /// - For stateful operators: `&singleton_op_XXX` or `&mut singleton_op_XXX`
-    /// - For HandoffKind::Option: `&(hoff_XXX_buf.as_ref().unwrap())` (shared) or
+    /// - For HandoffKind::Singleton: `&(hoff_XXX_buf.as_ref().unwrap())` (shared) or
     ///   `&mut(hoff_XXX_buf.as_mut().unwrap())` (mutable)
+    /// - For HandoffKind::Optional: `&(hoff_XXX_buf)` (shared) or `&mut(hoff_XXX_buf)` (mutable)
+    /// - For HandoffKind::Vec: `&(hoff_XXX_buf)` (shared) or `&mut(hoff_XXX_buf)` (mutable)
     fn helper_resolve_singletons(&self, node_id: GraphNodeId, span: Span) -> Vec<TokenStream> {
         self.node_singleton_references(node_id)
             .iter()
@@ -890,12 +892,12 @@ impl DfirGraph {
                     } => {
                         let buf_ident = self.hoff_buf_ident(ref_node_id, span);
                         if is_mut {
-                            // `&mut(buf)` produces `&mut Vec<T>` so that
-                            // postprocess_singletons' `(*expr)` deref gives `Vec<T>` as a place.
+                            // `&mut(buf)` produces `&mut Option<T>` so that
+                            // postprocess_singletons' `(*expr)` deref gives `Option<T>` as a place.
                             quote_spanned! {span=> &mut(#buf_ident) }
                         } else {
-                            // `&(buf)` produces `&Vec<T>` so that
-                            // postprocess_singletons' `(*expr)` deref gives `Vec<T>` as a place.
+                            // `&(buf)` produces `&Option<T>` so that
+                            // postprocess_singletons' `(*expr)` deref gives `Option<T>` as a place.
                             quote_spanned! {span=> &(#buf_ident) }
                         }
                     }
@@ -905,12 +907,12 @@ impl DfirGraph {
                     } => {
                         let buf_ident = self.hoff_buf_ident(ref_node_id, span);
                         if is_mut {
-                            // `&mut(buf)` produces `&mut Option<T>` so that
-                            // postprocess_singletons' `(*expr)` deref gives `Option<T>` as a place.
+                            // `&mut(buf)` produces `&mut Vec<T>` so that
+                            // postprocess_singletons' `(*expr)` deref gives `Vec<T>` as a place.
                             quote_spanned! {span=> &mut(#buf_ident) }
                         } else {
-                            // `&(buf)` produces `&Option<T>` so that
-                            // postprocess_singletons' `(*expr)` deref gives `Option<T>` as a place.
+                            // `&(buf)` produces `&Vec<T>` so that
+                            // postprocess_singletons' `(*expr)` deref gives `Vec<T>` as a place.
                             quote_spanned! {span=> &(#buf_ident) }
                         }
                     }

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -271,7 +271,8 @@ impl DfirGraph {
             // Recognize `handoff()`/`singleton()` pseudo-operators and lower to GraphNode::Handoff.
             let handoff_kind = match &*operator.name_string() {
                 "handoff" => Some(HandoffKind::Vec),
-                "singleton" => Some(HandoffKind::Option),
+                "singleton" => Some(HandoffKind::Singleton),
+                "optional" => Some(HandoffKind::Optional),
                 _ => None,
             };
             if let Some(kind) = handoff_kind {
@@ -820,7 +821,7 @@ impl DfirGraph {
                 if is_pred { "recv" } else { "send" }
             ),
             GraphNode::Handoff {
-                kind: HandoffKind::Option,
+                kind: HandoffKind::Singleton | HandoffKind::Optional,
                 ..
             } => format!(
                 "singleton_{:?}_{}",
@@ -858,7 +859,6 @@ impl DfirGraph {
     /// - For stateful operators: `&singleton_op_XXX` or `&mut singleton_op_XXX`
     /// - For HandoffKind::Option: `&(hoff_XXX_buf.as_ref().unwrap())` (shared) or
     ///   `&mut(hoff_XXX_buf.as_mut().unwrap())` (mutable)
-    /// - For HandoffKind::Vec: `&(&#buf)` (shared) or `&mut(&mut #buf)` (mutable)
     fn helper_resolve_singletons(&self, node_id: GraphNodeId, span: Span) -> Vec<TokenStream> {
         self.node_singleton_references(node_id)
             .iter()
@@ -868,48 +868,59 @@ impl DfirGraph {
                     .node_id
                     .expect("Expected singleton to be resolved but was not, this is a bug.");
                 let is_mut = resolved_ref.is_mut;
-                if matches!(
-                    self.node(ref_node_id),
+                match self.node(ref_node_id) {
                     GraphNode::Handoff {
-                        kind: HandoffKind::Option,
+                        kind: HandoffKind::Singleton,
                         ..
+                    } => {
+                        let buf_ident = self.hoff_buf_ident(ref_node_id, span);
+                        if is_mut {
+                            // `&mut(buf.as_mut().unwrap())` produces `&mut &mut T` so that
+                            // postprocess_singletons' `(*expr)` deref gives `&mut T`.
+                            quote_spanned! {span=> &mut(#buf_ident.as_mut().unwrap()) }
+                        } else {
+                            // `&(buf.as_ref().unwrap())` produces `&&T` so that
+                            // postprocess_singletons' `(*expr)` deref gives `&T`.
+                            quote_spanned! {span=> &(#buf_ident.as_ref().unwrap()) }
+                        }
                     }
-                ) {
-                    let buf_ident = self.hoff_buf_ident(ref_node_id, span);
-                    if is_mut {
-                        // `&mut(buf.as_mut().unwrap())` produces `&mut &mut T` so that
-                        // postprocess_singletons' `(*expr)` deref gives `&mut T`.
-                        quote_spanned! {span=> &mut(#buf_ident.as_mut().unwrap()) }
-                    } else {
-                        // `&(buf.as_ref().unwrap())` produces `&&T` so that
-                        // postprocess_singletons' `(*expr)` deref gives `&T`.
-                        quote_spanned! {span=> &(#buf_ident.as_ref().unwrap()) }
+                    GraphNode::Handoff {
+                        kind: HandoffKind::Optional,
+                        ..
+                    } => {
+                        let buf_ident = self.hoff_buf_ident(ref_node_id, span);
+                        if is_mut {
+                            // `&mut(buf)` produces `&mut Vec<T>` so that
+                            // postprocess_singletons' `(*expr)` deref gives `Vec<T>` as a place.
+                            quote_spanned! {span=> &mut(#buf_ident) }
+                        } else {
+                            // `&(buf)` produces `&Vec<T>` so that
+                            // postprocess_singletons' `(*expr)` deref gives `Vec<T>` as a place.
+                            quote_spanned! {span=> &(#buf_ident) }
+                        }
                     }
-                } else if matches!(
-                    self.node(ref_node_id),
                     GraphNode::Handoff {
                         kind: HandoffKind::Vec,
                         ..
+                    } => {
+                        let buf_ident = self.hoff_buf_ident(ref_node_id, span);
+                        if is_mut {
+                            // `&mut(buf)` produces `&mut Option<T>` so that
+                            // postprocess_singletons' `(*expr)` deref gives `Option<T>` as a place.
+                            quote_spanned! {span=> &mut(#buf_ident) }
+                        } else {
+                            // `&(buf)` produces `&Option<T>` so that
+                            // postprocess_singletons' `(*expr)` deref gives `Option<T>` as a place.
+                            quote_spanned! {span=> &(#buf_ident) }
+                        }
                     }
-                ) {
-                    let buf_ident = self.hoff_buf_ident(ref_node_id, span);
-                    if is_mut {
-                        // `&mut(#buf_ident)` produces `&mut Vec<T>` so that
-                        // postprocess_singletons' `(*expr)` deref gives `Vec<T>` as a place.
-                        // But we actually want `&mut Vec<T>`, so we need an extra indirection:
-                        // `&mut(&mut #buf_ident)` produces `&mut &mut Vec<T>`, deref gives `&mut Vec<T>`.
-                        quote_spanned! {span=> &mut(&mut #buf_ident) }
-                    } else {
-                        // `&(&#buf_ident)` produces `&&Vec<T>` so that
-                        // postprocess_singletons' `(*expr)` deref gives `&Vec<T>`.
-                        quote_spanned! {span=> &(&#buf_ident) }
-                    }
-                } else {
-                    let singleton_ident = self.node_as_singleton_ident(ref_node_id, span);
-                    if is_mut {
-                        quote_spanned! {span=> &mut #singleton_ident }
-                    } else {
-                        quote_spanned! {span=> &#singleton_ident }
+                    _ => {
+                        let singleton_ident = self.node_as_singleton_ident(ref_node_id, span);
+                        if is_mut {
+                            quote_spanned! {span=> &mut #singleton_ident }
+                        } else {
+                            quote_spanned! {span=> &#singleton_ident }
+                        }
                     }
                 }
             })
@@ -1229,7 +1240,7 @@ impl DfirGraph {
 
                         // Compute len and drain expressions based on handoff kind.
                         let (len_expr, drain_expr) = match kind {
-                            HandoffKind::Option => (
+                            HandoffKind::Singleton | HandoffKind::Optional => (
                                 quote! { if #buf_ident.is_some() { 1usize } else { 0usize } },
                                 quote! { #root::dfir_pipes::pull::iter(#buf_ident.take().into_iter()) },
                             ),
@@ -1273,12 +1284,22 @@ impl DfirGraph {
                     .zip(send_kinds.iter())
                     .map(|((port_ident, buf_ident), &kind)| {
                         match kind {
-                            HandoffKind::Option => {
+                            HandoffKind::Singleton => {
                                 // Singleton slot: store exactly one item, panic on duplicate.
                                 quote_spanned! {port_ident.span()=>
                                     let #port_ident = #root::dfir_pipes::push::for_each(|__item| {
                                         if #buf_ident.replace(__item).is_some() {
                                             panic!("singleton() received more than one item");
+                                        }
+                                    });
+                                }
+                            }
+                            HandoffKind::Optional => {
+                                // Optional slot: store at most one item, panic on duplicate.
+                                quote_spanned! {port_ident.span()=>
+                                    let #port_ident = #root::dfir_pipes::push::for_each(|__item| {
+                                        if #buf_ident.replace(__item).is_some() {
+                                            panic!("optional() received more than one item");
                                         }
                                     });
                                 }
@@ -1674,7 +1695,7 @@ impl DfirGraph {
                     .map(|((&hoff_id, buf_ident), &kind)| {
                         let hoff_ffi = hoff_id.data().as_ffi();
                         let len_expr = match kind {
-                            HandoffKind::Option => {
+                            HandoffKind::Singleton | HandoffKind::Optional => {
                                 quote! { if #buf_ident.is_some() { 1 } else { 0 } }
                             }
                             HandoffKind::Vec => {
@@ -1706,7 +1727,7 @@ impl DfirGraph {
                                 HandoffKind::Vec => quote_spanned! {span=>
                                     let mut #buf_ident = #root::bumpalo::collections::Vec::new_in(&#bump_ident);
                                 },
-                                HandoffKind::Option => quote_spanned! {span=>
+                                HandoffKind::Singleton | HandoffKind::Optional => quote_spanned! {span=>
                                     let mut #buf_ident = ::std::option::Option::None;
                                 },
                             }
@@ -2179,10 +2200,16 @@ impl DfirGraph {
                     writeln!(write, "{:?} = handoff();", key.data())?;
                 }
                 GraphNode::Handoff {
-                    kind: HandoffKind::Option,
+                    kind: HandoffKind::Singleton,
                     ..
                 } => {
                     writeln!(write, "{:?} = singleton();", key.data())?;
+                }
+                GraphNode::Handoff {
+                    kind: HandoffKind::Optional,
+                    ..
+                } => {
+                    writeln!(write, "{:?} = optional();", key.data())?;
                 }
                 GraphNode::ModuleBoundary { .. } => panic!(),
             }
@@ -2228,7 +2255,7 @@ impl DfirGraph {
                     writeln!(write, r#"    {:?}{{"{}"}}"#, key.data(), HANDOFF_NODE_STR)
                 }
                 GraphNode::Handoff {
-                    kind: HandoffKind::Option,
+                    kind: HandoffKind::Singleton | HandoffKind::Optional,
                     ..
                 } => {
                     writeln!(

--- a/dfir_lang/src/graph/mod.rs
+++ b/dfir_lang/src/graph/mod.rs
@@ -93,8 +93,12 @@ pub struct Varname(#[serde(with = "serde_syn")] pub Ident);
 pub enum HandoffKind {
     /// A `Vec<T>` buffer for streams (zero or more items).
     Vec,
-    /// An `Option<T>` slot for singletons/optionals (zero or one item).
-    Option,
+    /// An `Option<T>` slot for singletons (exactly one item expected).
+    /// `#varname` gives `&T` (panics if empty).
+    Singleton,
+    /// An `Option<T>` slot for optionals (zero or one item).
+    /// `#varname` gives `&Option<T>`.
+    Optional,
 }
 
 /// A node, corresponding to an operator or a handoff.
@@ -136,7 +140,7 @@ impl GraphNode {
                 ..
             } => HANDOFF_NODE_STR.into(),
             GraphNode::Handoff {
-                kind: HandoffKind::Option,
+                kind: HandoffKind::Singleton | HandoffKind::Optional,
                 ..
             } => SINGLETON_SLOT_NODE_STR.into(),
             GraphNode::ModuleBoundary { .. } => MODULE_BOUNDARY_NODE_STR.into(),
@@ -152,7 +156,7 @@ impl GraphNode {
                 ..
             } => HANDOFF_NODE_STR.into(),
             GraphNode::Handoff {
-                kind: HandoffKind::Option,
+                kind: HandoffKind::Singleton | HandoffKind::Optional,
                 ..
             } => SINGLETON_SLOT_NODE_STR.into(),
             GraphNode::ModuleBoundary { .. } => MODULE_BOUNDARY_NODE_STR.into(),

--- a/dfir_lang/src/graph/ops/reduce.rs
+++ b/dfir_lang/src/graph/ops/reduce.rs
@@ -41,7 +41,7 @@ pub const REDUCE: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=1),
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: true,
+    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,
@@ -54,12 +54,13 @@ pub const REDUCE: OperatorConstraints = OperatorConstraints {
                    ident,
                    inputs,
                    is_pull,
-                   singleton_output_ident,
                    arguments,
                    ..
                },
                diagnostics| {
         let [persistence] = wc.persistence_args_disallow_mutable(diagnostics);
+
+        let singleton_output_ident = wc.make_ident("singleton_output");
 
         let write_prologue = quote_spanned! {op_span=>
             let mut #singleton_output_ident = ::std::option::Option::None;

--- a/dfir_lang/src/graph/ops/reduce_no_replay.rs
+++ b/dfir_lang/src/graph/ops/reduce_no_replay.rs
@@ -24,7 +24,7 @@ pub const REDUCE_NO_REPLAY: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=1),
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: true,
+    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,
@@ -38,12 +38,13 @@ pub const REDUCE_NO_REPLAY: OperatorConstraints = OperatorConstraints {
                    ident,
                    inputs,
                    is_pull,
-                   singleton_output_ident,
                    arguments,
                    ..
                },
                diagnostics| {
         let [persistence] = wc.persistence_args_disallow_mutable(diagnostics);
+
+        let singleton_output_ident = wc.make_ident("singleton_output");
 
         let write_prologue = quote_spanned! {op_span=>
             let mut #singleton_output_ident = ::std::option::Option::None;

--- a/dfir_rs/tests/snapshots/surface_singleton__reduce_singleton@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_singleton__reduce_singleton@graphvis_dot.snap
@@ -8,22 +8,24 @@ digraph {
     n1v1 [label="(n1v1) source_iter(1..=10)", shape=invhouse, fillcolor="#88aaff"]
     n2v1 [label="(n2v1) source_iter(3..=5)", shape=invhouse, fillcolor="#88aaff"]
     n3v1 [label="(n3v1) reduce(|a, b| *a = std::cmp::max(*a, b))", shape=invhouse, fillcolor="#88aaff"]
-    n4v1 [label="(n4v1) persist::<'static>()", shape=invhouse, fillcolor="#88aaff"]
-    n5v1 [label="(n5v1) filter(|&value| { value <= max_of_stream2.unwrap_or(0) })", shape=invhouse, fillcolor="#88aaff"]
-    n6v1 [label="(n6v1) map(|x| (context.current_tick(), x))", shape=invhouse, fillcolor="#88aaff"]
-    n7v1 [label="(n7v1) for_each(|x| filter_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
-    n8v1 [label="(n8v1) map(|x| (context.current_tick(), x))", shape=invhouse, fillcolor="#88aaff"]
-    n9v1 [label="(n9v1) for_each(|x| max_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
-    n10v1 [label="(n10v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n2v1 -> n10v1
+    n4v1 [label="(n4v1) singleton", shape=parallelogram, fillcolor="#ddddff"]
+    n5v1 [label="(n5v1) persist::<'static>()", shape=invhouse, fillcolor="#88aaff"]
+    n6v1 [label="(n6v1) filter(|&value| { value <= max_of_stream2.unwrap_or(0) })", shape=invhouse, fillcolor="#88aaff"]
+    n7v1 [label="(n7v1) map(|x| (context.current_tick(), x))", shape=invhouse, fillcolor="#88aaff"]
+    n8v1 [label="(n8v1) for_each(|x| filter_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
+    n9v1 [label="(n9v1) map(|x| (context.current_tick(), x))", shape=invhouse, fillcolor="#88aaff"]
+    n10v1 [label="(n10v1) for_each(|x| max_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
+    n11v1 [label="(n11v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
+    n3v1 -> n4v1
+    n2v1 -> n11v1
+    n7v1 -> n8v1
     n6v1 -> n7v1
     n5v1 -> n6v1
-    n4v1 -> n5v1
-    n1v1 -> n4v1
-    n8v1 -> n9v1
-    n3v1 -> n8v1
-    n10v1 -> n3v1 [color=red]
-    n3v1 -> n5v1 [color=red]
+    n1v1 -> n5v1
+    n9v1 -> n10v1
+    n4v1 -> n9v1
+    n11v1 -> n3v1 [color=red]
+    n4v1 -> n6v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
@@ -40,18 +42,10 @@ digraph {
         fillcolor="#dddddd"
         style=filled
         label = "sg_2v1"
-        subgraph sg_2v1_var_filtered_stream1 {
+        subgraph sg_2v1_var_max_of_stream2 {
             cluster=true
-            label="var filtered_stream1"
-            n4v1
-            n5v1
-            n6v1
-            n7v1
-        }
-        subgraph sg_2v1_var_stream1 {
-            cluster=true
-            label="var stream1"
-            n1v1
+            label="var max_of_stream2"
+            n3v1
         }
     }
     subgraph sg_3v1 {
@@ -59,12 +53,26 @@ digraph {
         fillcolor="#dddddd"
         style=filled
         label = "sg_3v1"
-        n8v1
-        n9v1
-        subgraph sg_3v1_var_max_of_stream2 {
+        subgraph sg_3v1_var_filtered_stream1 {
             cluster=true
-            label="var max_of_stream2"
-            n3v1
+            label="var filtered_stream1"
+            n5v1
+            n6v1
+            n7v1
+            n8v1
         }
+        subgraph sg_3v1_var_stream1 {
+            cluster=true
+            label="var stream1"
+            n1v1
+        }
+    }
+    subgraph sg_4v1 {
+        cluster=true
+        fillcolor="#dddddd"
+        style=filled
+        label = "sg_4v1"
+        n9v1
+        n10v1
     }
 }

--- a/dfir_rs/tests/snapshots/surface_singleton__reduce_singleton@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_singleton__reduce_singleton@graphvis_mermaid.snap
@@ -11,42 +11,46 @@ linkStyle default stroke:#aaa
 1v1[\"(1v1) <code>source_iter(1..=10)</code>"/]:::pullClass
 2v1[\"(2v1) <code>source_iter(3..=5)</code>"/]:::pullClass
 3v1[\"(3v1) <code>reduce(|a, b| *a = std::cmp::max(*a, b))</code>"/]:::pullClass
-4v1[\"(4v1) <code>persist::&lt;'static&gt;()</code>"/]:::pullClass
-5v1[\"(5v1) <code>filter(|&amp;value| { value &lt;= max_of_stream2.unwrap_or(0) })</code>"/]:::pullClass
-6v1[\"(6v1) <code>map(|x| (context.current_tick(), x))</code>"/]:::pullClass
-7v1[/"(7v1) <code>for_each(|x| filter_send.send(x).unwrap())</code>"\]:::pushClass
-8v1[\"(8v1) <code>map(|x| (context.current_tick(), x))</code>"/]:::pullClass
-9v1[/"(9v1) <code>for_each(|x| max_send.send(x).unwrap())</code>"\]:::pushClass
-10v1["(10v1) <code>handoff</code>"]:::otherClass
-2v1-->10v1
+4v1["(4v1) <code>singleton</code>"]:::otherClass
+5v1[\"(5v1) <code>persist::&lt;'static&gt;()</code>"/]:::pullClass
+6v1[\"(6v1) <code>filter(|&amp;value| { value &lt;= max_of_stream2.unwrap_or(0) })</code>"/]:::pullClass
+7v1[\"(7v1) <code>map(|x| (context.current_tick(), x))</code>"/]:::pullClass
+8v1[/"(8v1) <code>for_each(|x| filter_send.send(x).unwrap())</code>"\]:::pushClass
+9v1[\"(9v1) <code>map(|x| (context.current_tick(), x))</code>"/]:::pullClass
+10v1[/"(10v1) <code>for_each(|x| max_send.send(x).unwrap())</code>"\]:::pushClass
+11v1["(11v1) <code>handoff</code>"]:::otherClass
+3v1-->4v1
+2v1-->11v1
+7v1-->8v1
 6v1-->7v1
 5v1-->6v1
-4v1-->5v1
-1v1-->4v1
-8v1-->9v1
-3v1-->8v1
-10v1--x3v1; linkStyle 7 stroke:red
-3v1--x5v1; linkStyle 8 stroke:red
+1v1-->5v1
+9v1-->10v1
+4v1-->9v1
+11v1--x3v1; linkStyle 8 stroke:red
+4v1--x6v1; linkStyle 9 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
     subgraph sg_1v1_var_stream2 ["var <tt>stream2</tt>"]
         2v1
     end
 end
 subgraph sg_2v1 ["sg_2v1"]
-    subgraph sg_2v1_var_filtered_stream1 ["var <tt>filtered_stream1</tt>"]
-        4v1
-        5v1
-        6v1
-        7v1
-    end
-    subgraph sg_2v1_var_stream1 ["var <tt>stream1</tt>"]
-        1v1
+    subgraph sg_2v1_var_max_of_stream2 ["var <tt>max_of_stream2</tt>"]
+        3v1
     end
 end
 subgraph sg_3v1 ["sg_3v1"]
-    8v1
-    9v1
-    subgraph sg_3v1_var_max_of_stream2 ["var <tt>max_of_stream2</tt>"]
-        3v1
+    subgraph sg_3v1_var_filtered_stream1 ["var <tt>filtered_stream1</tt>"]
+        5v1
+        6v1
+        7v1
+        8v1
     end
+    subgraph sg_3v1_var_stream1 ["var <tt>stream1</tt>"]
+        1v1
+    end
+end
+subgraph sg_4v1 ["sg_4v1"]
+    9v1
+    10v1
 end

--- a/dfir_rs/tests/snapshots/surface_singleton__reduce_singleton_push@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_singleton__reduce_singleton_push@graphvis_dot.snap
@@ -7,19 +7,21 @@ digraph {
     edge [fontname="Monaco,Menlo,Consolas,&quot;Droid Sans Mono&quot;,Inconsolata,&quot;Courier New&quot;,monospace"];
     n1v1 [label="(n1v1) source_iter(1..=10)", shape=invhouse, fillcolor="#88aaff"]
     n2v1 [label="(n2v1) source_iter(3..=5)", shape=invhouse, fillcolor="#88aaff"]
-    n3v1 [label="(n3v1) reduce(|a, b| *a = std::cmp::max(*a, b))", shape=house, fillcolor="#ffff88"]
-    n4v1 [label="(n4v1) persist::<'static>()", shape=invhouse, fillcolor="#88aaff"]
-    n5v1 [label="(n5v1) filter(|&value| { value <= max_of_stream2.unwrap_or(0) })", shape=invhouse, fillcolor="#88aaff"]
-    n6v1 [label="(n6v1) map(|x| (context.current_tick(), x))", shape=invhouse, fillcolor="#88aaff"]
-    n7v1 [label="(n7v1) for_each(|x| filter_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
-    n8v1 [label="(n8v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
-    n2v1 -> n8v1
+    n3v1 [label="(n3v1) reduce(|a, b| *a = std::cmp::max(*a, b))", shape=invhouse, fillcolor="#88aaff"]
+    n4v1 [label="(n4v1) singleton", shape=parallelogram, fillcolor="#ddddff"]
+    n5v1 [label="(n5v1) persist::<'static>()", shape=invhouse, fillcolor="#88aaff"]
+    n6v1 [label="(n6v1) filter(|&value| { value <= max_of_stream2.unwrap_or(0) })", shape=invhouse, fillcolor="#88aaff"]
+    n7v1 [label="(n7v1) map(|x| (context.current_tick(), x))", shape=invhouse, fillcolor="#88aaff"]
+    n8v1 [label="(n8v1) for_each(|x| filter_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
+    n9v1 [label="(n9v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
+    n3v1 -> n4v1
+    n2v1 -> n9v1
+    n7v1 -> n8v1
     n6v1 -> n7v1
     n5v1 -> n6v1
-    n4v1 -> n5v1
-    n1v1 -> n4v1
-    n8v1 -> n3v1 [color=red]
-    n3v1 -> n5v1 [color=red]
+    n1v1 -> n5v1
+    n9v1 -> n3v1 [color=red]
+    n4v1 -> n6v1 [color=red]
     subgraph sg_1v1 {
         cluster=true
         fillcolor="#dddddd"
@@ -50,10 +52,10 @@ digraph {
         subgraph sg_3v1_var_filtered_stream1 {
             cluster=true
             label="var filtered_stream1"
-            n4v1
             n5v1
             n6v1
             n7v1
+            n8v1
         }
         subgraph sg_3v1_var_stream1 {
             cluster=true

--- a/dfir_rs/tests/snapshots/surface_singleton__reduce_singleton_push@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_singleton__reduce_singleton_push@graphvis_mermaid.snap
@@ -10,19 +10,21 @@ classDef otherClass fill:#fdc,stroke:#000,text-align:left,white-space:pre
 linkStyle default stroke:#aaa
 1v1[\"(1v1) <code>source_iter(1..=10)</code>"/]:::pullClass
 2v1[\"(2v1) <code>source_iter(3..=5)</code>"/]:::pullClass
-3v1[/"(3v1) <code>reduce(|a, b| *a = std::cmp::max(*a, b))</code>"\]:::pushClass
-4v1[\"(4v1) <code>persist::&lt;'static&gt;()</code>"/]:::pullClass
-5v1[\"(5v1) <code>filter(|&amp;value| { value &lt;= max_of_stream2.unwrap_or(0) })</code>"/]:::pullClass
-6v1[\"(6v1) <code>map(|x| (context.current_tick(), x))</code>"/]:::pullClass
-7v1[/"(7v1) <code>for_each(|x| filter_send.send(x).unwrap())</code>"\]:::pushClass
-8v1["(8v1) <code>handoff</code>"]:::otherClass
-2v1-->8v1
+3v1[\"(3v1) <code>reduce(|a, b| *a = std::cmp::max(*a, b))</code>"/]:::pullClass
+4v1["(4v1) <code>singleton</code>"]:::otherClass
+5v1[\"(5v1) <code>persist::&lt;'static&gt;()</code>"/]:::pullClass
+6v1[\"(6v1) <code>filter(|&amp;value| { value &lt;= max_of_stream2.unwrap_or(0) })</code>"/]:::pullClass
+7v1[\"(7v1) <code>map(|x| (context.current_tick(), x))</code>"/]:::pullClass
+8v1[/"(8v1) <code>for_each(|x| filter_send.send(x).unwrap())</code>"\]:::pushClass
+9v1["(9v1) <code>handoff</code>"]:::otherClass
+3v1-->4v1
+2v1-->9v1
+7v1-->8v1
 6v1-->7v1
 5v1-->6v1
-4v1-->5v1
-1v1-->4v1
-8v1--x3v1; linkStyle 5 stroke:red
-3v1--x5v1; linkStyle 6 stroke:red
+1v1-->5v1
+9v1--x3v1; linkStyle 6 stroke:red
+4v1--x6v1; linkStyle 7 stroke:red
 subgraph sg_1v1 ["sg_1v1"]
     subgraph sg_1v1_var_stream2 ["var <tt>stream2</tt>"]
         2v1
@@ -35,10 +37,10 @@ subgraph sg_2v1 ["sg_2v1"]
 end
 subgraph sg_3v1 ["sg_3v1"]
     subgraph sg_3v1_var_filtered_stream1 ["var <tt>filtered_stream1</tt>"]
-        4v1
         5v1
         6v1
         7v1
+        8v1
     end
     subgraph sg_3v1_var_stream1 ["var <tt>stream1</tt>"]
         1v1

--- a/dfir_rs/tests/surface_singleton.rs
+++ b/dfir_rs/tests/surface_singleton.rs
@@ -246,7 +246,7 @@ pub fn test_reduce_singleton() {
     let mut df = dfir_rs::dfir_syntax! {
         stream1 = source_iter(1..=10);
         stream2 = source_iter(3..=5);
-        max_of_stream2 = stream2 -> reduce(|a, b| *a = std::cmp::max(*a, b));
+        max_of_stream2 = stream2 -> reduce(|a, b| *a = std::cmp::max(*a, b)) -> optional();
 
         filtered_stream1 = stream1
             -> persist::<'static>()
@@ -288,7 +288,7 @@ pub fn test_reduce_singleton_push() {
     let mut df = dfir_rs::dfir_syntax! {
         stream1 = source_iter(1..=10);
         stream2 = source_iter(3..=5);
-        max_of_stream2 = stream2 -> reduce(|a, b| *a = std::cmp::max(*a, b));
+        max_of_stream2 = stream2 -> reduce(|a, b| *a = std::cmp::max(*a, b)) -> optional();
 
         filtered_stream1 = stream1
             -> persist::<'static>()


### PR DESCRIPTION
Introduced `HandoffKind::Optional` as a new handoff variant alongside
`HandoffKind::Singleton` (renamed from the former `HandoffKind::Option`).

Both use `Option<T>` storage and panic on >1 items. The difference is in
`#varname` resolution:
- `singleton()`: `#var` gives `&T` (unwraps, panics if empty)
- `optional()`: `#var` gives `&Option<T>` (exposes optionality)

Changes:
- `HandoffKind::Option` split into `HandoffKind::Singleton` and
  `HandoffKind::Optional`
- `optional()` recognized as a pseudo-operator in dfir_syntax
- `helper_resolve_singletons` handles the three cases separately
- `reduce` and `reduce_no_replay` now have `has_singleton_output: false`
  with locally-generated idents (like all other operators)
- Migrated `test_reduce_singleton` and `test_reduce_singleton_push` to use
  `reduce(...) -> optional()`

Result: **no operators** have `has_singleton_output: true` anymore. The old
mechanism of directly referencing stateful operator internals via `#varname`
is fully removed from the operator side.

Co-authored-by: Infinity 🤖 <infinity@hydro.run>