### PR TITLE
fix(hydro_lang): remove `SingletonRef` global counter causing codegen non-determinism

### DIFF
--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -32,6 +32,8 @@ use crate::compile::builder::{CycleId, ExternalPortId};
 use crate::compile::deploy_provider::{Deploy, Node, RegisterPort};
 use crate::location::dynamic::{ClusterConsistency, LocationId};
 use crate::location::{LocationKey, NetworkHint};
+#[cfg(feature = "build")]
+use crate::singleton_ref::singleton_ref_ident;
 
 pub mod backtrace;
 use backtrace::Backtrace;
@@ -42,9 +44,10 @@ use backtrace::Backtrace;
 /// alongside the closure's expression. This allows per-closure tracking of singleton
 /// captures, which is important for nodes with multiple closures (e.g. Fold has `init` and `acc`).
 pub struct ClosureExpr {
-    pub expr: DebugExpr,
-    /// Each entry is `(local_ident, singleton_node, is_mut)`.
-    pub singleton_refs: Vec<(syn::Ident, HydroNode, bool)>,
+    pub(crate) expr: DebugExpr,
+    /// Each entry is `(singleton_node, is_mut)`.
+    /// The index in the Vec determines the ident name via [`singleton_ref_ident`].
+    pub(crate) singleton_refs: Vec<(HydroNode, bool)>,
 }
 
 impl Clone for ClosureExpr {
@@ -54,15 +57,17 @@ impl Clone for ClosureExpr {
             singleton_refs: self
                 .singleton_refs
                 .iter()
-                .map(|(ident, node, is_mut)| {
-                    let cloned_node = match node {
-                        HydroNode::Singleton { inner, metadata } => HydroNode::Singleton {
-                            inner: SharedNode(inner.0.clone()),
+                .map(|(node, is_mut)| {
+                    let HydroNode::Singleton { inner, metadata } = node else {
+                        panic!("singleton_refs should only contain HydroNode::Singleton");
+                    };
+                    (
+                        HydroNode::Singleton {
+                            inner: SharedNode(Rc::clone(&inner.0)),
                             metadata: metadata.clone(),
                         },
-                        _ => panic!("singleton_refs should only contain HydroNode::Singleton"),
-                    };
-                    (ident.clone(), cloned_node, *is_mut)
+                        *is_mut,
+                    )
                 })
                 .collect(),
         }
@@ -91,14 +96,14 @@ impl serde::Serialize for ClosureExpr {
     }
 }
 
-struct SerializableSingletonRefs<'a>(&'a [(syn::Ident, HydroNode, bool)]);
+struct SerializableSingletonRefs<'a>(&'a [(HydroNode, bool)]);
 
 impl serde::Serialize for SerializableSingletonRefs<'_> {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         use serde::ser::SerializeSeq;
         let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
-        for (ident, node, is_mut) in self.0 {
-            seq.serialize_element(&(ident.to_string(), node, is_mut))?;
+        for (node, is_mut) in self.0.iter() {
+            seq.serialize_element(&(node, is_mut))?;
         }
         seq.end()
     }
@@ -135,7 +140,7 @@ impl From<DebugExpr> for ClosureExpr {
 }
 
 impl ClosureExpr {
-    pub fn new(expr: DebugExpr, singleton_refs: Vec<(syn::Ident, HydroNode, bool)>) -> Self {
+    pub fn new(expr: DebugExpr, singleton_refs: Vec<(HydroNode, bool)>) -> Self {
         Self {
             expr,
             singleton_refs,
@@ -148,7 +153,7 @@ impl ClosureExpr {
             singleton_refs: self
                 .singleton_refs
                 .iter()
-                .map(|(ident, node, is_mut)| (ident.clone(), node.deep_clone(seen_tees), *is_mut))
+                .map(|(node, is_mut)| (node.deep_clone(seen_tees), *is_mut))
                 .collect(),
         }
     }
@@ -158,7 +163,7 @@ impl ClosureExpr {
         transform: &mut impl FnMut(&mut HydroNode, &mut SeenSharedNodes),
         seen_tees: &mut SeenSharedNodes,
     ) {
-        for (_ident, ref_node, _is_mut) in self.singleton_refs.iter_mut() {
+        for (ref_node, _is_mut) in self.singleton_refs.iter_mut() {
             transform(ref_node, seen_tees);
         }
     }
@@ -174,16 +179,11 @@ impl ClosureExpr {
         if self.singleton_refs.is_empty() {
             self.expr.0.to_token_stream()
         } else {
-            let ref_idents = (0..self.singleton_refs.len())
-                .map(|_| ident_stack.pop().unwrap())
-                .collect::<Vec<_>>()
-                .into_iter()
-                .rev()
-                .collect::<Vec<_>>();
+            let ref_idents = ident_stack.drain(ident_stack.len() - self.singleton_refs.len()..);
 
             let mut let_bindings = Vec::new();
-            for ((local_ident, node, is_mut), ref_ident) in
-                self.singleton_refs.iter().zip(ref_idents.iter())
+            for ((i, (node, is_mut)), ref_ident) in
+                self.singleton_refs.iter().enumerate().zip(ref_idents)
             {
                 let HydroNode::Singleton { inner, .. } = node else {
                     panic!("singleton_refs should only contain HydroNode::Singleton");
@@ -200,8 +200,9 @@ impl ClosureExpr {
                 };
 
                 // TODO(mingwei): proper spanning?
-                let group_lit = proc_macro2::Literal::u32_unsuffixed(group);
+                let local_ident = singleton_ref_ident(i);
                 let hash = proc_macro2::Punct::new('#', proc_macro2::Spacing::Alone);
+                let group_lit = proc_macro2::Literal::u32_unsuffixed(group);
                 let mut_token = is_mut.then(|| quote!(mut));
                 let binding = quote! {
                     let #local_ident = #hash {#group_lit} #mut_token #ref_ident;

--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -179,6 +179,12 @@ impl ClosureExpr {
         if self.singleton_refs.is_empty() {
             self.expr.0.to_token_stream()
         } else {
+            assert!(
+                ident_stack.len() >= self.singleton_refs.len(),
+                "ident_stack has {} entries but expected at least {} for singleton_refs",
+                ident_stack.len(),
+                self.singleton_refs.len()
+            );
             let ref_idents = ident_stack.drain(ident_stack.len() - self.singleton_refs.len()..);
 
             let mut let_bindings = Vec::new();

--- a/hydro_lang/src/singleton_ref.rs
+++ b/hydro_lang/src/singleton_ref.rs
@@ -97,7 +97,7 @@ where
     L: Location<'a>,
 {
     fn to_tokens_helper(self, _ctx: &L) -> (QuoteTokens, ()) {
-        let ident =SINGLETON_REFS.with(|cell| {
+        let ident = SINGLETON_REFS.with(|cell| {
             let mut guard = cell.borrow_mut();
             let refs = guard.as_mut().expect(
                 "SingletonRef used inside q!() but no singleton capture scope is active. \

--- a/hydro_lang/src/singleton_ref.rs
+++ b/hydro_lang/src/singleton_ref.rs
@@ -60,9 +60,18 @@ impl<T, L, const IS_MUT: bool> Clone for SingletonRef<'_, '_, T, L, IS_MUT> {
 }
 
 // Thread-local storage for singleton references captured during `q!()` expansion.
-// Maps local ident name -> (SharedNode, is_mut) for each singleton captured in the current closure.
+// Stores the HydroNode `(SharedNode, is_mut)` for each singleton captured in the current closure.
+// The index in the Vec determines the ident name via `singleton_ref_ident`.
 thread_local! {
-    static SINGLETON_REFS: RefCell<Option<Vec<(syn::Ident, HydroNode, bool)>>> = const { RefCell::new(None) };
+    static SINGLETON_REFS: RefCell<Option<Vec<(HydroNode, bool)>>> = const { RefCell::new(None) };
+}
+
+/// Returns the canonical ident for a singleton ref at the given index within a closure.
+pub(crate) fn singleton_ref_ident(index: usize) -> syn::Ident {
+    syn::Ident::new(
+        &format!("__hydro_singleton_ref_{}", index),
+        Span::call_site(),
+    )
 }
 
 /// Activate the singleton reference capture context. Must be called before `q!()` expansion
@@ -83,23 +92,20 @@ pub fn with_singleton_capture(
     crate::compile::ir::ClosureExpr::new(expr, singleton_refs)
 }
 
-static SINGLETON_REF_COUNTER: std::sync::atomic::AtomicUsize =
-    std::sync::atomic::AtomicUsize::new(0);
-
 impl<'a, 'slf, T: 'a, L, const IS_MUT: bool> SingletonRef<'a, 'slf, T, L, IS_MUT>
 where
     L: Location<'a>,
 {
     fn to_tokens_helper(self, _ctx: &L) -> (QuoteTokens, ()) {
-        let id = SINGLETON_REF_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let ident = syn::Ident::new(&format!("__hydro_singleton_ref_{}", id), Span::call_site());
-
-        SINGLETON_REFS.with(|cell| {
+        let ident =SINGLETON_REFS.with(|cell| {
             let mut guard = cell.borrow_mut();
             let refs = guard.as_mut().expect(
                 "SingletonRef used inside q!() but no singleton capture scope is active. \
                  This is a bug — singleton capture should be set up by the operator that uses q!().",
             );
+
+            let index = refs.len();
+            let ident = singleton_ref_ident(index);
 
             let metadata = self.ir_node.borrow().metadata().clone();
 
@@ -119,13 +125,14 @@ where
             };
 
             refs.push((
-                ident.clone(),
                 HydroNode::Singleton {
                     inner: SharedNode(Rc::clone(&inner.0)),
                     metadata,
                 },
                 IS_MUT,
             ));
+
+            ident
         });
 
         (

--- a/hydro_test/src/local/singleton_ref.rs
+++ b/hydro_test/src/local/singleton_ref.rs
@@ -246,6 +246,74 @@ mod tests {
         assert_eq!(results, vec![44, 45]);
     }
 
+    /// Test: two singleton refs of *different incompatible types* captured in one closure.
+    ///
+    /// This catches bugs where singleton refs get mixed up (e.g., wrong ident_stack ordering).
+    /// If ref_a (i32) and ref_b (String) are swapped, the code won't compile or will
+    /// produce a type error at runtime — which is exactly the failure mode we want to guard.
+    #[tokio::test]
+    async fn test_singleton_ref_two_different_types_one_closure() {
+        let mut deployment = Deployment::new();
+
+        let mut builder = FlowBuilder::new();
+        let external = builder.external::<()>();
+        let p1 = builder.process::<()>();
+
+        // Singleton A: i32, fold 0..5 => 10
+        let sum = p1
+            .source_iter(q!(0..5i32))
+            .fold(q!(|| 0i32), q!(|acc: &mut i32, x| *acc += x));
+
+        // Singleton B: String, fold ["hello", " ", "world"] => "hello world"
+        let greeting = p1
+            .source_iter(q!(vec![
+                "hello".to_owned(),
+                " ".to_owned(),
+                "world".to_owned(),
+            ]))
+            .fold(
+                q!(|| String::new()),
+                q!(|acc: &mut String, x| acc.push_str(&x)),
+            );
+
+        let ref_a = sum.by_ref();
+        let ref_b = greeting.by_ref();
+
+        // Capture both refs in one closure — ref_a is &i32, ref_b is &String.
+        // If they get swapped, this won't type-check.
+        let out_port = p1
+            .source_iter(q!(1..=2i32))
+            .map(q!(|x| {
+                let numeric = *ref_a; // should be 10
+                let text = ref_b.clone(); // should be "hello world"
+                format!("{}-{}-{}", text, numeric, x)
+            }))
+            .send_bincode_external(&external);
+
+        let nodes = builder
+            .with_default_optimize()
+            .with_process(&p1, deployment.Localhost())
+            .with_external(&external, deployment.Localhost())
+            .deploy(&mut deployment);
+
+        deployment.deploy().await.unwrap();
+
+        let mut out_recv = nodes.connect(out_port).await;
+
+        deployment.start().await.unwrap();
+
+        let mut results: Vec<String> = Vec::new();
+        for _ in 0..2 {
+            results.push(out_recv.next().await.unwrap());
+        }
+        results.sort();
+        // ref_a = 10, ref_b = "hello world", so results = "hello world-10-1", "hello world-10-2"
+        assert_eq!(
+            results,
+            vec!["hello world-10-1".to_owned(), "hello world-10-2".to_owned()],
+        );
+    }
+
     /// Test: singleton ref inside a filter closure.
     #[tokio::test]
     async fn test_singleton_ref_filter() {


### PR DESCRIPTION
The global `static SINGLETON_REF_COUNTER: AtomicUsize` was shared across all
tests in a binary, causing `__hydro_singleton_ref_N` idents to shift depending
on test execution order. For example, paxos snapshots expected IDs 0-6 but got
12-18 when singleton_ref tests ran first.

Fix: Remove the global counter entirely. Instead, derive the ident index from
`refs.len()` within each `with_singleton_capture` scope, so every closure's
captured singleton refs are numbered starting from 0. This is safe because each
closure gets its own lexical block in the generated code.

Changes:
- hydro_lang/src/singleton_ref.rs: Remove `SINGLETON_REF_COUNTER` static. Add
  `singleton_ref_ident(index)` helper. Simplify thread-local from
  `Vec<(syn::Ident, HydroNode, is_mut)>` to `Vec<(HydroNode, is_mut)>`. Use `refs.len()` as index.
- hydro_lang/src/compile/ir/mod.rs: Change `ClosureExpr::singleton_refs` from
  `Vec<(syn::Ident, HydroNode, is_mut)>` to `Vec<(HydroNode, is_mut)>`. Update Clone, Serialize,
  deep_clone, transform_children, and emit_tokens to use index-based idents via
  the new helper.
- hydro_test snapshots: Regenerated paxos IR and mermaid snapshots (stable only;
  nightly snapshots need a nightly CI run).

Also adds a test to make sure singleton idents are processed in the correct order.

Co-authored-by: Infinity 🤖 <infinity@hydro.run>