### PR TITLE
refactor(dfir_lang): remove old singleton mechanism entirely

### DIFF
--- a/dfir_lang/src/graph/flat_graph_builder.rs
+++ b/dfir_lang/src/graph/flat_graph_builder.rs
@@ -850,16 +850,14 @@ impl FlatGraphBuilder {
                                 continue;
                             };
                             let ref_op_constraints = ref_op_inst.op_constraints;
-                            if !ref_op_constraints.has_singleton_output {
-                                self.diagnostics.push(Diagnostic::spanned(
-                                    singleton_ref_token.span(),
-                                    Level::Error,
-                                    format!(
-                                        "Cannot reference operator `{}`. Only operators with singleton state can be referenced.",
-                                        ref_op_constraints.name,
-                                    ),
-                                ));
-                            }
+                            self.diagnostics.push(Diagnostic::spanned(
+                                singleton_ref_token.span(),
+                                Level::Error,
+                                format!(
+                                    "Cannot reference operator `{}`. Use `singleton()`, `optional()`, or `handoff()` to create a referenceable name.",
+                                    ref_op_constraints.name,
+                                ),
+                            ));
                         }
                     }
                 }

--- a/dfir_lang/src/graph/flat_graph_builder.rs
+++ b/dfir_lang/src/graph/flat_graph_builder.rs
@@ -837,10 +837,10 @@ impl FlatGraphBuilder {
                                 // Error already emitted by `connect_operator_links`, "Cannot find referenced name...".
                                 continue;
                             };
-                            // Handoff nodes (Option or Vec) are valid reference targets.
+                            // Handoff nodes are valid reference targets.
                             if matches!(
                                 self.flat_graph.node(singleton_node_id),
-                                GraphNode::Handoff { .. }
+                                GraphNode::Handoff { .. },
                             ) {
                                 continue;
                             }
@@ -887,7 +887,7 @@ impl FlatGraphBuilder {
                         false,
                         true,
                         out_degree,
-                        &(0..=1), /* Both `handoff()` and `singleton()` may be no-output, for use by ref. */
+                        &(0..=1), // Handoffs may be no-output, for use only by ref.
                         &mut self.diagnostics,
                     );
                 }

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -849,11 +849,6 @@ impl DfirGraph {
         Ident::new(&format!("hoff_{:?}_back", hoff_id.data()), span)
     }
 
-    /// For per-node singleton references. Helper to generate a deterministic `Ident` for the given node.
-    fn node_as_singleton_ident(&self, node_id: GraphNodeId, span: Span) -> Ident {
-        Ident::new(&format!("singleton_op_{:?}", node_id.data()), span)
-    }
-
     /// Resolve the singletons via [`Self::node_singleton_references`] for the given `node_id`.
     /// Returns token streams for each reference:
     /// - For HandoffKind::Singleton: `buf.as_ref().unwrap()` (shared, `&T`) or
