### PR TITLE
feat(hydro_lang,hydro_deploy): parallel compilation with per-job target dirs and shared artifact symlinks [ci-full]

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -4,7 +4,6 @@ default-filter = "not (package(hydro_test) & kind(bench))"
 
 [test-groups]
 serial-integration = { max-threads = 1 }
-hydro-trybuild-group = { max-threads = 1 }
 
 # TODO(inline): deadlock_detector disabled (intra-tick cycles)
 # [[profile.default.overrides]]
@@ -28,17 +27,18 @@ filter = 'binary(echo_local)'
 test-group = 'serial-integration'
 
 [[profile.default.overrides]]
-filter = 'package(hydro_lang)'
-test-group = 'hydro-trybuild-group'
+filter = 'test(fuzz_with_cargo_sim)'
+threads-required = 'num-test-threads'
 
 [[profile.default.overrides]]
-filter = 'package(hydro_std)'
-test-group = 'hydro-trybuild-group'
+filter = 'test(test_distributed_echo_example_docker)'
+threads-required = 'num-test-threads'
+
+# under heavy CPU load, Maelstrom is flaky when multiple nodes are launched
+[[profile.default.overrides]]
+filter = 'test(maelstrom::broadcast::tests::broadcast_3b_maelstrom)'
+threads-required = 'num-test-threads'
 
 [[profile.default.overrides]]
