### PR TITLE
feat(hydro_lang): capture fold commutativity/idempotency in IR nodes

### DIFF
--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -2475,6 +2475,10 @@ pub enum HydroNode {
         init: ClosureExpr,
         acc: ClosureExpr,
         input: Box<HydroNode>,
+        /// Whether the accumulator was proven commutative.
+        is_commutative: bool,
+        /// Whether the accumulator was proven idempotent.
+        is_idempotent: bool,
         metadata: HydroIrMetadata,
     },
 
@@ -2494,23 +2498,39 @@ pub enum HydroNode {
         init: ClosureExpr,
         acc: ClosureExpr,
         input: Box<HydroNode>,
+        /// Whether the accumulator was proven commutative.
+        is_commutative: bool,
+        /// Whether the accumulator was proven idempotent.
+        is_idempotent: bool,
         metadata: HydroIrMetadata,
     },
 
     Reduce {
         f: ClosureExpr,
         input: Box<HydroNode>,
+        /// Whether the reducer was proven commutative.
+        is_commutative: bool,
+        /// Whether the reducer was proven idempotent.
+        is_idempotent: bool,
         metadata: HydroIrMetadata,
     },
     ReduceKeyed {
         f: ClosureExpr,
         input: Box<HydroNode>,
+        /// Whether the reducer was proven commutative.
+        is_commutative: bool,
+        /// Whether the reducer was proven idempotent.
+        is_idempotent: bool,
         metadata: HydroIrMetadata,
     },
     ReduceKeyedWatermark {
         f: ClosureExpr,
         input: Box<HydroNode>,
         watermark: Box<HydroNode>,
+        /// Whether the reducer was proven commutative.
+        is_commutative: bool,
+        /// Whether the reducer was proven idempotent.
+        is_idempotent: bool,
         metadata: HydroIrMetadata,
     },
 
