### PR TITLE
fix(hydro_lang): support MinRetries in cross_product

### DIFF
--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -1093,13 +1093,18 @@ where
     /// # stream.map(|i| assert!(expected.contains(&i)));
     /// # }));
     /// # }
-    pub fn cross_product<T2, B2: Boundedness, O2: Ordering>(
+    #[expect(
+        clippy::type_complexity,
+        reason = "MinRetries projection in return type"
+    )]
+    pub fn cross_product<T2, B2: Boundedness, O2: Ordering, R2: Retries>(
         self,
-        other: Stream<T2, L, B2, O2, R>,
-    ) -> Stream<(T, T2), L, B, B2::PreserveOrderIfBounded<O>, R>
+        other: Stream<T2, L, B2, O2, R2>,
+    ) -> Stream<(T, T2), L, B, B2::PreserveOrderIfBounded<O>, <R as MinRetries<R2>>::Min>
     where
         T: Clone,
         T2: Clone,
+        R: MinRetries<R2>,
     {
         self.map(q!(|v| ((), v)))
             .join(other.map(q!(|v| ((), v))))
@@ -2574,14 +2579,19 @@ where
     /// Forms the cross-product (Cartesian product, cross-join) of the items in the 2 input streams.
     /// Unlike [`Stream::cross_product`], the output order is totally ordered when the inputs are
     /// because this is compiled into a nested loop.
-    pub fn cross_product_nested_loop<T2, O2: Ordering + MinOrder<O>>(
+    #[expect(
+        clippy::type_complexity,
+        reason = "MinRetries projection in return type"
+    )]
+    pub fn cross_product_nested_loop<T2, O2: Ordering + MinOrder<O>, R2: Retries>(
         self,
-        other: Stream<T2, L, Bounded, O2, R>,
-    ) -> Stream<(T, T2), L, Bounded, <O2 as MinOrder<O>>::Min, R>
+        other: Stream<T2, L, Bounded, O2, R2>,
+    ) -> Stream<(T, T2), L, Bounded, <O2 as MinOrder<O>>::Min, <R as MinRetries<R2>>::Min>
     where
         B: IsBounded,
         T: Clone,
         T2: Clone,
+        R: MinRetries<R2>,
     {
         let this = self.make_bounded();
         check_matching_location(&this.location, &other.location);
@@ -2596,7 +2606,7 @@ where
                     L,
                     Bounded,
                     <O2 as MinOrder<O>>::Min,
-                    R,
+                    <R as MinRetries<R2>>::Min,
                 >::collection_kind()),
             },
         )
@@ -2649,7 +2659,6 @@ where
         T: Clone,
     {
         keys.keys()
-            .weaken_retries()
             .assume_ordering_trusted::<TotalOrder>(
                 nondet!(/** keyed stream does not depend on ordering of keys */),
             )

--- a/hydro_lang/src/live_collections/stream/networking.rs
+++ b/hydro_lang/src/live_collections/stream/networking.rs
@@ -377,7 +377,7 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Process<'a, L>
 
         // Late joiners will receive no data from this broadcast, which is
         // future-monotone and eventually consistent (a safe under-approximation).
-        self.cross_product(member_ids.weaken_retries())
+        self.cross_product(member_ids)
             .map(q!(|(data, member_id)| (member_id, data)))
             .into_keyed()
             .demux(to, via)

--- a/hydro_test/src/cluster/snapshots/paxos_ir.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir.snap
@@ -594,69 +594,59 @@ expression: built.ir()
                             inner: Cast {
                                 inner: CrossProduct {
                                     left: ObserveNonDet {
-                                        inner: Cast {
-                                            inner: Map {
-                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
-                                                input: Cast {
-                                                    inner: Cast {
-                                                        inner: Filter {
-                                                            f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , bool) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | b | * b }) ; { let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) } }),
-                                                            input: Batch {
-                                                                inner: FoldKeyed {
-                                                                    init: stageleft :: runtime_support :: fn0_type_hint :: < bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | | false }),
-                                                                    acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < bool , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | present , event | { match event { MembershipEvent :: Joined => * present = true , MembershipEvent :: Left => * present = false , } } }),
-                                                                    input: Cast {
-                                                                        inner: Map {
-                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | (k , v) | (MemberId :: from_tagless (k) , v) }),
-                                                                            input: Source {
-                                                                                source: ClusterMembers(
-                                                                                    Cluster(loc1v1),
-                                                                                    Uninit,
-                                                                                ),
-                                                                                metadata: HydroIrMetadata {
-                                                                                    location_id: Cluster(loc1v1),
-                                                                                    collection_kind: Stream {
-                                                                                        bound: Unbounded,
-                                                                                        order: TotalOrder,
-                                                                                        retry: ExactlyOnce,
-                                                                                        element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
-                                                                                    },
-                                                                                },
-                                                                            },
+                                        inner: Map {
+                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; | (k , _) | k }),
+                                            input: Cast {
+                                                inner: Cast {
+                                                    inner: Filter {
+                                                        f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , bool) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; let f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | b | * b }) ; { let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) } }),
+                                                        input: Batch {
+                                                            inner: FoldKeyed {
+                                                                init: stageleft :: runtime_support :: fn0_type_hint :: < bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | | false }),
+                                                                acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < bool , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; | present , event | { match event { MembershipEvent :: Joined => * present = true , MembershipEvent :: Left => * present = false , } } }),
+                                                                input: Cast {
+                                                                    inner: Map {
+                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; | (k , v) | (MemberId :: from_tagless (k) , v) }),
+                                                                        input: Source {
+                                                                            source: ClusterMembers(
+                                                                                Cluster(loc1v1),
+                                                                                Uninit,
+                                                                            ),
                                                                             metadata: HydroIrMetadata {
                                                                                 location_id: Cluster(loc1v1),
                                                                                 collection_kind: Stream {
                                                                                     bound: Unbounded,
                                                                                     order: TotalOrder,
                                                                                     retry: ExactlyOnce,
-                                                                                    element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
+                                                                                    element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
                                                                                 },
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
                                                                             location_id: Cluster(loc1v1),
-                                                                            collection_kind: KeyedStream {
+                                                                            collection_kind: Stream {
                                                                                 bound: Unbounded,
-                                                                                value_order: TotalOrder,
-                                                                                value_retry: ExactlyOnce,
-                                                                                key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
-                                                                                value_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent,
+                                                                                order: TotalOrder,
+                                                                                retry: ExactlyOnce,
+                                                                                element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
                                                                             },
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
                                                                         location_id: Cluster(loc1v1),
-                                                                        collection_kind: KeyedSingleton {
+                                                                        collection_kind: KeyedStream {
                                                                             bound: Unbounded,
+                                                                            value_order: TotalOrder,
+                                                                            value_retry: ExactlyOnce,
                                                                             key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
-                                                                            value_type: bool,
+                                                                            value_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent,
                                                                         },
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(6, Cluster(loc1v1)),
+                                                                    location_id: Cluster(loc1v1),
                                                                     collection_kind: KeyedSingleton {
-                                                                        bound: Bounded,
+                                                                        bound: Unbounded,
                                                                         key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                                                         value_type: bool,
                                                                     },
@@ -673,10 +663,8 @@ expression: built.ir()
                                                         },
                                                         metadata: HydroIrMetadata {
                                                             location_id: Tick(6, Cluster(loc1v1)),
-                                                            collection_kind: KeyedStream {
+                                                            collection_kind: KeyedSingleton {
                                                                 bound: Bounded,
-                                                                value_order: TotalOrder,
-                                                                value_retry: ExactlyOnce,
                                                                 key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                                                 value_type: bool,
                                                             },
@@ -684,11 +672,12 @@ expression: built.ir()
                                                     },
                                                     metadata: HydroIrMetadata {
                                                         location_id: Tick(6, Cluster(loc1v1)),
-                                                        collection_kind: Stream {
+                                                        collection_kind: KeyedStream {
                                                             bound: Bounded,
-                                                            order: NoOrder,
-                                                            retry: ExactlyOnce,
-                                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , bool),
+                                                            value_order: TotalOrder,
+                                                            value_retry: ExactlyOnce,
+                                                            key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
+                                                            value_type: bool,
                                                         },
                                                     },
                                                 },
@@ -698,7 +687,7 @@ expression: built.ir()
                                                         bound: Bounded,
                                                         order: NoOrder,
                                                         retry: ExactlyOnce,
-                                                        element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
+                                                        element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , bool),
                                                     },
                                                 },
                                             },
