### PR TITLE
fix(dfir_lang): drain source_stream to register waker, fixing sim partitioning/panic sensitivity

### DIFF
--- a/dfir_lang/src/graph/ops/source_stream.rs
+++ b/dfir_lang/src/graph/ops/source_stream.rs
@@ -40,14 +40,14 @@ pub const SOURCE_STREAM: OperatorConstraints = OperatorConstraints {
     ports_out: None,
     input_delaytype_fn: |_| None,
     write_fn: |wc @ &WriteContextArgs {
-                   root,
-                   context,
-                   op_span,
-                   ident,
-                   arguments,
-                   ..
-               },
-               _| {
+                     root,
+                     context,
+                     op_span,
+                     ident,
+                     arguments,
+                     ..
+                 },
+                 _| {
         let receiver = &arguments[0];
         let stream_ident = wc.make_ident("stream");
         let write_prologue = quote_spanned! {op_span=>
@@ -67,9 +67,23 @@ pub const SOURCE_STREAM: OperatorConstraints = OperatorConstraints {
                 #context.waker(),
             );
         };
+
+        // Drain remaining items from the stream to ensure the waker is registered
+        // (poll_next must return Pending at least once to register the waker for
+        // future sends to wake this DFIR).
+        let write_iterator_after = quote_spanned! {op_span=>
+            {
+                use #root::futures::stream::Stream;
+                let waker = #context.waker();
+                let mut cx = ::std::task::Context::from_waker(&waker);
+                while let ::std::task::Poll::Ready(Some(_)) = ::std::pin::Pin::new(&mut #stream_ident).poll_next(&mut cx) {}
+            }
+        };
+
         Ok(OperatorWriteOutput {
             write_prologue,
             write_iterator,
+            write_iterator_after,
             ..Default::default()
         })
     },

--- a/dfir_lang/src/graph/ops/source_stream.rs
+++ b/dfir_lang/src/graph/ops/source_stream.rs
@@ -61,22 +61,24 @@ pub const SOURCE_STREAM: OperatorConstraints = OperatorConstraints {
                 check_stream(#receiver)
             };
         };
+        let fused_ident = wc.make_ident("stream_fused");
         let write_iterator = quote_spanned! {op_span=>
-            let #ident = #root::dfir_pipes::pull::stream_ready(
+            let mut #fused_ident = #root::dfir_pipes::pull::Pull::fuse(#root::dfir_pipes::pull::stream_ready(
                 &mut #stream_ident,
                 #context.waker(),
-            );
+            ));
+            let #ident = &mut #fused_ident;
         };
 
         // Drain remaining items from the stream to ensure the waker is registered
         // (poll_next must return Pending at least once to register the waker for