@@ -2982,11 +3002,15 @@ impl HydroNode {
                 init,
                 acc,
                 input,
+                is_commutative,
+                is_idempotent,
                 metadata,
             } => HydroNode::Fold {
                 init: init.deep_clone(seen_tees),
                 acc: acc.deep_clone(seen_tees),
                 input: Box::new(input.deep_clone(seen_tees)),
+                is_commutative: *is_commutative,
+                is_idempotent: *is_idempotent,
                 metadata: metadata.clone(),
             },
             HydroNode::Scan {
@@ -3015,32 +3039,56 @@ impl HydroNode {
                 init,
                 acc,
                 input,
+                is_commutative,
+                is_idempotent,
                 metadata,
             } => HydroNode::FoldKeyed {
                 init: init.deep_clone(seen_tees),
                 acc: acc.deep_clone(seen_tees),
                 input: Box::new(input.deep_clone(seen_tees)),
+                is_commutative: *is_commutative,
+                is_idempotent: *is_idempotent,
                 metadata: metadata.clone(),
             },
             HydroNode::ReduceKeyedWatermark {
                 f,
                 input,
                 watermark,
+                is_commutative,
+                is_idempotent,
                 metadata,
             } => HydroNode::ReduceKeyedWatermark {
                 f: f.deep_clone(seen_tees),
                 input: Box::new(input.deep_clone(seen_tees)),
                 watermark: Box::new(watermark.deep_clone(seen_tees)),
+                is_commutative: *is_commutative,
+                is_idempotent: *is_idempotent,
                 metadata: metadata.clone(),
             },
-            HydroNode::Reduce { f, input, metadata } => HydroNode::Reduce {
+            HydroNode::Reduce {
+                f,
+                input,
+                is_commutative,
+                is_idempotent,
+                metadata,
+            } => HydroNode::Reduce {
                 f: f.deep_clone(seen_tees),
                 input: Box::new(input.deep_clone(seen_tees)),
+                is_commutative: *is_commutative,
+                is_idempotent: *is_idempotent,
                 metadata: metadata.clone(),
             },
-            HydroNode::ReduceKeyed { f, input, metadata } => HydroNode::ReduceKeyed {
+            HydroNode::ReduceKeyed {
+                f,
+                input,
+                is_commutative,
+                is_idempotent,
+                metadata,
+            } => HydroNode::ReduceKeyed {
                 f: f.deep_clone(seen_tees),
                 input: Box::new(input.deep_clone(seen_tees)),
+                is_commutative: *is_commutative,
+                is_idempotent: *is_idempotent,
                 metadata: metadata.clone(),
             },
             HydroNode::Network {

--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -1986,8 +1986,8 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     ) -> KeyedSingleton<K, A, L, B2>
     where
         K: Eq + Hash,
-        C: ValidCommutativityFor<O>,
-        Idemp: ValidIdempotenceFor<R>,
+        C: ValidCommutativityFor<O> + crate::properties::IsProved,
+        Idemp: ValidIdempotenceFor<R> + crate::properties::IsProved,
         B: ApplyMonotoneKeyedStream<M, B2>,
     {
         let init = init.splice_fn0_ctx(&self.location).into();
@@ -2003,6 +2003,8 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
                 init,
                 acc: comb.into(),
                 input: Box::new(retried.ir_node.replace(HydroNode::Placeholder)),
+                is_commutative: C::IS_PROVED,
+                is_idempotent: Idemp::IS_PROVED,
                 metadata: retried
                     .location
                     .new_node_metadata(KeyedSingleton::<K, A, L, B2>::collection_kind()),
@@ -2051,8 +2053,8 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     ) -> KeyedSingleton<K, V, L, B>
     where
         K: Eq + Hash,
-        C: ValidCommutativityFor<O>,
-        Idemp: ValidIdempotenceFor<R>,
+        C: ValidCommutativityFor<O> + crate::properties::IsProved,
+        Idemp: ValidIdempotenceFor<R> + crate::properties::IsProved,
     {
         let (f, proof) = comb.splice_fn2_borrow_mut_ctx_props(&self.location);
         proof.register_proof(&f);
@@ -2066,6 +2068,8 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
             HydroNode::ReduceKeyed {
                 f: f.into(),
                 input: Box::new(ordered.ir_node.replace(HydroNode::Placeholder)),
+                is_commutative: C::IS_PROVED,
+                is_idempotent: Idemp::IS_PROVED,
                 metadata: ordered
                     .location
                     .new_node_metadata(KeyedSingleton::<K, V, L, B>::collection_kind()),
@@ -2111,8 +2115,8 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
         K: Eq + Hash,
         O2: Clone,
         F: Fn(&mut V, V) + 'a,
-        C: ValidCommutativityFor<O>,
-        Idemp: ValidIdempotenceFor<R>,
+        C: ValidCommutativityFor<O> + crate::properties::IsProved,
+        Idemp: ValidIdempotenceFor<R> + crate::properties::IsProved,
     {
         let other: Optional<O2, Tick<L::Root>, Bounded> = other.into();
         check_matching_location(&self.location.root(), other.location.outer());
@@ -2129,6 +2133,8 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
                 f: f.into(),
                 input: Box::new(ordered.ir_node.replace(HydroNode::Placeholder)),
                 watermark: Box::new(other.ir_node.replace(HydroNode::Placeholder)),
+                is_commutative: C::IS_PROVED,
+                is_idempotent: Idemp::IS_PROVED,
                 metadata: ordered
                     .location
                     .new_node_metadata(KeyedSingleton::<K, V, L, B>::collection_kind()),

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -1340,8 +1340,8 @@ where
     where
         I: Fn() -> A + 'a,
         F: 'a + Fn(&mut A, T),
-        C: ValidCommutativityFor<O>,
-        Idemp: ValidIdempotenceFor<R>,
+        C: ValidCommutativityFor<O> + crate::properties::IsProved,
+        Idemp: ValidIdempotenceFor<R> + crate::properties::IsProved,
         B: ApplyMonotoneStream<M, B2>,
     {
         let init = init.splice_fn0_ctx(&self.location).into();
@@ -1357,6 +1357,8 @@ where
             init,
             acc: comb.into(),
             input: Box::new(retried.ir_node.replace(HydroNode::Placeholder)),
+            is_commutative: C::IS_PROVED,
+            is_idempotent: Idemp::IS_PROVED,
             metadata: retried
                 .location
                 .new_node_metadata(Singleton::<A, L::DropConsistency, B2>::collection_kind()),
@@ -1398,8 +1400,8 @@ where
     ) -> Optional<T, L, B>
     where
         F: Fn(&mut T, T) + 'a,
-        C: ValidCommutativityFor<O>,
-        Idemp: ValidIdempotenceFor<R>,
+        C: ValidCommutativityFor<O> + crate::properties::IsProved,
+        Idemp: ValidIdempotenceFor<R> + crate::properties::IsProved,
     {
         let (f, proof) = comb.splice_fn2_borrow_mut_ctx_props(&self.location);
         proof.register_proof(&f);
@@ -1411,6 +1413,8 @@ where
         let core = HydroNode::Reduce {
             f: f.into(),
             input: Box::new(ordered_etc.ir_node.replace(HydroNode::Placeholder)),
+            is_commutative: C::IS_PROVED,
+            is_idempotent: Idemp::IS_PROVED,
             metadata: ordered_etc
                 .location
                 .new_node_metadata(Optional::<T, L::DropConsistency, B>::collection_kind()),

--- a/hydro_lang/src/properties/mod.rs
+++ b/hydro_lang/src/properties/mod.rs
@@ -106,6 +106,18 @@ pub enum NotProved {}
 /// Marks that the property is proven.
 pub enum Proved {}
 
+/// Query whether a proof marker is `Proved`.
+pub trait IsProved {
+    /// Whether the property has been proven.
+    const IS_PROVED: bool;
+}
+impl IsProved for NotProved {
+    const IS_PROVED: bool = false;
+}
+impl IsProved for Proved {
+    const IS_PROVED: bool = true;
+}
+
 /// Algebraic properties for an aggregation function of type (T, &mut A) -> ().
 ///
 /// Commutativity:

--- a/hydro_lang/src/viz/render.rs
+++ b/hydro_lang/src/viz/render.rs
@@ -1281,8 +1281,12 @@ impl HydroNode {
             ),
 
             // Single-expression Aggregation operations - grouped by node type
-            HydroNode::Reduce { f, input, metadata }
-            | HydroNode::ReduceKeyed { f, input, metadata } => build_single_expr_transform(
+            HydroNode::Reduce {
+                f, input, metadata, ..
+            }
+            | HydroNode::ReduceKeyed {
+                f, input, metadata, ..
+            } => build_single_expr_transform(
                 TransformParams {
                     structure,
                     seen_tees,
@@ -1443,6 +1447,7 @@ impl HydroNode {
                 input,
                 watermark,
                 metadata,
+                ..
             } => {
                 let input_id = input.build_graph_structure(structure, seen_tees, config);
                 let watermark_id = watermark.build_graph_structure(structure, seen_tees, config);

--- a/hydro_lang/tests/compile-fail/stable/non_commutative.stderr
+++ b/hydro_lang/tests/compile-fail/stable/non_commutative.stderr
@@ -18,5 +18,5 @@ note: required by a bound in `hydro_lang::prelude::Stream::<T, L, B, O, R>::fold
   |     pub fn fold<A, I, F, C, Idemp, M, B2: SingletonBound>(
   |            ---- required by a bound in this associated function
 ...
-  |         C: ValidCommutativityFor<O>,
+  |         C: ValidCommutativityFor<O> + crate::properties::IsProved,
   |            ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Stream::<T, L, B, O, R>::fold`

--- a/hydro_test/src/cluster/snapshots/compute_pi_ir.snap
+++ b/hydro_test/src/cluster/snapshots/compute_pi_ir.snap
@@ -108,6 +108,8 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                         },
+                                                                        is_commutative: false,
+                                                                        is_idempotent: false,
                                                                         metadata: HydroIrMetadata {
                                                                             location_id: Tick(0, Cluster(loc1v1)),
                                                                             collection_kind: Singleton {
@@ -188,6 +190,8 @@ expression: built.ir()
                                                 },
                                             },
                                         },
+                                        is_commutative: true,
+                                        is_idempotent: false,
                                         metadata: HydroIrMetadata {
                                             location_id: Process(loc2v1),
                                             collection_kind: Optional {
@@ -266,6 +270,8 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                             },
+                                                            is_commutative: false,
+                                                            is_idempotent: false,
                                                             metadata: HydroIrMetadata {
                                                                 location_id: Tick(1, Process(loc2v1)),
                                                                 collection_kind: Optional {

--- a/hydro_test/src/cluster/snapshots/many_to_many_ir.snap
+++ b/hydro_test/src/cluster/snapshots/many_to_many_ir.snap
@@ -74,6 +74,8 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                             },
+                                                            is_commutative: false,
+                                                            is_idempotent: false,
                                                             metadata: HydroIrMetadata {
                                                                 location_id: Cluster(loc1v1),
                                                                 collection_kind: KeyedSingleton {

--- a/hydro_test/src/cluster/snapshots/map_reduce_ir.snap
+++ b/hydro_test/src/cluster/snapshots/map_reduce_ir.snap
@@ -161,6 +161,8 @@ expression: built.ir()
                                                                                                                                                         },
                                                                                                                                                     },
                                                                                                                                                 },
+                                                                                                                                                is_commutative: false,
+                                                                                                                                                is_idempotent: false,
                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                     location_id: Process(loc1v1),
                                                                                                                                                     collection_kind: KeyedSingleton {
@@ -230,6 +232,8 @@ expression: built.ir()
                                                                                                                             },
                                                                                                                         },
                                                                                                                     },
+                                                                                                                    is_commutative: false,
+                                                                                                                    is_idempotent: false,
                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                         location_id: Tick(0, Process(loc1v1)),
                                                                                                                         collection_kind: Singleton {
@@ -329,6 +333,8 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                             },
+                                                                            is_commutative: false,
+                                                                            is_idempotent: false,
                                                                             metadata: HydroIrMetadata {
                                                                                 location_id: Tick(1, Cluster(loc2v1)),
                                                                                 collection_kind: KeyedSingleton {
@@ -443,6 +449,8 @@ expression: built.ir()
                                         },
                                     },
                                 },
+                                is_commutative: true,
+                                is_idempotent: false,
                                 metadata: HydroIrMetadata {
                                     location_id: Process(loc1v1),
                                     collection_kind: KeyedSingleton {

--- a/hydro_test/src/cluster/snapshots/paxos_ir.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir.snap
@@ -367,6 +367,8 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                             },
+                                                            is_commutative: false,
+                                                            is_idempotent: false,
                                                             metadata: HydroIrMetadata {
                                                                 location_id: Cluster(loc1v1),
                                                                 collection_kind: Optional {
@@ -643,6 +645,8 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                 },
+                                                                is_commutative: false,
+                                                                is_idempotent: false,
                                                                 metadata: HydroIrMetadata {
                                                                     location_id: Cluster(loc1v1),
                                                                     collection_kind: KeyedSingleton {
@@ -905,6 +909,8 @@ expression: built.ir()
                                                                                                 },
                                                                                             },
                                                                                         },
+                                                                                        is_commutative: false,
+                                                                                        is_idempotent: false,
                                                                                         metadata: HydroIrMetadata {
                                                                                             location_id: Tick(5, Cluster(loc1v1)),
                                                                                             collection_kind: Optional {
@@ -1239,6 +1245,8 @@ expression: built.ir()
                                                                                                                                     },
                                                                                                                                 },
                                                                                                                             },
+                                                                                                                            is_commutative: false,
+                                                                                                                            is_idempotent: false,
                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                 location_id: Cluster(loc1v1),
                                                                                                                                 collection_kind: KeyedSingleton {
@@ -1375,6 +1383,8 @@ expression: built.ir()
                                                                                                                                                                                                 },
                                                                                                                                                                                             },
                                                                                                                                                                                         },
+                                                                                                                                                                                        is_commutative: true,
+                                                                                                                                                                                        is_idempotent: false,
                                                                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                                                                             location_id: Cluster(loc1v1),
                                                                                                                                                                                             collection_kind: Singleton {
@@ -1581,6 +1591,8 @@ expression: built.ir()
                                                                                                                                                                         },
                                                                                                                                                                     },
                                                                                                                                                                 },
+                                                                                                                                                                is_commutative: false,
+                                                                                                                                                                is_idempotent: false,
                                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                                     location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                                                                     collection_kind: Optional {
@@ -1874,6 +1886,8 @@ expression: built.ir()
                                                                                                 },
                                                                                             },
                                                                                         },
+                                                                                        is_commutative: false,
+                                                                                        is_idempotent: false,
                                                                                         metadata: HydroIrMetadata {
                                                                                             location_id: Atomic(Tick(2, Cluster(loc2v1))),
                                                                                             collection_kind: Optional {
@@ -2130,6 +2144,8 @@ expression: built.ir()
                                                 },
                                             },
                                         },
+                                        is_commutative: true,
+                                        is_idempotent: false,
                                         metadata: HydroIrMetadata {
                                             location_id: Tick(9, Cluster(loc1v1)),
                                             collection_kind: KeyedSingleton {
@@ -2555,6 +2571,8 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                 },
+                                                                is_commutative: false,
+                                                                is_idempotent: true,
                                                                 metadata: HydroIrMetadata {
                                                                     location_id: Cluster(loc1v1),
                                                                     collection_kind: Optional {
@@ -3113,6 +3131,8 @@ expression: built.ir()
                                                                                                                             },
                                                                                                                         },
                                                                                                                     },
+                                                                                                                    is_commutative: false,
+                                                                                                                    is_idempotent: false,
                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                         location_id: Cluster(loc1v1),
                                                                                                                         collection_kind: KeyedSingleton {
@@ -3492,6 +3512,8 @@ expression: built.ir()
                                                                 },
                                                             },
                                                         },