@@ -707,7 +696,7 @@ expression: built.ir()
                                                 collection_kind: Stream {
                                                     bound: Bounded,
                                                     order: NoOrder,
-                                                    retry: AtLeastOnce,
+                                                    retry: ExactlyOnce,
                                                     element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                                 },
                                             },
@@ -718,7 +707,7 @@ expression: built.ir()
                                             collection_kind: Stream {
                                                 bound: Bounded,
                                                 order: TotalOrder,
-                                                retry: AtLeastOnce,
+                                                retry: ExactlyOnce,
                                                 element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                             },
                                         },

--- a/hydro_test/src/cluster/snapshots/paxos_ir@acceptor_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir@acceptor_mermaid.snap
@@ -130,157 +130,157 @@ subgraph var_cycle_4 ["var <tt>cycle_4</tt>"]
     style var_cycle_4 fill:transparent
     40v1
 end
-subgraph var_reduce_keyed_watermark_chain_525 ["var <tt>reduce_keyed_watermark_chain_525</tt>"]
-    style var_reduce_keyed_watermark_chain_525 fill:transparent
+subgraph var_reduce_keyed_watermark_chain_524 ["var <tt>reduce_keyed_watermark_chain_524</tt>"]
+    style var_reduce_keyed_watermark_chain_524 fill:transparent
     33v1
 end
-subgraph var_stream_163 ["var <tt>stream_163</tt>"]
-    style var_stream_163 fill:transparent
+subgraph var_stream_162 ["var <tt>stream_162</tt>"]
+    style var_stream_162 fill:transparent
     3v1
     4v1
 end
-subgraph var_stream_165 ["var <tt>stream_165</tt>"]
-    style var_stream_165 fill:transparent
+subgraph var_stream_164 ["var <tt>stream_164</tt>"]
+    style var_stream_164 fill:transparent
     5v1
 end
-subgraph var_stream_167 ["var <tt>stream_167</tt>"]
-    style var_stream_167 fill:transparent
+subgraph var_stream_166 ["var <tt>stream_166</tt>"]
+    style var_stream_166 fill:transparent
     6v1
 end
-subgraph var_stream_169 ["var <tt>stream_169</tt>"]
-    style var_stream_169 fill:transparent
+subgraph var_stream_168 ["var <tt>stream_168</tt>"]
+    style var_stream_168 fill:transparent
     7v1
 end
-subgraph var_stream_172 ["var <tt>stream_172</tt>"]
-    style var_stream_172 fill:transparent
+subgraph var_stream_171 ["var <tt>stream_171</tt>"]
+    style var_stream_171 fill:transparent
     8v1
 end
-subgraph var_stream_174 ["var <tt>stream_174</tt>"]
-    style var_stream_174 fill:transparent
+subgraph var_stream_173 ["var <tt>stream_173</tt>"]
+    style var_stream_173 fill:transparent
     9v1
     10v1
 end
-subgraph var_stream_176 ["var <tt>stream_176</tt>"]
-    style var_stream_176 fill:transparent
+subgraph var_stream_175 ["var <tt>stream_175</tt>"]
+    style var_stream_175 fill:transparent
     11v1
 end
-subgraph var_stream_178 ["var <tt>stream_178</tt>"]
-    style var_stream_178 fill:transparent
+subgraph var_stream_177 ["var <tt>stream_177</tt>"]
+    style var_stream_177 fill:transparent
     12v1
 end
-subgraph var_stream_180 ["var <tt>stream_180</tt>"]
-    style var_stream_180 fill:transparent
+subgraph var_stream_179 ["var <tt>stream_179</tt>"]
+    style var_stream_179 fill:transparent
     13v1
+end
+subgraph var_stream_182 ["var <tt>stream_182</tt>"]
+    style var_stream_182 fill:transparent
+    14v1
 end
 subgraph var_stream_183 ["var <tt>stream_183</tt>"]
     style var_stream_183 fill:transparent
-    14v1
-end
-subgraph var_stream_184 ["var <tt>stream_184</tt>"]
-    style var_stream_184 fill:transparent
     15v1
 end
 subgraph var_stream_24 ["var <tt>stream_24</tt>"]
     style var_stream_24 fill:transparent
     1v1
 end
-subgraph var_stream_455 ["var <tt>stream_455</tt>"]
-    style var_stream_455 fill:transparent
+subgraph var_stream_454 ["var <tt>stream_454</tt>"]
+    style var_stream_454 fill:transparent
     18v1
     19v1
 end
-subgraph var_stream_457 ["var <tt>stream_457</tt>"]
-    style var_stream_457 fill:transparent
+subgraph var_stream_456 ["var <tt>stream_456</tt>"]
+    style var_stream_456 fill:transparent
     20v1
 end
-subgraph var_stream_459 ["var <tt>stream_459</tt>"]
-    style var_stream_459 fill:transparent
+subgraph var_stream_458 ["var <tt>stream_458</tt>"]
+    style var_stream_458 fill:transparent
     21v1
+end
+subgraph var_stream_461 ["var <tt>stream_461</tt>"]
+    style var_stream_461 fill:transparent
+    22v1
 end
 subgraph var_stream_462 ["var <tt>stream_462</tt>"]
     style var_stream_462 fill:transparent
-    22v1
-end
-subgraph var_stream_463 ["var <tt>stream_463</tt>"]
-    style var_stream_463 fill:transparent
     23v1
+end
+subgraph var_stream_509 ["var <tt>stream_509</tt>"]
+    style var_stream_509 fill:transparent
+    26v1
 end
 subgraph var_stream_510 ["var <tt>stream_510</tt>"]
     style var_stream_510 fill:transparent
-    26v1
+    27v1
 end
 subgraph var_stream_511 ["var <tt>stream_511</tt>"]
     style var_stream_511 fill:transparent
-    27v1
-end
-subgraph var_stream_512 ["var <tt>stream_512</tt>"]
-    style var_stream_512 fill:transparent
     28v1
     29v1
 end
-subgraph var_stream_514 ["var <tt>stream_514</tt>"]
-    style var_stream_514 fill:transparent
+subgraph var_stream_513 ["var <tt>stream_513</tt>"]
+    style var_stream_513 fill:transparent
     30v1
+end
+subgraph var_stream_518 ["var <tt>stream_518</tt>"]
+    style var_stream_518 fill:transparent
+    31v1
 end
 subgraph var_stream_519 ["var <tt>stream_519</tt>"]
     style var_stream_519 fill:transparent
-    31v1
-end
-subgraph var_stream_520 ["var <tt>stream_520</tt>"]
-    style var_stream_520 fill:transparent
     32v1
 end
-subgraph var_stream_525 ["var <tt>stream_525</tt>"]
-    style var_stream_525 fill:transparent
+subgraph var_stream_524 ["var <tt>stream_524</tt>"]
+    style var_stream_524 fill:transparent
     36v1
     37v1
 end
-subgraph var_stream_529 ["var <tt>stream_529</tt>"]
-    style var_stream_529 fill:transparent
+subgraph var_stream_528 ["var <tt>stream_528</tt>"]
+    style var_stream_528 fill:transparent
     38v1
 end
-subgraph var_stream_530 ["var <tt>stream_530</tt>"]
-    style var_stream_530 fill:transparent
+subgraph var_stream_529 ["var <tt>stream_529</tt>"]
+    style var_stream_529 fill:transparent
     39v1
 end
-subgraph var_stream_642 ["var <tt>stream_642</tt>"]
-    style var_stream_642 fill:transparent
+subgraph var_stream_641 ["var <tt>stream_641</tt>"]
+    style var_stream_641 fill:transparent
     41v1
     42v1
 end
-subgraph var_stream_643 ["var <tt>stream_643</tt>"]
-    style var_stream_643 fill:transparent
+subgraph var_stream_642 ["var <tt>stream_642</tt>"]
+    style var_stream_642 fill:transparent
     43v1
 end
-subgraph var_stream_645 ["var <tt>stream_645</tt>"]
-    style var_stream_645 fill:transparent
+subgraph var_stream_644 ["var <tt>stream_644</tt>"]
+    style var_stream_644 fill:transparent
     44v1
