### PR TITLE
fix(hydro_lang): observe non-determinism for mut closures on non-strict inputs in simulator

### DIFF
--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -154,6 +154,10 @@ impl ClosureExpr {
         }
     }
 
+    pub fn has_mut_ref(&self) -> bool {
+        self.singleton_refs.iter().any(|(_, is_mut)| *is_mut)
+    }
+
     pub fn deep_clone(&self, seen_tees: &mut SeenSharedNodes) -> Self {
         Self {
             expr: self.expr.clone(),
@@ -583,6 +587,18 @@ pub trait DfirBuilder {
         in_ident: syn::Ident,
         out_ident: &syn::Ident,
     );
+
+    /// Observes non-determinism introduced by a mut closure operating on a non-strict
+    /// (unordered / at-least-once) input. In production this is identity; in simulation
+    /// it delegates to `observe_nondet` with the strict output kind.
+    fn observe_for_mut(
+        &mut self,
+        location: &LocationId,
+        in_ident: syn::Ident,
+        in_kind: &CollectionKind,
+        out_ident: &syn::Ident,
+        op_meta: &HydroIrOpMetadata,
+    );
 }
 
 #[cfg(feature = "build")]
@@ -857,6 +873,24 @@ impl DfirBuilder for SecondaryMap<LocationKey, FlatGraphBuilder> {
         location: &LocationId,
         in_ident: syn::Ident,
         out_ident: &syn::Ident,
+    ) {
+        let builder = self.get_dfir_mut(location);
+        builder.add_dfir(
+            parse_quote! {
+                #out_ident = #in_ident;
+            },
+            None,
+            None,
+        );
+    }
+
+    fn observe_for_mut(
+        &mut self,
+        location: &LocationId,
+        in_ident: syn::Ident,
+        _in_kind: &CollectionKind,
+        out_ident: &syn::Ident,
+        _op_meta: &HydroIrOpMetadata,
     ) {
         let builder = self.get_dfir_mut(location);
         builder.add_dfir(
@@ -2200,6 +2234,57 @@ impl CollectionKind {
             }
         )
     }
+
+    /// Returns whether this collection kind is already "strict" (TotalOrder + ExactlyOnce),
+    /// meaning no non-determinism needs to be observed for mut closures.
+    pub fn is_strict(&self) -> bool {
+        match self {
+            CollectionKind::Stream { order, retry, .. } => {
+                *order == StreamOrder::TotalOrder && *retry == StreamRetry::ExactlyOnce
+            }
+            CollectionKind::KeyedStream {
+                value_order,
+                value_retry,
+                ..
+            } => {
+                *value_order == StreamOrder::TotalOrder && *value_retry == StreamRetry::ExactlyOnce
+            }
+            // Singletons/Optionals/KeyedSingletons do not have observable
+            // non-determinism other than snapshots / batching
+            CollectionKind::Singleton { .. }
+            | CollectionKind::Optional { .. }
+            | CollectionKind::KeyedSingleton { .. } => true,
+        }
+    }
+
+    /// Creates a "strict" version of this kind with TotalOrder and ExactlyOnce.
+    pub fn strict_kind(&self) -> CollectionKind {
+        match self {
+            CollectionKind::Stream {
+                bound,
+                element_type,
+                ..
+            } => CollectionKind::Stream {
+                bound: bound.clone(),
+                order: StreamOrder::TotalOrder,
+                retry: StreamRetry::ExactlyOnce,
+                element_type: element_type.clone(),
+            },
+            CollectionKind::KeyedStream {
+                bound,
+                key_type,
+                value_type,
+                ..
+            } => CollectionKind::KeyedStream {
+                bound: bound.clone(),
+                value_order: StreamOrder::TotalOrder,
+                value_retry: StreamRetry::ExactlyOnce,
+                key_type: key_type.clone(),
+                value_type: value_type.clone(),
+            },
+            other => other.clone(),
+        }
+    }
 }
 
 #[derive(Clone, serde::Serialize)]