+                                                        is_commutative: false,
+                                                        is_idempotent: false,
                                                         metadata: HydroIrMetadata {
                                                             location_id: Cluster(loc3v1),
                                                             collection_kind: Optional {
@@ -3944,6 +3966,8 @@ expression: built.ir()
                                                                                                             },
                                                                                                         },
                                                                                                     },
+                                                                                                    is_commutative: true,
+                                                                                                    is_idempotent: false,
                                                                                                     metadata: HydroIrMetadata {
                                                                                                         location_id: Tick(15, Cluster(loc1v1)),
                                                                                                         collection_kind: KeyedSingleton {
@@ -4013,6 +4037,8 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                         },
+                                                                        is_commutative: false,
+                                                                        is_idempotent: false,
                                                                         metadata: HydroIrMetadata {
                                                                             location_id: Tick(15, Cluster(loc1v1)),
                                                                             collection_kind: Optional {
@@ -4183,6 +4209,8 @@ expression: built.ir()
                                 },
                             },
                         },
+                        is_commutative: false,
+                        is_idempotent: false,
                         metadata: HydroIrMetadata {
                             location_id: Tick(15, Cluster(loc1v1)),
                             collection_kind: Singleton {
@@ -4351,6 +4379,8 @@ expression: built.ir()
                                                                                                                             },
                                                                                                                         },
                                                                                                                     },
