### PR TITLE
feat(hydro_lang): add Stream::weaken_consistency() and cluster_with_consistency()

### DIFF
--- a/hydro_lang/src/compile/builder.rs
+++ b/hydro_lang/src/compile/builder.rs
@@ -228,6 +228,14 @@ impl<'a> FlowBuilder<'a> {
         }
     }
 
+    /// Create a cluster with a specific consistency guarantee.
+    pub fn cluster_with_consistency<C, Con: crate::location::cluster::Consistency>(
+        &mut self,
+    ) -> Cluster<'a, C, Con> {
+        use crate::location::Location;
+        Cluster::from_drop_consistency(self.cluster::<C>())
+    }
+
     pub fn external<E>(&mut self) -> External<'a, E> {
         let key = self.locations.insert(LocationType::External);
         self.location_names.insert(key, type_name::<E>().to_owned());


### PR DESCRIPTION
Adds two utility methods for working with consistency-typed clusters:

- `Stream::weaken_consistency()`: Weakens the consistency guarantee of a stream (e.g., going from `EventualConsistency` to `NoConsistency`), with the type system enforcing the direction is safe. No IR node is inserted. Follows the same pattern as `weaken_ordering()` and `weaken_retries()`. Useful when a stream produced by `broadcast_closed` needs to flow through APIs that expect `NoConsistency`.

- `FlowBuilder::cluster_with_consistency<C, Con>()`: Creates a cluster with an explicit consistency type parameter (e.g. `EventualConsistency`), rather than defaulting to `NoConsistency`.

These are building blocks for the consistency label analysis in the next PR.