@@ -884,43 +879,19 @@ impl DfirGraph {
                         }
                     }
                     GraphNode::Handoff {
-                        kind: HandoffKind::Optional,
+                        kind: HandoffKind::Optional | HandoffKind::Vec,
                         ..
                     } => {
                         let buf_ident = self.hoff_buf_ident(ref_node_id, span);
                         if is_mut {
-                            // `&mut(buf)` produces `&mut Option<T>` so that
-                            // postprocess_singletons' `(*expr)` deref gives `Option<T>` as a place.
-                            quote_spanned! {span=> &mut(#buf_ident) }
+                            quote_spanned! {span=> &mut #buf_ident }
                         } else {
-                            // `&(buf)` produces `&Option<T>` so that
-                            // postprocess_singletons' `(*expr)` deref gives `Option<T>` as a place.
-                            quote_spanned! {span=> &(#buf_ident) }
+                            quote_spanned! {span=> &#buf_ident }
                         }
                     }
-                    GraphNode::Handoff {
-                        kind: HandoffKind::Vec,
-                        ..
-                    } => {
-                        let buf_ident = self.hoff_buf_ident(ref_node_id, span);
-                        if is_mut {
-                            // `&mut(buf)` produces `&mut Vec<T>` so that
-                            // postprocess_singletons' `(*expr)` deref gives `Vec<T>` as a place.
-                            quote_spanned! {span=> &mut(#buf_ident) }
-                        } else {
-                            // `&(buf)` produces `&Vec<T>` so that
-                            // postprocess_singletons' `(*expr)` deref gives `Vec<T>` as a place.
-                            quote_spanned! {span=> &(#buf_ident) }
-                        }
-                    }
-                    _ => {
-                        let singleton_ident = self.node_as_singleton_ident(ref_node_id, span);
-                        if is_mut {
-                            quote_spanned! {span=> &mut #singleton_ident }
-                        } else {
-                            quote_spanned! {span=> &#singleton_ident }
-                        }
-                    }
+                    _ => unreachable!(
+                        "Only handoff nodes should be reachable as singleton references"
+                    ),
                 }
             })
             .collect::<Vec<_>>()
@@ -1381,13 +1352,6 @@ impl DfirGraph {
 
                             let is_pull = idx < pull_to_push_idx;
 
-                            let singleton_output_ident = &if op_constraints.has_singleton_output {
-                                self.node_as_singleton_ident(node_id, op_span)
-                            } else {
-                                // This ident *should* go unused.
-                                Ident::new(&format!("{}_has_no_singleton_output", op_name), op_span)
-                            };
-
                             // There's a bit of dark magic hidden in `Span`s... you'd think it's just a `file:line:column`,
                             // but it has one extra bit of info for _name resolution_, used for `Ident`s. `Span::call_site()`
                             // has the (unhygienic) resolution we want, an ident is just solely determined by its string name,
@@ -1462,7 +1426,6 @@ impl DfirGraph {
                                 is_pull,
                                 inputs: &inputs,
                                 outputs: &outputs,
-                                singleton_output_ident,
                                 op_name,
                                 op_inst,
                                 arguments,

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -856,11 +856,12 @@ impl DfirGraph {
 
     /// Resolve the singletons via [`Self::node_singleton_references`] for the given `node_id`.
     /// Returns token streams for each reference:
-    /// - For stateful operators: `&singleton_op_XXX` or `&mut singleton_op_XXX`
-    /// - For HandoffKind::Singleton: `&(hoff_XXX_buf.as_ref().unwrap())` (shared) or
-    ///   `&mut(hoff_XXX_buf.as_mut().unwrap())` (mutable)
-    /// - For HandoffKind::Optional: `&(hoff_XXX_buf)` (shared) or `&mut(hoff_XXX_buf)` (mutable)
-    /// - For HandoffKind::Vec: `&(hoff_XXX_buf)` (shared) or `&mut(hoff_XXX_buf)` (mutable)
+    /// - For HandoffKind::Singleton: `buf.as_ref().unwrap()` (shared, `&T`) or
+    ///   `buf.as_mut().unwrap()` (mutable, `&mut T`)
+    /// - For HandoffKind::Optional: `&buf` (shared, `&Option<T>`) or
+    ///   `&mut buf` (mutable, `&mut Option<T>`)
+    /// - For HandoffKind::Vec: `&buf` (shared, `&Vec<T>`) or
+    ///   `&mut buf` (mutable, `&mut Vec<T>`)
     fn helper_resolve_singletons(&self, node_id: GraphNodeId, span: Span) -> Vec<TokenStream> {
         self.node_singleton_references(node_id)
             .iter()
@@ -877,13 +878,9 @@ impl DfirGraph {
                     } => {
                         let buf_ident = self.hoff_buf_ident(ref_node_id, span);
                         if is_mut {
-                            // `&mut(buf.as_mut().unwrap())` produces `&mut &mut T` so that
-                            // postprocess_singletons' `(*expr)` deref gives `&mut T`.
-                            quote_spanned! {span=> &mut(#buf_ident.as_mut().unwrap()) }
+                            quote_spanned! {span=> #buf_ident.as_mut().unwrap() }
                         } else {
-                            // `&(buf.as_ref().unwrap())` produces `&&T` so that
-                            // postprocess_singletons' `(*expr)` deref gives `&T`.
-                            quote_spanned! {span=> &(#buf_ident.as_ref().unwrap()) }
+                            quote_spanned! {span=> #buf_ident.as_ref().unwrap() }
                         }
                     }
                     GraphNode::Handoff {

--- a/dfir_lang/src/graph/ops/_counter.rs
+++ b/dfir_lang/src/graph/ops/_counter.rs
@@ -43,7 +43,6 @@ pub const _COUNTER: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/_lattice_fold_batch.rs
+++ b/dfir_lang/src/graph/ops/_lattice_fold_batch.rs
@@ -41,7 +41,6 @@ pub const _LATTICE_FOLD_BATCH: OperatorConstraints = OperatorConstraints {
     soft_range_out: RANGE_1,
     num_args: 0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: Some(|| PortListSpec::Fixed(parse_quote! { input, signal })),
     ports_out: None,

--- a/dfir_lang/src/graph/ops/_lattice_join_fused_join.rs
+++ b/dfir_lang/src/graph/ops/_lattice_join_fused_join.rs
@@ -84,7 +84,6 @@ pub const _LATTICE_JOIN_FUSED_JOIN: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=2),
     type_args: &(2..=2),
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { 0, 1 })),
     ports_out: None,

--- a/dfir_lang/src/graph/ops/all_iterations.rs
+++ b/dfir_lang/src/graph/ops/all_iterations.rs
@@ -12,7 +12,6 @@ pub const ALL_ITERATIONS: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: &(0..=1),
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: Some(FloType::Unwindowing),
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/all_once.rs
+++ b/dfir_lang/src/graph/ops/all_once.rs
@@ -14,7 +14,6 @@ pub const ALL_ONCE: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: Some(FloType::Windowing),
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/anti_join.rs
+++ b/dfir_lang/src/graph/ops/anti_join.rs
@@ -33,7 +33,6 @@ pub const ANTI_JOIN: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=2),
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { pos, neg })),
     ports_out: None,

--- a/dfir_lang/src/graph/ops/assert.rs
+++ b/dfir_lang/src/graph/ops/assert.rs
@@ -25,7 +25,6 @@ pub const ASSERT: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/assert_eq.rs
+++ b/dfir_lang/src/graph/ops/assert_eq.rs
@@ -36,7 +36,6 @@ pub const ASSERT_EQ: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/batch.rs
+++ b/dfir_lang/src/graph/ops/batch.rs
@@ -19,7 +19,6 @@ pub const BATCH: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: Some(FloType::Windowing),
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/chain.rs
+++ b/dfir_lang/src/graph/ops/chain.rs
@@ -29,7 +29,6 @@ pub const CHAIN: OperatorConstraints = OperatorConstraints {
     soft_range_out: RANGE_1,
     num_args: 0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/chain_first_n.rs
+++ b/dfir_lang/src/graph/ops/chain_first_n.rs
@@ -33,7 +33,6 @@ pub const CHAIN_FIRST_N: OperatorConstraints = OperatorConstraints {
     soft_range_out: RANGE_1,
     num_args: 1,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/cross_join.rs
+++ b/dfir_lang/src/graph/ops/cross_join.rs
@@ -44,7 +44,6 @@ pub const CROSS_JOIN: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=2),
     type_args: &(0..=1),
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { 0, 1 })),
     ports_out: None,

--- a/dfir_lang/src/graph/ops/cross_join_multiset.rs
+++ b/dfir_lang/src/graph/ops/cross_join_multiset.rs
@@ -34,7 +34,6 @@ pub const CROSS_JOIN_MULTISET: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=2),
     type_args: &(0..=1),
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { 0, 1 })),
     ports_out: None,

--- a/dfir_lang/src/graph/ops/cross_singleton.rs
+++ b/dfir_lang/src/graph/ops/cross_singleton.rs
@@ -38,7 +38,6 @@ pub const CROSS_SINGLETON: OperatorConstraints = OperatorConstraints {
     soft_range_out: RANGE_1,
     num_args: 0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { input, single })),
     ports_out: None,

--- a/dfir_lang/src/graph/ops/defer_signal.rs
+++ b/dfir_lang/src/graph/ops/defer_signal.rs
@@ -33,7 +33,6 @@ pub const DEFER_SIGNAL: OperatorConstraints = OperatorConstraints {
     soft_range_out: RANGE_1,
     num_args: 0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { input, signal })),
     ports_out: None,

--- a/dfir_lang/src/graph/ops/defer_tick.rs
+++ b/dfir_lang/src/graph/ops/defer_tick.rs
@@ -68,7 +68,6 @@ pub const DEFER_TICK: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: &(0..=1),
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/defer_tick_lazy.rs
+++ b/dfir_lang/src/graph/ops/defer_tick_lazy.rs
@@ -16,7 +16,6 @@ pub const DEFER_TICK_LAZY: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/demux_enum.rs
+++ b/dfir_lang/src/graph/ops/demux_enum.rs
@@ -51,7 +51,6 @@ pub const DEMUX_ENUM: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_1,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: Some(|| PortListSpec::Variadic),

--- a/dfir_lang/src/graph/ops/dest_file.rs
+++ b/dfir_lang/src/graph/ops/dest_file.rs
@@ -31,7 +31,6 @@ pub const DEST_FILE: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/dest_sink.rs
+++ b/dfir_lang/src/graph/ops/dest_sink.rs
@@ -91,7 +91,6 @@ pub const DEST_SINK: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/dest_sink_serde.rs
+++ b/dfir_lang/src/graph/ops/dest_sink_serde.rs
@@ -34,7 +34,6 @@ pub const DEST_SINK_SERDE: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/difference.rs
+++ b/dfir_lang/src/graph/ops/difference.rs
@@ -33,7 +33,6 @@ pub const DIFFERENCE: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=2),
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { pos, neg })),
     ports_out: None,

--- a/dfir_lang/src/graph/ops/enumerate.rs
+++ b/dfir_lang/src/graph/ops/enumerate.rs
@@ -30,7 +30,6 @@ pub const ENUMERATE: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=1),
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/filter.rs
+++ b/dfir_lang/src/graph/ops/filter.rs
@@ -29,7 +29,6 @@ pub const FILTER: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/filter_map.rs
+++ b/dfir_lang/src/graph/ops/filter_map.rs
@@ -27,7 +27,6 @@ pub const FILTER_MAP: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/flat_map.rs
+++ b/dfir_lang/src/graph/ops/flat_map.rs
@@ -31,7 +31,6 @@ pub const FLAT_MAP: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/flat_map_stream_blocking.rs
+++ b/dfir_lang/src/graph/ops/flat_map_stream_blocking.rs
@@ -29,7 +29,6 @@ pub const FLAT_MAP_STREAM_BLOCKING: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/flatten.rs
+++ b/dfir_lang/src/graph/ops/flatten.rs
@@ -26,7 +26,6 @@ pub const FLATTEN: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/flatten_stream_blocking.rs
+++ b/dfir_lang/src/graph/ops/flatten_stream_blocking.rs
@@ -27,7 +27,6 @@ pub const FLATTEN_STREAM_BLOCKING: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/fold.rs
+++ b/dfir_lang/src/graph/ops/fold.rs
@@ -43,7 +43,6 @@ pub const FOLD: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=1),
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/fold_keyed.rs
+++ b/dfir_lang/src/graph/ops/fold_keyed.rs
@@ -76,7 +76,6 @@ pub const FOLD_KEYED: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=1),
     type_args: &(0..=2),
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/fold_no_replay.rs
+++ b/dfir_lang/src/graph/ops/fold_no_replay.rs
@@ -25,7 +25,6 @@ pub const FOLD_NO_REPLAY: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=1),
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/for_each.rs
+++ b/dfir_lang/src/graph/ops/for_each.rs
@@ -29,7 +29,6 @@ pub const FOR_EACH: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/identity.rs
+++ b/dfir_lang/src/graph/ops/identity.rs
@@ -32,7 +32,6 @@ pub const IDENTITY: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: &(0..=1),
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/initialize.rs
+++ b/dfir_lang/src/graph/ops/initialize.rs
@@ -25,7 +25,6 @@ pub const INITIALIZE: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/inspect.rs
+++ b/dfir_lang/src/graph/ops/inspect.rs
@@ -29,7 +29,6 @@ pub const INSPECT: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/iter_ref.rs
+++ b/dfir_lang/src/graph/ops/iter_ref.rs
@@ -32,7 +32,6 @@ pub const ITER_REF: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/join.rs
+++ b/dfir_lang/src/graph/ops/join.rs
@@ -89,7 +89,6 @@ pub const JOIN: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=2),
     type_args: &(0..=1),
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { 0, 1 })),
     ports_out: None,