+                                                                                                                    is_commutative: false,
+                                                                                                                    is_idempotent: false,
                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                         location_id: Cluster(loc1v1),
                                                                                                                         collection_kind: KeyedSingleton {
@@ -4618,6 +4648,8 @@ expression: built.ir()
                                                                                                                                                                     },
                                                                                                                                                                 },
                                                                                                                                                             },
+                                                                                                                                                            is_commutative: false,
+                                                                                                                                                            is_idempotent: false,
                                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                                 location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                                                                 collection_kind: Optional {
@@ -5225,6 +5257,8 @@ expression: built.ir()
                                                 },
                                             },
                                         },
+                                        is_commutative: true,
+                                        is_idempotent: false,
                                         metadata: HydroIrMetadata {
                                             location_id: Tick(14, Cluster(loc1v1)),
                                             collection_kind: KeyedSingleton {
@@ -5799,6 +5833,8 @@ expression: built.ir()
                                                     },
                                                 },
                                             },
+                                            is_commutative: true,
+                                            is_idempotent: false,
                                             metadata: HydroIrMetadata {
                                                 location_id: Atomic(Tick(2, Cluster(loc2v1))),
                                                 collection_kind: KeyedSingleton {
@@ -5838,6 +5874,8 @@ expression: built.ir()
                                     },
                                 },
                             },