+end
+subgraph var_stream_651 ["var <tt>stream_651</tt>"]
+    style var_stream_651 fill:transparent
+    45v1
 end
 subgraph var_stream_652 ["var <tt>stream_652</tt>"]
     style var_stream_652 fill:transparent
-    45v1
+    46v1
 end
 subgraph var_stream_653 ["var <tt>stream_653</tt>"]
     style var_stream_653 fill:transparent
-    46v1
+    47v1
 end
 subgraph var_stream_654 ["var <tt>stream_654</tt>"]
     style var_stream_654 fill:transparent
-    47v1
+    48v1
 end
 subgraph var_stream_655 ["var <tt>stream_655</tt>"]
     style var_stream_655 fill:transparent
-    48v1
+    49v1
 end
 subgraph var_stream_656 ["var <tt>stream_656</tt>"]
     style var_stream_656 fill:transparent
-    49v1
-end
-subgraph var_stream_657 ["var <tt>stream_657</tt>"]
-    style var_stream_657 fill:transparent
     50v1
 end
-subgraph var_stream_659 ["var <tt>stream_659</tt>"]
-    style var_stream_659 fill:transparent
+subgraph var_stream_658 ["var <tt>stream_658</tt>"]
+    style var_stream_658 fill:transparent
     51v1
 end

--- a/hydro_test/src/cluster/snapshots/paxos_ir@proposer_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir@proposer_mermaid.snap
@@ -626,225 +626,229 @@ subgraph var_cycle_9 ["var <tt>cycle_9</tt>"]
     style var_cycle_9 fill:transparent
     101v1
 end
-subgraph var_stream_102 ["var <tt>stream_102</tt>"]
-    style var_stream_102 fill:transparent
+subgraph var_stream_101 ["var <tt>stream_101</tt>"]
+    style var_stream_101 fill:transparent
     46v1
     47v1
 end
-subgraph var_stream_104 ["var <tt>stream_104</tt>"]
-    style var_stream_104 fill:transparent
+subgraph var_stream_103 ["var <tt>stream_103</tt>"]
+    style var_stream_103 fill:transparent
     48v1
 end
-subgraph var_stream_105 ["var <tt>stream_105</tt>"]
-    style var_stream_105 fill:transparent
+subgraph var_stream_104 ["var <tt>stream_104</tt>"]
+    style var_stream_104 fill:transparent
     49v1
+end
+subgraph var_stream_106 ["var <tt>stream_106</tt>"]
+    style var_stream_106 fill:transparent
+    51v1
 end
 subgraph var_stream_107 ["var <tt>stream_107</tt>"]
     style var_stream_107 fill:transparent
-    51v1
+    52v1
 end
 subgraph var_stream_108 ["var <tt>stream_108</tt>"]
     style var_stream_108 fill:transparent
-    52v1
-end
-subgraph var_stream_109 ["var <tt>stream_109</tt>"]
-    style var_stream_109 fill:transparent
     53v1
 end
-subgraph var_stream_111 ["var <tt>stream_111</tt>"]
-    style var_stream_111 fill:transparent
+subgraph var_stream_110 ["var <tt>stream_110</tt>"]
+    style var_stream_110 fill:transparent
     54v1
 end
-subgraph var_stream_113 ["var <tt>stream_113</tt>"]
-    style var_stream_113 fill:transparent
+subgraph var_stream_112 ["var <tt>stream_112</tt>"]
+    style var_stream_112 fill:transparent
     55v1
 end
-subgraph var_stream_116 ["var <tt>stream_116</tt>"]
-    style var_stream_116 fill:transparent
+subgraph var_stream_115 ["var <tt>stream_115</tt>"]
+    style var_stream_115 fill:transparent
     56v1
 end
-subgraph var_stream_121 ["var <tt>stream_121</tt>"]
-    style var_stream_121 fill:transparent
+subgraph var_stream_120 ["var <tt>stream_120</tt>"]
+    style var_stream_120 fill:transparent
     57v1
 end
-subgraph var_stream_123 ["var <tt>stream_123</tt>"]
-    style var_stream_123 fill:transparent
+subgraph var_stream_122 ["var <tt>stream_122</tt>"]
+    style var_stream_122 fill:transparent
     58v1
+end
+subgraph var_stream_126 ["var <tt>stream_126</tt>"]
+    style var_stream_126 fill:transparent
+    59v1
 end
 subgraph var_stream_127 ["var <tt>stream_127</tt>"]
     style var_stream_127 fill:transparent
-    59v1
+    60v1
 end
 subgraph var_stream_128 ["var <tt>stream_128</tt>"]
     style var_stream_128 fill:transparent
-    60v1
+    61v1
 end
 subgraph var_stream_129 ["var <tt>stream_129</tt>"]
     style var_stream_129 fill:transparent
-    61v1
+    62v1
 end
 subgraph var_stream_130 ["var <tt>stream_130</tt>"]
     style var_stream_130 fill:transparent
-    62v1
+    63v1
 end
 subgraph var_stream_131 ["var <tt>stream_131</tt>"]
     style var_stream_131 fill:transparent
-    63v1
+    64v1
 end
 subgraph var_stream_132 ["var <tt>stream_132</tt>"]
     style var_stream_132 fill:transparent
-    64v1
-end
-subgraph var_stream_133 ["var <tt>stream_133</tt>"]
-    style var_stream_133 fill:transparent
     65v1
     66v1
 end
-subgraph var_stream_135 ["var <tt>stream_135</tt>"]
-    style var_stream_135 fill:transparent
+subgraph var_stream_134 ["var <tt>stream_134</tt>"]
+    style var_stream_134 fill:transparent
     67v1
+end
+subgraph var_stream_136 ["var <tt>stream_136</tt>"]
+    style var_stream_136 fill:transparent
+    68v1
 end
 subgraph var_stream_137 ["var <tt>stream_137</tt>"]
     style var_stream_137 fill:transparent
-    68v1
-end
-subgraph var_stream_138 ["var <tt>stream_138</tt>"]
-    style var_stream_138 fill:transparent
     69v1
+end
+subgraph var_stream_139 ["var <tt>stream_139</tt>"]
+    style var_stream_139 fill:transparent
+    70v1
 end
 subgraph var_stream_140 ["var <tt>stream_140</tt>"]
     style var_stream_140 fill:transparent
-    70v1
+    71v1
 end
 subgraph var_stream_141 ["var <tt>stream_141</tt>"]
     style var_stream_141 fill:transparent
-    71v1
+    72v1
 end
 subgraph var_stream_142 ["var <tt>stream_142</tt>"]
     style var_stream_142 fill:transparent
-    72v1
+    73v1
 end
 subgraph var_stream_143 ["var <tt>stream_143</tt>"]
     style var_stream_143 fill:transparent
-    73v1
+    74v1
 end
 subgraph var_stream_144 ["var <tt>stream_144</tt>"]
     style var_stream_144 fill:transparent
-    74v1
-end
-subgraph var_stream_145 ["var <tt>stream_145</tt>"]
-    style var_stream_145 fill:transparent
     75v1
     76v1
 end
-subgraph var_stream_147 ["var <tt>stream_147</tt>"]
-    style var_stream_147 fill:transparent
+subgraph var_stream_146 ["var <tt>stream_146</tt>"]
+    style var_stream_146 fill:transparent
     77v1
+end
+subgraph var_stream_148 ["var <tt>stream_148</tt>"]
+    style var_stream_148 fill:transparent
+    78v1
 end
 subgraph var_stream_149 ["var <tt>stream_149</tt>"]
     style var_stream_149 fill:transparent
-    78v1
-end
-subgraph var_stream_150 ["var <tt>stream_150</tt>"]
-    style var_stream_150 fill:transparent
     79v1
+end
+subgraph var_stream_151 ["var <tt>stream_151</tt>"]
+    style var_stream_151 fill:transparent
+    80v1
 end
 subgraph var_stream_152 ["var <tt>stream_152</tt>"]
     style var_stream_152 fill:transparent
-    80v1
+    81v1
 end
 subgraph var_stream_153 ["var <tt>stream_153</tt>"]
     style var_stream_153 fill:transparent
-    81v1
+    82v1
 end
 subgraph var_stream_154 ["var <tt>stream_154</tt>"]
     style var_stream_154 fill:transparent