--- a/dfir_lang/src/graph/ops/join_fused.rs
+++ b/dfir_lang/src/graph/ops/join_fused.rs
@@ -106,7 +106,6 @@ pub const JOIN_FUSED: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=2),
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { 0, 1 })),
     ports_out: None,

--- a/dfir_lang/src/graph/ops/join_fused_lhs.rs
+++ b/dfir_lang/src/graph/ops/join_fused_lhs.rs
@@ -33,7 +33,6 @@ pub const JOIN_FUSED_LHS: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=2),
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { 0, 1 })),
     ports_out: None,

--- a/dfir_lang/src/graph/ops/join_fused_rhs.rs
+++ b/dfir_lang/src/graph/ops/join_fused_rhs.rs
@@ -20,7 +20,6 @@ pub const JOIN_FUSED_RHS: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=2),
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { 0, 1 })),
     ports_out: None,

--- a/dfir_lang/src/graph/ops/join_multiset.rs
+++ b/dfir_lang/src/graph/ops/join_multiset.rs
@@ -36,7 +36,6 @@ pub const JOIN_MULTISET: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=2),
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { 0, 1 })),
     ports_out: None,

--- a/dfir_lang/src/graph/ops/join_multiset_half.rs
+++ b/dfir_lang/src/graph/ops/join_multiset_half.rs
@@ -31,7 +31,6 @@ pub const JOIN_MULTISET_HALF: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=2),
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { build, probe })),
     ports_out: None,

--- a/dfir_lang/src/graph/ops/lattice_bimorphism.rs
+++ b/dfir_lang/src/graph/ops/lattice_bimorphism.rs
@@ -52,7 +52,6 @@ pub const LATTICE_BIMORPHISM: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { 0, 1 })),
     ports_out: None,