+                            is_commutative: true,
+                            is_idempotent: false,
                             metadata: HydroIrMetadata {
                                 location_id: Tick(2, Cluster(loc2v1)),
                                 collection_kind: Singleton {
@@ -6081,6 +6119,8 @@ expression: built.ir()
                                                                                                         },
                                                                                                     },
                                                                                                 },
+                                                                                                is_commutative: false,
+                                                                                                is_idempotent: false,
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_id: Cluster(loc1v1),
                                                                                                     collection_kind: KeyedSingleton {
@@ -6475,6 +6515,8 @@ expression: built.ir()
                                         },
                                     },
                                 },
+                                is_commutative: false,
+                                is_idempotent: false,
                                 metadata: HydroIrMetadata {
                                     location_id: Tick(17, Cluster(loc5v1)),
                                     collection_kind: Singleton {
@@ -6630,6 +6672,8 @@ expression: built.ir()
                                 },
                             },
                         },
+                        is_commutative: false,
+                        is_idempotent: false,
                         metadata: HydroIrMetadata {
                             location_id: Atomic(Tick(17, Cluster(loc5v1))),
                             collection_kind: Singleton {
@@ -6723,6 +6767,8 @@ expression: built.ir()
                                                     },
                                                 },
                                             },
+                                            is_commutative: false,
+                                            is_idempotent: false,
                                             metadata: HydroIrMetadata {
                                                 location_id: Atomic(Tick(17, Cluster(loc5v1))),
                                                 collection_kind: Optional {
@@ -6967,6 +7013,8 @@ expression: built.ir()
                                                                                                         },
                                                                                                     },
                                                                                                 },