-    82v1
-end
-subgraph var_stream_155 ["var <tt>stream_155</tt>"]
-    style var_stream_155 fill:transparent
     83v1
 end
-subgraph var_stream_158 ["var <tt>stream_158</tt>"]
-    style var_stream_158 fill:transparent
+subgraph var_stream_157 ["var <tt>stream_157</tt>"]
+    style var_stream_157 fill:transparent
     84v1
 end
-subgraph var_stream_160 ["var <tt>stream_160</tt>"]
-    style var_stream_160 fill:transparent
+subgraph var_stream_159 ["var <tt>stream_159</tt>"]
+    style var_stream_159 fill:transparent
     85v1
 end
-subgraph var_stream_187 ["var <tt>stream_187</tt>"]
-    style var_stream_187 fill:transparent
+subgraph var_stream_186 ["var <tt>stream_186</tt>"]
+    style var_stream_186 fill:transparent
     88v1
     89v1
 end
+subgraph var_stream_188 ["var <tt>stream_188</tt>"]
+    style var_stream_188 fill:transparent
+    90v1
+end
 subgraph var_stream_189 ["var <tt>stream_189</tt>"]
     style var_stream_189 fill:transparent
-    90v1
+    91v1
 end
 subgraph var_stream_190 ["var <tt>stream_190</tt>"]
     style var_stream_190 fill:transparent
-    91v1
-end
-subgraph var_stream_191 ["var <tt>stream_191</tt>"]
-    style var_stream_191 fill:transparent
     92v1
+end
+subgraph var_stream_192 ["var <tt>stream_192</tt>"]
+    style var_stream_192 fill:transparent
+    93v1
 end
 subgraph var_stream_193 ["var <tt>stream_193</tt>"]
     style var_stream_193 fill:transparent
-    93v1
-end
-subgraph var_stream_194 ["var <tt>stream_194</tt>"]
-    style var_stream_194 fill:transparent
     94v1
+end
+subgraph var_stream_196 ["var <tt>stream_196</tt>"]
+    style var_stream_196 fill:transparent
+    95v1
 end
 subgraph var_stream_197 ["var <tt>stream_197</tt>"]
     style var_stream_197 fill:transparent
-    95v1
+    96v1
 end
 subgraph var_stream_198 ["var <tt>stream_198</tt>"]
     style var_stream_198 fill:transparent
-    96v1
-end
-subgraph var_stream_199 ["var <tt>stream_199</tt>"]
-    style var_stream_199 fill:transparent
     97v1
+end
+subgraph var_stream_201 ["var <tt>stream_201</tt>"]
+    style var_stream_201 fill:transparent
+    98v1
 end
 subgraph var_stream_202 ["var <tt>stream_202</tt>"]
     style var_stream_202 fill:transparent
-    98v1
+    99v1
 end
 subgraph var_stream_203 ["var <tt>stream_203</tt>"]
     style var_stream_203 fill:transparent
-    99v1
-end
-subgraph var_stream_204 ["var <tt>stream_204</tt>"]
-    style var_stream_204 fill:transparent
     100v1
 end
-subgraph var_stream_206 ["var <tt>stream_206</tt>"]
-    style var_stream_206 fill:transparent
+subgraph var_stream_205 ["var <tt>stream_205</tt>"]
+    style var_stream_205 fill:transparent
     102v1
 end
-subgraph var_stream_209 ["var <tt>stream_209</tt>"]
-    style var_stream_209 fill:transparent
+subgraph var_stream_208 ["var <tt>stream_208</tt>"]
+    style var_stream_208 fill:transparent
     103v1
 end
-subgraph var_stream_211 ["var <tt>stream_211</tt>"]
-    style var_stream_211 fill:transparent
+subgraph var_stream_210 ["var <tt>stream_210</tt>"]
+    style var_stream_210 fill:transparent
     104v1
 end
-subgraph var_stream_214 ["var <tt>stream_214</tt>"]
-    style var_stream_214 fill:transparent
+subgraph var_stream_213 ["var <tt>stream_213</tt>"]
+    style var_stream_213 fill:transparent
     106v1
+end
+subgraph var_stream_216 ["var <tt>stream_216</tt>"]
+    style var_stream_216 fill:transparent
+    107v1
 end
 subgraph var_stream_217 ["var <tt>stream_217</tt>"]
     style var_stream_217 fill:transparent
-    107v1
-end
-subgraph var_stream_218 ["var <tt>stream_218</tt>"]
-    style var_stream_218 fill:transparent
     108v1
+end
+subgraph var_stream_219 ["var <tt>stream_219</tt>"]
+    style var_stream_219 fill:transparent
+    109v1
 end
 subgraph var_stream_22 ["var <tt>stream_22</tt>"]
     style var_stream_22 fill:transparent
@@ -852,307 +856,307 @@ subgraph var_stream_22 ["var <tt>stream_22</tt>"]
 end
 subgraph var_stream_220 ["var <tt>stream_220</tt>"]
     style var_stream_220 fill:transparent
-    109v1
+    110v1
 end
 subgraph var_stream_221 ["var <tt>stream_221</tt>"]
     style var_stream_221 fill:transparent
-    110v1
-end
-subgraph var_stream_222 ["var <tt>stream_222</tt>"]
-    style var_stream_222 fill:transparent
     111v1
+end
+subgraph var_stream_225 ["var <tt>stream_225</tt>"]
+    style var_stream_225 fill:transparent
+    112v1
 end
 subgraph var_stream_226 ["var <tt>stream_226</tt>"]
     style var_stream_226 fill:transparent
-    112v1
-end
-subgraph var_stream_227 ["var <tt>stream_227</tt>"]
-    style var_stream_227 fill:transparent
     113v1
 end
-subgraph var_stream_232 ["var <tt>stream_232</tt>"]
-    style var_stream_232 fill:transparent
+subgraph var_stream_231 ["var <tt>stream_231</tt>"]
+    style var_stream_231 fill:transparent
     114v1
+end
+subgraph var_stream_235 ["var <tt>stream_235</tt>"]
+    style var_stream_235 fill:transparent
+    115v1
 end
 subgraph var_stream_236 ["var <tt>stream_236</tt>"]
     style var_stream_236 fill:transparent
-    115v1
+    116v1
 end
 subgraph var_stream_237 ["var <tt>stream_237</tt>"]
     style var_stream_237 fill:transparent
-    116v1
+    117v1
 end
 subgraph var_stream_238 ["var <tt>stream_238</tt>"]
     style var_stream_238 fill:transparent
-    117v1
+    118v1
 end
 subgraph var_stream_239 ["var <tt>stream_239</tt>"]
     style var_stream_239 fill:transparent
-    118v1
+    119v1
 end
 subgraph var_stream_240 ["var <tt>stream_240</tt>"]
     style var_stream_240 fill:transparent
-    119v1
-end
-subgraph var_stream_241 ["var <tt>stream_241</tt>"]
-    style var_stream_241 fill:transparent
     120v1
     121v1
 end
-subgraph var_stream_243 ["var <tt>stream_243</tt>"]
-    style var_stream_243 fill:transparent
+subgraph var_stream_242 ["var <tt>stream_242</tt>"]
+    style var_stream_242 fill:transparent
     122v1
 end
-subgraph var_stream_245 ["var <tt>stream_245</tt>"]
-    style var_stream_245 fill:transparent
+subgraph var_stream_244 ["var <tt>stream_244</tt>"]
+    style var_stream_244 fill:transparent
     123v1
 end
-subgraph var_stream_248 ["var <tt>stream_248</tt>"]
-    style var_stream_248 fill:transparent
+subgraph var_stream_247 ["var <tt>stream_247</tt>"]
+    style var_stream_247 fill:transparent
     124v1
 end
-subgraph var_stream_250 ["var <tt>stream_250</tt>"]
-    style var_stream_250 fill:transparent
+subgraph var_stream_249 ["var <tt>stream_249</tt>"]
+    style var_stream_249 fill:transparent
     125v1
 end
-subgraph var_stream_253 ["var <tt>stream_253</tt>"]
-    style var_stream_253 fill:transparent
+subgraph var_stream_252 ["var <tt>stream_252</tt>"]
+    style var_stream_252 fill:transparent
     126v1
