### PR TITLE
fix(dfir_lang): `join_multiset_half` `CanPend`/`CanEnd` propagation, for `chain`/`union` compatibility

### DIFF
--- a/dfir_lang/src/graph/ops/join_multiset_half.rs
+++ b/dfir_lang/src/graph/ops/join_multiset_half.rs
@@ -112,7 +112,7 @@ pub const JOIN_MULTISET_HALF: OperatorConstraints = OperatorConstraints {
                     fn probe_join<'a, K, V1, V2, I>(
                         probe: I,
                         build_state: &'a #root::rustc_hash::FxHashMap<K, ::std::vec::Vec<V1>>,
-                    ) -> impl 'a + #root::dfir_pipes::pull::Pull<Item = (K, (V2, V1)), Meta = ()>
+                    ) -> impl 'a + #root::dfir_pipes::pull::Pull<Item = (K, (V2, V1)), Meta = (), CanPend = I::CanPend, CanEnd = I::CanEnd>
                     where
                         K: ::std::cmp::Eq + ::std::hash::Hash + ::std::clone::Clone + 'a,
                         V1: ::std::clone::Clone + 'a,


### PR DESCRIPTION
The probe_join helper function in join_multiset_half's codegen was returning
`impl Pull<Item = ..., Meta = ()>` without specifying CanEnd/CanPend. This
caused a type error when the output was used as the first input to chain/union,
which requires `CanEnd = Yes` for Pull::fuse().

Fixed by adding `CanPend = I::CanPend, CanEnd = I::CanEnd` to the return type,
propagating the probe input's type-level guarantees through to the output.