+                                                                                                is_commutative: false,
+                                                                                                is_idempotent: false,
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_id: Cluster(loc5v1),
                                                                                                     collection_kind: KeyedSingleton {
@@ -7122,6 +7170,8 @@ expression: built.ir()
                                                             },
                                                         },
                                                     },
+                                                    is_commutative: true,
+                                                    is_idempotent: false,
                                                     metadata: HydroIrMetadata {
                                                         location_id: Cluster(loc2v1),
                                                         collection_kind: KeyedSingleton {
@@ -7223,6 +7273,8 @@ expression: built.ir()
                                                     },
                                                 },
                                             },
+                                            is_commutative: false,
+                                            is_idempotent: false,
                                             metadata: HydroIrMetadata {
                                                 location_id: Tick(19, Cluster(loc2v1)),
                                                 collection_kind: Singleton {
@@ -7288,6 +7340,8 @@ expression: built.ir()
                         },
                     },
                 },
+                is_commutative: false,
+                is_idempotent: false,
                 metadata: HydroIrMetadata {
                     location_id: Tick(19, Cluster(loc2v1)),
                     collection_kind: Optional {
@@ -7518,6 +7572,8 @@ expression: built.ir()
                                             },
                                         },
                                     },
+                                    is_commutative: true,
+                                    is_idempotent: false,
                                     metadata: HydroIrMetadata {
                                         location_id: Tick(20, Cluster(loc3v1)),
                                         collection_kind: KeyedSingleton {
@@ -7746,6 +7802,8 @@ expression: built.ir()
                                                                                                         },
                                                                                                     },
                                                                                                 },