--- a/dfir_lang/src/graph/ops/lattice_fold.rs
+++ b/dfir_lang/src/graph/ops/lattice_fold.rs
@@ -38,7 +38,6 @@ pub const LATTICE_FOLD: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=1),
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/lattice_reduce.rs
+++ b/dfir_lang/src/graph/ops/lattice_reduce.rs
@@ -39,7 +39,6 @@ pub const LATTICE_REDUCE: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=1),
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/map.rs
+++ b/dfir_lang/src/graph/ops/map.rs
@@ -31,7 +31,6 @@ pub const MAP: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/mod.rs
+++ b/dfir_lang/src/graph/ops/mod.rs
@@ -68,10 +68,6 @@ pub struct OperatorConstraints {
     /// If this operator receives external inputs and therefore must be in
     /// stratum 0.
     pub is_external_input: bool,
-    /// If this operator has a singleton reference output. For stateful operators.
-    /// If true, [`WriteContextArgs::singleton_output_ident`] will be set to a meaningful value in
-    /// the [`Self::write_fn`] invocation.
-    pub has_singleton_output: bool,
     /// Flo semantics type.
     pub flo_type: Option<FloType>,
 
@@ -416,8 +412,6 @@ pub struct WriteContextArgs<'a> {
     pub inputs: &'a [Ident],
     /// Output `Sink` operator idents (or ref idents; used for push).
     pub outputs: &'a [Ident],
-    /// Ident for the singleton output of this operator, if any.
-    pub singleton_output_ident: &'a Ident,
 
     /// Operator name.
     pub op_name: &'static str,

--- a/dfir_lang/src/graph/ops/multiset_delta.rs
+++ b/dfir_lang/src/graph/ops/multiset_delta.rs
@@ -44,7 +44,6 @@ pub const MULTISET_DELTA: OperatorConstraints = OperatorConstraints {
     // to prevent reading uncleared data if this subgraph doesn't run.
     // https://github.com/hydro-project/hydro/issues/1298
     // If `'tick` lifetimes are added.
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/next_iteration.rs
+++ b/dfir_lang/src/graph/ops/next_iteration.rs
@@ -17,7 +17,6 @@ pub const NEXT_ITERATION: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: Some(FloType::NextIteration),
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/null.rs
+++ b/dfir_lang/src/graph/ops/null.rs
@@ -25,7 +25,6 @@ pub const NULL: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: &(0..=1),
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/partition.rs
+++ b/dfir_lang/src/graph/ops/partition.rs
@@ -64,7 +64,6 @@ pub const PARTITION: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: Some(|| PortListSpec::Variadic),

--- a/dfir_lang/src/graph/ops/persist.rs
+++ b/dfir_lang/src/graph/ops/persist.rs
@@ -46,7 +46,6 @@ pub const PERSIST: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_1,
     type_args: &(0..=1),
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/persist_mut.rs
+++ b/dfir_lang/src/graph/ops/persist_mut.rs
@@ -38,7 +38,6 @@ pub const PERSIST_MUT: OperatorConstraints = OperatorConstraints {
     // to prevent reading uncleared data if this subgraph doesn't run.
     // https://github.com/hydro-project/hydro/issues/1298
     // If `'tick` lifetimes are added.
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/persist_mut_keyed.rs
+++ b/dfir_lang/src/graph/ops/persist_mut_keyed.rs
@@ -38,7 +38,6 @@ pub const PERSIST_MUT_KEYED: OperatorConstraints = OperatorConstraints {
     // to prevent reading uncleared data if this subgraph doesn't run.
     // https://github.com/hydro-project/hydro/issues/1298
     // If `'tick` lifetimes are added.
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/prefix.rs
+++ b/dfir_lang/src/graph/ops/prefix.rs
@@ -19,7 +19,6 @@ pub const PREFIX: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: Some(FloType::Windowing),
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/reduce.rs
+++ b/dfir_lang/src/graph/ops/reduce.rs
@@ -41,7 +41,6 @@ pub const REDUCE: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=1),
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/reduce_keyed.rs
+++ b/dfir_lang/src/graph/ops/reduce_keyed.rs
@@ -65,7 +65,6 @@ pub const REDUCE_KEYED: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=1),
     type_args: &(0..=2),
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/reduce_no_replay.rs
+++ b/dfir_lang/src/graph/ops/reduce_no_replay.rs
@@ -24,7 +24,6 @@ pub const REDUCE_NO_REPLAY: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=1),
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/repeat_n.rs
+++ b/dfir_lang/src/graph/ops/repeat_n.rs
@@ -19,7 +19,6 @@ pub const REPEAT_N: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: Some(FloType::Windowing),
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/resolve_futures.rs
+++ b/dfir_lang/src/graph/ops/resolve_futures.rs
@@ -19,7 +19,6 @@ pub const RESOLVE_FUTURES: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/resolve_futures_blocking.rs
+++ b/dfir_lang/src/graph/ops/resolve_futures_blocking.rs
@@ -19,7 +19,6 @@ pub const RESOLVE_FUTURES_BLOCKING: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/resolve_futures_blocking_ordered.rs
+++ b/dfir_lang/src/graph/ops/resolve_futures_blocking_ordered.rs
@@ -20,7 +20,6 @@ pub const RESOLVE_FUTURES_BLOCKING_ORDERED: OperatorConstraints = OperatorConstr
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/resolve_futures_ordered.rs
+++ b/dfir_lang/src/graph/ops/resolve_futures_ordered.rs
@@ -21,7 +21,6 @@ pub const RESOLVE_FUTURES_ORDERED: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/scan.rs
+++ b/dfir_lang/src/graph/ops/scan.rs
@@ -56,7 +56,6 @@ pub const SCAN: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=1),
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/scan_async_blocking.rs
+++ b/dfir_lang/src/graph/ops/scan_async_blocking.rs
@@ -45,7 +45,6 @@ pub const SCAN_ASYNC_BLOCKING: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=1),
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/sort.rs
+++ b/dfir_lang/src/graph/ops/sort.rs
@@ -26,7 +26,6 @@ pub const SORT: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/sort_by_key.rs
+++ b/dfir_lang/src/graph/ops/sort_by_key.rs
@@ -26,7 +26,6 @@ pub const SORT_BY_KEY: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/source_file.rs
+++ b/dfir_lang/src/graph/ops/source_file.rs
@@ -29,7 +29,6 @@ pub const SOURCE_FILE: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: &(0..=1),
     is_external_input: true,
-    has_singleton_output: false,
     flo_type: Some(FloType::Source),
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/source_interval.rs
+++ b/dfir_lang/src/graph/ops/source_interval.rs
@@ -53,7 +53,6 @@ pub const SOURCE_INTERVAL: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: true,
-    has_singleton_output: false,
     flo_type: Some(FloType::Source),
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/source_iter.rs
+++ b/dfir_lang/src/graph/ops/source_iter.rs
@@ -29,7 +29,6 @@ pub const SOURCE_ITER: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: Some(FloType::Source),
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/source_json.rs
+++ b/dfir_lang/src/graph/ops/source_json.rs
@@ -26,7 +26,6 @@ pub const SOURCE_JSON: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: &(0..=1),
     is_external_input: true,