-        // future sends to wake this DFIR).
+        // future sends to wake this DFIR). The fused pull returns Ended immediately
+        // if Pending was already hit during the pipeline.
         let write_iterator_after = quote_spanned! {op_span=>
             {
-                use #root::futures::stream::Stream;
-                let waker = #context.waker();
-                let mut cx = ::std::task::Context::from_waker(&waker);
-                while let ::std::task::Poll::Ready(Some(_)) = ::std::pin::Pin::new(&mut #stream_ident).poll_next(&mut cx) {}
+                use #root::dfir_pipes::pull::Pull;
+                let mut drain = ::std::pin::pin!(#fused_ident);
+                while let #root::dfir_pipes::pull::PullStep::Ready(_, _) = drain.as_mut().pull(&mut ()) {}
             }
         };
 

--- a/dfir_rs/tests/surface_cross_singleton.rs
+++ b/dfir_rs/tests/surface_cross_singleton.rs
@@ -129,3 +129,43 @@ pub fn test_tick_persistence_resets() {
     let out: Vec<_> = collect_ready(&mut egress_rx);
     assert_eq!(out, []);
 }
+
+/// Regression test: `source_stream` must register waker even when downstream
+/// (e.g. `cross_singleton`) only pulls one item. Without the drain-to-pending
+/// cleanup, subsequent sends wouldn't wake the DFIR for another tick.
+#[multiplatform_test(test, wasm, env_tracing)]
+pub fn test_source_stream_waker_registration() {
+    let (input_tx, input_rx) = dfir_rs::util::unbounded_channel::<i32>();
+    let (single_tx, single_rx) = dfir_rs::util::unbounded_channel::<i32>();
+    let (egress_tx, mut egress_rx) = dfir_rs::util::unbounded_channel();
+
+    let mut df = dfir_syntax! {
+        source_stream(input_rx) -> [input]join;
+        source_stream(single_rx) -> [single]join;
+        join = cross_singleton();
+        join -> for_each(|x| egress_tx.send(x).unwrap());
+    };
+
+    // First tick: send one item on each channel.
+    input_tx.send(1).unwrap();
+    single_tx.send(100).unwrap();
+    df.run_tick_sync();
+    let out: Vec<_> = collect_ready(&mut egress_rx);
+    assert_eq!(out, vec![(1, 100)]);
+
+    // Second tick: send again. The singleton channel must have its waker
+    // registered from the first tick (via drain-to-pending) so that this
+    // send wakes the DFIR.
+    input_tx.send(2).unwrap();
+    single_tx.send(200).unwrap();
+    df.run_tick_sync();
+    let out: Vec<_> = collect_ready(&mut egress_rx);
+    assert_eq!(out, vec![(2, 200)]);
+
+    // Third tick: same pattern to confirm stability.
+    input_tx.send(3).unwrap();
+    single_tx.send(300).unwrap();
+    df.run_tick_sync();
+    let out: Vec<_> = collect_ready(&mut egress_rx);
+    assert_eq!(out, vec![(3, 300)]);
+}

--- a/dfir_rs/tests/surface_cross_singleton.rs
+++ b/dfir_rs/tests/surface_cross_singleton.rs
@@ -149,7 +149,7 @@ pub fn test_source_stream_waker_registration() {
     // First tick: send one item on each channel.
     input_tx.send(1).unwrap();
     single_tx.send(100).unwrap();
-    df.run_tick_sync();
+    assert!(df.run_tick_sync());
     let out: Vec<_> = collect_ready(&mut egress_rx);
     assert_eq!(out, vec![(1, 100)]);
 
@@ -158,14 +158,14 @@ pub fn test_source_stream_waker_registration() {
     // send wakes the DFIR.
     input_tx.send(2).unwrap();
     single_tx.send(200).unwrap();
-    df.run_tick_sync();
+    assert!(df.run_tick_sync());
     let out: Vec<_> = collect_ready(&mut egress_rx);
     assert_eq!(out, vec![(2, 200)]);
 
     // Third tick: same pattern to confirm stability.
     input_tx.send(3).unwrap();
     single_tx.send(300).unwrap();
-    df.run_tick_sync();
+    assert!(df.run_tick_sync());
     let out: Vec<_> = collect_ready(&mut egress_rx);
     assert_eq!(out, vec![(3, 300)]);
 }


### PR DESCRIPTION
The simulator was sensitive to tick DFIR subgraph partitioning because
`source_stream` didn't always register its waker with the underlying
tokio channel. When `cross_singleton` (or any downstream operator) only
pulled one item from the singleton stream without hitting Pending, the
waker was never registered. This meant subsequent `send()` calls from
hooks couldn't wake the tick DFIR, causing `run_tick()` to return false
and the simulator to terminate branches early via silent panic (fixed
in subsequent PR)

The fix adds a `write_iterator_after` cleanup step to `source_stream`
(mirroring `source_iter`'s pattern) that drains remaining items from the
stream after the subgraph's main pipeline runs. This ensures `poll_next`
eventually returns Pending, registering the waker for future sends.