+end
+subgraph var_stream_254 ["var <tt>stream_254</tt>"]
+    style var_stream_254 fill:transparent
+    127v1
 end
 subgraph var_stream_255 ["var <tt>stream_255</tt>"]
     style var_stream_255 fill:transparent
-    127v1
-end
-subgraph var_stream_256 ["var <tt>stream_256</tt>"]
-    style var_stream_256 fill:transparent
     128v1
+end
+subgraph var_stream_257 ["var <tt>stream_257</tt>"]
+    style var_stream_257 fill:transparent
+    130v1
 end
 subgraph var_stream_258 ["var <tt>stream_258</tt>"]
     style var_stream_258 fill:transparent
-    130v1
-end
-subgraph var_stream_259 ["var <tt>stream_259</tt>"]
-    style var_stream_259 fill:transparent
     131v1
+end
+subgraph var_stream_276 ["var <tt>stream_276</tt>"]
+    style var_stream_276 fill:transparent
+    133v1
 end
 subgraph var_stream_277 ["var <tt>stream_277</tt>"]
     style var_stream_277 fill:transparent
-    133v1
-end
-subgraph var_stream_278 ["var <tt>stream_278</tt>"]
-    style var_stream_278 fill:transparent
     134v1
+end
+subgraph var_stream_279 ["var <tt>stream_279</tt>"]
+    style var_stream_279 fill:transparent
+    135v1
 end
 subgraph var_stream_28 ["var <tt>stream_28</tt>"]
     style var_stream_28 fill:transparent
     3v1
 end
-subgraph var_stream_280 ["var <tt>stream_280</tt>"]
-    style var_stream_280 fill:transparent
-    135v1
-end
-subgraph var_stream_282 ["var <tt>stream_282</tt>"]
-    style var_stream_282 fill:transparent
+subgraph var_stream_281 ["var <tt>stream_281</tt>"]
+    style var_stream_281 fill:transparent
     136v1
 end
-subgraph var_stream_285 ["var <tt>stream_285</tt>"]
-    style var_stream_285 fill:transparent
+subgraph var_stream_284 ["var <tt>stream_284</tt>"]
+    style var_stream_284 fill:transparent
     137v1
+end
+subgraph var_stream_289 ["var <tt>stream_289</tt>"]
+    style var_stream_289 fill:transparent
+    138v1
 end
 subgraph var_stream_290 ["var <tt>stream_290</tt>"]
     style var_stream_290 fill:transparent
-    138v1
+    139v1
 end
 subgraph var_stream_291 ["var <tt>stream_291</tt>"]
     style var_stream_291 fill:transparent
-    139v1
+    140v1
 end
 subgraph var_stream_292 ["var <tt>stream_292</tt>"]
     style var_stream_292 fill:transparent
-    140v1
+    141v1
 end
 subgraph var_stream_293 ["var <tt>stream_293</tt>"]
     style var_stream_293 fill:transparent
-    141v1
+    142v1
 end
 subgraph var_stream_294 ["var <tt>stream_294</tt>"]
     style var_stream_294 fill:transparent
-    142v1
-end
-subgraph var_stream_295 ["var <tt>stream_295</tt>"]
-    style var_stream_295 fill:transparent
     143v1
     144v1
 end
-subgraph var_stream_297 ["var <tt>stream_297</tt>"]
-    style var_stream_297 fill:transparent
+subgraph var_stream_296 ["var <tt>stream_296</tt>"]
+    style var_stream_296 fill:transparent
     145v1
+end
+subgraph var_stream_298 ["var <tt>stream_298</tt>"]
+    style var_stream_298 fill:transparent
+    146v1
 end
 subgraph var_stream_299 ["var <tt>stream_299</tt>"]
     style var_stream_299 fill:transparent
-    146v1
+    147v1
 end
 subgraph var_stream_30 ["var <tt>stream_30</tt>"]
     style var_stream_30 fill:transparent
     4v1
 end
-subgraph var_stream_300 ["var <tt>stream_300</tt>"]
-    style var_stream_300 fill:transparent
-    147v1
+subgraph var_stream_301 ["var <tt>stream_301</tt>"]
+    style var_stream_301 fill:transparent
+    148v1
 end
 subgraph var_stream_302 ["var <tt>stream_302</tt>"]
     style var_stream_302 fill:transparent
-    148v1
+    149v1
 end
 subgraph var_stream_303 ["var <tt>stream_303</tt>"]
     style var_stream_303 fill:transparent
-    149v1
+    150v1
 end
 subgraph var_stream_304 ["var <tt>stream_304</tt>"]
     style var_stream_304 fill:transparent
-    150v1
+    151v1
 end
 subgraph var_stream_305 ["var <tt>stream_305</tt>"]
     style var_stream_305 fill:transparent
-    151v1
-end
-subgraph var_stream_306 ["var <tt>stream_306</tt>"]
-    style var_stream_306 fill:transparent
     152v1
 end
-subgraph var_stream_310 ["var <tt>stream_310</tt>"]
-    style var_stream_310 fill:transparent
+subgraph var_stream_309 ["var <tt>stream_309</tt>"]
+    style var_stream_309 fill:transparent
     153v1
 end
 subgraph var_stream_33 ["var <tt>stream_33</tt>"]
     style var_stream_33 fill:transparent
     5v1
 end
-subgraph var_stream_338 ["var <tt>stream_338</tt>"]
-    style var_stream_338 fill:transparent
+subgraph var_stream_337 ["var <tt>stream_337</tt>"]
+    style var_stream_337 fill:transparent
     156v1
     157v1
 end
-subgraph var_stream_340 ["var <tt>stream_340</tt>"]
-    style var_stream_340 fill:transparent
+subgraph var_stream_339 ["var <tt>stream_339</tt>"]
+    style var_stream_339 fill:transparent
     158v1
+end
+subgraph var_stream_343 ["var <tt>stream_343</tt>"]
+    style var_stream_343 fill:transparent
+    159v1
 end
 subgraph var_stream_344 ["var <tt>stream_344</tt>"]
     style var_stream_344 fill:transparent
-    159v1
+    160v1
 end
 subgraph var_stream_345 ["var <tt>stream_345</tt>"]
     style var_stream_345 fill:transparent
-    160v1
-end
-subgraph var_stream_346 ["var <tt>stream_346</tt>"]
-    style var_stream_346 fill:transparent
     161v1
 end
-subgraph var_stream_349 ["var <tt>stream_349</tt>"]
-    style var_stream_349 fill:transparent
+subgraph var_stream_348 ["var <tt>stream_348</tt>"]
+    style var_stream_348 fill:transparent
     162v1
 end
 subgraph var_stream_35 ["var <tt>stream_35</tt>"]
     style var_stream_35 fill:transparent
     6v1
 end
+subgraph var_stream_351 ["var <tt>stream_351</tt>"]
+    style var_stream_351 fill:transparent
+    163v1
+end
 subgraph var_stream_352 ["var <tt>stream_352</tt>"]
     style var_stream_352 fill:transparent
-    163v1
+    164v1
 end
 subgraph var_stream_353 ["var <tt>stream_353</tt>"]
     style var_stream_353 fill:transparent
-    164v1
+    165v1
 end
 subgraph var_stream_354 ["var <tt>stream_354</tt>"]
     style var_stream_354 fill:transparent
-    165v1
-end
-subgraph var_stream_355 ["var <tt>stream_355</tt>"]
-    style var_stream_355 fill:transparent
     166v1
+end
+subgraph var_stream_356 ["var <tt>stream_356</tt>"]
+    style var_stream_356 fill:transparent
+    167v1
 end
 subgraph var_stream_357 ["var <tt>stream_357</tt>"]
     style var_stream_357 fill:transparent
-    167v1
+    168v1
 end
 subgraph var_stream_358 ["var <tt>stream_358</tt>"]
     style var_stream_358 fill:transparent
-    168v1
-end
-subgraph var_stream_359 ["var <tt>stream_359</tt>"]
-    style var_stream_359 fill:transparent
     169v1
 end
 subgraph var_stream_36 ["var <tt>stream_36</tt>"]
     style var_stream_36 fill:transparent
     7v1
 end
-subgraph var_stream_362 ["var <tt>stream_362</tt>"]
-    style var_stream_362 fill:transparent
+subgraph var_stream_361 ["var <tt>stream_361</tt>"]
+    style var_stream_361 fill:transparent
     170v1
