### PR TITLE
refactor(hydro_lang): separate Counter<T> from ID types to enforce get_and_increment

### DIFF
--- a/hydro_lang/src/compile/builder.rs
+++ b/hydro_lang/src/compile/builder.rs
@@ -84,16 +84,16 @@ pub(crate) struct FlowStateInner {
     roots: Option<Vec<HydroRoot>>,
 
     /// Counter for generating unique external output identifiers.
-    next_external_port: ExternalPortId,
+    next_external_port: crate::Counter<ExternalPortId>,
 
     /// Counters for generating identifiers for cycles.
-    next_cycle_id: CycleId,
+    next_cycle_id: crate::Counter<CycleId>,
 
     /// Counters for clock IDs.
-    next_clock_id: ClockId,
+    next_clock_id: crate::Counter<ClockId>,
 
     /// Counter for generating unique sidecar identifiers, not used for anything else.
-    next_sidecar_id: SidecarId,
+    next_sidecar_id: crate::Counter<SidecarId>,
 
     /// Compile-time sidecar directives. Processed during compilation,
     /// not part of the dataflow IR.
@@ -190,10 +190,10 @@ impl<'a> FlowBuilder<'a> {
         Self {
             flow_state: Rc::new(RefCell::new(FlowStateInner {
                 roots: Some(vec![]),
-                next_external_port: ExternalPortId::default(),
-                next_cycle_id: CycleId::default(),
-                next_clock_id: ClockId::default(),
-                next_sidecar_id: SidecarId::default(),
+                next_external_port: crate::Counter::default(),
+                next_cycle_id: crate::Counter::default(),
+                next_clock_id: crate::Counter::default(),
+                next_sidecar_id: crate::Counter::default(),
                 sidecars: Vec::new(),
             })),
             locations: SlotMap::with_key(),
@@ -335,10 +335,10 @@ impl<'a> FlowBuilder<'a> {
         FlowBuilder {
             flow_state: Rc::new(RefCell::new(FlowStateInner {
                 roots: None,
-                next_external_port: ExternalPortId::default(),
-                next_cycle_id: CycleId::default(),
-                next_clock_id: ClockId::default(),
-                next_sidecar_id: SidecarId::default(),
+                next_external_port: crate::Counter::default(),
+                next_cycle_id: crate::Counter::default(),
+                next_clock_id: crate::Counter::default(),
+                next_sidecar_id: crate::Counter::default(),
                 sidecars: Vec::new(),
             })),
             locations: built.locations.clone(),

--- a/hydro_lang/src/compile/built.rs
+++ b/hydro_lang/src/compile/built.rs
@@ -124,7 +124,7 @@ impl<'a> BuiltFlow<'a> {
 
         use crate::sim::graph::SimNodePort;
 
-        let shared_port_counter = Rc::new(RefCell::new(SimNodePort::default()));
+        let shared_port_counter = Rc::new(RefCell::new(crate::Counter::<SimNodePort>::default()));
 
         let mut processes = SparseSecondaryMap::new();
         let mut clusters = SparseSecondaryMap::new();

--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -872,8 +872,8 @@ impl DfirBuilder for SecondaryMap<LocationKey, FlatGraphBuilder> {
 #[cfg(feature = "build")]
 pub enum BuildersOrCallback<'a, L, N>
 where
-    L: FnMut(&mut HydroRoot, &mut StmtId),
-    N: FnMut(&mut HydroNode, &mut StmtId),
+    L: FnMut(&mut HydroRoot, &mut crate::Counter<StmtId>),
+    N: FnMut(&mut HydroNode, &mut crate::Counter<StmtId>),
 {
     Builders(&'a mut dyn DfirBuilder),
     Callback(L, N),
@@ -1405,13 +1405,13 @@ impl HydroRoot {
         graph_builders: &mut dyn DfirBuilder,
         seen_tees: &mut SeenSharedNodes,
         built_tees: &mut HashMap<*const RefCell<HydroNode>, Vec<syn::Ident>>,
-        next_stmt_id: &mut StmtId,
+        next_stmt_id: &mut crate::Counter<StmtId>,
         fold_hooked_idents: &mut HashSet<String>,
     ) {
         self.emit_core(
             &mut BuildersOrCallback::<
-                fn(&mut HydroRoot, &mut StmtId),
-                fn(&mut HydroNode, &mut StmtId),
+                fn(&mut HydroRoot, &mut crate::Counter<StmtId>),
+                fn(&mut HydroNode, &mut crate::Counter<StmtId>),
             >::Builders(graph_builders),
             seen_tees,
             built_tees,
@@ -1424,12 +1424,12 @@ impl HydroRoot {
     pub fn emit_core(
         &mut self,
         builders_or_callback: &mut BuildersOrCallback<
-            impl FnMut(&mut HydroRoot, &mut StmtId),
-            impl FnMut(&mut HydroNode, &mut StmtId),
+            impl FnMut(&mut HydroRoot, &mut crate::Counter<StmtId>),
+            impl FnMut(&mut HydroNode, &mut crate::Counter<StmtId>),
         >,
         seen_tees: &mut SeenSharedNodes,
         built_tees: &mut HashMap<*const RefCell<HydroNode>, Vec<syn::Ident>>,
-        next_stmt_id: &mut StmtId,
+        next_stmt_id: &mut crate::Counter<StmtId>,
         fold_hooked_idents: &mut HashSet<String>,
     ) {
         match self {
@@ -1837,7 +1837,7 @@ pub fn emit(ir: &mut Vec<HydroRoot>) -> SecondaryMap<LocationKey, FlatGraphBuild
     let mut builders = SecondaryMap::new();
     let mut seen_tees = HashMap::new();
     let mut built_tees = HashMap::new();
-    let mut next_stmt_id = StmtId::default();
+    let mut next_stmt_id = crate::Counter::<StmtId>::default();
     let mut fold_hooked_idents = HashSet::new();
     for leaf in ir {
         leaf.emit(
@@ -1854,12 +1854,12 @@ pub fn emit(ir: &mut Vec<HydroRoot>) -> SecondaryMap<LocationKey, FlatGraphBuild
 #[cfg(feature = "build")]
 pub fn traverse_dfir(
     ir: &mut [HydroRoot],
-    transform_root: impl FnMut(&mut HydroRoot, &mut StmtId),
-    transform_node: impl FnMut(&mut HydroNode, &mut StmtId),
+    transform_root: impl FnMut(&mut HydroRoot, &mut crate::Counter<StmtId>),
+    transform_node: impl FnMut(&mut HydroNode, &mut crate::Counter<StmtId>),
 ) {
     let mut seen_tees = HashMap::new();
     let mut built_tees = HashMap::new();
-    let mut next_stmt_id = StmtId::default();
+    let mut next_stmt_id = crate::Counter::<StmtId>::default();
     let mut fold_hooked_idents = HashSet::new();
     let mut callback = BuildersOrCallback::Callback(transform_root, transform_node);
     ir.iter_mut().for_each(|leaf| {
@@ -3122,12 +3122,12 @@ impl HydroNode {
     pub fn emit_core(
         &mut self,
         builders_or_callback: &mut BuildersOrCallback<
-            impl FnMut(&mut HydroRoot, &mut StmtId),
-            impl FnMut(&mut HydroNode, &mut StmtId),
+            impl FnMut(&mut HydroRoot, &mut crate::Counter<StmtId>),
+            impl FnMut(&mut HydroNode, &mut crate::Counter<StmtId>),
         >,
         seen_tees: &mut SeenSharedNodes,
         built_tees: &mut HashMap<*const RefCell<HydroNode>, Vec<syn::Ident>>,
-        next_stmt_id: &mut StmtId,
+        next_stmt_id: &mut crate::Counter<StmtId>,
         fold_hooked_idents: &mut HashSet<String>,
     ) -> syn::Ident {
         let mut ident_stack: Vec<syn::Ident> = Vec::new();

--- a/hydro_lang/src/deploy/deploy_graph_containerized.rs
+++ b/hydro_lang/src/deploy/deploy_graph_containerized.rs
@@ -231,7 +231,7 @@ pub struct DockerDeployExternal {
     next_port: Rc<RefCell<u16>>,
 
     /// Counter for generating ExternalPortId values at deploy time.
-    next_external_port_id: Rc<RefCell<ExternalPortId>>,
+    next_external_port_id: Rc<RefCell<crate::Counter<ExternalPortId>>>,
 
     ports: Rc<RefCell<HashMap<ExternalPortId, u16>>>,
 
@@ -1477,7 +1477,7 @@ impl<'a> ExternalSpec<'a, DockerDeploy> for DockerDeployExternalSpec {
             key,
             name: self.name,
             next_port: Rc::new(RefCell::new(10000)),
-            next_external_port_id: Rc::new(RefCell::new(ExternalPortId::default())),
+            next_external_port_id: Rc::new(RefCell::new(crate::Counter::default())),
             ports: Rc::new(RefCell::new(HashMap::new())),
             connection_info: Rc::new(RefCell::new(HashMap::new())),
         }

--- a/hydro_lang/src/lib.rs
+++ b/hydro_lang/src/lib.rs
@@ -153,7 +153,7 @@ mod test_init {
 /// Creates a newtype wrapper around an integer type.
 ///
 /// Usage:
-/// ```rust
+/// ```rust,ignore
 /// hydro_lang::newtype_counter! {
 ///     /// My counter.
 ///     pub struct MyCounter(u32);
@@ -174,27 +174,11 @@ macro_rules! newtype_counter {
         $(
             $( #[$attr] )*
             #[repr(transparent)]
-            #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+            #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
             $vis struct $name($typ);
 
             #[allow(clippy::allow_attributes, dead_code, reason = "macro-generated methods may be unused")]
             impl $name {
-                /// Gets the current ID and increments for the next.
-                pub fn get_and_increment(&mut self) -> Self {
-                    let id = self.0;
-                    self.0 += 1;
-                    Self(id)
-                }
-
-                /// Returns an iterator from zero up to (but excluding) `self`.
-                ///
-                /// This is useful for iterating already-allocated values.
-                pub fn range_up_to(&self) -> impl std::iter::DoubleEndedIterator<Item = Self>
-                    + std::iter::FusedIterator
-                {
-                    (0..self.0).map(Self)
-                }
-
                 /// Reveals the inner ID.
                 pub fn into_inner(self) -> $typ {
                     self.0
@@ -224,6 +208,53 @@ macro_rules! newtype_counter {
                     serde::de::Deserialize::deserialize(deserializer).map(Self)
                 }
             }
+
+            #[sealed::sealed]
+            impl $crate::Countable for $name {
+                fn from_count(val: usize) -> Self {
+                    Self(val as $typ)
+                }
+            }
         )*
     };
+}
+
+/// Sealed trait implemented by ID types produced via [`newtype_counter!`].
+///
+/// This allows [`Counter<T>`] to mint new IDs without exposing a public
+/// constructor on the ID types themselves.
+#[doc(hidden)]
+#[sealed::sealed]
+pub trait Countable {
+    #[doc(hidden)]
+    fn from_count(val: usize) -> Self;
+}
+
+/// An opaque counter that produces unique IDs of type `T` via [`Counter::get_and_increment`].
+///
+/// This is separate from the ID types themselves so that holding an ID does not
+/// give the ability to mint new IDs.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Counter<T: Countable>(usize, std::marker::PhantomData<T>);
+
+impl<T: Countable> Default for Counter<T> {
+    fn default() -> Self {
+        Self(0, std::marker::PhantomData)
+    }
+}
+
+impl<T: Countable> Counter<T> {
+    /// Gets the current counter value and increments for the next call.
+    pub fn get_and_increment(&mut self) -> T {
+        let id = self.0;
+        self.0 += 1;
+        T::from_count(id)
+    }
+
+    /// Returns an iterator from zero up to (but excluding) the current counter value.
+    ///
+    /// This is useful for iterating already-allocated values.
+    pub fn range_up_to(&self) -> impl DoubleEndedIterator<Item = T> + std::iter::FusedIterator {
+        (0..self.0).map(T::from_count)
+    }
 }

--- a/hydro_lang/src/sim/builder.rs
+++ b/hydro_lang/src/sim/builder.rs
@@ -34,7 +34,7 @@ pub struct SimBuilder {
     pub cluster_graphs: BTreeMap<LocationId, FlatGraphBuilder>,
     pub process_tick_dfirs: BTreeMap<LocationId, FlatGraphBuilder>,
     pub cluster_tick_dfirs: BTreeMap<LocationId, FlatGraphBuilder>,
-    pub next_hoff_id: HandoffId,
+    pub next_hoff_id: crate::Counter<HandoffId>,
     pub test_safety_only: bool,
     pub skip_consistency_assertions: bool,
 }

--- a/hydro_lang/src/sim/flow.rs
+++ b/hydro_lang/src/sim/flow.rs
@@ -12,7 +12,7 @@ use slotmap::SparseSecondaryMap;
 use super::builder::SimBuilder;
 use super::compiled::{CompiledSim, CompiledSimInstance};
 use super::graph::{SimDeploy, SimExternal, SimNode, compile_sim, create_sim_graph_trybuild};
-use crate::compile::builder::{HandoffId, StmtId};
+use crate::compile::builder::StmtId;
 use crate::compile::ir::HydroRoot;
 use crate::location::LocationKey;
 use crate::location::dynamic::LocationId;
@@ -132,7 +132,7 @@ impl<'a> SimFlow<'a> {
             cluster_tick_dfirs: BTreeMap::new(),
             extra_stmts_global: vec![],
             extra_stmts_cluster: BTreeMap::new(),
-            next_hoff_id: HandoffId::default(),
+            next_hoff_id: crate::Counter::default(),
             test_safety_only: self.test_safety_only,
             skip_consistency_assertions: self.skip_consistency_assertions,
         };
@@ -161,7 +161,7 @@ impl<'a> SimFlow<'a> {
 
         let mut seen_tees = HashMap::new();
         let mut built_tees = HashMap::new();
-        let mut next_stmt_id = StmtId::default();
+        let mut next_stmt_id = crate::Counter::<StmtId>::default();
         let mut fold_hooked_idents = HashSet::new();
         for leaf in &mut self.ir {
             leaf.emit(

--- a/hydro_lang/src/sim/graph.rs
+++ b/hydro_lang/src/sim/graph.rs
@@ -40,7 +40,7 @@ crate::newtype_counter! {
 #[derive(Clone)]
 pub struct SimNode {
     /// Counter for port IDs, must be shared across all nodes in a simulation to prevent collisions.
-    pub shared_port_counter: Rc<RefCell<SimNodePort>>,
+    pub shared_port_counter: Rc<RefCell<crate::Counter<SimNodePort>>>,
 }
 
 impl Node for SimNode {
@@ -67,7 +67,7 @@ impl Node for SimNode {
 
 #[derive(Clone, Default)]
 pub(crate) struct SimExternalPortRegistry {
-    pub(crate) port_counter: SimExternalPort,
+    pub(crate) port_counter: crate::Counter<SimExternalPort>,
     /// A mapping from external port IDs (generated in `FlowState`)
     /// which are used for looking up connections, to the IDs
     /// of the external channels created in the simulation.


### PR DESCRIPTION
Previously, `newtype_counter!` generated a single type that served as both
the counter (with `Default` + `get_and_increment`) and the returned ID value.
This meant holding an ID implicitly gave the ability to mint new IDs.

Now:
- ID types (StmtId, HandoffId, ExternalPortId, etc.) are pure opaque values
  with only `into_inner`, `Display`, and `Serialize`/`Deserialize`. They have
  no `Default`, no `From<usize>`, and no `get_and_increment`.
- A new generic `Counter<T>` type is the sole way to produce IDs. It owns the
  incrementing state and exposes `get_and_increment()` and `range_up_to()`.
- A sealed `Countable` trait (using the `sealed` crate) connects `Counter<T>`
  to the ID types without exposing a public constructor. External code cannot
  implement `Countable` or call `from_count`.

All usage sites updated to use `Counter<T>` where counters are held:
- `next_stmt_id: &mut StmtId` → `&mut Counter<StmtId>`
- `BuildersOrCallback` callback bounds updated
- `FlowStateInner`, `SimBuilder`, `SimNode`, `SimExternalPortRegistry`,
  `DockerDeployExternal` fields changed to `Counter<T>`


Co-authored-by: Infinity 🤖 <infinity@hydro.run>