-    has_singleton_output: false,
     flo_type: Some(FloType::Source),
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/source_stdin.rs
+++ b/dfir_lang/src/graph/ops/source_stdin.rs
@@ -28,7 +28,6 @@ pub const SOURCE_STDIN: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: true,
-    has_singleton_output: false,
     flo_type: Some(FloType::Source),
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/source_stream.rs
+++ b/dfir_lang/src/graph/ops/source_stream.rs
@@ -35,7 +35,6 @@ pub const SOURCE_STREAM: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: true,
-    has_singleton_output: false,
     flo_type: Some(FloType::Source),
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/source_stream_serde.rs
+++ b/dfir_lang/src/graph/ops/source_stream_serde.rs
@@ -37,7 +37,6 @@ pub const SOURCE_STREAM_SERDE: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: &(0..=1),
     is_external_input: true,
-    has_singleton_output: false,
     flo_type: Some(FloType::Source),
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/spin.rs
+++ b/dfir_lang/src/graph/ops/spin.rs
@@ -27,7 +27,6 @@ pub const SPIN: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/state.rs
+++ b/dfir_lang/src/graph/ops/state.rs
@@ -36,7 +36,6 @@ pub const STATE: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=1),
     type_args: &(0..=1),
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: Some(|| PortListSpec::Fixed(parse_quote_spanned!(Span::call_site()=> items, state))),

--- a/dfir_lang/src/graph/ops/state_by.rs
+++ b/dfir_lang/src/graph/ops/state_by.rs
@@ -59,7 +59,6 @@ pub const STATE_BY: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=1),
     type_args: &(0..=1),
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: Some(|| PortListSpec::Fixed(parse_quote!(items, state))),

--- a/dfir_lang/src/graph/ops/tee.rs
+++ b/dfir_lang/src/graph/ops/tee.rs
@@ -27,7 +27,6 @@ pub const TEE: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/union.rs
+++ b/dfir_lang/src/graph/ops/union.rs
@@ -31,7 +31,6 @@ pub const UNION: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/unique.rs
+++ b/dfir_lang/src/graph/ops/unique.rs
@@ -52,7 +52,6 @@ pub const UNIQUE: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=1),
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: None,

--- a/dfir_lang/src/graph/ops/unzip.rs
+++ b/dfir_lang/src/graph/ops/unzip.rs
@@ -27,7 +27,6 @@ pub const UNZIP: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: None,
     ports_out: Some(|| super::PortListSpec::Fixed(parse_quote!(0, 1))),

--- a/dfir_lang/src/graph/ops/zip.rs
+++ b/dfir_lang/src/graph/ops/zip.rs
@@ -31,7 +31,6 @@ pub const ZIP: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=2),
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { 0, 1 })),
     ports_out: None,

--- a/dfir_lang/src/graph/ops/zip_longest.rs
+++ b/dfir_lang/src/graph/ops/zip_longest.rs
@@ -36,7 +36,6 @@ pub const ZIP_LONGEST: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=1),
     type_args: RANGE_0,
     is_external_input: false,
-    has_singleton_output: false,
     flo_type: None,
     ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { 0, 1 })),
     ports_out: None,

--- a/dfir_lang/src/process_singletons.rs
+++ b/dfir_lang/src/process_singletons.rs
@@ -29,8 +29,8 @@ pub fn preprocess_singletons(tokens: TokenStream, found: &mut Vec<SingletonRef>)
 /// * `resolved_exprs` - Token streams that correspond 1:1 and in the same
 ///   order as the singleton references within `tokens` (found in-order via [`preprocess_singletons`]).
 ///