+end
+subgraph var_stream_363 ["var <tt>stream_363</tt>"]
+    style var_stream_363 fill:transparent
+    171v1
 end
 subgraph var_stream_364 ["var <tt>stream_364</tt>"]
     style var_stream_364 fill:transparent
-    171v1
-end
-subgraph var_stream_365 ["var <tt>stream_365</tt>"]
-    style var_stream_365 fill:transparent
     172v1
 end
-subgraph var_stream_368 ["var <tt>stream_368</tt>"]
-    style var_stream_368 fill:transparent
+subgraph var_stream_367 ["var <tt>stream_367</tt>"]
+    style var_stream_367 fill:transparent
     173v1
+end
+subgraph var_stream_369 ["var <tt>stream_369</tt>"]
+    style var_stream_369 fill:transparent
+    174v1
 end
 subgraph var_stream_370 ["var <tt>stream_370</tt>"]
     style var_stream_370 fill:transparent
-    174v1
-end
-subgraph var_stream_371 ["var <tt>stream_371</tt>"]
-    style var_stream_371 fill:transparent
     175v1
     176v1
 end
-subgraph var_stream_373 ["var <tt>stream_373</tt>"]
-    style var_stream_373 fill:transparent
+subgraph var_stream_372 ["var <tt>stream_372</tt>"]
+    style var_stream_372 fill:transparent
     177v1
 end
-subgraph var_stream_376 ["var <tt>stream_376</tt>"]
-    style var_stream_376 fill:transparent
+subgraph var_stream_375 ["var <tt>stream_375</tt>"]
+    style var_stream_375 fill:transparent
     178v1
 end
-subgraph var_stream_378 ["var <tt>stream_378</tt>"]
-    style var_stream_378 fill:transparent
+subgraph var_stream_377 ["var <tt>stream_377</tt>"]
+    style var_stream_377 fill:transparent
     179v1
+end
+subgraph var_stream_379 ["var <tt>stream_379</tt>"]
+    style var_stream_379 fill:transparent
+    180v1
 end
 subgraph var_stream_380 ["var <tt>stream_380</tt>"]
     style var_stream_380 fill:transparent
-    180v1
+    181v1
 end
 subgraph var_stream_381 ["var <tt>stream_381</tt>"]
     style var_stream_381 fill:transparent
-    181v1
+    182v1
 end
 subgraph var_stream_382 ["var <tt>stream_382</tt>"]
     style var_stream_382 fill:transparent
-    182v1
-end
-subgraph var_stream_383 ["var <tt>stream_383</tt>"]
-    style var_stream_383 fill:transparent
     183v1
 end
-subgraph var_stream_385 ["var <tt>stream_385</tt>"]
-    style var_stream_385 fill:transparent
+subgraph var_stream_384 ["var <tt>stream_384</tt>"]
+    style var_stream_384 fill:transparent
     184v1
 end
-subgraph var_stream_387 ["var <tt>stream_387</tt>"]
-    style var_stream_387 fill:transparent
+subgraph var_stream_386 ["var <tt>stream_386</tt>"]
+    style var_stream_386 fill:transparent
     185v1
+end
+subgraph var_stream_388 ["var <tt>stream_388</tt>"]
+    style var_stream_388 fill:transparent
+    187v1
 end
 subgraph var_stream_389 ["var <tt>stream_389</tt>"]
     style var_stream_389 fill:transparent
-    187v1
+    188v1
 end
 subgraph var_stream_39 ["var <tt>stream_39</tt>"]
     style var_stream_39 fill:transparent
@@ -1160,165 +1164,165 @@ subgraph var_stream_39 ["var <tt>stream_39</tt>"]
 end
 subgraph var_stream_390 ["var <tt>stream_390</tt>"]
     style var_stream_390 fill:transparent
-    188v1
-end
-subgraph var_stream_391 ["var <tt>stream_391</tt>"]
-    style var_stream_391 fill:transparent
     189v1
 end
-subgraph var_stream_393 ["var <tt>stream_393</tt>"]
-    style var_stream_393 fill:transparent
+subgraph var_stream_392 ["var <tt>stream_392</tt>"]
+    style var_stream_392 fill:transparent
     190v1
 end
-subgraph var_stream_395 ["var <tt>stream_395</tt>"]
-    style var_stream_395 fill:transparent
+subgraph var_stream_394 ["var <tt>stream_394</tt>"]
+    style var_stream_394 fill:transparent
     191v1
 end
-subgraph var_stream_398 ["var <tt>stream_398</tt>"]
-    style var_stream_398 fill:transparent
+subgraph var_stream_397 ["var <tt>stream_397</tt>"]
+    style var_stream_397 fill:transparent
     192v1
+end
+subgraph var_stream_404 ["var <tt>stream_404</tt>"]
+    style var_stream_404 fill:transparent
+    193v1
 end
 subgraph var_stream_405 ["var <tt>stream_405</tt>"]
     style var_stream_405 fill:transparent
-    193v1
-end
-subgraph var_stream_406 ["var <tt>stream_406</tt>"]
-    style var_stream_406 fill:transparent
     194v1
 end
-subgraph var_stream_412 ["var <tt>stream_412</tt>"]
-    style var_stream_412 fill:transparent
+subgraph var_stream_411 ["var <tt>stream_411</tt>"]
+    style var_stream_411 fill:transparent
     195v1
 end
-subgraph var_stream_414 ["var <tt>stream_414</tt>"]
-    style var_stream_414 fill:transparent
+subgraph var_stream_413 ["var <tt>stream_413</tt>"]
+    style var_stream_413 fill:transparent
     196v1
+end
+subgraph var_stream_415 ["var <tt>stream_415</tt>"]
+    style var_stream_415 fill:transparent
+    197v1
 end
 subgraph var_stream_416 ["var <tt>stream_416</tt>"]
     style var_stream_416 fill:transparent
-    197v1
+    198v1
 end
 subgraph var_stream_417 ["var <tt>stream_417</tt>"]
     style var_stream_417 fill:transparent
-    198v1
-end
-subgraph var_stream_418 ["var <tt>stream_418</tt>"]
-    style var_stream_418 fill:transparent
     199v1
     200v1
 end
-subgraph var_stream_420 ["var <tt>stream_420</tt>"]
-    style var_stream_420 fill:transparent
+subgraph var_stream_419 ["var <tt>stream_419</tt>"]
+    style var_stream_419 fill:transparent
     201v1
 end
-subgraph var_stream_422 ["var <tt>stream_422</tt>"]
-    style var_stream_422 fill:transparent
+subgraph var_stream_421 ["var <tt>stream_421</tt>"]
+    style var_stream_421 fill:transparent
     202v1
+end
+subgraph var_stream_423 ["var <tt>stream_423</tt>"]
+    style var_stream_423 fill:transparent
+    203v1
 end
 subgraph var_stream_424 ["var <tt>stream_424</tt>"]
     style var_stream_424 fill:transparent
-    203v1
-end
-subgraph var_stream_425 ["var <tt>stream_425</tt>"]
-    style var_stream_425 fill:transparent
     204v1
 end
-subgraph var_stream_429 ["var <tt>stream_429</tt>"]
-    style var_stream_429 fill:transparent
+subgraph var_stream_428 ["var <tt>stream_428</tt>"]
+    style var_stream_428 fill:transparent
     205v1
 end
-subgraph var_stream_431 ["var <tt>stream_431</tt>"]
-    style var_stream_431 fill:transparent
+subgraph var_stream_430 ["var <tt>stream_430</tt>"]
+    style var_stream_430 fill:transparent
     206v1
+end
+subgraph var_stream_434 ["var <tt>stream_434</tt>"]
+    style var_stream_434 fill:transparent
+    207v1
 end
 subgraph var_stream_435 ["var <tt>stream_435</tt>"]
     style var_stream_435 fill:transparent
-    207v1
-end
-subgraph var_stream_436 ["var <tt>stream_436</tt>"]
-    style var_stream_436 fill:transparent
     208v1
+end
+subgraph var_stream_438 ["var <tt>stream_438</tt>"]
+    style var_stream_438 fill:transparent
+    209v1
 end
 subgraph var_stream_439 ["var <tt>stream_439</tt>"]
     style var_stream_439 fill:transparent