@@ -2572,6 +2657,35 @@ pub enum HydroNode {
 
 pub type SeenSharedNodes = HashMap<*const RefCell<HydroNode>, Rc<RefCell<HydroNode>>>;
 pub type SeenSharedNodeLocations = HashMap<*const RefCell<HydroNode>, LocationId>;
+
+/// If `f` has a mut singleton ref and `in_kind` is non-strict, emits an
+/// `observe_for_mut` node and returns the new ident. Otherwise returns
+/// `in_ident` unchanged. Always consumes a stmt_id when applicable.
+#[cfg(feature = "build")]
+fn maybe_observe_for_mut(
+    f: &ClosureExpr,
+    in_ident: syn::Ident,
+    in_location: &LocationId,
+    in_kind: &CollectionKind,
+    op_meta: &HydroIrOpMetadata,
+    builders_or_callback: &mut BuildersOrCallback<
+        impl FnMut(&mut HydroRoot, &mut crate::Counter<StmtId>),
+        impl FnMut(&mut HydroNode, &mut crate::Counter<StmtId>),
+    >,
+    next_stmt_id: &mut crate::Counter<StmtId>,
+) -> syn::Ident {
+    if f.has_mut_ref() && !in_kind.is_strict() {
+        let observe_stmt_id = next_stmt_id.get_and_increment();
+        let observe_ident =
+            syn::Ident::new(&format!("stream_{}", observe_stmt_id), Span::call_site());
+        if let BuildersOrCallback::Builders(graph_builders) = builders_or_callback {
+            graph_builders.observe_for_mut(in_location, in_ident, in_kind, &observe_ident, op_meta);
+        }
+        observe_ident
+    } else {
+        in_ident
+    }
+}
 
 impl HydroNode {
     pub fn transform_bottom_up(
@@ -3625,7 +3739,7 @@ impl HydroNode {
                     }
 
                     HydroNode::Partition {
-                        inner, f, is_true, ..
+                        inner, f, is_true, metadata,
                     } => {
                         let is_true = *is_true; // need to copy early to avoid borrow checking issues with node
                         let ptr = inner.0.as_ref() as *const RefCell<HydroNode>;
@@ -3646,6 +3760,17 @@ impl HydroNode {
                             // so its ident is on the stack
                             let inner_ident = ident_stack.pop().unwrap();
                             let f_tokens = f.emit_tokens(&mut ident_stack);
+
+                            let inner_ident = {
+                                let inner_borrow = inner.0.borrow();
+                                maybe_observe_for_mut(
+                                    f, inner_ident,
+                                    &inner_borrow.metadata().location_id,
+                                    &inner_borrow.metadata().collection_kind,
+                                    &metadata.op,
+                                    builders_or_callback, next_stmt_id,
+                                )
+                            };
 
                             let partition_ident = syn::Ident::new(
                                 &format!("stream_{}_partition", stmt_id),
@@ -4057,10 +4182,24 @@ impl HydroNode {
                         ident_stack.push(futures_ident);
                     }
 
-                    HydroNode::Map { f, .. } => {
+                    HydroNode::Map {
+                        f,
+                        input,
+                        metadata,
+                    } => {
                         // Pop input ident (pushed last by transform_children).
                         let input_ident = ident_stack.pop().unwrap();
                         let f_tokens = f.emit_tokens(&mut ident_stack);
+
+                        let input_ident = maybe_observe_for_mut(
+                            f,
+                            input_ident,
+                            &input.metadata().location_id,
+                            &input.metadata().collection_kind,
+                            &metadata.op,
+                            builders_or_callback,
+                            next_stmt_id,
+                        );
 
                         let stmt_id = next_stmt_id.get_and_increment();
                         let map_ident =
@@ -4085,9 +4224,17 @@ impl HydroNode {
                         ident_stack.push(map_ident);
                     }
 
-                    HydroNode::FlatMap { f, .. } => {
+                    HydroNode::FlatMap { f, input, metadata } => {
                         let input_ident = ident_stack.pop().unwrap();
                         let f_tokens = f.emit_tokens(&mut ident_stack);
+
+                        let input_ident = maybe_observe_for_mut(
+                            f, input_ident,
+                            &input.metadata().location_id,
+                            &input.metadata().collection_kind,
+                            &metadata.op,
+                            builders_or_callback, next_stmt_id,
+                        );
 
                         let stmt_id = next_stmt_id.get_and_increment();
                         let flat_map_ident =
@@ -4112,9 +4259,17 @@ impl HydroNode {
                         ident_stack.push(flat_map_ident);
                     }
 
-                    HydroNode::FlatMapStreamBlocking { f, .. } => {
+                    HydroNode::FlatMapStreamBlocking { f, input, metadata } => {
                         let input_ident = ident_stack.pop().unwrap();
                         let f_tokens = f.emit_tokens(&mut ident_stack);
+
+                        let input_ident = maybe_observe_for_mut(
+                            f, input_ident,
+                            &input.metadata().location_id,
+                            &input.metadata().collection_kind,
+                            &metadata.op,
+                            builders_or_callback, next_stmt_id,
+                        );
 
                         let stmt_id = next_stmt_id.get_and_increment();
                         let flat_map_stream_blocking_ident =
@@ -4139,9 +4294,17 @@ impl HydroNode {
                         ident_stack.push(flat_map_stream_blocking_ident);
                     }
 
-                    HydroNode::Filter { f, .. } => {
+                    HydroNode::Filter { f, input, metadata } => {
                         let input_ident = ident_stack.pop().unwrap();
                         let f_tokens = f.emit_tokens(&mut ident_stack);
+
+                        let input_ident = maybe_observe_for_mut(
+                            f, input_ident,
+                            &input.metadata().location_id,
+                            &input.metadata().collection_kind,
+                            &metadata.op,
+                            builders_or_callback, next_stmt_id,
+                        );
 
                         let stmt_id = next_stmt_id.get_and_increment();
                         let filter_ident =
@@ -4166,9 +4329,17 @@ impl HydroNode {
                         ident_stack.push(filter_ident);
                     }
 
-                    HydroNode::FilterMap { f, .. } => {
+                    HydroNode::FilterMap { f, input, metadata } => {
                         let input_ident = ident_stack.pop().unwrap();
                         let f_tokens = f.emit_tokens(&mut ident_stack);
+
+                        let input_ident = maybe_observe_for_mut(
+                            f, input_ident,
+                            &input.metadata().location_id,
+                            &input.metadata().collection_kind,
+                            &metadata.op,
+                            builders_or_callback, next_stmt_id,
+                        );
 
                         let stmt_id = next_stmt_id.get_and_increment();
                         let filter_map_ident =
@@ -4276,9 +4447,17 @@ impl HydroNode {
                         ident_stack.push(enumerate_ident);
                     }
 
-                    HydroNode::Inspect { f, .. } => {
+                    HydroNode::Inspect { f, input, metadata } => {
                         let input_ident = ident_stack.pop().unwrap();
                         let f_tokens = f.emit_tokens(&mut ident_stack);
+
+                        let input_ident = maybe_observe_for_mut(
+                            f, input_ident,
+                            &input.metadata().location_id,
+                            &input.metadata().collection_kind,
+                            &metadata.op,
+                            builders_or_callback, next_stmt_id,
+                        );
 
                         let stmt_id = next_stmt_id.get_and_increment();
                         let inspect_ident =

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -4814,4 +4814,90 @@ mod tests {
         // After retain(> 3): [4, 5] => len = 2
         assert_eq!(result, 2);
     }
+
+    /// A map with a mut singleton ref on an unordered input should produce > 1
+    /// simulation instance because the ordering of elements through the mut closure
+    /// is non-deterministic.
+    #[cfg(feature = "sim")]
+    #[test]
+    fn sim_map_with_mut_on_unordered_explores_multiple_states() {
+        use crate::live_collections::sliced::sliced;
+        use crate::live_collections::stream::ExactlyOnce;
+        use crate::properties::manual_proof;
+
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<()>();
+
+        let (trigger_send, trigger) = node.sim_input::<i32, TotalOrder, ExactlyOnce>();
+
+        let out_recv = sliced! {
+            let batch = use(trigger, nondet!(/** test */));
+            let counter = batch.location().source_iter(q!(vec![0i32]))
+                .fold(q!(|| 0i32), q!(|acc, v| *acc += v));
+            let counter_mut = counter.by_mut();
+            let items = batch.location().source_iter(q!(vec![1i32, 2])).weaken_ordering::<NoOrder>();
+            items.map(q!(
+                |x| {
+                    *counter_mut += x;
+                    *counter_mut
+                },
+                commutative = manual_proof!(/** test */)
+            ))
+        }
+        .sim_output();
+
+        let count = flow.sim().exhaustive(async || {
+            trigger_send.send(1);
+            let _all: Vec<i32> = out_recv.collect_sorted().await;
+        });
+
+        assert_eq!(
+            count, 2,
+            "Expected 2 simulation instances due to mut on unordered input, got {}",
+            count
+        );
+    }
+
+    /// A map with a mut singleton ref on a top-level unordered input should produce > 1
+    /// simulation instance. Currently panics because observe_nondet doesn't support
+    /// top-level bounded inputs yet.
+    #[cfg(feature = "sim")]
+    #[test]
+    #[ignore = "observe_nondet not yet supported for top-level bounded inputs (https://github.com/hydro-project/hydro/issues/2950)"]
+    fn sim_map_with_mut_on_unordered_top_level() {
+        use crate::properties::manual_proof;
+
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<()>();
+
+        let counter = node
+            .source_iter(q!(vec![0i32]))
+            .fold(q!(|| 0i32), q!(|acc, v| *acc += v));
+        let counter_mut = counter.by_mut();
+
+        let out_recv = node
+            .source_iter(q!(vec![1i32, 2]))
+            .weaken_ordering::<NoOrder>()
+            .map(q!(
+                |x| {
+                    *counter_mut += x;
+                    *counter_mut
+                },
+                commutative = manual_proof!(/** test */)
+            ))
+            .assume_ordering::<TotalOrder>(nondet!(/** test */))
+            .sim_output();
+
+        counter.into_stream().for_each(q!(|_| {}));
+
+        let count = flow.sim().exhaustive(async || {
+            let _all: Vec<i32> = out_recv.collect().await;
+        });
+
+        assert_eq!(
+            count, 2,
+            "Expected 2 simulation instances due to mut on unordered input, got {}",
+            count
+        );
+    }
 }

--- a/hydro_lang/src/sim/builder.rs
+++ b/hydro_lang/src/sim/builder.rs
@@ -1677,6 +1677,20 @@ impl DfirBuilder for SimBuilder {
             );
         }
     }
+
+    fn observe_for_mut(
+        &mut self,
+        location: &LocationId,
+        in_ident: syn::Ident,
+        in_kind: &CollectionKind,
+        out_ident: &syn::Ident,
+        op_meta: &HydroIrOpMetadata,
+    ) {
+        let out_kind = in_kind.strict_kind();
+        self.observe_nondet(
+            false, location, in_ident, in_kind, out_ident, &out_kind, op_meta,
+        );
+    }
 }
 
 /// Extract a location string, line, and caret indent from an op's metadata backtrace.


### PR DESCRIPTION
When a closure (map, flat_map, filter, filter_map, inspect, partition)
captures a singleton via `by_mut()` and operates on a non-strict input
(unordered or at-least-once), the ordering of elements through the closure
is non-deterministic. Previously the simulator blindly allowed this without
exploring different orderings.

- Added `CollectionKind::is_strict()` and `CollectionKind::strict_kind()`
  helpers to check/create TotalOrder+ExactlyOnce versions of a kind.
- Added `observe_for_mut` to the `DfirBuilder` trait (identity in prod,
  delegates to `observe_nondet` with strict output kind in sim).
- In `emit_core`, for Map/FlatMap/FlatMapStreamBlocking/Filter/FilterMap/
  Inspect/Partition: if the closure has any `is_mut` singleton ref and the
  input's collection kind is not strict, emit `observe_for_mut` before the
  operator.
- Added passing test `sim_map_with_mut_on_unordered_explores_multiple_states`.
- Added ignored test `sim_map_with_mut_on_unordered_top_level` for the
  top-level bounded case (https://github.com/hydro-project/hydro/issues/2950).

Co-authored-by: Infinity 🤖 <infinity@hydro.run>