+                                                                                                is_commutative: true,
+                                                                                                is_idempotent: false,
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_id: Cluster(loc3v1),
                                                                                                     collection_kind: KeyedSingleton {
@@ -7838,6 +7896,8 @@ expression: built.ir()
                                                                                                     },
                                                                                                 },
                                                                                             },
+                                                                                            is_commutative: true,
+                                                                                            is_idempotent: false,
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_id: Tick(21, Cluster(loc3v1)),
                                                                                                 collection_kind: KeyedSingleton {
@@ -7989,6 +8049,8 @@ expression: built.ir()
                                         },
                                     },
                                 },
+                                is_commutative: true,
+                                is_idempotent: false,
                                 metadata: HydroIrMetadata {
                                     location_id: Tick(22, Cluster(loc3v1)),
                                     collection_kind: Singleton {
@@ -8140,6 +8202,8 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                     },
+                                                                    is_commutative: false,
+                                                                    is_idempotent: false,
                                                                     metadata: HydroIrMetadata {
                                                                         location_id: Tick(22, Cluster(loc3v1)),
                                                                         collection_kind: Optional {
@@ -8348,6 +8412,8 @@ expression: built.ir()
                                         },
                                     },
                                 },
+                                is_commutative: false,
+                                is_idempotent: false,
                                 metadata: HydroIrMetadata {
                                     location_id: Tick(22, Cluster(loc3v1)),
                                     collection_kind: Singleton {
@@ -8928,6 +8994,8 @@ expression: built.ir()
                                                     },
                                                 },
                                             },
+                                            is_commutative: true,
+                                            is_idempotent: false,
                                             metadata: HydroIrMetadata {
                                                 location_id: Tick(23, Process(loc4v1)),
                                                 collection_kind: Optional {
@@ -9054,6 +9122,8 @@ expression: built.ir()
                                                     },
                                                 },
                                             },
+                                            is_commutative: false,
+                                            is_idempotent: false,
                                             metadata: HydroIrMetadata {
                                                 location_id: Tick(23, Process(loc4v1)),
                                                 collection_kind: Optional {
@@ -9559,6 +9629,8 @@ expression: built.ir()
                     },
                 },
             },
+            is_commutative: true,
+            is_idempotent: false,
             metadata: HydroIrMetadata {
                 location_id: Tick(23, Process(loc4v1)),
                 collection_kind: Singleton {

--- a/hydro_test/src/cluster/snapshots/two_pc_ir.snap
+++ b/hydro_test/src/cluster/snapshots/two_pc_ir.snap
@@ -341,6 +341,8 @@ expression: built.ir()
                                                                                                     },
                                                                                                 },
                                                                                             },
+                                                                                            is_commutative: false,
+                                                                                            is_idempotent: false,
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_id: Process(loc1v1),
                                                                                                 collection_kind: KeyedSingleton {
@@ -753,6 +755,8 @@ expression: built.ir()
                                             },
                                         },
                                     },
+                                    is_commutative: true,
+                                    is_idempotent: false,
                                     metadata: HydroIrMetadata {
                                         location_id: Tick(2, Process(loc1v1)),
                                         collection_kind: KeyedSingleton {
@@ -999,6 +1003,8 @@ expression: built.ir()
                                                                                                     },
                                                                                                 },
                                                                                             },