-    209v1
+    210v1
 end
 subgraph var_stream_440 ["var <tt>stream_440</tt>"]
     style var_stream_440 fill:transparent
-    210v1
+    211v1
 end
 subgraph var_stream_441 ["var <tt>stream_441</tt>"]
     style var_stream_441 fill:transparent
-    211v1
-end
-subgraph var_stream_442 ["var <tt>stream_442</tt>"]
-    style var_stream_442 fill:transparent
     212v1
+end
+subgraph var_stream_443 ["var <tt>stream_443</tt>"]
+    style var_stream_443 fill:transparent
+    213v1
 end
 subgraph var_stream_444 ["var <tt>stream_444</tt>"]
     style var_stream_444 fill:transparent
-    213v1
+    214v1
 end
 subgraph var_stream_445 ["var <tt>stream_445</tt>"]
     style var_stream_445 fill:transparent
-    214v1
-end
-subgraph var_stream_446 ["var <tt>stream_446</tt>"]
-    style var_stream_446 fill:transparent
     215v1
 end
-subgraph var_stream_448 ["var <tt>stream_448</tt>"]
-    style var_stream_448 fill:transparent
+subgraph var_stream_447 ["var <tt>stream_447</tt>"]
+    style var_stream_447 fill:transparent
     216v1
+end
+subgraph var_stream_449 ["var <tt>stream_449</tt>"]
+    style var_stream_449 fill:transparent
+    217v1
 end
 subgraph var_stream_45 ["var <tt>stream_45</tt>"]
     style var_stream_45 fill:transparent
     9v1
 end
-subgraph var_stream_450 ["var <tt>stream_450</tt>"]
-    style var_stream_450 fill:transparent
-    217v1
-end
-subgraph var_stream_452 ["var <tt>stream_452</tt>"]
-    style var_stream_452 fill:transparent
+subgraph var_stream_451 ["var <tt>stream_451</tt>"]
+    style var_stream_451 fill:transparent
     218v1
 end
-subgraph var_stream_466 ["var <tt>stream_466</tt>"]
-    style var_stream_466 fill:transparent
+subgraph var_stream_465 ["var <tt>stream_465</tt>"]
+    style var_stream_465 fill:transparent
     221v1
     222v1
 end
-subgraph var_stream_468 ["var <tt>stream_468</tt>"]
-    style var_stream_468 fill:transparent
+subgraph var_stream_467 ["var <tt>stream_467</tt>"]
+    style var_stream_467 fill:transparent
     223v1
 end
-subgraph var_stream_469 ["var <tt>stream_469</tt>"]
-    style var_stream_469 fill:transparent
+subgraph var_stream_468 ["var <tt>stream_468</tt>"]
+    style var_stream_468 fill:transparent
     224v1
 end
 subgraph var_stream_47 ["var <tt>stream_47</tt>"]
     style var_stream_47 fill:transparent
     10v1
 end
-subgraph var_stream_471 ["var <tt>stream_471</tt>"]
-    style var_stream_471 fill:transparent
+subgraph var_stream_470 ["var <tt>stream_470</tt>"]
+    style var_stream_470 fill:transparent
     225v1
 end
-subgraph var_stream_472 ["var <tt>stream_472</tt>"]
-    style var_stream_472 fill:transparent
+subgraph var_stream_471 ["var <tt>stream_471</tt>"]
+    style var_stream_471 fill:transparent
     226v1
+end
+subgraph var_stream_474 ["var <tt>stream_474</tt>"]
+    style var_stream_474 fill:transparent
+    227v1
 end
 subgraph var_stream_475 ["var <tt>stream_475</tt>"]
     style var_stream_475 fill:transparent
-    227v1
+    228v1
 end
 subgraph var_stream_476 ["var <tt>stream_476</tt>"]
     style var_stream_476 fill:transparent
-    228v1
-end
-subgraph var_stream_477 ["var <tt>stream_477</tt>"]
-    style var_stream_477 fill:transparent
     229v1
+end
+subgraph var_stream_479 ["var <tt>stream_479</tt>"]
+    style var_stream_479 fill:transparent
+    230v1
 end
 subgraph var_stream_48 ["var <tt>stream_48</tt>"]
     style var_stream_48 fill:transparent
@@ -1327,39 +1331,39 @@ subgraph var_stream_48 ["var <tt>stream_48</tt>"]
 end
 subgraph var_stream_480 ["var <tt>stream_480</tt>"]
     style var_stream_480 fill:transparent
-    230v1
+    231v1
 end
 subgraph var_stream_481 ["var <tt>stream_481</tt>"]
     style var_stream_481 fill:transparent
-    231v1
-end
-subgraph var_stream_482 ["var <tt>stream_482</tt>"]
-    style var_stream_482 fill:transparent
     232v1
+end
+subgraph var_stream_485 ["var <tt>stream_485</tt>"]
+    style var_stream_485 fill:transparent
+    234v1
 end
 subgraph var_stream_486 ["var <tt>stream_486</tt>"]
     style var_stream_486 fill:transparent
-    234v1
-end
-subgraph var_stream_487 ["var <tt>stream_487</tt>"]
-    style var_stream_487 fill:transparent
     235v1
 end
-subgraph var_stream_489 ["var <tt>stream_489</tt>"]
-    style var_stream_489 fill:transparent
+subgraph var_stream_488 ["var <tt>stream_488</tt>"]
+    style var_stream_488 fill:transparent
     236v1
 end
-subgraph var_stream_491 ["var <tt>stream_491</tt>"]
-    style var_stream_491 fill:transparent
+subgraph var_stream_490 ["var <tt>stream_490</tt>"]
+    style var_stream_490 fill:transparent
     238v1
+end
+subgraph var_stream_495 ["var <tt>stream_495</tt>"]
+    style var_stream_495 fill:transparent
+    239v1
 end
 subgraph var_stream_496 ["var <tt>stream_496</tt>"]
     style var_stream_496 fill:transparent
-    239v1
-end
-subgraph var_stream_497 ["var <tt>stream_497</tt>"]
-    style var_stream_497 fill:transparent
     240v1
+end
+subgraph var_stream_499 ["var <tt>stream_499</tt>"]
+    style var_stream_499 fill:transparent
+    241v1
 end
 subgraph var_stream_50 ["var <tt>stream_50</tt>"]
     style var_stream_50 fill:transparent
@@ -1367,43 +1371,43 @@ subgraph var_stream_50 ["var <tt>stream_50</tt>"]
 end
 subgraph var_stream_500 ["var <tt>stream_500</tt>"]
     style var_stream_500 fill:transparent
-    241v1
-end
-subgraph var_stream_501 ["var <tt>stream_501</tt>"]
-    style var_stream_501 fill:transparent
     242v1
 end
-subgraph var_stream_503 ["var <tt>stream_503</tt>"]
-    style var_stream_503 fill:transparent
+subgraph var_stream_502 ["var <tt>stream_502</tt>"]
+    style var_stream_502 fill:transparent
     243v1
+end
+subgraph var_stream_504 ["var <tt>stream_504</tt>"]
+    style var_stream_504 fill:transparent
+    244v1
 end
 subgraph var_stream_505 ["var <tt>stream_505</tt>"]
     style var_stream_505 fill:transparent
-    244v1
+    245v1
 end
 subgraph var_stream_506 ["var <tt>stream_506</tt>"]
     style var_stream_506 fill:transparent
-    245v1
-end
-subgraph var_stream_507 ["var <tt>stream_507</tt>"]
-    style var_stream_507 fill:transparent
     246v1
 end
 subgraph var_stream_52 ["var <tt>stream_52</tt>"]
     style var_stream_52 fill:transparent
     14v1
 end
-subgraph var_stream_535 ["var <tt>stream_535</tt>"]
-    style var_stream_535 fill:transparent
+subgraph var_stream_534 ["var <tt>stream_534</tt>"]
+    style var_stream_534 fill:transparent
     248v1
 end
-subgraph var_stream_536 ["var <tt>stream_536</tt>"]
-    style var_stream_536 fill:transparent
+subgraph var_stream_535 ["var <tt>stream_535</tt>"]
+    style var_stream_535 fill:transparent
     249v1
+end
+subgraph var_stream_538 ["var <tt>stream_538</tt>"]
+    style var_stream_538 fill:transparent
+    251v1
 end
 subgraph var_stream_539 ["var <tt>stream_539</tt>"]
     style var_stream_539 fill:transparent