-filter = 'package(hydro_test)'
-test-group = 'hydro-trybuild-group'
-
-[[profile.default.overrides]]
-filter = 'package(hydro_test_template)'
-test-group = 'hydro-trybuild-group'
+filter = 'test(maelstrom::broadcast::tests::broadcast_3c_maelstrom)'
+threads-required = 'num-test-threads'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,7 @@ jobs:
           INSTA_UPDATE: ${{ (matrix.rust_release == 'latest-nightly' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')) && 'always' || '' }}
           INSTA_FORCE_PASS: ${{ (matrix.rust_release == 'latest-nightly' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')) && '1' || '' }}
           RUST_BACKTRACE: "1"
+          __CARGO_DEFAULT_LIB_METADATA: "1"
         run: cargo nextest run --no-fail-fast --all-targets --features "deploy,test_embedded,test_ecs,test_docker"
 
       - name: Run doctests
@@ -154,6 +155,7 @@ jobs:
           # note: no-capture is not supported by doctests, that's why the unstable is needed (nightly only).
           RUSTDOCFLAGS: ${{ matrix.rust_release == 'latest-nightly' && '-Zunstable-options --no-capture' || '' }}
           RUST_BACKTRACE: "1"
+          __CARGO_DEFAULT_LIB_METADATA: "1"
         run: cargo test --no-fail-fast --doc
 
       # Nightly snapshot update logic

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2612,6 +2612,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "hydro_concurrent_cargo"
+version = "0.1.0-alpha.0"
+dependencies = [
+ "parking_lot",
+]
+
+[[package]]
 name = "hydro_deploy"
 version = "0.17.0-alpha.2"
 dependencies = [
@@ -2627,6 +2634,7 @@ dependencies = [
  "cargo_metadata",
  "dunce",
  "futures",
+ "hydro_concurrent_cargo",
  "hydro_deploy_integration",
  "indicatif",
  "inferno",
@@ -2689,6 +2697,7 @@ dependencies = [
  "futures",
  "http-body-util",
  "hydro_build_utils",
+ "hydro_concurrent_cargo",
  "hydro_deploy",
  "hydro_deploy_integration",
  "indenter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "dfir_rs",
     "dfir_pipes",
     "example_test",
+    "hydro_concurrent_cargo",
     "hydro_deploy/core",
     "hydro_deploy/hydro_deploy_integration",
     "hydro_lang",

--- a/hydro_concurrent_cargo/Cargo.toml
+++ b/hydro_concurrent_cargo/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "hydro_concurrent_cargo"
+publish = true
+version = "0.1.0-alpha.0"
+description = "Shared locking and job directory utilities for parallel cargo builds in Hydro"
+edition = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
+
+[dependencies]
+parking_lot = "0.12"

--- a/hydro_concurrent_cargo/src/lib.rs
+++ b/hydro_concurrent_cargo/src/lib.rs
@@ -1,0 +1,426 @@
+//! Shared locking and job directory utilities for parallel cargo builds in Hydro.
+//!
+//! This crate provides the coordination primitives for running multiple cargo
+//! builds concurrently against a shared target directory using per-job symlinked
+//! directories.
+
+use std::collections::HashMap;
+use std::fs;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::sync::{LazyLock, Mutex};
+use std::time::SystemTime;
+
+// ---------------------------------------------------------------------------
+// Logging
+// ---------------------------------------------------------------------------
+
+/// Log a timestamped message to the build coordination log.
+pub fn log_build_event(project_dir: &Path, msg: &str) {
+    let log_path = project_dir.join("build-coordination.log");
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path)
+        .unwrap();
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis();
+    let thread_id = std::thread::current().id();
+    let _ = writeln!(file, "[{now}ms] [{thread_id:?}] {msg}");
+}
+
+// ---------------------------------------------------------------------------
+// In-process RwLocks
+// ---------------------------------------------------------------------------
+
+/// Global prebuild serialization lock (in-process).
+static GLOBAL_PREBUILD_LOCK: parking_lot::RwLock<()> = parking_lot::RwLock::new(());
+
+/// Per-feature-hash locks for when `__CARGO_DEFAULT_LIB_METADATA` is set.
+static DEP_BUILD_LOCK: parking_lot::RwLock<()> = parking_lot::RwLock::new(());
+static DEP_BUILD_LOCKS_PER_HASH: LazyLock<
+    Mutex<HashMap<String, &'static parking_lot::RwLock<()>>>,
+> = LazyLock::new(|| Mutex::new(HashMap::new()));
+
+fn get_dep_lock(features_hash: Option<&str>) -> &'static parking_lot::RwLock<()> {
+    match features_hash {
+        None => &DEP_BUILD_LOCK,
+        Some(hash) => {
+            let mut map = DEP_BUILD_LOCKS_PER_HASH.lock().unwrap();
+            map.entry(hash.to_owned())
+                .or_insert_with(|| Box::leak(Box::new(parking_lot::RwLock::new(()))))
+        }
+    }
+}
+
+/// Per-job-dir mutexes for serializing job dir setup/population within a process.
+static JOB_DIR_LOCKS: LazyLock<Mutex<HashMap<PathBuf, &'static Mutex<()>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+fn get_job_dir_lock(job_dir: &Path) -> &'static Mutex<()> {
+    let mut map = JOB_DIR_LOCKS.lock().unwrap();
+    map.entry(job_dir.to_owned())
+        .or_insert_with(|| Box::leak(Box::new(Mutex::new(()))))
+}
+
+// ---------------------------------------------------------------------------
+// CargoBuildLock
+// ---------------------------------------------------------------------------
+
+/// Guard holding the cargo build directory file lock (shared).
+pub struct CargoBuildLock {
+    _file: fs::File,
+}
+
+impl CargoBuildLock {
+    pub fn lock_shared(lock_path: &Path) -> Self {
+        eprintln!(
+            "[hydro-build] acquiring .cargo-build-lock shared: {}",
+            lock_path.display()
+        );
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(lock_path)
+            .unwrap();
+        file.lock_shared().unwrap();
+        eprintln!("[hydro-build] acquired .cargo-build-lock shared");
+        CargoBuildLock { _file: file }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PrebuildGuard
+// ---------------------------------------------------------------------------
+
+/// Guard holding both in-process and file locks for prebuild coordination.
+pub struct PrebuildGuard {
+    _rw_guard: RwGuard,
+    _global_guard: Option<parking_lot::RwLockWriteGuard<'static, ()>>,
+    _global_file: Option<fs::File>,
+    _file: fs::File,
+    lock_dir: PathBuf,
+}
+
+#[expect(
+    dead_code,
+    reason = "variants hold lock guards that are released on drop"
+)]
+enum RwGuard {
+    Read(parking_lot::RwLockReadGuard<'static, ()>),
+    Upgradable(parking_lot::RwLockUpgradableReadGuard<'static, ()>),
+    Write(parking_lot::RwLockWriteGuard<'static, ()>),
+}
+
+impl PrebuildGuard {
+    /// Acquire an upgradable lock (in-process upgradable read + file shared).
+    /// When `features_hash` is Some, uses a per-hash lock (for `__CARGO_DEFAULT_LIB_METADATA` mode).
+    pub fn lock_upgradable(lock_path: &Path, features_hash: Option<&str>) -> Self {
+        eprintln!(
+            "[hydro-build] acquiring prebuild upgradable lock: {}",
+            lock_path.display()
+        );
+        let rw_guard = get_dep_lock(features_hash).upgradable_read();
+        let lock_dir = lock_path.parent().unwrap().to_owned();
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(lock_path)
+            .unwrap();
+        file.lock_shared().unwrap();
+        eprintln!("[hydro-build] acquired prebuild upgradable lock");
+        PrebuildGuard {
+            _rw_guard: RwGuard::Upgradable(rw_guard),
+            _global_guard: None,
+            _global_file: None,
+            _file: file,
+            lock_dir,
+        }
+    }
+
+    /// Upgrade to exclusive (in-process write + file exclusive + global locks).
+    pub fn upgrade(self) -> Self {
+        eprintln!("[hydro-build] upgrading prebuild lock to exclusive");
+        let file = self._file;
+        let rw_guard = match self._rw_guard {
+            RwGuard::Upgradable(u) => parking_lot::RwLockUpgradableReadGuard::upgrade(u),
+            _ => panic!("can only upgrade from upgradable"),
+        };
+        // Release per-feature shared lock before acquiring global exclusive
+        // to avoid deadlock (other processes hold per-feature shared and wait for global).
+        file.unlock().unwrap();
+        eprintln!("[hydro-build] acquiring global prebuild file lock");
+        let global_guard = GLOBAL_PREBUILD_LOCK.write();
+        let global_file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(self.lock_dir.join(".global-prebuild.lock"))
+            .unwrap();
+        global_file.lock().unwrap();
+        eprintln!("[hydro-build] acquiring exclusive on per-feature lock");
+        file.lock().unwrap();
+        eprintln!("[hydro-build] acquired prebuild exclusive lock");
+        PrebuildGuard {
+            _rw_guard: RwGuard::Write(rw_guard),
+            _global_guard: Some(global_guard),
+            _global_file: Some(global_file),
+            _file: file,
+            lock_dir: self.lock_dir,
+        }
+    }
+
+    /// Downgrade from exclusive to shared (releases global lock).
+    pub fn downgrade(self) -> Self {
+        let file = self._file;
+        file.lock_shared().unwrap();
+        let rw_guard = match self._rw_guard {
+            RwGuard::Write(w) => RwGuard::Read(parking_lot::RwLockWriteGuard::downgrade(w)),
+            RwGuard::Upgradable(u) => {
+                RwGuard::Read(parking_lot::RwLockUpgradableReadGuard::downgrade(u))
+            }
+            r @ RwGuard::Read(_) => r,
+        };
+        PrebuildGuard {
+            _rw_guard: rw_guard,
+            _global_guard: None,
+            _global_file: None,
+            _file: file,
+            lock_dir: self.lock_dir,
+        }
+    }
+
+    /// Get mutable access to the underlying file (for writing timestamps).
+    pub fn file_mut(&mut self) -> &mut fs::File {
+        &mut self._file
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Job directory setup
+// ---------------------------------------------------------------------------
+
+/// Set up a job directory with symlinked .fingerprint and deps subdirs.
+/// Does NOT set up build/ — use `populate_job_build_dir` for final builds
+/// or manually symlink for prebuild.
+pub fn setup_job_dir(jobs_dir: &Path, name: &str, shared_debug: &Path) -> PathBuf {
+    let job = jobs_dir.join(name);
+    let _lock = get_job_dir_lock(&job);
+    let _lock = _lock.lock().unwrap();
+
+    // File lock for cross-process serialization on the same job dir.
+    fs::create_dir_all(&job).unwrap();
+    let job_lock_file = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(job.join(".job.lock"))
+        .unwrap();
+    job_lock_file.lock().unwrap();
+
+    let job_debug = job.join("debug");
+    fs::create_dir_all(&job_debug).unwrap();
+    for subdir in [".fingerprint", "deps"] {
+        let link = job_debug.join(subdir);
+        if !link.exists() {
+            let target = shared_debug.join(subdir);
+            fs::create_dir_all(&target).unwrap();
+            #[cfg(unix)]
+            std::os::unix::fs::symlink(&target, &link).unwrap();
+            #[cfg(windows)]
+            std::os::windows::fs::symlink_dir(&target, &link).unwrap();
+        }
+    }
+    job
+}
+
+/// Symlink the build/ directory for prebuild jobs (writes through to shared).
+pub fn symlink_prebuild_build_dir(prebuild_target: &Path, shared_debug: &Path) {
+    let link = prebuild_target.join("debug").join("build");
+    if !link.exists() {
+        let target = shared_debug.join("build");
+        fs::create_dir_all(&target).unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_dir(&target, &link).unwrap();
+    }
+}
+
+/// Guard that holds the job directory lock for the duration of a build.
+pub struct JobBuildGuard {
+    _mutex_guard: std::sync::MutexGuard<'static, ()>,
+    _file: fs::File,
+}
+
+/// Populate the per-job build/ directory from the shared build/ directory.
+/// Returns a guard that holds the job lock — keep alive for the entire final build.
+/// This prevents races from cargo's `link_or_copy` on build script binaries.
+pub fn populate_job_build_dir(job_debug: &Path, shared_debug: &Path) -> JobBuildGuard {
+    let shared_build = shared_debug.join("build");
+    let job_build = job_debug.join("build");
+
+    let job_dir = job_debug.parent().unwrap();
+    let mutex_guard = get_job_dir_lock(job_dir);
+    let mutex_guard = mutex_guard.lock().unwrap();
+
+    // Also hold a file lock for cross-process serialization on the same job dir.
+    let job_lock_path = job_dir.join(".job.lock");
+    let job_lock_file = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&job_lock_path)
+        .unwrap();
+    job_lock_file.lock().unwrap();
+
+    let _ = fs::remove_dir_all(&job_build);
+    fs::create_dir_all(&job_build).unwrap();
+    if shared_build.exists() {
+        for entry in fs::read_dir(&shared_build).unwrap() {
+            let entry = entry.unwrap();
+            if !entry.file_type().unwrap().is_dir() {
+                continue;
+            }
+            let dest = job_build.join(entry.file_name());
+            // Create dir and symlink each child individually so cargo can
+            // safely remove+relink build-script-build without racing other jobs.
+            fs::create_dir_all(&dest).unwrap();
+            for file in fs::read_dir(entry.path()).unwrap() {
+                let file = file.unwrap();
+                let file_dest = dest.join(file.file_name());
+                #[cfg(unix)]
+                std::os::unix::fs::symlink(file.path(), &file_dest).unwrap();
+                #[cfg(windows)]
+                {
+                    if file.file_type().unwrap().is_dir() {
+                        std::os::windows::fs::symlink_dir(file.path(), &file_dest).unwrap();
+                    } else {
+                        std::os::windows::fs::symlink_file(file.path(), &file_dest).unwrap();
+                    }
+                }
+            }
+        }
+    }
+
+    JobBuildGuard {
+        _mutex_guard: mutex_guard,
+        _file: job_lock_file,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Prebuild orchestration
+// ---------------------------------------------------------------------------
+
+/// Run the prebuild phase with proper locking and freshness checking.
+///
+/// - `target_dir`: the shared target directory (e.g. `target/`)
+/// - `crate_name`: unique identifier for the crate being built (included in hash)
+/// - `features`: list of features for hashing
+/// - `staged_paths`: paths to check mtime against for freshness
+/// - `build_fn`: closure called with `prebuild_target` path; should run cargo build(s)
+///
+/// Returns `(PrebuildGuard, CargoBuildLock)` both held in shared mode.
+/// Caller should keep both alive during the final build.
+pub fn run_prebuild(
+    target_dir: &Path,
+    crate_name: &str,
+    features: &[String],
+    staged_paths: &[PathBuf],
+    build_fn: impl FnOnce(&Path),
+) -> (PrebuildGuard, CargoBuildLock) {
+    // Acquire cargo build lock shared for the entire prebuild + final build duration.
+    let shared_debug = target_dir.join("debug");
+    fs::create_dir_all(&shared_debug).ok();
+    let cargo_lock = CargoBuildLock::lock_shared(&shared_debug.join(".cargo-build-lock"));
+
+    let features_hash = {
+        use std::hash::{Hash, Hasher};
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        crate_name.hash(&mut hasher);
+        let mut sorted = features.to_vec();
+        sorted.sort();
+        sorted.hash(&mut hasher);
+        format!("{:016x}", hasher.finish())
+    };
+
+    let has_lib_metadata = std::env::var("__CARGO_DEFAULT_LIB_METADATA").is_ok();
+    let lock_path = if has_lib_metadata {
+        target_dir.join(format!(".prebuild-{features_hash}.lock"))
+    } else {
+        target_dir.join(".prebuild.lock")
+    };
+
+    let staged_mtime = staged_paths
+        .iter()
+        .filter_map(|p| fs::metadata(p).and_then(|m| m.modified()).ok())
+        .max()
+        .unwrap_or(SystemTime::UNIX_EPOCH);
+
+    let prebuild_is_fresh = |path: &Path, expected_hash: &str| -> bool {
+        fs::read_to_string(path)
+            .ok()
+            .and_then(|s| {
+                let mut parts = s.trim().splitn(2, ':');
+                let hash = parts.next()?;
+                let nanos = parts.next()?.parse::<u128>().ok()?;
+                let ts = SystemTime::UNIX_EPOCH
+                    .checked_add(std::time::Duration::from_nanos(nanos as u64))?;
+                Some((hash.to_owned(), ts))
+            })
+            .is_some_and(|(hash, ts)| hash == expected_hash && ts >= staged_mtime)
+    };
+
+    let lock_hash = if has_lib_metadata {
+        Some(features_hash.as_str())
+    } else {
+        None
+    };
+
+    log_build_event(
+        target_dir,
+        &format!("prebuild: lock_upgradable, hash={features_hash}"),
+    );
+    let guard = PrebuildGuard::lock_upgradable(&lock_path, lock_hash);
+    if prebuild_is_fresh(&lock_path, &features_hash) {
+        log_build_event(target_dir, "prebuild: fresh, downgrading to shared");
+        return (guard.downgrade(), cargo_lock);
+    }
+
+    log_build_event(target_dir, "prebuild: not fresh, upgrading to exclusive");
+    let mut guard = guard.upgrade();
+    log_build_event(target_dir, "prebuild: exclusive acquired");
+
+    // Re-check after acquiring exclusive.
+    if !prebuild_is_fresh(&lock_path, &features_hash) {
+        let shared_debug = target_dir.join("debug");
+        let jobs_dir = target_dir.join("jobs");
+        let prebuild_target = setup_job_dir(&jobs_dir, "prebuild", &shared_debug);
+        symlink_prebuild_build_dir(&prebuild_target, &shared_debug);
+
+        build_fn(&prebuild_target);
+
+        // Write features_hash:timestamp.
+        use std::io::Seek;
+        let now_nanos = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let file = guard.file_mut();
+        file.set_len(0).unwrap();
+        file.seek(std::io::SeekFrom::Start(0)).unwrap();
+        write!(file, "{}:{}", features_hash, now_nanos).unwrap();
+    }
+
+    (guard.downgrade(), cargo_lock)
+}

--- a/hydro_deploy/core/Cargo.toml
+++ b/hydro_deploy/core/Cargo.toml
@@ -28,6 +28,7 @@ bytes = "1.1.0"
 cargo_metadata = "0.18.0"
 dunce = "1.0.0"
 futures = "0.3.0"
+hydro_concurrent_cargo = { path = "../../hydro_concurrent_cargo", version = "^0.1.0-alpha.0" }
 hydro_deploy_integration = { path = "../hydro_deploy_integration", version = "^0.17.0-alpha.2" }
 indicatif = "0.17.0"
 inferno = { version = "0.11.0", default-features = false, optional = true }

--- a/hydro_deploy/core/src/rust_crate/build.rs
+++ b/hydro_deploy/core/src/rust_crate/build.rs
@@ -123,8 +123,158 @@ pub async fn build_crate_memoized(params: BuildParams) -> Result<&'static BuildO
         .get_or_try_init(move || {
             ProgressTracker::rich_leaf("build", move |set_msg| async move {
                 tokio::task::spawn_blocking(move || {
+                    let base_target_dir = params
+                        .target_dir
+                        .as_ref()
+                        .cloned()
+                        .unwrap_or_else(|| params.src.join("target"));
+                    let job_name = params
+                        .bin
+                        .as_deref()
+                        .or(params.example.as_deref())
+                        .unwrap_or("default");
+
+                    // Only use prebuild + per-job target dirs for dylib mode.
+                    // Without dylib, build directly into the base target dir.
+                    let (per_job_target_dir, _prebuild_guard, _cargo_lock) = if params.is_dylib {
+                        let shared_debug = base_target_dir.join("debug");
+                        let jobs_dir = base_target_dir.join("jobs");
+                        let per_job = hydro_concurrent_cargo::setup_job_dir(&jobs_dir, job_name, &shared_debug);
+
+                        let features = params.features.clone().unwrap_or_default();
+                        let staged_paths = vec![
+                            params.src.join("src").join("__staged.rs"),
+                            params.src.join("Cargo.lock"),
+                            std::env::current_exe().unwrap(),
+                        ];
+
+                        let src = params.src.clone();
+                        let profile = params.profile.clone();
+                        let target_type = params.target_type;
+                        let no_default_features = params.no_default_features;
+                        let features_for_closure = features.clone();
+                        let config = params.config.clone();
+                        let rustflags = params.rustflags.clone();
+                        let build_env = params.build_env.clone();
+
+                        let (prebuild_guard, cargo_lock) = hydro_concurrent_cargo::run_prebuild(
+                            &base_target_dir,
+                            params.src.parent().unwrap().file_name().unwrap().to_str().unwrap(),
+                            &features,
+                            &staged_paths,
+                            |prebuild_target| {
+                                set_msg("building dependencies".to_owned());
+
+                                let mut dep_cmd = Command::new("cargo");
+                                dep_cmd.current_dir(src.join("..").join("dylib"));
+                                dep_cmd.args(["build", "--locked"]);
+
+                                if let Some(profile) = profile.as_ref() {
+                                    dep_cmd.args(["--profile", profile]);
+                                }
+
+                                match target_type {
+                                    HostTargetType::Local => {}
+                                    HostTargetType::Linux(crate::LinuxCompileType::Glibc) => {
+                                        dep_cmd.args(["--target", "x86_64-unknown-linux-gnu"]);
+                                    }
+                                    HostTargetType::Linux(crate::LinuxCompileType::Musl) => {
+                                        dep_cmd.args(["--target", "x86_64-unknown-linux-musl"]);
+                                    }
+                                }
+
+                                if no_default_features {
+                                    dep_cmd.arg("--no-default-features");
+                                }
+
+                                if !features_for_closure.is_empty() {
+                                    dep_cmd.args(["--features", &features_for_closure.join(",")]);
+                                }
+
+                                for c in &config {
+                                    dep_cmd.args(["--config", c]);
+                                }
+
+                                dep_cmd.args(["--target-dir", prebuild_target.to_str().unwrap()]);
+
+                                if let Some(rustflags) = rustflags.as_ref() {
+                                    dep_cmd.env("RUSTFLAGS", rustflags);
+                                }
+
+                                for (k, v) in &build_env {
+                                    dep_cmd.env(k, v);
+                                }
+
+                                eprintln!("[hydro-build] starting deploy prebuild child cargo");
+                                let status = dep_cmd
+                                    .stdin(Stdio::null())
+                                    .status()
+                                    .unwrap();
+                                eprintln!("[hydro-build] deploy prebuild child cargo finished, success={}", status.success());
+                                if !status.success() {
+                                    panic!("dep prebuild failed");
+                                }
+
+                                // Also prebuild the dylib-examples lib.
+                                eprintln!("[hydro-build] starting deploy prebuild dylib-examples lib");
+                                let mut lib_cmd = Command::new("cargo");
+                                lib_cmd.current_dir(&src);
+                                lib_cmd.args(["build", "--locked", "--lib"]);
+                                if let Some(profile) = profile.as_ref() {
+                                    lib_cmd.args(["--profile", profile]);
+                                }
+                                match target_type {
+                                    HostTargetType::Local => {}
+                                    HostTargetType::Linux(crate::LinuxCompileType::Glibc) => {
+                                        lib_cmd.args(["--target", "x86_64-unknown-linux-gnu"]);
+                                    }
+                                    HostTargetType::Linux(crate::LinuxCompileType::Musl) => {
+                                        lib_cmd.args(["--target", "x86_64-unknown-linux-musl"]);
+                                    }
+                                }
+                                if no_default_features {
+                                    lib_cmd.arg("--no-default-features");
+                                }
+                                if !features_for_closure.is_empty() {
+                                    lib_cmd.args(["--features", &features_for_closure.join(",")]);
+                                }
+                                for c in &config {
+                                    lib_cmd.args(["--config", c]);
+                                }
+                                lib_cmd.args(["--target-dir", prebuild_target.to_str().unwrap()]);
+                                if let Some(rustflags) = rustflags.as_ref() {
+                                    lib_cmd.env("RUSTFLAGS", rustflags);
+                                }
+                                for (k, v) in &build_env {
+                                    lib_cmd.env(k, v);
+                                }
+                                let lib_status = lib_cmd
+                                    .stdin(Stdio::null())
+                                    .status()
+                                    .unwrap();
+                                if !lib_status.success() {
+                                    panic!("dylib-examples lib prebuild failed");
+                                }
+                            },
+                        );
+
+                        (per_job, Some(prebuild_guard), Some(cargo_lock))
+                    } else {
+                        (base_target_dir.clone(), None, None)
+                    };
+
+                    hydro_concurrent_cargo::log_build_event(&base_target_dir, "deploy: starting final build");
+
+                    // Populate per-job build/ dir. Hold guard for entire final build.
+                    let _job_build_guard = if params.is_dylib {
+                        let shared_debug = base_target_dir.join("debug");
+                        Some(hydro_concurrent_cargo::populate_job_build_dir(&per_job_target_dir.join("debug"), &shared_debug))
+                    } else {
+                        None
+                    };
+
                     let mut command = Command::new("cargo");
-                    command.args(["build", "--locked"]);
+                    command.args(["build", if params.is_dylib { "--frozen" } else { "--locked" }]);
 
                     if let Some(profile) = params.profile.as_ref() {
                         command.args(["--profile", profile]);
@@ -161,10 +311,7 @@ pub async fn build_crate_memoized(params: BuildParams) -> Result<&'static BuildO
                     }
 
                     command.arg("--message-format=json-diagnostic-rendered-ansi");
-
-                    if let Some(target_dir) = params.target_dir.as_ref() {
-                        command.args(["--target-dir", target_dir.to_str().unwrap()]);
-                    }
+                    command.args(["--target-dir", per_job_target_dir.to_str().unwrap()]);
 
                     if let Some(rustflags) = params.rustflags.as_ref() {
                         command.env("RUSTFLAGS", rustflags);
@@ -213,19 +360,29 @@ pub async fn build_crate_memoized(params: BuildParams) -> Result<&'static BuildO
                                     let path_buf: PathBuf = path.clone().into();
                                     let path = path.into_string();
                                     let data = std::fs::read(path).unwrap();
-                                    assert!(spawned.wait().unwrap().success());
+                                    let exit_status = spawned.wait().unwrap();
+
+                                    let stderr_lines = stderr_worker.join().unwrap();
+
+                                    // Check for unexpected recompilations (only in dylib mode with prebuild).
+                                    if params.is_dylib {
+                                        for line in &stderr_lines {
+                                            if line.contains("Compiling") && !line.contains("dylib-examples") && !line.contains(job_name) {
+                                                panic!(
+                                                    "unexpected recompilation in deploy final build: {line}\nfull stderr:\n{}",
+                                                    stderr_lines.join("\n")
+                                                );
+                                            }
+                                        }
+                                    }
+
+                                    assert!(exit_status.success(), "deploy final build failed:\n{}", stderr_lines.join("\n"));
+
                                     return Ok(BuildOutput {
                                         bin_data: data,
                                         bin_path: path_buf,
                                         shared_library_path: if params.is_dylib {
-                                            Some(
-                                                params
-                                                    .target_dir
-                                                    .as_ref()
-                                                    .unwrap_or(&params.src.join("target"))
-                                                    .join("debug")
-                                                    .join("deps"),
-                                            )
+                                            Some(per_job_target_dir.join("debug").join("deps"))
                                         } else {
                                             None
                                         },
@@ -274,6 +431,7 @@ pub async fn build_crate_memoized(params: BuildParams) -> Result<&'static BuildO
                         let stderr_lines = stderr_worker
                             .join()
                             .expect("Stderr worker unexpectedly panicked.");
+
                         Err(BuildError::FailedToBuildCrate {
                             exit_status,
                             diagnostics,

--- a/hydro_lang/Cargo.toml
+++ b/hydro_lang/Cargo.toml
@@ -33,6 +33,7 @@ deploy = [
 
 sim = [
     "trybuild",
+    "dep:hydro_concurrent_cargo",
     "dep:hydro_deploy_integration",
     "dep:bolero",
     "dep:cargo_metadata",
@@ -72,6 +73,7 @@ ecs_deploy = [
 maelstrom = [
     "trybuild",
     "maelstrom_runtime",
+    "dep:tempfile",
 ]
 
 sim_runtime = [
@@ -130,6 +132,7 @@ ctor = { version = "0.2", optional = true }
 dfir_lang = { path = "../dfir_lang", version = "^0.17.0-alpha.2", optional = true }
 dfir_rs = { path = "../dfir_rs", version = "^0.17.0-alpha.3", default-features = false, optional = true }
 futures = "0.3.0"
+hydro_concurrent_cargo = { path = "../hydro_concurrent_cargo", version = "^0.1.0-alpha.0", optional = true }
 hydro_deploy = { path = "../hydro_deploy/core", version = "^0.17.0-alpha.2", optional = true }
 hydro_deploy_integration = { path = "../hydro_deploy/hydro_deploy_integration", version = "^0.17.0-alpha.2", optional = true }
 nameof = { version = "1.0.0", optional = true }

--- a/hydro_lang/src/compile/trybuild/generate.rs
+++ b/hydro_lang/src/compile/trybuild/generate.rs
@@ -259,7 +259,7 @@ pub fn compile_graph_trybuild(
         #[cfg(any(feature = "docker_deploy", feature = "ecs_deploy"))]
         DeployMode::Containerized => {
             syn::parse_quote! {
-                #![allow(unused_imports, unused_crate_dependencies, missing_docs, non_snake_case)]
+                #![allow(unused_imports, unused_crate_dependencies, missing_docs, non_snake_case, unexpected_cfgs, unfulfilled_lint_expectations)]
                 use #trybuild_crate_name_ident::__root as #orig_crate_name;
                 use #trybuild_crate_name_ident::__root::*;
                 use #trybuild_crate_name_ident::__staged::__deps::*;
@@ -287,7 +287,7 @@ pub fn compile_graph_trybuild(
         #[cfg(feature = "deploy")]
         DeployMode::HydroDeploy => {
             syn::parse_quote! {
-                #![allow(unused_imports, unused_crate_dependencies, missing_docs, non_snake_case)]
+                #![allow(unused_imports, unused_crate_dependencies, missing_docs, non_snake_case, unexpected_cfgs, unfulfilled_lint_expectations)]
                 use #trybuild_crate_name_ident::__root as #orig_crate_name;
                 use #trybuild_crate_name_ident::__root::*;
                 use #trybuild_crate_name_ident::__staged::__deps::*;
@@ -324,7 +324,7 @@ pub fn compile_graph_trybuild(
         #[cfg(feature = "maelstrom")]
         DeployMode::Maelstrom => {
             syn::parse_quote! {
-                #![allow(unused_imports, unused_crate_dependencies, missing_docs, non_snake_case)]
+                #![allow(unused_imports, unused_crate_dependencies, missing_docs, non_snake_case, unexpected_cfgs, unfulfilled_lint_expectations)]
                 use #trybuild_crate_name_ident::__root as #orig_crate_name;
                 use #trybuild_crate_name_ident::__root::*;
                 use #trybuild_crate_name_ident::__staged::__deps::*;
@@ -491,7 +491,7 @@ pub fn create_trybuild()
 
         write_atomic(
             prettyplease::unparse(&syn::parse_quote! {
-                #![allow(unused_imports, unused_crate_dependencies, missing_docs, non_snake_case)]
+                #![allow(unused_imports, unused_crate_dependencies, missing_docs, non_snake_case, unexpected_cfgs, unfulfilled_lint_expectations)]
 
                 pub use #crate_name_ident as __root;
 
@@ -521,7 +521,7 @@ pub fn create_trybuild()
         );
         write_atomic(
             prettyplease::unparse(&syn::parse_quote! {
-                #![allow(unused_imports, unused_crate_dependencies, missing_docs, non_snake_case)]
+                #![allow(unused_imports, unused_crate_dependencies, missing_docs, non_snake_case, unexpected_cfgs, unfulfilled_lint_expectations)]
                 pub use #trybuild_crate_name_ident::*;
             })
             .as_bytes(),
@@ -535,9 +535,14 @@ pub fn create_trybuild()
         )
         .unwrap();
 
-        // Dylib crate Cargo.toml - only dylib crate-type, no features needed
-        // Features are enabled on the base crate directly from dylib-examples
+        // Dylib crate Cargo.toml - only dylib crate-type, with feature forwarding to base crate
         // On Windows, we currently disable dylib compilation due to https://github.com/bevyengine/bevy/pull/2016
+        let dylib_features_section = feature_names
+            .iter()
+            .map(|f| format!("{f} = [\"{project_name}/{f}\"]"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
         let dylib_manifest = format!(
             r#"[package]
 name = "{project_name}-dylib"
@@ -549,6 +554,9 @@ crate-type = ["{}"]
 
 [dependencies]
 {project_name} = {{ path = "..", default-features = false }}
+
+[features]
+{dylib_features_section}
 "#,
             serialized_edition,
             if cfg!(target_os = "windows") {
@@ -568,14 +576,14 @@ crate-type = ["{}"]
             &path!(dylib_examples_dir / "src" / "lib.rs"),
         )?;
 
-        // Build feature forwarding for dylib-examples - forward directly to base crate
+        // Build feature forwarding for dylib-examples - forward to both base and dylib crates
         let features_section = feature_names
             .iter()
-            .map(|f| format!("{f} = [\"{project_name}/{f}\"]"))
+            .map(|f| format!("{f} = [\"{project_name}/{f}\", \"{project_name}-dylib/{f}\"]"))
             .collect::<Vec<_>>()
             .join("\n");
 
-        // Dylib-examples crate Cargo.toml - has dylib as dev-dependency, features go to base crate
+        // Dylib-examples crate Cargo.toml - has base crate and dylib as dev-dependencies
         let dylib_examples_manifest = format!(
             r#"[package]
 name = "{project_name}-dylib-examples"
@@ -602,7 +610,7 @@ crate-type = ["cdylib"]
 
         // sim-dylib.rs for the base crate and dylib-examples crate
         let sim_dylib_contents = prettyplease::unparse(&syn::parse_quote! {
-            #![allow(unused_imports, unused_crate_dependencies, missing_docs, non_snake_case)]
+            #![allow(unused_imports, unused_crate_dependencies, missing_docs, non_snake_case, unexpected_cfgs, unfulfilled_lint_expectations)]
             include!(std::concat!(env!("TRYBUILD_LIB_NAME"), ".rs"));
         });
         write_atomic(

--- a/hydro_lang/src/deploy/maelstrom/deploy_maelstrom.rs
+++ b/hydro_lang/src/deploy/maelstrom/deploy_maelstrom.rs
@@ -514,6 +514,9 @@ impl MaelstromDeployment {
     pub fn run(self) -> Result<(), Error> {
         let binary_path = self.build()?;
 
+        // Use a unique working directory per run to avoid conflicts with concurrent tests.
+        let run_dir = tempfile::tempdir().map_err(Error::other)?;
+
         let mut cmd = std::process::Command::new(&self.maelstrom_path);
         cmd.arg("test")
             .arg("-w")
@@ -522,6 +525,7 @@ impl MaelstromDeployment {
             .arg(&binary_path)
             .arg("--node-count")
             .arg(self.node_count.to_string())
+            .current_dir(run_dir.path())
             .stdout(Stdio::piped());
 
         if let Some(time_limit) = self.time_limit {
@@ -551,7 +555,11 @@ impl MaelstromDeployment {
             eprintln!("{}", &line);
 
             if line.starts_with("Analysis invalid!") {
-                return Err(Error::other("Analysis was invalid"));
+                let path = run_dir.keep();
+                return Err(Error::other(format!(
+                    "Analysis was invalid. Maelstrom store at: {}",
+                    path.display()
+                )));
             } else if line.starts_with("Errors occurred during analysis, but no anomalies found.")
                 || line.starts_with("Everything looks good!")
             {
@@ -559,7 +567,11 @@ impl MaelstromDeployment {
             }
         }
 
-        Err(Error::other("Maelstrom produced an unexpected result"))
+        let path = run_dir.keep();
+        Err(Error::other(format!(
+            "Maelstrom produced an unexpected result. Store at: {}",
+            path.display()
+        )))
     }
 
     /// Get the path to the compiled binary (after building).

--- a/hydro_lang/src/sim/graph.rs
+++ b/hydro_lang/src/sim/graph.rs
@@ -427,9 +427,10 @@ impl<'a> Deploy<'a> for SimDeploy {
 }
 
 pub(super) fn compile_sim(bin: String, trybuild: TrybuildConfig) -> Result<TempPath, ()> {
-    let mut command = Command::new("cargo");
-
     let is_fuzz = std::env::var("BOLERO_FUZZER").is_ok();
+    // When RUSTFLAGS is set, our prebuild fingerprint doesn't account for it, so skip the
+    // parallel build machinery entirely and build directly into the shared target dir.
+    let has_custom_rustflags = std::env::var("RUSTFLAGS").is_ok();
 
     // Run from dylib-examples crate which has the dylib as a dev-dependency (only if not fuzzing)
     let crate_to_compile = if is_fuzz {
@@ -437,10 +438,100 @@ pub(super) fn compile_sim(bin: String, trybuild: TrybuildConfig) -> Result<TempP
     } else {
         path!(trybuild.project_dir / "dylib-examples")
     };
+
+    let (final_target_dir, _prebuild_guard, _cargo_lock) = if !has_custom_rustflags {
+        let shared_debug = trybuild.target_dir.join("debug");
+        let jobs_dir = trybuild.target_dir.join("jobs");
+        let per_job = hydro_concurrent_cargo::setup_job_dir(&jobs_dir, &bin, &shared_debug);
+
+        let mut features: Vec<String> = trybuild.features.clone().unwrap_or_default();
+        features.push("hydro___feature_sim_runtime".to_owned());
+
+        let staged_paths = vec![
+            path!(trybuild.project_dir / "src" / "__staged.rs"),
+            path!(trybuild.project_dir / "Cargo.lock"),
+            std::env::current_exe().unwrap(),
+        ];
+
+        let project_dir = trybuild.project_dir.clone();
+        let features_for_closure = features.clone();
+        let is_fuzz_for_closure = is_fuzz;
+
+        let (guard, cargo_lock) = hydro_concurrent_cargo::run_prebuild(
+            &trybuild.target_dir,
+            trybuild.project_dir.file_name().unwrap().to_str().unwrap(),
+            &features,
+            &staged_paths,
+            |prebuild_target| {
+                let features_str = features_for_closure.join(",");
+
+                let dylib_crate = path!(project_dir / "dylib");
+                let mut dep_cmd = Command::new("cargo");
+                dep_cmd.current_dir(&dylib_crate);
+                dep_cmd.args(["build", "--locked"]);
+                dep_cmd.args(["--target-dir", prebuild_target.to_str().unwrap()]);
+                dep_cmd.args(["--features", &features_str]);
+                dep_cmd.args(["--config", "build.incremental = false"]);
+                dep_cmd.env("STAGELEFT_TRYBUILD_BUILD_STAGED", "1");
+                eprintln!("[hydro-build] starting sim prebuild child cargo");
+                let status = dep_cmd.stdin(Stdio::null()).status().unwrap();
+                eprintln!(
+                    "[hydro-build] sim prebuild child cargo finished, success={}",
+                    status.success()
+                );
+                if !status.success() {
+                    panic!("dep prebuild failed");
+                }
+
+                // Also prebuild the dylib-examples lib so concurrent final builds
+                // don't race on compiling it. Skip in fuzz mode since fuzzing
+                // compiles from the base trybuild crate directly (no dylib-examples).
+                if !is_fuzz_for_closure {
+                    eprintln!("[hydro-build] starting sim prebuild dylib-examples lib");
+                    let dylib_examples_crate = path!(project_dir / "dylib-examples");
+                    let mut lib_cmd = Command::new("cargo");
+                    lib_cmd.current_dir(&dylib_examples_crate);
+                    lib_cmd.args(["build", "--locked", "--lib"]);
+                    lib_cmd.args(["--target-dir", prebuild_target.to_str().unwrap()]);
+                    lib_cmd.args(["--features", &features_str]);
+                    lib_cmd.args(["--config", "build.incremental = false"]);
+                    lib_cmd.env("STAGELEFT_TRYBUILD_BUILD_STAGED", "1");
+                    let lib_status = lib_cmd.stdin(Stdio::null()).status().unwrap();
+                    if !lib_status.success() {
+                        panic!("dylib-examples lib prebuild failed");
+                    }
+                }
+            },
+        );
+
+        (per_job, Some(guard), Some(cargo_lock))
+    } else {
+        (trybuild.target_dir.clone(), None, None)
+    };
+
+    // Populate per-job build/ dir right before final build. Hold guard for entire build.
+    let _job_build_guard = if !has_custom_rustflags {
+        let shared_debug = trybuild.target_dir.join("debug");
+        Some(hydro_concurrent_cargo::populate_job_build_dir(
+            &final_target_dir.join("debug"),
+            &shared_debug,
+        ))
+    } else {
+        None
+    };
+
+    let mut command = Command::new("cargo");
     command.current_dir(&crate_to_compile);
-    command.args(["rustc", "--locked"]);
+    command.args([
+        "rustc",
+        if has_custom_rustflags {
+            "--locked"
+        } else {
+            "--frozen"
+        },
+    ]);
     command.args(["--example", "sim-dylib"]);
-    command.args(["--target-dir", trybuild.target_dir.to_str().unwrap()]);
+    command.args(["--target-dir", final_target_dir.to_str().unwrap()]);
     command.args([
         "--features",
         &trybuild
@@ -461,9 +552,9 @@ pub(super) fn compile_sim(bin: String, trybuild: TrybuildConfig) -> Result<TempP
 
     if cfg!(target_os = "linux") {
         let debug_path = if let Ok(target) = std::env::var("CARGO_BUILD_TARGET") {
-            path!(trybuild.target_dir / target / "debug")
+            path!(final_target_dir / target / "debug")
         } else {
-            path!(trybuild.target_dir / "debug")
+            path!(final_target_dir / "debug")
         };
 
         command.args([&format!(
@@ -497,10 +588,20 @@ pub(super) fn compile_sim(bin: String, trybuild: TrybuildConfig) -> Result<TempP
 
     let mut spawned = command
         .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
         .stdin(Stdio::null())
         .spawn()
         .unwrap();
     let reader = std::io::BufReader::new(spawned.stdout.take().unwrap());
+    let stderr_handle = spawned.stderr.take().unwrap();
+    let stderr_thread = std::thread::spawn(move || {
+        use std::io::Read;
+        let mut buf = String::new();
+        std::io::BufReader::new(stderr_handle)
+            .read_to_string(&mut buf)
+            .unwrap();
+        buf
+    });
 
     let mut out = Err(());
     for message in cargo_metadata::Message::parse_stream(reader) {
@@ -546,6 +647,23 @@ pub(super) fn compile_sim(bin: String, trybuild: TrybuildConfig) -> Result<TempP
     }
 
     spawned.wait().unwrap();
+    let stderr_output = stderr_thread.join().unwrap();
+
+    // Check for unexpected recompilations — only dylib-examples should be compiled.
+    // (Only relevant when prebuild is active, i.e. no custom RUSTFLAGS.)
+    if !has_custom_rustflags {
+        for line in stderr_output.lines() {
+            if line.contains("Compiling") && !line.contains("dylib-examples") {
+                panic!(
+                    "unexpected recompilation in final build: {line}\nfull stderr:\n{stderr_output}"
+                );
+            }
+        }
+    }
+
+    if out.is_err() {
+        panic!("final build failed to produce binary.\nstderr:\n{stderr_output}");
+    }
 
     let out_file = tempfile::NamedTempFile::new().unwrap().into_temp_path();
     fs::copy(out.as_ref().unwrap(), &out_file).unwrap();


### PR DESCRIPTION
Each compilation job gets its own `--target-dir` (under `{target}/jobs/{name}`) to
avoid cargo's global artifact-dir lock, while sharing compiled artifacts via symlinks
to `.fingerprint`, `build`, and `deps` in the shared target dir.

A prebuild step compiles the dylib crate (or --lib for non-dylib) into the shared
target dir before the parallel final builds start, ensuring all dependencies are ready.

Also adds feature forwarding to the generated dylib crate's Cargo.toml.

Note: Set `__CARGO_DEFAULT_LIB_METADATA` in CI to avoid dylib fingerprint thrashing
across different feature sets.

Co-authored-by: Infinity 🤖 <infinity@hydro.run>