-/// For shared refs: generates `(*expr)` — an immutable place expression.
-/// For mutable refs: generates `(*expr)` — a mutable place expression (expr itself is `&mut`).
+/// For shared refs: splices the resolved expression directly (e.g. `&T` or `&Option<T>`).
+/// For mutable refs: splices the resolved expression directly (e.g. `&mut T` or `&mut Option<T>`).
 pub fn postprocess_singletons(
     tokens: TokenStream,
     resolved_exprs: impl IntoIterator<Item = TokenStream>,
@@ -39,16 +39,8 @@ pub fn postprocess_singletons(
     let processed = process_singletons(tokens, &mut |_ref_token| {
         let span = _ref_token.ident.span();
         let expr_tokens = resolved_exprs_iter.next().unwrap();
-        // Emit `(*expr)` so consumers get a place expression.
-        // For shared refs, expr is `&T` so `(*expr)` is immutable.
-        // For mutable refs, expr is `&mut T` so `(*expr)` is mutable.
-        let deref_tokens: TokenStream = std::iter::once(TokenTree::Punct(proc_macro2::Punct::new(
-            '*',
-            proc_macro2::Spacing::Alone,
-        )))
-        .chain(expr_tokens)
-        .collect();
-        let mut group = Group::new(proc_macro2::Delimiter::Parenthesis, deref_tokens);
+        // Wrap in parentheses to preserve precedence.
+        let mut group = Group::new(proc_macro2::Delimiter::Parenthesis, expr_tokens);
         group.set_span(span);
         TokenTree::Group(group)
     });

--- a/dfir_rs/tests/compile-fail/nightly/surface_singleton_mutation.stderr
+++ b/dfir_rs/tests/compile-fail/nightly/surface_singleton_mutation.stderr
@@ -1,19 +1,7 @@
-error[E0308]: mismatched types
-  --> tests/compile-fail/nightly/surface_singleton_mutation.rs:9:35
-   |
- 3 |       let mut df = dfir_rs::dfir_syntax! {
-   |  __________________-
- 4 | |         stream2 = source_iter(3..=5);
- 5 | |         max_of_stream2 = stream2 -> fold(|| 0usize, |a, b| *a = std::cmp::max(*a, b)) -> singleton();
-...  |
- 9 | |                 #max_of_stream2 = 999;
-   | |                                   ^^^ expected `&usize`, found integer
-...  |
-12 | |             -> for_each(|x| println!("{}", x));
-13 | |     };
-   | |_____- expected due to the type of this binding
-   |
-help: consider borrowing here
-   |
- 9 |                 #max_of_stream2 = &999;
-   |                                   +
+error[E0070]: invalid left-hand side of assignment
+ --> tests/compile-fail/nightly/surface_singleton_mutation.rs:9:33
+  |
+8 |             -> map(|x| {
+  |                --- cannot assign to this expression
+9 |                 #max_of_stream2 = 999;
+  |                                 ^

--- a/dfir_rs/tests/compile-fail/nightly/surface_singleton_mutation.stderr
+++ b/dfir_rs/tests/compile-fail/nightly/surface_singleton_mutation.stderr
@@ -1,7 +1,19 @@
-error[E0594]: cannot assign to data in a `&` reference
- --> tests/compile-fail/nightly/surface_singleton_mutation.rs:9:17
-  |
-8 |             -> map(|x| {
-  |                --- this cannot be written to
-9 |                 *#max_of_stream2 = 999;
-  |                 ^^^^^^^^^^^^^^^^^^^^^^ cannot assign
+error[E0308]: mismatched types
+  --> tests/compile-fail/nightly/surface_singleton_mutation.rs:9:35
+   |
+ 3 |       let mut df = dfir_rs::dfir_syntax! {
+   |  __________________-
+ 4 | |         stream2 = source_iter(3..=5);
+ 5 | |         max_of_stream2 = stream2 -> fold(|| 0usize, |a, b| *a = std::cmp::max(*a, b)) -> singleton();
+...  |
+ 9 | |                 #max_of_stream2 = 999;
+   | |                                   ^^^ expected `&usize`, found integer
+...  |
+12 | |             -> for_each(|x| println!("{}", x));
+13 | |     };
+   | |_____- expected due to the type of this binding
+   |
+help: consider borrowing here
+   |
+ 9 |                 #max_of_stream2 = &999;
+   |                                   +

--- a/dfir_rs/tests/compile-fail/nightly/surface_singleton_mutation.stderr
+++ b/dfir_rs/tests/compile-fail/nightly/surface_singleton_mutation.stderr
@@ -1,7 +1,7 @@
-error[E0070]: invalid left-hand side of assignment
- --> tests/compile-fail/nightly/surface_singleton_mutation.rs:9:33
+error[E0594]: cannot assign to data in a `&` reference
+ --> tests/compile-fail/nightly/surface_singleton_mutation.rs:9:17
   |
 8 |             -> map(|x| {
-  |                --- cannot assign to this expression
-9 |                 #max_of_stream2 = 999;
-  |                                 ^
+  |                --- this cannot be written to
+9 |                 *#max_of_stream2 = 999;
+  |                 ^^^^^^^^^^^^^^^^^^^^^^ cannot assign

--- a/dfir_rs/tests/compile-fail/stable/surface_singleton_mutation.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_singleton_mutation.stderr
@@ -1,7 +1,7 @@
-error[E0070]: invalid left-hand side of assignment
- --> tests/compile-fail/stable/surface_singleton_mutation.rs:9:33
+error[E0594]: cannot assign to data in a `&` reference
+ --> tests/compile-fail/stable/surface_singleton_mutation.rs:9:17
   |
 8 |             -> map(|x| {
-  |                --- cannot assign to this expression
-9 |                 #max_of_stream2 = 999;
-  |                                 ^
+  |                --- this cannot be written to
+9 |                 *#max_of_stream2 = 999;
+  |                 ^^^^^^^^^^^^^^^^^^^^^^ cannot assign

--- a/dfir_rs/tests/compile-fail/stable/surface_singleton_mutation.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_singleton_mutation.stderr
@@ -1,19 +1,7 @@
-error[E0308]: mismatched types
-  --> tests/compile-fail/stable/surface_singleton_mutation.rs:9:35
-   |
- 3 |       let mut df = dfir_rs::dfir_syntax! {
-   |  __________________-
- 4 | |         stream2 = source_iter(3..=5);
- 5 | |         max_of_stream2 = stream2 -> fold(|| 0usize, |a, b| *a = std::cmp::max(*a, b)) -> singleton();
-...  |
- 9 | |                 #max_of_stream2 = 999;
-   | |                                   ^^^ expected `&usize`, found integer
-...  |
-12 | |             -> for_each(|x| println!("{}", x));
-13 | |     };
-   | |_____- expected due to the type of this binding
-   |
-help: consider borrowing here
-   |
- 9 |                 #max_of_stream2 = &999;
-   |                                   +
+error[E0070]: invalid left-hand side of assignment
+ --> tests/compile-fail/stable/surface_singleton_mutation.rs:9:33
+  |
+8 |             -> map(|x| {
+  |                --- cannot assign to this expression
+9 |                 #max_of_stream2 = 999;
+  |                                 ^

--- a/dfir_rs/tests/compile-fail/stable/surface_singleton_nostate.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_singleton_nostate.stderr
@@ -1,4 +1,4 @@
-error: Cannot reference operator `null`. Only operators with singleton state can be referenced.
+error: Cannot reference operator `null`. Use `singleton()`, `optional()`, or `handoff()` to create a referenceable name.
  --> tests/compile-fail/stable/surface_singleton_nostate.rs:7:40
   |
 7 |             -> filter(|value| value <= #my_ref.as_reveal_ref())

--- a/dfir_rs/tests/compile-fail/stable/surface_singleton_nostate_undefined.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_singleton_nostate_undefined.stderr
@@ -4,7 +4,7 @@ error: Cannot find referenced name `unknown`; name was never assigned.
 6 |             -> filter(|value| value <= #my_ref.as_reveal_ref() && value <= #unknown.as_reveal_ref())
   |                                                                            ^
 
-error: Cannot reference operator `null`. Only operators with singleton state can be referenced.
+error: Cannot reference operator `null`. Use `singleton()`, `optional()`, or `handoff()` to create a referenceable name.
  --> tests/compile-fail/stable/surface_singleton_nostate_undefined.rs:6:40
   |
 6 |             -> filter(|value| value <= #my_ref.as_reveal_ref() && value <= #unknown.as_reveal_ref())

--- a/dfir_rs/tests/compile-fail/stable/surface_singleton_undefined_nostate.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_singleton_undefined_nostate.stderr
@@ -4,7 +4,7 @@ error: Cannot find referenced name `unknown`; name was never assigned.
 6 |             -> filter(|value| value <= #unknown.as_reveal_ref() && value <= #my_ref.as_reveal_ref())
   |                                        ^
 
-error: Cannot reference operator `null`. Only operators with singleton state can be referenced.
+error: Cannot reference operator `null`. Use `singleton()`, `optional()`, or `handoff()` to create a referenceable name.
  --> tests/compile-fail/stable/surface_singleton_undefined_nostate.rs:6:77
   |
 6 |             -> filter(|value| value <= #unknown.as_reveal_ref() && value <= #my_ref.as_reveal_ref())

--- a/dfir_rs/tests/compile-fail/surface_singleton_mutation.rs
+++ b/dfir_rs/tests/compile-fail/surface_singleton_mutation.rs
@@ -6,7 +6,7 @@ fn main() {
 
         source_iter(1..=3)
             -> map(|x| {
-                #max_of_stream2 = 999;
+                *#max_of_stream2 = 999;
                 x
             })
             -> for_each(|x| println!("{}", x));

--- a/dfir_rs/tests/snapshots/surface_singleton__reduce_singleton@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_singleton__reduce_singleton@graphvis_dot.snap
@@ -10,7 +10,7 @@ digraph {
     n3v1 [label="(n3v1) reduce(|a, b| *a = std::cmp::max(*a, b))", shape=invhouse, fillcolor="#88aaff"]
     n4v1 [label="(n4v1) singleton", shape=parallelogram, fillcolor="#ddddff"]
     n5v1 [label="(n5v1) persist::<'static>()", shape=invhouse, fillcolor="#88aaff"]
-    n6v1 [label="(n6v1) filter(|&value| { value <= (*max_of_stream2).unwrap_or(0) })", shape=invhouse, fillcolor="#88aaff"]
+    n6v1 [label="(n6v1) filter(|&value| { value <= max_of_stream2.unwrap_or(0) })", shape=invhouse, fillcolor="#88aaff"]
     n7v1 [label="(n7v1) map(|x| (context.current_tick(), x))", shape=invhouse, fillcolor="#88aaff"]
     n8v1 [label="(n8v1) for_each(|x| filter_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
     n9v1 [label="(n9v1) map(|x| (context.current_tick(), x))", shape=invhouse, fillcolor="#88aaff"]

--- a/dfir_rs/tests/snapshots/surface_singleton__reduce_singleton@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_singleton__reduce_singleton@graphvis_dot.snap
@@ -10,7 +10,7 @@ digraph {
     n3v1 [label="(n3v1) reduce(|a, b| *a = std::cmp::max(*a, b))", shape=invhouse, fillcolor="#88aaff"]
     n4v1 [label="(n4v1) singleton", shape=parallelogram, fillcolor="#ddddff"]
     n5v1 [label="(n5v1) persist::<'static>()", shape=invhouse, fillcolor="#88aaff"]
-    n6v1 [label="(n6v1) filter(|&value| { value <= max_of_stream2.unwrap_or(0) })", shape=invhouse, fillcolor="#88aaff"]
+    n6v1 [label="(n6v1) filter(|&value| { value <= (*max_of_stream2).unwrap_or(0) })", shape=invhouse, fillcolor="#88aaff"]
     n7v1 [label="(n7v1) map(|x| (context.current_tick(), x))", shape=invhouse, fillcolor="#88aaff"]
     n8v1 [label="(n8v1) for_each(|x| filter_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
     n9v1 [label="(n9v1) map(|x| (context.current_tick(), x))", shape=invhouse, fillcolor="#88aaff"]

--- a/dfir_rs/tests/snapshots/surface_singleton__reduce_singleton@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_singleton__reduce_singleton@graphvis_mermaid.snap
@@ -13,7 +13,7 @@ linkStyle default stroke:#aaa
 3v1[\"(3v1) <code>reduce(|a, b| *a = std::cmp::max(*a, b))</code>"/]:::pullClass
 4v1["(4v1) <code>singleton</code>"]:::otherClass
 5v1[\"(5v1) <code>persist::&lt;'static&gt;()</code>"/]:::pullClass
-6v1[\"(6v1) <code>filter(|&amp;value| { value &lt;= (*max_of_stream2).unwrap_or(0) })</code>"/]:::pullClass
+6v1[\"(6v1) <code>filter(|&amp;value| { value &lt;= max_of_stream2.unwrap_or(0) })</code>"/]:::pullClass
 7v1[\"(7v1) <code>map(|x| (context.current_tick(), x))</code>"/]:::pullClass
 8v1[/"(8v1) <code>for_each(|x| filter_send.send(x).unwrap())</code>"\]:::pushClass
 9v1[\"(9v1) <code>map(|x| (context.current_tick(), x))</code>"/]:::pullClass

--- a/dfir_rs/tests/snapshots/surface_singleton__reduce_singleton@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_singleton__reduce_singleton@graphvis_mermaid.snap
@@ -13,7 +13,7 @@ linkStyle default stroke:#aaa
 3v1[\"(3v1) <code>reduce(|a, b| *a = std::cmp::max(*a, b))</code>"/]:::pullClass
 4v1["(4v1) <code>singleton</code>"]:::otherClass
 5v1[\"(5v1) <code>persist::&lt;'static&gt;()</code>"/]:::pullClass
-6v1[\"(6v1) <code>filter(|&amp;value| { value &lt;= max_of_stream2.unwrap_or(0) })</code>"/]:::pullClass
+6v1[\"(6v1) <code>filter(|&amp;value| { value &lt;= (*max_of_stream2).unwrap_or(0) })</code>"/]:::pullClass
 7v1[\"(7v1) <code>map(|x| (context.current_tick(), x))</code>"/]:::pullClass
 8v1[/"(8v1) <code>for_each(|x| filter_send.send(x).unwrap())</code>"\]:::pushClass
 9v1[\"(9v1) <code>map(|x| (context.current_tick(), x))</code>"/]:::pullClass

--- a/dfir_rs/tests/snapshots/surface_singleton__reduce_singleton_push@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_singleton__reduce_singleton_push@graphvis_dot.snap
@@ -10,7 +10,7 @@ digraph {
     n3v1 [label="(n3v1) reduce(|a, b| *a = std::cmp::max(*a, b))", shape=invhouse, fillcolor="#88aaff"]
     n4v1 [label="(n4v1) singleton", shape=parallelogram, fillcolor="#ddddff"]
     n5v1 [label="(n5v1) persist::<'static>()", shape=invhouse, fillcolor="#88aaff"]
-    n6v1 [label="(n6v1) filter(|&value| { value <= (*max_of_stream2).unwrap_or(0) })", shape=invhouse, fillcolor="#88aaff"]
+    n6v1 [label="(n6v1) filter(|&value| { value <= max_of_stream2.unwrap_or(0) })", shape=invhouse, fillcolor="#88aaff"]
     n7v1 [label="(n7v1) map(|x| (context.current_tick(), x))", shape=invhouse, fillcolor="#88aaff"]
     n8v1 [label="(n8v1) for_each(|x| filter_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
     n9v1 [label="(n9v1) handoff", shape=parallelogram, fillcolor="#ddddff"]

--- a/dfir_rs/tests/snapshots/surface_singleton__reduce_singleton_push@graphvis_dot.snap
+++ b/dfir_rs/tests/snapshots/surface_singleton__reduce_singleton_push@graphvis_dot.snap
@@ -10,7 +10,7 @@ digraph {
     n3v1 [label="(n3v1) reduce(|a, b| *a = std::cmp::max(*a, b))", shape=invhouse, fillcolor="#88aaff"]
     n4v1 [label="(n4v1) singleton", shape=parallelogram, fillcolor="#ddddff"]
     n5v1 [label="(n5v1) persist::<'static>()", shape=invhouse, fillcolor="#88aaff"]
-    n6v1 [label="(n6v1) filter(|&value| { value <= max_of_stream2.unwrap_or(0) })", shape=invhouse, fillcolor="#88aaff"]
+    n6v1 [label="(n6v1) filter(|&value| { value <= (*max_of_stream2).unwrap_or(0) })", shape=invhouse, fillcolor="#88aaff"]
     n7v1 [label="(n7v1) map(|x| (context.current_tick(), x))", shape=invhouse, fillcolor="#88aaff"]
     n8v1 [label="(n8v1) for_each(|x| filter_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
     n9v1 [label="(n9v1) handoff", shape=parallelogram, fillcolor="#ddddff"]

--- a/dfir_rs/tests/snapshots/surface_singleton__reduce_singleton_push@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_singleton__reduce_singleton_push@graphvis_mermaid.snap
@@ -13,7 +13,7 @@ linkStyle default stroke:#aaa
 3v1[\"(3v1) <code>reduce(|a, b| *a = std::cmp::max(*a, b))</code>"/]:::pullClass
 4v1["(4v1) <code>singleton</code>"]:::otherClass
 5v1[\"(5v1) <code>persist::&lt;'static&gt;()</code>"/]:::pullClass
-6v1[\"(6v1) <code>filter(|&amp;value| { value &lt;= (*max_of_stream2).unwrap_or(0) })</code>"/]:::pullClass
+6v1[\"(6v1) <code>filter(|&amp;value| { value &lt;= max_of_stream2.unwrap_or(0) })</code>"/]:::pullClass
 7v1[\"(7v1) <code>map(|x| (context.current_tick(), x))</code>"/]:::pullClass
 8v1[/"(8v1) <code>for_each(|x| filter_send.send(x).unwrap())</code>"\]:::pushClass
 9v1["(9v1) <code>handoff</code>"]:::otherClass

--- a/dfir_rs/tests/snapshots/surface_singleton__reduce_singleton_push@graphvis_mermaid.snap
+++ b/dfir_rs/tests/snapshots/surface_singleton__reduce_singleton_push@graphvis_mermaid.snap
@@ -13,7 +13,7 @@ linkStyle default stroke:#aaa
 3v1[\"(3v1) <code>reduce(|a, b| *a = std::cmp::max(*a, b))</code>"/]:::pullClass
 4v1["(4v1) <code>singleton</code>"]:::otherClass
 5v1[\"(5v1) <code>persist::&lt;'static&gt;()</code>"/]:::pullClass
-6v1[\"(6v1) <code>filter(|&amp;value| { value &lt;= max_of_stream2.unwrap_or(0) })</code>"/]:::pullClass
+6v1[\"(6v1) <code>filter(|&amp;value| { value &lt;= (*max_of_stream2).unwrap_or(0) })</code>"/]:::pullClass
 7v1[\"(7v1) <code>map(|x| (context.current_tick(), x))</code>"/]:::pullClass
 8v1[/"(8v1) <code>for_each(|x| filter_send.send(x).unwrap())</code>"\]:::pushClass
 9v1["(9v1) <code>handoff</code>"]:::otherClass

--- a/dfir_rs/tests/surface_singleton.rs
+++ b/dfir_rs/tests/surface_singleton.rs
@@ -252,7 +252,7 @@ pub fn test_reduce_singleton() {
             -> persist::<'static>()
             -> filter(|&value| {
                 // This is not monotonic.
-                value <= (*#max_of_stream2).unwrap_or(0)
+                value <= #max_of_stream2.unwrap_or(0)
             })
             -> map(|x| (context.current_tick(), x))
             -> for_each(|x| filter_send.send(x).unwrap());
@@ -294,7 +294,7 @@ pub fn test_reduce_singleton_push() {
             -> persist::<'static>()
             -> filter(|&value| {
                 // This is not monotonic.
-                value <= (*#max_of_stream2).unwrap_or(0)
+                value <= #max_of_stream2.unwrap_or(0)
             })
             -> map(|x| (context.current_tick(), x))
             -> for_each(|x| filter_send.send(x).unwrap());

--- a/dfir_rs/tests/surface_singleton.rs
+++ b/dfir_rs/tests/surface_singleton.rs
@@ -252,7 +252,7 @@ pub fn test_reduce_singleton() {
             -> persist::<'static>()
             -> filter(|&value| {
                 // This is not monotonic.
-                value <= #max_of_stream2.unwrap_or(0)
+                value <= (*#max_of_stream2).unwrap_or(0)
             })
             -> map(|x| (context.current_tick(), x))
             -> for_each(|x| filter_send.send(x).unwrap());
@@ -294,7 +294,7 @@ pub fn test_reduce_singleton_push() {
             -> persist::<'static>()
             -> filter(|&value| {
                 // This is not monotonic.
-                value <= #max_of_stream2.unwrap_or(0)
+                value <= (*#max_of_stream2).unwrap_or(0)
             })
             -> map(|x| (context.current_tick(), x))
             -> for_each(|x| filter_send.send(x).unwrap());


### PR DESCRIPTION
Removed `has_singleton_output` field from `OperatorConstraints` and
`singleton_output_ident` from `WriteContextArgs`. Removed the
`node_as_singleton_ident` helper and the old stateful-operator branch
from `helper_resolve_singletons`.

The `#varname` reference validation now unconditionally rejects references
to non-handoff operators with: "Cannot reference operator `{name}`. Use
`singleton()`, `optional()`, or `handoff()` to create a referenceable value."

All `#varname` references must now target handoff nodes
(`singleton()`, `optional()`, or `handoff()`). The old mechanism of directly
referencing operator internals is fully removed.

Co-authored-by: Infinity 🤖 <infinity@hydro.run>