-    251v1
+    252v1
 end
 subgraph var_stream_54 ["var <tt>stream_54</tt>"]
     style var_stream_54 fill:transparent
@@ -1411,54 +1415,50 @@ subgraph var_stream_54 ["var <tt>stream_54</tt>"]
 end
 subgraph var_stream_540 ["var <tt>stream_540</tt>"]
     style var_stream_540 fill:transparent
-    252v1
-end
-subgraph var_stream_541 ["var <tt>stream_541</tt>"]
-    style var_stream_541 fill:transparent
     253v1
+end
+subgraph var_stream_544 ["var <tt>stream_544</tt>"]
+    style var_stream_544 fill:transparent
+    255v1
 end
 subgraph var_stream_545 ["var <tt>stream_545</tt>"]
     style var_stream_545 fill:transparent
-    255v1
-end
-subgraph var_stream_546 ["var <tt>stream_546</tt>"]
-    style var_stream_546 fill:transparent
     256v1
 end
-subgraph var_stream_548 ["var <tt>stream_548</tt>"]
-    style var_stream_548 fill:transparent
+subgraph var_stream_547 ["var <tt>stream_547</tt>"]
+    style var_stream_547 fill:transparent
     257v1
+end
+subgraph var_stream_549 ["var <tt>stream_549</tt>"]
+    style var_stream_549 fill:transparent
+    258v1
 end
 subgraph var_stream_55 ["var <tt>stream_55</tt>"]
     style var_stream_55 fill:transparent
     16v1
 end
-subgraph var_stream_550 ["var <tt>stream_550</tt>"]
-    style var_stream_550 fill:transparent
-    258v1
-end
-subgraph var_stream_553 ["var <tt>stream_553</tt>"]
-    style var_stream_553 fill:transparent
+subgraph var_stream_552 ["var <tt>stream_552</tt>"]
+    style var_stream_552 fill:transparent
     259v1
+end
+subgraph var_stream_556 ["var <tt>stream_556</tt>"]
+    style var_stream_556 fill:transparent
+    260v1
 end
 subgraph var_stream_557 ["var <tt>stream_557</tt>"]
     style var_stream_557 fill:transparent
-    260v1
-end
-subgraph var_stream_558 ["var <tt>stream_558</tt>"]
-    style var_stream_558 fill:transparent
     261v1
+end
+subgraph var_stream_559 ["var <tt>stream_559</tt>"]
+    style var_stream_559 fill:transparent
+    262v1
 end
 subgraph var_stream_56 ["var <tt>stream_56</tt>"]
     style var_stream_56 fill:transparent
     18v1
 end
-subgraph var_stream_560 ["var <tt>stream_560</tt>"]
-    style var_stream_560 fill:transparent
-    262v1
-end
-subgraph var_stream_562 ["var <tt>stream_562</tt>"]
-    style var_stream_562 fill:transparent
+subgraph var_stream_561 ["var <tt>stream_561</tt>"]
+    style var_stream_561 fill:transparent
     263v1
 end
 subgraph var_stream_57 ["var <tt>stream_57</tt>"]
@@ -1477,84 +1477,84 @@ subgraph var_stream_64 ["var <tt>stream_64</tt>"]
     style var_stream_64 fill:transparent
     22v1
 end
-subgraph var_stream_68 ["var <tt>stream_68</tt>"]
-    style var_stream_68 fill:transparent
+subgraph var_stream_67 ["var <tt>stream_67</tt>"]
+    style var_stream_67 fill:transparent
     23v1
 end
-subgraph var_stream_69 ["var <tt>stream_69</tt>"]
-    style var_stream_69 fill:transparent
+subgraph var_stream_68 ["var <tt>stream_68</tt>"]
+    style var_stream_68 fill:transparent
     24v1
 end
-subgraph var_stream_72 ["var <tt>stream_72</tt>"]
-    style var_stream_72 fill:transparent
+subgraph var_stream_71 ["var <tt>stream_71</tt>"]
+    style var_stream_71 fill:transparent
     25v1
+end
+subgraph var_stream_73 ["var <tt>stream_73</tt>"]
+    style var_stream_73 fill:transparent
+    26v1
 end
 subgraph var_stream_74 ["var <tt>stream_74</tt>"]
     style var_stream_74 fill:transparent
-    26v1
+    27v1
 end
 subgraph var_stream_75 ["var <tt>stream_75</tt>"]
     style var_stream_75 fill:transparent
-    27v1
+    28v1
 end
 subgraph var_stream_76 ["var <tt>stream_76</tt>"]
     style var_stream_76 fill:transparent
-    28v1
-end
-subgraph var_stream_77 ["var <tt>stream_77</tt>"]
-    style var_stream_77 fill:transparent
     29v1
 end
-subgraph var_stream_80 ["var <tt>stream_80</tt>"]
-    style var_stream_80 fill:transparent
+subgraph var_stream_79 ["var <tt>stream_79</tt>"]
+    style var_stream_79 fill:transparent
     30v1
+end
+subgraph var_stream_81 ["var <tt>stream_81</tt>"]
+    style var_stream_81 fill:transparent
+    31v1
 end
 subgraph var_stream_82 ["var <tt>stream_82</tt>"]
     style var_stream_82 fill:transparent
-    31v1
+    32v1
 end
 subgraph var_stream_83 ["var <tt>stream_83</tt>"]
     style var_stream_83 fill:transparent
-    32v1
+    33v1
 end
 subgraph var_stream_84 ["var <tt>stream_84</tt>"]
     style var_stream_84 fill:transparent
-    33v1
+    34v1
 end
 subgraph var_stream_85 ["var <tt>stream_85</tt>"]
     style var_stream_85 fill:transparent
-    34v1
+    35v1
 end
 subgraph var_stream_86 ["var <tt>stream_86</tt>"]
     style var_stream_86 fill:transparent
-    35v1
-end
-subgraph var_stream_87 ["var <tt>stream_87</tt>"]
-    style var_stream_87 fill:transparent
     36v1
     37v1
 end
-subgraph var_stream_89 ["var <tt>stream_89</tt>"]
-    style var_stream_89 fill:transparent
+subgraph var_stream_88 ["var <tt>stream_88</tt>"]
+    style var_stream_88 fill:transparent
     38v1
+end
+subgraph var_stream_90 ["var <tt>stream_90</tt>"]
+    style var_stream_90 fill:transparent
+    39v1
 end
 subgraph var_stream_91 ["var <tt>stream_91</tt>"]
     style var_stream_91 fill:transparent
-    39v1
+    40v1
 end
 subgraph var_stream_92 ["var <tt>stream_92</tt>"]
     style var_stream_92 fill:transparent
-    40v1
+    41v1
 end
 subgraph var_stream_93 ["var <tt>stream_93</tt>"]
     style var_stream_93 fill:transparent
-    41v1
-end
-subgraph var_stream_94 ["var <tt>stream_94</tt>"]
-    style var_stream_94 fill:transparent
     42v1
 end
-subgraph var_stream_99 ["var <tt>stream_99</tt>"]
-    style var_stream_99 fill:transparent
+subgraph var_stream_98 ["var <tt>stream_98</tt>"]
+    style var_stream_98 fill:transparent
     43v1
 end


### PR DESCRIPTION
## Summary

`cross_product` and `cross_product_nested_loop` previously required both input streams to have the same `Retries` type parameter. This forced callers to manually `weaken_retries()` when combining `ExactlyOnce` streams with `AtLeastOnce` streams — an unnecessary ergonomic friction since `join` (which `cross_product` delegates to) already handles this via `MinRetries`.

## Changes

- **`cross_product`**: now accepts `R2: Retries` as a separate type parameter with `R: MinRetries<R2>`, outputting `<R as MinRetries<R2>>::Min`
- **`cross_product_nested_loop`**: same treatment  
- **`broadcast_closed` (Process)**: removed now-unnecessary `.weaken_retries()` on `member_ids`
- **`repeat_with_keys`**: removed now-unnecessary `.weaken_retries()` on keys stream

## Motivation

This aligns `cross_product` with `join`'s handling of retries and unblocks adding `broadcast_closed` for cluster-to-cluster streams (where the source has generic `R` and the member IDs are `ExactlyOnce`).