+                                                                                            is_commutative: false,
+                                                                                            is_idempotent: false,
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_id: Process(loc1v1),
                                                                                                 collection_kind: KeyedSingleton {
@@ -1268,6 +1274,8 @@ expression: built.ir()
                                             },
                                         },
                                     },
+                                    is_commutative: true,
+                                    is_idempotent: false,
                                     metadata: HydroIrMetadata {
                                         location_id: Tick(4, Process(loc1v1)),
                                         collection_kind: KeyedSingleton {
@@ -1530,6 +1538,8 @@ expression: built.ir()
                                                                                                         },
                                                                                                     },
                                                                                                 },
+                                                                                                is_commutative: true,
+                                                                                                is_idempotent: false,
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_id: Cluster(loc3v1),
                                                                                                     collection_kind: KeyedSingleton {
@@ -1622,6 +1632,8 @@ expression: built.ir()
                                                                                                     },
                                                                                                 },
                                                                                             },
+                                                                                            is_commutative: true,
+                                                                                            is_idempotent: false,
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_id: Tick(5, Cluster(loc3v1)),
                                                                                                 collection_kind: KeyedSingleton {
@@ -1773,6 +1785,8 @@ expression: built.ir()
                                         },
                                     },
                                 },
+                                is_commutative: true,
+                                is_idempotent: false,
                                 metadata: HydroIrMetadata {
                                     location_id: Tick(6, Cluster(loc3v1)),
                                     collection_kind: Singleton {
@@ -1924,6 +1938,8 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                     },
+                                                                    is_commutative: false,
+                                                                    is_idempotent: false,
                                                                     metadata: HydroIrMetadata {
                                                                         location_id: Tick(6, Cluster(loc3v1)),
                                                                         collection_kind: Optional {
@@ -2132,6 +2148,8 @@ expression: built.ir()
                                         },
                                     },
                                 },
+                                is_commutative: false,
+                                is_idempotent: false,
                                 metadata: HydroIrMetadata {
                                     location_id: Tick(6, Cluster(loc3v1)),
                                     collection_kind: Singleton {
@@ -2712,6 +2730,8 @@ expression: built.ir()
                                                     },
                                                 },
                                             },
+                                            is_commutative: true,
+                                            is_idempotent: false,
                                             metadata: HydroIrMetadata {
                                                 location_id: Tick(7, Process(loc4v1)),
                                                 collection_kind: Optional {
@@ -2838,6 +2858,8 @@ expression: built.ir()
                                                     },
                                                 },
                                             },
+                                            is_commutative: false,
+                                            is_idempotent: false,
                                             metadata: HydroIrMetadata {
                                                 location_id: Tick(7, Process(loc4v1)),
                                                 collection_kind: Optional {
@@ -3343,6 +3365,8 @@ expression: built.ir()
                     },
                 },
             },
+            is_commutative: true,
+            is_idempotent: false,
             metadata: HydroIrMetadata {
                 location_id: Tick(7, Process(loc4v1)),
                 collection_kind: Singleton {


### PR DESCRIPTION
Adds `IsProved` trait to the properties module and records algebraic properties directly on fold/reduce IR nodes, enabling downstream analysis passes to distinguish lattice operations from non-commutative/non-idempotent ones without re-deriving properties from types.

Changes:
- `properties/mod.rs`: `IsProved` trait with const `IS_PROVED: bool`
- `compile/ir/mod.rs`: `is_commutative`/`is_idempotent` fields on `Fold`, `FoldKeyed`, `Reduce`, `ReduceKeyed`, `ReduceKeyedWatermark`
- `stream/mod.rs`, `keyed_stream/mod.rs`: `IsProved` bounds on fold/reduce, capture proof status at construction
- `viz/render.rs`: pattern matches updated with `..`
- Snapshot updates for IR tests in `hydro_test` and compile-fail stderr

Cherry-picked from the `coord-criterion` branch.